### PR TITLE
Expose job attempt configuration for AWS Batch jobs

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -160,6 +160,10 @@ class BatchJob(object):
         self.payload['parameters'][key] = str(value)
         return self
 
+    def attempts(self, attempts):
+        self.payload['retryStrategy']['attempts'] = attempts
+        return self
+
 
 class Throttle(object):
     def __init__(self, delta_in_secs=1, num_tries=20):


### PR DESCRIPTION
StepFunctions cannot control the retrying strategy for AWS Batch since `$$.State.RetryCount` in SFN ContextObject is a number and AWS Batch only accepts strings as configuration values.

So, instead of relying on StepFunctions to retry failed jobs, we will pass on the baton to AWS Batch instead.