### PR TITLE
Trigger release on `published`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   test:
     name: Test on ${{ matrix.os }}


### PR DESCRIPTION
`created` event is not emitted when a draft release is published, while `published` event is always emitted with or without a draft release.