### PR TITLE
Mute datastore creation log on AWS Batch for local metadata store

### DIFF
--- a/metaflow/environment.py
+++ b/metaflow/environment.py
@@ -83,6 +83,7 @@ class MetaflowEnvironment(object):
                     --user -qqq" % self._python(),
                 "mkdir metaflow",
                 "cd metaflow",
+                "mkdir .metaflow", # mute local datastore creation log
                 "i=0; while [ $i -le 5 ]; do "
                     "echo \'Downloading code package.\'; "
                     "%s -m awscli s3 cp %s job.tar >/dev/null && \


### PR DESCRIPTION
Purely a cosmetic change in AWS Batch job execution logs

Running with local metadata service pollutes the job logs with the statement `Creating local datastore in current directory (/metaflow/.metaflow)`.