### PR TITLE
Fixing directory issue of local metadataprovider with aws batch.

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -145,7 +145,6 @@ class Batch(object):
             .environment_variable('METAFLOW_USER', attrs['metaflow.user']) \
             .environment_variable('METAFLOW_SERVICE_URL', BATCH_METADATA_SERVICE_URL) \
             .environment_variable('METAFLOW_SERVICE_HEADERS', json.dumps(BATCH_METADATA_SERVICE_HEADERS)) \
-            .environment_variable('METAFLOW_DATASTORE_SYSROOT_LOCAL', DATASTORE_LOCAL_DIR) \
             .environment_variable('METAFLOW_DATASTORE_SYSROOT_S3', DATASTORE_SYSROOT_S3) \
             .environment_variable('METAFLOW_DATATOOLS_S3ROOT', DATATOOLS_S3ROOT) \
             .environment_variable('METAFLOW_DEFAULT_DATASTORE', 's3') \

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -126,14 +126,14 @@ class Batch(object):
                     'Unable to launch Batch job. No job queue '
                     ' specified and no valid & enabled queue found.'
                 )
-
+        """ 
+        The environment variable for METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set because
+        the syncing of the metadata (provided in task_finished in batch_decorator.py and
+        in  _sync_metadata  in batch_cli.py) assumes ',that DATASTORE_LOCAL_DIR is where
+        the metadata is stored on the remote batch instance This is the default value if
+        METAFLOW_DATASTORE_SYSROOT_LOCAL  is  NOT  set  if  it  is the resulting path is
+        different (see get_datastore_root_from_config in datastore/local.py
         """
