### PR TITLE
Pin click (metaflow's dependency) to v7.0 or greater

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='metaflow',
         metaflow=metaflow.main_cli:main
       ''',
       install_requires = [
-        'click',
+        'click>=7.0',
         'requests',
         'boto3'
       ],


### PR DESCRIPTION
Fixes #97
See: pallets/click#966