### PR TITLE
Addition of conditional branching of Tasks

### DIFF
--- a/metaflow/graph.py
+++ b/metaflow/graph.py
@@ -180,7 +180,7 @@ class FlowGraph(object):
                         traverse(child, seen + [n], split_parents)
 
         vis = set()
-        def traverse2(node, cnt):
+        def traverse_fix_split_or(node, cnt):
             if node.name in vis:
                 return
 
@@ -197,11 +197,11 @@ class FlowGraph(object):
             for n in node.out_funcs[::-1]:
                 if n in self:
                     child = self[n]
-                    traverse2(child, cnt)
+                    traverse_fix_split_or(child, cnt)
 
         if 'start' in self:
             traverse(self['start'], [], [])
-            traverse2(self['start'], 0)
+            traverse_fix_split_or(self['start'], 0)
 
         # fix the order of in_funcs
         for node in self.nodes.values():

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -340,9 +340,11 @@ class NativeRuntime(object):
             if trans:
                 next_steps = trans[0]
                 foreach = trans[1]
+                condition = trans[2]
             else:
                 next_steps = []
                 foreach = None
+                condition = None
             expected = self._graph[task.step].out_funcs
             if next_steps != expected:
                 msg = 'Based on static analysis of the code, step *{step}* '\
@@ -363,6 +365,13 @@ class NativeRuntime(object):
             elif foreach:
                 # Next step is a foreach child
                 self._queue_task_foreach(task, next_steps)
+            elif condition:
+                condition_res = task.results[condition]
+                if condition_res:
+                    next_step = next_steps[0]
+                else:
+                    next_step = next_steps[1]
+                self._queue_push(next_step, {'input_paths': [task.path]})
             else:
                 # Next steps are normal linear steps
                 for step in next_steps:

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -282,12 +282,17 @@ class NativeRuntime(object):
             required_tasks = [self._finished.get((task.step, s))
                               for s in siblings(foreach_stack)]
             join_type = 'foreach'
-        else:
+        elif matching_split.type == 'split-and':
             # next step is a split-and
             # required tasks are all branches joined by the next step
             required_tasks = [self._finished.get((step, foreach_stack))
                               for step in self._graph[next_step].in_funcs]
-            join_type = 'linear'
+            join_type = 'split-and'
+        elif matching_split.type == 'split-or':
+            # next step is a split-or join step
+            # required task is the task queueing this task
+            required_tasks = [task.path]
+            join_type = 'split-or'
 
         if all(required_tasks):
             # all tasks to be joined are ready. Schedule the next join step.


### PR DESCRIPTION
Pull request for adding the functionality of branching of tasks based on a condition.

The following changes are made - 

1. With the already existing implementation, a join operation is checked if there is an extra parameter passed to the function. But a join task for split-or takes only one input, the input from the branch being run. Hence another function **traverse_fix_split_or** is run after **split_or** to fix the graph.
2. Conditions are added for scheduling of out tasks of split-or and the scheduling of split-or join.