### PR TITLE
Mute `ThrottleException` for AWS Logs API for AWS Batch

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -166,7 +166,7 @@ class BatchJob(object):
 
 
 class Throttle(object):
-    def __init__(self, delta_in_secs=1, num_tries=200):
+    def __init__(self, delta_in_secs=1, num_tries=20):
         self.delta_in_secs = delta_in_secs
         self.num_tries = num_tries
         self._now = None

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -166,7 +166,7 @@ class BatchJob(object):
 
 
 class Throttle(object):
-    def __init__(self, delta_in_secs=1, num_tries=20):
+    def __init__(self, delta_in_secs=1, num_tries=200):
         self.delta_in_secs = delta_in_secs
         self.num_tries = num_tries
         self._now = None
@@ -406,23 +406,32 @@ class BatchLogs(object):
         self._token = None
 
     def _get_events(self):
-        if self._token:
-            response = self._client.get_log_events(
-                logGroupName=self._group,
-                logStreamName=self._stream,
-                startTime=self._pos,
-                nextToken=self._token,
-                startFromHead=True,
-            )
-        else:
-            response = self._client.get_log_events(
-                logGroupName=self._group,
-                logStreamName=self._stream,
-                startTime=self._pos,
-                startFromHead=True,
-            )
-        self._token = response['nextForwardToken']
-        return response['events']
+        try:
+            if self._token:
+                response = self._client.get_log_events(
+                    logGroupName=self._group,
+                    logStreamName=self._stream,
+                    startTime=self._pos,
+                    nextToken=self._token,
+                    startFromHead=True,
+                )
+            else:
+                response = self._client.get_log_events(
+                    logGroupName=self._group,
+                    logStreamName=self._stream,
+                    startTime=self._pos,
+                    startFromHead=True,
+                )
+            self._token = response['nextForwardToken']
+            return response['events']
+        except self._client.exceptions.ClientError as err:
+            code = err.response['Error']['Code']
+            if 'ThrottlingException' in code:
+                # AWS Logs API is throttling us, better
+                # try our luck next time. We will continue to
+                # poll till the AWS Batch task is alive.
+                return []
+            raise err
 
     def __iter__(self):
         while True:


### PR DESCRIPTION
Currently, the flow logs are polluted with  occasional `ThrottleExceptions`.
They don't result in flow failures since we retry log fetching till the tasks
are alive and do a best-effort pull after the tasks have finished. This patch
swallows the `ThrottleExceptions` so that the end-user isn't thrown off track.

resolves #184 