### PR TITLE
Better decorator parsing on CLI

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -1,5 +1,6 @@
 import traceback
 from functools import partial
+import re
 
 from .flowspec import FlowSpec
 from .exception import MetaflowException, InvalidDecoratorAttribute
@@ -99,7 +100,8 @@ class Decorator(object):
             return cls()
         else:
             name, attrspec = top
-            attrs = dict(a.split('=') for a in attrspec.split(','))
+            attrs = dict(a.split('=') for a in 
+                re.split(''',(?=(?:[^'"]|'[^']*'|"[^"]*")*$)''', attrspec))
             return cls(attributes=attrs)
 
     def make_decorator_spec(self):

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -100,8 +100,8 @@ class Decorator(object):
             return cls()
         else:
             name, attrspec = top
-            attrs = dict(a.split('=') for a in 
-                re.split(''',(?=(?:[^'"]|'[^']*'|"[^"]*")*$)''', attrspec))
+            attrs = dict(map(lambda x: x.strip(), a.split('=')) 
+                for a in re.split(''',(?=[\s\w]+=)''', attrspec.strip('"\'')))
             return cls(attributes=attrs)
 
     def make_decorator_spec(self):

--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -85,9 +85,9 @@ class CondaStepDecorator(StepDecorator):
         deps.update(base_deps)
         step_deps = self.attributes['libraries']
         if isinstance(step_deps, (unicode, basestring)):
-            step_deps = step_deps.strip('"{}"')
+            step_deps = step_deps.strip('"{}\'')
             if step_deps:
-                step_deps = dict(a.split(':') for a in step_deps.split(','))
+                step_deps = dict(map(lambda x: x.strip().strip('"\''), a.split(':')) for a in step_deps.split(','))
         deps.update(step_deps)
         return deps
 

--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -24,6 +24,11 @@ from metaflow.datatools import S3
 from . import read_conda_manifest, write_to_conda_manifest
 from .conda import Conda
 
+try:
+    unicode
+except NameError:
+    unicode = str
+    basestring = str
 
 class CondaStepDecorator(StepDecorator):
     """
@@ -79,8 +84,11 @@ class CondaStepDecorator(StepDecorator):
         base_deps = self.base_attributes['libraries']
         deps.update(base_deps)
         step_deps = self.attributes['libraries']
-        if isinstance(step_deps, collections.Mapping):
-            deps.update(step_deps)
+        if isinstance(step_deps, (unicode, basestring)):
+            step_deps = step_deps.strip('"{}"')
+            if step_deps:
+                step_deps = dict(a.split(':') for a in step_deps.split(','))
+        deps.update(step_deps)
         return deps
 
     def _step_deps(self):


### PR DESCRIPTION
Decorators can be specified for Metaflow steps via CLI. Some of the
decorator args can include commas, which break the current logic.

For eg, `--with conda:'libraries="{a:x.y,b:x.y}"',python=x.y.z`

This patch fixes the behavior by updating the parsing logic for decospec.