### PR TITLE
Fix docker registry parsing for AWS Batch decorator

### DIFF
--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -198,6 +198,6 @@ class BatchDecorator(StepDecorator):
         groups = pattern.match(image).groups()
         registry = groups[0]
         namespace = groups[1]
-        if not namespace and registry and not re.match(r'[:.]', registry):
+        if not namespace and registry and not re.search(r'[:.]', registry):
             return None
         return registry


### PR DESCRIPTION
re.search instead of re.match to disambiguate between valid docker
registry urls