### PR TITLE
Include LICENSE.txt in sdist and wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_files = LICENSE


### PR DESCRIPTION
The distributions should come with the license files. This makes the life of packagers easier, e.g. https://github.com/conda-forge/staged-recipes/pull/10358