### PR TITLE
Add hook for metaflow R bindings

### DIFF
--- a/metaflow/R.py
+++ b/metaflow/R.py
@@ -1,0 +1,62 @@
+import os
+import imp
+from tempfile import NamedTemporaryFile
+
+from .util import to_bytes
+
+R_FUNCTIONS = {}
+R_PACKAGE_PATHS = None
+
+def call_r(func_name, args):
+    R_FUNCTIONS[func_name](*args)
+
+def get_r_func(func_name):
+    return R_FUNCTIONS[func_name]
+
+def package_paths():
+    if R_PACKAGE_PATHS is not None:
+        root = R_PACKAGE_PATHS['package']
+        prefixlen = len('%s/' % root.rstrip('/'))
+        for path, dirs, files in os.walk(R_PACKAGE_PATHS['package']):
+            if '/.' in path:
+                continue
+            for fname in files:
+                if fname[0] == '.':
+                    continue
+                p = os.path.join(path, fname)
+                yield p, os.path.join('metaflow-r/metaflow.core', p[prefixlen:])
+        flow = R_PACKAGE_PATHS['flow']
+        yield flow, os.path.basename(flow)
+
+def entrypoint():
+    return 'PYTHONPATH=/root/metaflow R_LIBS_SITE=`Rscript -e \'cat(paste(.libPaths(), collapse=\\":\\"))\'`:metaflow-r/ Rscript metaflow-r/metaflow.core/run_batch.R'
+
+def use_r():
+    return R_PACKAGE_PATHS is not None
+
+def working_dir():
+    if use_r(): 
+        return R_PACKAGE_PATHS['wd']
+    return None
+
+def run(flow_script, r_functions, metaflow_args, full_cmdline, r_paths):
+    global R_FUNCTIONS, R_PACKAGE_PATHS
+    R_FUNCTIONS = r_functions
+    R_PACKAGE_PATHS = r_paths
+    # there's some reticulate(?) sillyness which causes metaflow_args
+    # not to be a list if it has only one item. Here's a workaround
+    if not isinstance(metaflow_args, list):
+        metaflow_args = [metaflow_args]
+    # remove any reference to local path structure from R
+    full_cmdline[0] = os.path.basename(full_cmdline[0])
+    with NamedTemporaryFile(prefix="metaflowR.", delete=False) as tmp:
+        tmp.write(to_bytes(flow_script))
+    module = imp.load_source('metaflowR', tmp.name)
+    flow = module.FLOW(use_cli=False)
+    try:
+        from . import cli
+        cli.main(flow,
+                 args=metaflow_args,
+                 entrypoint=full_cmdline[:-len(metaflow_args)])
+    finally:
+        os.remove(tmp.name)

--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -6,6 +6,7 @@ from hashlib import sha1
 from itertools import chain
 
 from .util import to_unicode
+from . import R
 
 try:
     # python2
@@ -16,7 +17,7 @@ except:
     import io
     BytesIO = io.BytesIO
 
-DEFAULT_SUFFIXES = ['.py']
+DEFAULT_SUFFIXES = ['.py', '.R']
 
 
 class MetaflowPackage(object):
@@ -61,10 +62,18 @@ class MetaflowPackage(object):
         # the package folders for environment
         for path_tuple in self.environment.add_to_package():
             yield path_tuple
-        # the user's working directory
-        flowdir = os.path.dirname(os.path.abspath(sys.argv[0])) + '/'
-        for path_tuple in self._walk(flowdir):
-            yield path_tuple
+        if R.use_r():
+            # the R working directory
+            for path_tuple in self._walk('%s/' % R.working_dir()):
+                yield path_tuple
+            # the R package
+            for path_tuple in R.package_paths():
+                yield path_tuple
+        else:
+            # the user's working directory
+            flowdir = os.path.dirname(os.path.abspath(sys.argv[0])) + '/'
+            for path_tuple in self._walk(flowdir):
+                yield path_tuple
 
     def _add_info(self, tar):
         info = tarfile.TarInfo('INFO')

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -15,6 +15,7 @@ from metaflow.datastore.local import LocalDataStore
 from metaflow.datastore.util.s3util import get_s3_client
 from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
 from metaflow import util
+from metaflow import R
 from metaflow.exception import (
     CommandException,
     METAFLOW_EXIT_DISALLOW_RETRY,
@@ -177,9 +178,13 @@ def step(
     if ctx.obj.datastore.datastore_root is None:
         ctx.obj.datastore.datastore_root = ctx.obj.datastore.get_datastore_root_from_config(echo)
 
-    if executable is None:
-        executable = ctx.obj.environment.executable(step_name)
-    entrypoint = "%s -u %s" % (executable, os.path.basename(sys.argv[0]))
+    if R.use_r():
+        entrypoint = R.entrypoint()
+    else:
+        if executable is None:
+            executable = ctx.obj.environment.executable(step_name)
+        entrypoint = '%s -u %s' % (executable,
+                                   os.path.basename(sys.argv[0]))
 
     top_args = " ".join(util.dict_to_cli_options(ctx.parent.parent.params))
 

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -12,6 +12,7 @@ from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
 from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task
 
 from metaflow import util
+from metaflow import R
 
 from .batch import Batch, BatchException
 from metaflow.metaflow_config import ECS_S3_ACCESS_IAM_ROLE, BATCH_JOB_QUEUE, \
@@ -157,7 +158,8 @@ class BatchDecorator(StepDecorator):
             cli_args.command_args.append(self.package_url)
             cli_args.command_options.update(self.attributes)
             cli_args.command_options['run-time-limit'] = self.run_time_limit
-            cli_args.entrypoint[0] = sys.executable
+            if not R.use_r():
+                cli_args.entrypoint[0] = sys.executable
 
     def task_pre_step(
             self, step_name, ds, meta, run_id, task_id, flow, graph, retry_count, max_retries):


### PR DESCRIPTION
Adds necessary hooks for customizing process entry-points to
R executables. This patch preps for the eventual metaflow-R
release.

Addresses #1