### PR TITLE
Issue 43 - change environment variable name to correct key

### DIFF
--- a/metaflow/main_cli.py
+++ b/metaflow/main_cli.py
@@ -408,7 +408,7 @@ def aws(profile):
             service_url = click.prompt('\tPlease enter the URL for your '
                                        'metadata service')
             env_dict['METAFLOW_DEFAULT_METADATA'] = 'service'
-            env_dict['METADATA_SERVICE_URL'] = service_url
+            env_dict['METAFLOW_SERVICE_URL'] = service_url
 
         # Conda (on S3) configuration.
         if use_s3:


### PR DESCRIPTION
The CLI incorrectly sets the environment config value of `METADATA_SERVICE_URL` during AWS config setup. This requires the user to manually set the value of `METAFLOW_SERVICE_URL` in it's place.

Fix for issue 43:
https://github.com/Netflix/metaflow/issues/43