### PR TITLE
Add PYTHONNOUSERSITE explicitly

### DIFF
--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -208,6 +208,7 @@ class CondaStepDecorator(StepDecorator):
         self.flow = flow
         self.datastore = datastore
         self.base_attributes = self._get_base_attributes()
+        os.environ['PYTHONNOUSERSITE'] = '1'
 
     def package_init(self, flow, step, environment):
         if self.is_enabled():


### PR DESCRIPTION
In some edge cases, `python -s` doesn't explicitly set PYTHONNOUSERSITE.

More context - https://gitter.im/metaflow_org/community?at=5e8ee8315d148a0460f51623