### PR TITLE
Use collections.abc for ABC import to fix Python 3.9 compatibility.

### DIFF
--- a/metaflow/datastore/datastore.py
+++ b/metaflow/datastore/datastore.py
@@ -4,7 +4,10 @@ import sys
 import time
 from hashlib import sha1
 from functools import partial
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 try:
     # Python 2

--- a/metaflow/datastore/datastore.py
+++ b/metaflow/datastore/datastore.py
@@ -4,10 +4,6 @@ import sys
 import time
 from hashlib import sha1
 from functools import partial
-try:
-    from collections.abc import Sequence
-except ImportError:
-    from collections import Sequence
 
 try:
     # Python 2

--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -1,4 +1,3 @@
-import collections
 import os
 import sys
 from hashlib import sha1


### PR DESCRIPTION
Importing ABC from collections module will raise `ImportError` in Python 3.9 and raises `DeprecationWarning` from 3.4 . Hence use `collections.abc` and also preserve compatibility with Python 2. Ref : https://github.com/python/cpython/pull/10596