### PR TITLE
pin pylint version to 2.4.4 since 2.5.0 does not like self.next() syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='metaflow',
         'click>=7.0',
         'requests',
         'boto3',
-        'pylint==2.4.4'
+        'pylint<2.5.0'
       ],
       tests_require = [
         'coverage'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(name='metaflow',
       install_requires = [
         'click>=7.0',
         'requests',
-        'boto3'
+        'boto3',
+        'pylint==2.4.4'
       ],
       tests_require = [
         'coverage'


### PR DESCRIPTION
Tested locally by running `pip3 install .` in the repo folder. It can automatically downgrades pylint from `2.5.0` to `2.4.4`.