### PR TITLE
Fix json loading in datastore

### DIFF
--- a/metaflow/datastore/datastore_set.py
+++ b/metaflow/datastore/datastore_set.py
@@ -1,5 +1,7 @@
 import json
 
+from metaflow import util
+
 """
 MetaflowDatastoreSet allows you to prefetch multiple (read) datastores into a
 cache and lets you access them.
@@ -30,7 +32,7 @@ class MetaflowDatastoreSet(object):
                                attempt=attempt,
                                event_logger=event_logger,
                                monitor=monitor,
-                               data_obj=json.loads(data_blob),
+                               data_obj=json.loads(util.to_unicode(data_blob)),
                                artifact_cache=artifact_cache)
                       for step_name, task_id, attempt, data_blob in data_blobs]
         if prefetch_data_artifacts:


### PR DESCRIPTION
This patch fixes json loading in python 3.5.

Before this patch one would get this error on metaflow resume:

 python3 playlist.py resume
Metaflow 2.0.1 executing PlayListFlow for user:atremblay
Validating your flow...
    The graph looks good!
Running pylint...
    Pylint is happy!
2019-12-18 14:54:41.596 Gathering required information to resume run (this may take a bit of time)...
    Internal error
Traceback (most recent call last):
  File "/home/atremblay/.local/lib/python3.5/site-packages/metaflow/cli.py", line 853, in main
    start(auto_envvar_prefix='METAFLOW', obj=state)
  File "/home/atremblay/.local/lib/python3.5/site-packages/click/core.py", line 764, in __call__
    return self.main(args, kwargs)
  File "/home/atremblay/.local/lib/python3.5/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/atremblay/.local/lib/python3.5/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/atremblay/.local/lib/python3.5/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, ctx.params)
  File "/home/atremblay/.local/lib/python3.5/site-packages/click/core.py", line 555, in invoke
    return callback(args, kwargs)
  File "/home/atremblay/.local/lib/python3.5/site-packages/metaflow/cli.py", line 508, in wrapper
    return func(args, kwargs)
  File "/home/atremblay/.local/lib/python3.5/site-packages/click/decorators.py", line 27, in new_func
    return f(get_current_context().obj, args, kwargs)
  File "/home/atremblay/.local/lib/python3.5/site-packages/metaflow/cli.py", line 557, in resume
    max_log_size=max_log_size  1024  1024)
  File "/home/atremblay/.local/lib/python3.5/site-packages/metaflow/runtime.py", line 123, in __init__
    prefetch_data_artifacts=PREFETCH_DATA_ARTIFACTS)
  File "/home/atremblay/.local/lib/python3.5/site-packages/metaflow/datastore/datastore_set.py", line 35, in __init__
    for step_name, task_id, attempt, data_blob in data_blobs]
  File "/home/atremblay/.local/lib/python3.5/site-packages/metaflow/datastore/datastore_set.py", line 35, in <listcomp>
    for step_name, task_id, attempt, data_blob in data_blobs]
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))


This patch makes it compatible with python 3.5 by decoding the blob as
utf-8

This is not an issue in 3.6 see: https://docs.python.org/3/whatsnew/3.6.html#json