### PR TITLE
Initialize datastore_root from cli args in cli.step(...)

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -401,6 +401,7 @@ def step(obj,
          fg='magenta',
          bold=False)
 
+    obj.datastore.datastore_root = obj.datastore_root
     if obj.datastore.datastore_root is None:
         obj.datastore.datastore_root = obj.datastore.get_datastore_root_from_config(obj.echo)
 
@@ -765,6 +766,8 @@ def start(ctx,
                                                   ctx.obj.event_logger,
                                                   ctx.obj.monitor)
     ctx.obj.datastore = DATASTORES[datastore]
+    if datastore_root is None:
+        datastore_root = ctx.obj.datastore.get_datastore_root_from_config(echo)
     ctx.obj.datastore_root = datastore_root
     if ctx.invoked_subcommand not in ('run', 'resume'):
         # run/resume are special cases because they can add more decorators with --with,

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -766,8 +766,6 @@ def start(ctx,
                                                   ctx.obj.event_logger,
                                                   ctx.obj.monitor)
     ctx.obj.datastore = DATASTORES[datastore]
-    if datastore_root is None:
-        datastore_root = ctx.obj.datastore.get_datastore_root_from_config(echo)
     ctx.obj.datastore_root = datastore_root
     if ctx.invoked_subcommand not in ('run', 'resume'):
         # run/resume are special cases because they can add more decorators with --with,

--- a/metaflow/datastore/datastore.py
+++ b/metaflow/datastore/datastore.py
@@ -328,7 +328,7 @@ class MetaflowDataStore(object):
                                 "Try with a different --run-id.")
         if self.datastore_root is None:
             raise DataException("Datastore root not found. "
-                                "Specify with DATASTORE_SYSROOT_%s "
+                                "Specify with METAFLOW_DATASTORE_SYSROOT_%s "
                                 "environment variable." % self.TYPE.upper())
         
         self.event_logger = event_logger


### PR DESCRIPTION
Gitter thread - https://gitter.im/metaflow_org/community?at=5e4b8e24d56ddb68a4aff877

Metaflow initializes datastore_root to fetch user code in `step` command. The behaviour defaults to relying on METAFLOW_DATASTORE_SYSROOT_S3 environment variable to initialize datastore_root. This patch checks if --datastore_root cli arg can be used instead.