### PR TITLE
Increase retry count for AWS Batch logs streaming

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -166,7 +166,7 @@ class BatchJob(object):
 
 
 class Throttle(object):
-    def __init__(self, delta_in_secs=1, num_tries=200):
+    def __init__(self, delta_in_secs=1, num_tries=20):
         self.delta_in_secs = delta_in_secs
         self.num_tries = num_tries
         self._now = None

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -166,7 +166,7 @@ class BatchJob(object):
 
 
 class Throttle(object):
-    def __init__(self, delta_in_secs=1, num_tries=20):
+    def __init__(self, delta_in_secs=1, num_tries=200):
         self.delta_in_secs = delta_in_secs
         self.num_tries = num_tries
         self._now = None


### PR DESCRIPTION
Modify the retry behavior for log fetching on AWS Batch by adding
jitters to exponential backoffs as well as reset the retry counter
for every successful request.

Additionally, fail the metaflow task even if AWS Batch task succeeds
but we fail to stream the task logs back to the user's terminal.