### PR TITLE
Release notes -

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.0.2'
+version = '2.0.3'
 
 setup(name='metaflow',
       version=version,


### PR DESCRIPTION
1. Use a smaller standalone Conda installer for AWS Batch
2. Add METAFLOW_S3_ENDPOINT_URL configuration (#130)
3. Use the CLI datastore-root before checking for METAFLOW_DATASTORE_SYSROOT_S3
4. Fix an issue where using the local metadata provider with Batch resulted
   in .metaflow/.metaflow instead of just .metaflow
5. Add a way to get parameter names passed to a flow (using
   current.parameter_names) (#137)
6. Properly indent on show (#92)
7. Surpress superfluous message when running on Batch