### PR TITLE
Extending support for other object datastores.

### DIFF
--- a/metaflow/datastore/datastore.py
+++ b/metaflow/datastore/datastore.py
@@ -607,10 +607,10 @@ class MetaflowDataStore(object):
         return '\n'.join(line for k, line in sorted(lines()))
 
     @staticmethod
-    def package_download_commands(environment,code_package):
+    def package_download_commands(environment, code_package):
         """
         Intended to download the package inside a container for the execution of a step. 
-        Static because it is a utility method WRT to the datastore child class defined for different object store. 
+        Static because it is a utility method WRT the datastore child class defined for different object store. 
         Will be called by the MetaflowEnvironment.get_package_commands
         """
         raise NotImplementedError()

--- a/metaflow/datastore/datastore.py
+++ b/metaflow/datastore/datastore.py
@@ -606,6 +606,15 @@ class MetaflowDataStore(object):
                          .format(key=k, value=v, **self.info[k])
         return '\n'.join(line for k, line in sorted(lines()))
 
+    @staticmethod
+    def package_download_commands(environment,code_package):
+        """
+        Intended to download the package inside a container for the execution of a step. 
+        Static because it is a utility method WRT to the datastore child class defined for different object store. 
+        Will be called by the MetaflowEnvironment.get_package_commands
+        """
+        raise NotImplementedError()
+
 class ArtifactTooLarge(object):
     def __str__(self):
         return '< artifact too large >'

--- a/metaflow/datastore/local.py
+++ b/metaflow/datastore/local.py
@@ -242,5 +242,6 @@ class LocalDataStore(MetaflowDataStore):
         path = os.path.join(self.root, filename)
         return os.path.exists(path)
 
-    def package_download_commands(environment,code_package):
+    def package_download_commands(environment, code_package):
+        
         return []

--- a/metaflow/datastore/local.py
+++ b/metaflow/datastore/local.py
@@ -241,3 +241,6 @@ class LocalDataStore(MetaflowDataStore):
         filename = self.get_done_filename_for_attempt(self.attempt)
         path = os.path.join(self.root, filename)
         return os.path.exists(path)
+
+    def package_download_commands(environment,code_package):
+        return []

--- a/metaflow/datastore/s3.py
+++ b/metaflow/datastore/s3.py
@@ -254,3 +254,15 @@ class S3DataStore(MetaflowDataStore):
         filename = self.get_done_filename_for_attempt(self.attempt)
         path = os.path.join(self.root, filename)
         return bool(self._head_s3_object(path))
+
+    
+    def package_download_commands(environment,code_package):
+        return [
+            "i=0; while [ $i -le 5 ]; do "
+                "echo \'Downloading code package.\'; "
+                "%s -m awscli s3 cp %s job.tar >/dev/null && \
+                echo \'Code package downloaded.\' && break; "
+                "sleep 10; i=$((i+1));"
+            "done " % (environment._python(), code_package),
+            "tar xf job.tar"
+        ]

--- a/metaflow/datastore/s3.py
+++ b/metaflow/datastore/s3.py
@@ -256,8 +256,14 @@ class S3DataStore(MetaflowDataStore):
         return bool(self._head_s3_object(path))
 
     
