### PR TITLE
Bump metaflow version to 2.0.2 in preparation for release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.0.1'
+version = '2.0.2'
 
 setup(name='metaflow',
       version=version,


### PR DESCRIPTION
1. Pin click to v7.0 or greater (#107)
2. Add checks to conda-package metadata to guard against .conda packages (#118)