### PR TITLE
fix: endpoint_url for boto3 client

### DIFF
--- a/metaflow/datastore/util/s3util.py
+++ b/metaflow/datastore/util/s3util.py
@@ -4,13 +4,13 @@ import time
 import sys
 
 from metaflow.exception import MetaflowException
-from metaflow.metaflow_config import get_authenticated_boto3_client, S3_ENDPOINT_URL
+from metaflow.metaflow_config import get_authenticated_boto3_client, S3_ENDPOINT_URL, S3_VERIFY_CERTIFICATE
 from botocore.exceptions import ClientError
 
 S3_NUM_RETRIES = 7
 
 def get_s3_client():
-    return get_authenticated_boto3_client('s3', { 'endpoint_url': S3_ENDPOINT_URL }), ClientError
+    return get_authenticated_boto3_client('s3', { 'endpoint_url': S3_ENDPOINT_URL, 'verify': S3_VERIFY_CERTIFICATE }), ClientError
 
 # decorator to retry functions that access S3
 def aws_retry(f):

--- a/metaflow/datastore/util/s3util.py
+++ b/metaflow/datastore/util/s3util.py
@@ -4,13 +4,13 @@ import time
 import sys
 
 from metaflow.exception import MetaflowException
-from metaflow.metaflow_config import get_authenticated_boto3_client
+from metaflow.metaflow_config import get_authenticated_boto3_client, S3_ENDPOINT_URL
 from botocore.exceptions import ClientError
 
 S3_NUM_RETRIES = 7
 
 def get_s3_client():
-    return get_authenticated_boto3_client('s3'), ClientError
+    return get_authenticated_boto3_client('s3', { 'endpoint_url': S3_ENDPOINT_URL }), ClientError
 
 # decorator to retry functions that access S3
 def aws_retry(f):

--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -27,6 +27,7 @@ except:
     from urllib.parse import urlparse
 
 from metaflow.datastore.util.s3util import get_s3_client
+from botocore.exceptions import ClientError
 
 NUM_S3OP_RETRIES = 8
 
@@ -535,7 +536,7 @@ class S3(object):
                                      prefix='metaflow.s3.one_file.',
                                      delete=False)
             try:
-                s3, ClientError = get_s3_client()
+                s3, _ = get_s3_client()
                 op(s3, tmp.name)
                 return tmp.name
             except ClientError as err:

--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -26,8 +26,7 @@ except:
     # python3
     from urllib.parse import urlparse
 
-from ..metaflow_config import get_authenticated_boto3_client
-from botocore.exceptions import ClientError
+from metaflow.datastore.util.s3util import get_s3_client
 
 NUM_S3OP_RETRIES = 8
 
@@ -536,7 +535,7 @@ class S3(object):
                                      prefix='metaflow.s3.one_file.',
                                      delete=False)
             try:
-                s3 = get_authenticated_boto3_client('s3')
+                s3, ClientError = get_s3_client()
                 op(s3, tmp.name)
                 return tmp.name
             except ClientError as err:

--- a/metaflow/datatools/s3op.py
+++ b/metaflow/datatools/s3op.py
@@ -66,8 +66,8 @@ def normalize_client_error(err):
 
 def worker(queue, mode):
     try:
-        from metaflow.metaflow_config import get_authenticated_boto3_client
-        s3 = get_authenticated_boto3_client('s3')
+        from metaflow.datastore.util.s3util import get_s3_client
+        s3, _ = get_s3_client()
         while True:
             url = queue.get()
             if url is None:
@@ -163,9 +163,9 @@ class S3Ops(object):
         self.s3 = None
 
     def reset_client(self, hard_reset=False):
-        from metaflow.metaflow_config import get_authenticated_boto3_client
+        from metaflow.datastore.util.s3util import get_s3_client
         if hard_reset or self.s3 is None:
-            self.s3 = get_authenticated_boto3_client('s3')
+            self.s3, _ = get_s3_client()
 
     @aws_retry
     def get_size(self, url):

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -173,7 +173,7 @@ def get_pinned_conda_libs():
 
 cached_aws_sandbox_creds = None
 
-def get_authenticated_boto3_client(module):
+def get_authenticated_boto3_client(module, params={}):
     from metaflow.exception import MetaflowException
     import requests
     try:
@@ -196,5 +196,5 @@ def get_authenticated_boto3_client(module):
                 cached_aws_sandbox_creds = r.json()
             except requests.exceptions.HTTPError as e:
                 raise MetaflowException(repr(e))
-        return boto3.session.Session(**cached_aws_sandbox_creds).client(module, endpoint_url=S3_ENDPOINT_URL)
-    return boto3.client(module, endpoint_url=S3_ENDPOINT_URL)
+        return boto3.session.Session(**cached_aws_sandbox_creds).client(module, **params)
+    return boto3.client(module, **params)

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -58,7 +58,7 @@ DATATOOLS_S3ROOT = from_conf(
         '%s/data' % from_conf('METAFLOW_DATASTORE_SYSROOT_S3'))
 
 # S3 endpoint url 
-S3_ENDPOINT_URL = from_conf('METAFLOW_S3_ENDPOINT_URL', 's3.amazonaws.com')
+S3_ENDPOINT_URL = from_conf('METAFLOW_S3_ENDPOINT_URL', None)
 
 ###
 # Datastore local cache

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -57,6 +57,9 @@ DATATOOLS_S3ROOT = from_conf(
     'METAFLOW_DATATOOLS_S3ROOT', 
         '%s/data' % from_conf('METAFLOW_DATASTORE_SYSROOT_S3'))
 
+# S3 endpoint url 
+S3_ENDPOINT_URL = from_conf('METAFLOW_S3_ENDPOINT_URL', 's3.amazonaws.com')
+
 ###
 # Datastore local cache
 ###
@@ -193,5 +196,5 @@ def get_authenticated_boto3_client(module):
                 cached_aws_sandbox_creds = r.json()
             except requests.exceptions.HTTPError as e:
                 raise MetaflowException(repr(e))
-        return boto3.session.Session(**cached_aws_sandbox_creds).client(module)
-    return boto3.client(module)
+        return boto3.session.Session(**cached_aws_sandbox_creds).client(module, endpoint_url=S3_ENDPOINT_URL)
+    return boto3.client(module, endpoint_url=S3_ENDPOINT_URL)

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -59,6 +59,7 @@ DATATOOLS_S3ROOT = from_conf(
 
 # S3 endpoint url 
 S3_ENDPOINT_URL = from_conf('METAFLOW_S3_ENDPOINT_URL', None)
+S3_VERIFY_CERTIFICATE = from_conf('METAFLOW_S3_VERIFY_CERTIFICATE', None)
 
 ###
 # Datastore local cache


### PR DESCRIPTION
#130 

I fixed `endpoint_url` and replaced every `s3 = get_authenticated_boto3_client('s3')` call with `get_s3_client()`, because we should have only one entrypoint.
Not sure about the default `s3.amazonaws.com` url.

Tested. It works fine.