-        # The environment variable for METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set because the syncing of the
-        # metadata (provided in task_finished in batch_decorator.py and in _sync_metadata in batch_cli.py) assumes that DATASTORE_LOCAL_DIR is where the metadata is stored on the remote batch instance. 
-        # This is the default value if METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set; 
-        # if it is, the resulting path is different (see get_datastore_root_from_config in datastore/local.py)
-        """
-
         job = self._client.job()
         job \
             .job_name(job_name) \

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -126,14 +126,7 @@ class Batch(object):
                     'Unable to launch Batch job. No job queue '
                     ' specified and no valid & enabled queue found.'
                 )
-        """ 
-        The environment variable for METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set because
-        the syncing of the metadata (provided in task_finished in batch_decorator.py and
-        in  _sync_metadata  in batch_cli.py) assumes ',that DATASTORE_LOCAL_DIR is where
-        the metadata is stored on the remote batch instance This is the default value if
-        METAFLOW_DATASTORE_SYSROOT_LOCAL  is  NOT  set  if  it  is the resulting path is
-        different (see get_datastore_root_from_config in datastore/local.py
-        """
+
         job = self._client.job()
         job \
             .job_name(job_name) \
@@ -157,6 +150,10 @@ class Batch(object):
             .environment_variable('METAFLOW_DATATOOLS_S3ROOT', DATATOOLS_S3ROOT) \
             .environment_variable('METAFLOW_DEFAULT_DATASTORE', 's3') \
             .environment_variable('METAFLOW_DEFAULT_METADATA', DEFAULT_METADATA)
+            # Skip setting METAFLOW_DATASTORE_SYSROOT_LOCAL because metadata sync between the local user 
+            # instance and the remote AWS Batch instance assumes metadata is stored in DATASTORE_LOCAL_DIR 
+            # on the remote AWS Batch instance; this happens when METAFLOW_DATASTORE_SYSROOT_LOCAL 
+            # is NOT set (see get_datastore_root_from_config in datastore/local.py).
         for name, value in env.items():
             job.environment_variable(name, value)
         for name, value in self.metadata.get_runtime_environment('batch').items():

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -126,11 +126,15 @@ class Batch(object):
                     'Unable to launch Batch job. No job queue '
                     ' specified and no valid & enabled queue found.'
                 )
+
+        """
         # Environment variable for METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set 
         # because of directory replication issues caused when working with local metadata provider and batch. 
         # The a local metadata provider will sync metadata from batch via tar'd object placed on S3. 
         # The syncing works by taring and untaring an archieve. if METAFLOW_DATASTORE_SYSROOT_LOCAL is set then  
         # it will create an extra folder under `.metaflow/.metaflow` and hence incorrectly syncing the information in your metadataprovidor's .metaflow directory. 
+        """
+
         job = self._client.job()
         job \
             .job_name(job_name) \

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -128,11 +128,10 @@ class Batch(object):
                 )
 
         """
-        # Environment variable for METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set 
-        # because of directory replication issues caused when working with local metadata provider and batch. 
-        # The a local metadata provider will sync metadata from batch via tar'd object placed on S3. 
-        # The syncing works by taring and untaring an archieve. if METAFLOW_DATASTORE_SYSROOT_LOCAL is set then  
-        # it will create an extra folder under `.metaflow/.metaflow` and hence incorrectly syncing the information in your metadataprovidor's .metaflow directory. 
+        # The environment variable for METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set because the syncing of the
+        # metadata (provided in task_finished in batch_decorator.py and in _sync_metadata in batch_cli.py) assumes that DATASTORE_LOCAL_DIR is where the metadata is stored on the remote batch instance. 
+        # This is the default value if METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set; 
+        # if it is, the resulting path is different (see get_datastore_root_from_config in datastore/local.py)
         """
 
         job = self._client.job()

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -128,7 +128,7 @@ class Batch(object):
                 )
         # Environment variable for METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set 
         # because of directory replication issues caused when working with local metadata provider and batch. 
-        # The a local metadata provider will sync metadata from batch via tar'd object placed on S3 from the batch container. 
+        # The a local metadata provider will sync metadata from batch via tar'd object placed on S3. 
         # The syncing works by taring and untaring an archieve. if METAFLOW_DATASTORE_SYSROOT_LOCAL is set then  
         # it will create an extra folder under `.metaflow/.metaflow` and hence incorrectly syncing the information in your metadataprovidor's .metaflow directory. 
         job = self._client.job()

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -126,6 +126,11 @@ class Batch(object):
                     'Unable to launch Batch job. No job queue '
                     ' specified and no valid & enabled queue found.'
                 )
+        # Environment variable for METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set 
+        # because of directory replication issues caused when working with local metadata provider and batch. 
+        # The a local metadata provider will sync metadata from batch via tar'd object placed on S3 from the batch container. 
+        # The syncing works by taring and untaring an archieve. if METAFLOW_DATASTORE_SYSROOT_LOCAL is set then  
+        # it will create an extra folder under `.metaflow/.metaflow` and hence incorrectly syncing the information in your metadataprovidor's .metaflow directory. 
         job = self._client.job()
         job \
             .job_name(job_name) \


### PR DESCRIPTION
There is an issue in syncing metadata for local metadata provider when using AWS Batch. 

I am using a local metadata provider with executes on Batch with S3 datastore. I was able to complete the flow successfully on batch and was trying to analyze results in a notebook. But when I access properties of the run like `run.data` it throws an error.

I am using https://github.com/valayDave/mnist-experiments-with-metaflow/blob/without_conda_test/hello_mnist.py as the file and running the following command :`python hello_mnist.py --with batch:cpu=2,memory=4000,image=tensorflow/tensorflow:latest-py3 run --num_training_examples 1000`. 

The odd thing is that there are two `.metaflow/.metaflow` folders in my directory and both of them holding the same flows and runs. When moved the data under `.metaflow/.metaflow/FLOWNAME/RUN_ID/STEP_NAME/TASK_ID/_meta` to `.metaflow/FLOWNAME/RUN_ID/STEP_NAME/TASK_ID/_meta` and executed my notebook, It worked perfectly fine. I am using version 2.0.2. 

I investigated that there is data sync after a step from S3 which brings metadata back to the client and does a copy tree operation.

While on batch because of the METAFLOW_DATASTORE_SYSROOT_LOCAL is being referenced to DATASTORE_LOCAL_DIR which is `DATASTORE_LOCAL_DIR = '.metaflow'` in the metaflow_config, the flow-related files are created under `.metaflow/.metaflow`. So when it Tars and untars the data back on the local client and performs copy tree, it creates a new `.metaflow` under the `.metaflow` folder on the local machine. 

Removing the METAFLOW_DATASTORE_SYSROOT_LOCAL the fixed the problem. 