### PR TITLE
Address #54 and improve interrupted shutdown

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -29,7 +29,16 @@ class Batch(object):
         self.metadata = metadata
         self.environment = environment
         self._client = BatchClient()
-        atexit.register(lambda : self.job.kill() if hasattr(self, 'job') else None)
+        def f():
+            print("Atexit executing")
+            if hasattr(self, 'job'):
+                print("Killing")
+                self.job.kill()
+                print("Done killing")
+            else:
+                print("No job")
+        atexit.register(f)
+        #atexit.register(lambda : self.job.kill() if hasattr(self, 'job') else None)
 
     def _command(self, code_package_url, environment, step_name, step_cli):
         cmds = environment.get_package_commands(code_package_url)

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -29,16 +29,7 @@ class Batch(object):
         self.metadata = metadata
         self.environment = environment
         self._client = BatchClient()
-        def f():
-            print("Atexit executing")
-            if hasattr(self, 'job'):
-                print("Killing")
-                self.job.kill()
-                print("Done killing")
-            else:
-                print("No job")
-        atexit.register(f)
-        #atexit.register(lambda : self.job.kill() if hasattr(self, 'job') else None)
+        atexit.register(lambda: self.job.kill() if hasattr(self, 'job') else None)
 
     def _command(self, code_package_url, environment, step_name, step_cli):
         cmds = environment.get_package_commands(code_package_url)

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -299,7 +299,6 @@ class RunningJob(object):
                     else:
                         yield line
             except Exception as ex:
-                last_exc = ex
                 if self.is_crashed:
                     break
                 sys.stderr.write(repr(ex))
@@ -307,12 +306,8 @@ class RunningJob(object):
 
     def kill(self):
         if not self.is_done:
-            print("In terminate part")
-            print("Going to call terminate_job with id %s" % self._id)
-            res = self._client.terminate_job(
-                jobId=self._id, reason='Metaflow initiated job termination.'
-            )
-            print("Done with terminate: %s" % res)
+            self._client.terminate_job(
+                jobId=self._id, reason='Metaflow initiated job termination.')
         return self.update()
 
 

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -307,9 +307,12 @@ class RunningJob(object):
 
     def kill(self):
         if not self.is_done:
-            self._client.terminate_job(
+            print("In terminate part")
+            print("Going to call terminate_job with id %s" % self._id)
+            res = self._client.terminate_job(
                 jobId=self._id, reason='Metaflow initiated job termination.'
             )
+            print("Done with terminate: %s" % res)
         return self.update()
 
 

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -240,11 +240,7 @@ class NativeRuntime(object):
     def _killall(self):
         # If we are here, all children have received a signal and are shutting down.
         # We want to give them an opportunity to do so and then kill
-        live_workers = []
-        temp_workers = {}
-        for worker in self._workers.values():
-            temp_workers[worker] = 1
-        live_workers = temp_workers.keys()
+        live_workers = list(set(self._workers.values()))
         now = int(time.time())
         self._logger('Terminating %d active tasks...' % len(live_workers),
                      system_msg=True, bad=True)
@@ -258,8 +254,7 @@ class NativeRuntime(object):
                          system_msg=True, bad=True)
             for worker in live_workers:
                 worker.kill()
-        self._logger('Flushing logs -- you may see messages from the tasks that were shutdown...',
-                     system_msg=True, bad=True)
+        self._logger('Flushing logs...', system_msg=True, bad=True)
         # give killed workers a chance to flush their logs to datastore
         for _ in range(3):
             list(self._poll_workers())

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -240,7 +240,7 @@ class NativeRuntime(object):
     def _killall(self):
         # If we are here, all children have received a signal and are shutting down.
         # We want to give them an opportunity to do so and then kill
-        live_workers = list(set(self._workers.values()))
+        live_workers = set(self._workers.values())
         now = int(time.time())
         self._logger('Terminating %d active tasks...' % len(live_workers),
                      system_msg=True, bad=True)
@@ -784,8 +784,12 @@ class Worker(object):
                                                    self._stdout)}
 
         self._encoding = sys.stdout.encoding or 'UTF-8'
-        self.killed = False
-        self.cleaned = False
+        self.killed = False  # Killed indicates that the task was forcibly killed
+                             # with SIGKILL by the master process.
+                             # A killed task is always considered cleaned
+        self.cleaned = False  # A cleaned task is one that is shutting down and has been
+                              # noticed by the runtime and queried for its state (whether or
+                              # not is is properly shut down)
 
     def _launch(self):
         args = CLIArgs(self.task)

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -216,13 +216,6 @@ class NativeRuntime(object):
 
         except KeyboardInterrupt as ex:
             self._logger('Workflow interrupted.', system_msg=True, bad=True)
-            # Ignore new signals
-            import signal
-
-            def print_ignore(signum, frame):
-                self._logger('Shutdown in progress -- ignoring additional CTRL-C',
-                             system_msg=True, bad=True)
-            signal.signal(signal.SIGINT, print_ignore)
             self._killall()
             exception = ex
             raise
@@ -259,7 +252,7 @@ class NativeRuntime(object):
             # While not all workers are dead and we have waited less than 5 seconds
             live_workers = [worker for worker in live_workers if not worker.clean()]
         if live_workers:
-            self._logger('Killing remaining %d tasks after having waited for %d seconds -- '
+            self._logger('Killing %d remaining tasks after having waited for %d seconds -- '
                          'some tasks may not exit cleanly' % (len(live_workers),
                                                               int(time.time()) - now),
                          system_msg=True, bad=True)


### PR DESCRIPTION
Although not fully guaranteeing a clean shutdown every time, this patch makes the shutdown a little more robust (giving time to children process to shutdown), prevents multiple CTRL-C from interrupting the shutdown (in most cases) and is possibly faster in the presence of large fan outs.