### PR TITLE
Add cli command to clean up local data store

### DIFF
--- a/metaflow/main_cli.py
+++ b/metaflow/main_cli.py
@@ -68,13 +68,13 @@ def main(ctx):
         short_help = {'tutorials': 'Browse and access metaflow tutorials.',
                       'configure': 'Configure metaflow to access the cloud.',
                       'status': 'Display the current working tree.',
-                      'reset-local': 'Resets your local data store',
+                      'reset-local': 'Resets your local data store.',
                       'help': 'Show all available commands to run.'}
 
         echo('Commands:', bold=False)
 
         for cmd, desc in short_help.items():
-            echo('  metaflow {0:<10} '.format(cmd),
+            echo('  metaflow {0:<12} '.format(cmd),
                  fg='cyan',
                  bold=False,
                  nl=False)
@@ -130,14 +130,15 @@ def reset_local():
     path = LocalDataStore.get_datastore_root_from_config(echo, create_on_absent=False)
     
     if path:
-        if click.confirm("This will reset your local data store." +\
-                        click.style("\nWARNING:", fg='red') +\
-                                    "This step cannot be undone!\nProceed to delete: " +\
-                                    click.style("\"{0}\"".format(path), fg='red') + "?"):
+        if click.confirm("Confirm deleting your local datastore at:" +\
+                        click.style("\"{0}\"".format(path), fg='cyan') + "? " +\
+                        click.style("WARNING:", fg='red') +\
+                                    "This step cannot be undone."):
             shutil.rmtree(path)
+            echo('Local datastore successfully reset.')
     else:
         # Nothing to do here since we didnt find an existing store.
-        pass
+        echo('Local datastore is already reset.')
     
 @main.group(help="Browse and access the metaflow tutorial episodes.")
 def tutorials():

--- a/metaflow/main_cli.py
+++ b/metaflow/main_cli.py
@@ -68,6 +68,7 @@ def main(ctx):
         short_help = {'tutorials': 'Browse and access metaflow tutorials.',
                       'configure': 'Configure metaflow to access the cloud.',
                       'status': 'Display the current working tree.',
+                      'reset-local': 'Resets your local data store',
                       'help': 'Show all available commands to run.'}
 
         echo('Commands:', bold=False)
@@ -123,6 +124,21 @@ def status():
     for flow in Metaflow():
         echo('* %s' % flow, fg='cyan')
 
+@main.command(help='Reset local data store. This will remove all information and artifacts from your runs.')
+def reset_local():
+    # Get the local data store path
+    path = LocalDataStore.get_datastore_root_from_config(echo, create_on_absent=False)
+    
+    if path:
+        if click.confirm("This will reset your local data store." +\
+                        click.style("\nWARNING:", fg='red') +\
+                                    "This step cannot be undone!\nProceed to delete: " +\
+                                    click.style("\"{0}\"".format(path), fg='red') + "?"):
+            shutil.rmtree(path)
+    else:
+        # Nothing to do here since we didnt find an existing store.
+        pass
+    
 @main.group(help="Browse and access the metaflow tutorial episodes.")
 def tutorials():
     pass


### PR DESCRIPTION
Addresses: https://github.com/Netflix/metaflow/issues/41

Simplistic implementation (for now) to clean up and reset your local data store. Adds a CLI command to achieve this. When invoked this will look for and delete the data store file. 

<img width="434" alt="Screen Shot 2019-12-12 at 13 27 20" src="https://user-images.githubusercontent.com/3901297/70750415-3b85cd80-1ce3-11ea-8e1e-fd6e84083150.png">

<img width="728" alt="Screen Shot 2019-12-12 at 13 22 58" src="https://user-images.githubusercontent.com/3901297/70750268-fbbee600-1ce2-11ea-9f48-3c4a4e189a77.png">

