### PR TITLE
Pre-empt log collection when Batch task crashes

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -173,11 +173,11 @@ class Batch(object):
                 if status != job.status or (time.time()-t) > 30:
                     status = job.status
                     echo(
-                        self.job.id,
+                        job.id,
                         'Task is starting (status %s)...' % status
                     )
                     t = time.time()
-                if self.job.is_running or self.job.is_done or self.job.is_crashed:
+                if job.is_running or job.is_done or job.is_crashed:
                     break
                 select.poll().poll(200)
 
@@ -199,16 +199,13 @@ class Batch(object):
                 select.poll().poll(500)
 
         if self.job.is_crashed:
-            if self.job.reason:
-                raise BatchException(
-                    'Task crashed due to %s .'
-                    'This could be a transient error. '
-                    'Use @retry to retry.' % self.job.reason
-                )
+            msg = next(msg for msg in 
+                [self.job.reason, self.job.status_reason, 'Task crashed.']
+                 if msg is not None)
             raise BatchException(
-                'Task crashed. '
+                '%s '
                 'This could be a transient error. '
-                'Use @retry to retry.'
+                'Use @retry to retry.' % msg
             )
         else:
             if self.job.is_running:

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -60,11 +60,11 @@ class BatchJob(object):
     def execute(self):
         if self._image is None:
             raise BatchJobException(
-                'Unable to launch Batch job. No docker image specified.'
+                'Unable to launch AWS Batch job. No docker image specified.'
             )
         if self._iam_role is None:
             raise BatchJobException(
-                'Unable to launch Batch job. No IAM role specified.'
+                'Unable to launch AWS Batch job. No IAM role specified.'
             )
         self.payload['jobDefinition'] = self._job_def_arn(self._image, self._iam_role)
         response = self._client.submit_job(**self.payload)
@@ -302,7 +302,7 @@ class RunningJob(object):
 
         log_stream = None
         while True:
-            if self.is_running or self.is_done:
+            if self.is_running or self.is_done or self.is_crashed:
                 log_stream = get_log_stream(self)
                 break
             elif not self.is_done:


### PR DESCRIPTION
Fix a bug where log collection gets into an infinite loop when AWS Batch job crashes before being executed on ECS. Clean up some log statements as well.