### PR TITLE
Add check on conda-package metadata to guard against .conda packages

### DIFF
--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -145,10 +145,15 @@ class CondaStepDecorator(StepDecorator):
                                 url.path.lstrip('/'),
                                 package_info['md5'],
                                 package_info['fn'])
-            #The tarball maybe missing when user invokes `conda clean`!
             tarball_path = package_info['package_tarball_full_path']
-            if os.path.isdir(package_info['package_tarball_full_path']):
-                tarball_path = '%s.tar.bz2' % package_info['package_tarball_full_path']
+            if tarball_path.endswith('.conda'):
+                #Conda doesn't set the metadata correctly for certain fields
+                # when the underlying OS is spoofed.
+                tarball_path = tarball_path[:-6]
+            if not tarball_path.endswith('.tar.bz2'):
+                tarball_path = '%s.tar.bz2' % tarball_path
+            if not os.path.isfile(tarball_path):
+                #The tarball maybe missing when user invokes `conda clean`!
                 to_download.append((package_info['url'], tarball_path))
             files.append((path, tarball_path))
         if to_download:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='metaflow',
         metaflow=metaflow.main_cli:main
       ''',
       install_requires = [
-        'click',
+        'click>=7.0',
         'requests',
         'boto3'
       ],


### PR DESCRIPTION
Looks like conda doesn't reliably/correctly update the `env/conda-meta/<package>.json` file which Metaflow relies on to identify which packages should be moved to S3 and their installation order on AWS Batch.

In this specific scenario, when the compute needs to execute on AWS Batch, Metaflow coaxes conda to generate an environment for `linux-64` architectures using only `.tar.bz2` dependencies, irrespective of where conda is executed from (usually a user's macOS or linux instance). In some very specific scenarios, conda correctly picks up the `.tar.bz2` dependencies from upstream repos but fails to update the manifest, incorrectly pointing to `.conda` dependencies instead. This leads to incorrect bundling of packages and the user job fails when executing on AWS Batch since we end up packaging a .conda dependency as a .tar.bz2 dependency.