### PR TITLE
Fix logging of prefixes in datatools.S3._read_many_files

### DIFF
--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -564,6 +564,7 @@ class S3(object):
     # Conversion between bytes and unicode is done through url_quote
     # and url_unquote.
     def _read_many_files(self, op, prefixes, **options):
+        prefixes = list(prefixes)
         with NamedTemporaryFile(dir=self._tmpdir,
                                 mode='wb',
                                 delete=not debug.s3client,


### PR DESCRIPTION
When `datatools.S3._read_many_files` is unsuccessful, instead of displaying the underlying error message, we get a `TypeError: 'map' object is not subscriptable` due to trying to access the first element of `prefixes` with `[0]`. The `prefixes` passed in is a generator (map) which doesn't support this sort of access. The simplest fix is ~to remove the attempted logging of the _first prefix_~ to assign to a list inside the function. 

Better to report the underlying error correctly than a mysterious `'map' object is not subscriptable`. In my case I had an issue with a version of the [typing](https://pypi.org/project/typing/) library being incompatible with a version of [`certifi`](https://pypi.org/project/certifi/) which became obvious once the underlying error message was not being hidden.

~If it's important to log the first prefix requested, we can instead change all callers of `_read_many_files` to pass a list instead of generator.~

## Related Issues

- Should Fix https://github.com/Netflix/metaflow/issues/104