-    def package_download_commands(environment,code_package):
+    def package_download_commands(environment, code_package):
+        """
+        Inherited from MetaflowDataStore. 
+        """
         return [
+            "echo 'Installing S3 Dependencies'",
+            "%s -m pip install awscli boto3 \
+                    --user -qqq" % environment._python(),
             "i=0; while [ $i -le 5 ]; do "
                 "echo \'Downloading code package.\'; "
                 "%s -m awscli s3 cp %s job.tar >/dev/null && \

--- a/metaflow/environment.py
+++ b/metaflow/environment.py
@@ -76,21 +76,15 @@ class MetaflowEnvironment(object):
         """
         return "Local environment"
 
-    def get_package_commands(self, code_package_url):
+    def get_package_commands(self, code_package_url,datastore):
         cmds = ["set -e",
                 "echo \'Setting up task environment.\'",
                 "%s -m pip install awscli click requests boto3 \
                     --user -qqq" % self._python(),
                 "mkdir metaflow",
-                "cd metaflow",
-                "i=0; while [ $i -le 5 ]; do "
-                    "echo \'Downloading code package.\'; "
-                    "%s -m awscli s3 cp %s job.tar >/dev/null && \
-                        echo \'Code package downloaded.\' && break; "
-                    "sleep 10; i=$((i+1));"
-                "done " % (self._python(), code_package_url),
-                "tar xf job.tar"
-                ]
+                "cd metaflow"]
+        env = self
+        cmds.extend(datastore.package_download_commands(env,code_package_url))
         return cmds
 
     def get_environment_info(self):

--- a/metaflow/environment.py
+++ b/metaflow/environment.py
@@ -82,7 +82,9 @@ class MetaflowEnvironment(object):
                 "%s -m pip install click requests \
                     --user -qqq" % self._python(),
                 "mkdir metaflow",
-                "cd metaflow"]
+                "cd metaflow",
+                "mkdir .metaflow" # mute local datastore creation log
+                ]
         env = self
         cmds.extend(datastore.package_download_commands(env, code_package_url))
         return cmds

--- a/metaflow/environment.py
+++ b/metaflow/environment.py
@@ -76,15 +76,15 @@ class MetaflowEnvironment(object):
         """
         return "Local environment"
 
-    def get_package_commands(self, code_package_url,datastore):
+    def get_package_commands(self, code_package_url, datastore):
         cmds = ["set -e",
                 "echo \'Setting up task environment.\'",
-                "%s -m pip install awscli click requests boto3 \
+                "%s -m pip install click requests \
                     --user -qqq" % self._python(),
                 "mkdir metaflow",
                 "cd metaflow"]
         env = self
-        cmds.extend(datastore.package_download_commands(env,code_package_url))
+        cmds.extend(datastore.package_download_commands(env, code_package_url))
         return cmds
 
     def get_environment_info(self):

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -26,14 +26,15 @@ class BatchKilledException(MetaflowException):
 
 
 class Batch(object):
-    def __init__(self, metadata, environment):
+    def __init__(self, metadata, environment,datastore):
         self.metadata = metadata
         self.environment = environment
         self._client = BatchClient()
+        self.datastore = datastore
         atexit.register(lambda: self.job.kill() if hasattr(self, 'job') else None)
-
+    
     def _command(self, code_package_url, environment, step_name, step_cli):
-        cmds = environment.get_package_commands(code_package_url)
+        cmds = environment.get_package_commands(code_package_url,self.datastore)
         cmds.extend(environment.bootstrap_commands(step_name))
         cmds.append("echo 'Task is starting.'")
         cmds.extend(step_cli)

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -95,7 +95,7 @@ def _sync_metadata(echo, metadata, datastore_root, attempt):
 @click.option("--run-id", default=None, help="List tasks corresponding to the run id.")
 @click.pass_context
 def list(ctx, run_id, user, my_runs):
-    batch = Batch(ctx.obj.metadata, ctx.obj.environment)
+    batch = Batch(ctx.obj.metadata, ctx.obj.environment,ctx.obj.datastore)
     _execute_cmd(
         batch.list_jobs, ctx.obj.flow.name, run_id, user, my_runs, ctx.obj.echo
     )
@@ -109,7 +109,7 @@ def list(ctx, run_id, user, my_runs):
 )
 @click.pass_context
 def kill(ctx, run_id, user, my_runs):
-    batch = Batch(ctx.obj.metadata, ctx.obj.environment)
+    batch = Batch(ctx.obj.metadata, ctx.obj.environment,ctx.obj.datastore)
     _execute_cmd(
         batch.kill_jobs, ctx.obj.flow.name, run_id, user, my_runs, ctx.obj.echo
     )
@@ -238,7 +238,7 @@ def step(
             "Sleeping %d minutes before the next Batch retry" % minutes_between_retries
         )
         time.sleep(minutes_between_retries * 60)
-    batch = Batch(ctx.obj.metadata, ctx.obj.environment)
+    batch = Batch(ctx.obj.metadata, ctx.obj.environment,ctx.obj.datastore)
     try:
         with ctx.obj.monitor.measure("metaflow.batch.launch"):
             batch.launch_job(


### PR DESCRIPTION
Added a `@staticmethod` to the `MetaflowDataStore` class pertaining to commands needed for code package download. 

The method needs to be implemented by each child class of a datastore so that commands related to package download can be different according to different child classes. 

This ensures the decoupling of classes relating to the environment and computational resources from the datastore itself. 