### PR TITLE
Verify that GitHub CI tests are failing due to large artifacts

### DIFF
--- a/test/core/tests/large_artifact.py
+++ b/test/core/tests/large_artifact.py
@@ -2,7 +2,7 @@ from metaflow_test import MetaflowTest, ExpectationFailed, steps
 
 class LargeArtifactTest(MetaflowTest):
     """
-    Test that you can serialize large objects (over 4GB)
+    Test that you can serialize large objects (over 2GB)
     with Python3.
     """
     PRIORITY = 2
@@ -11,7 +11,7 @@ class LargeArtifactTest(MetaflowTest):
     def step_single(self):
         import sys
         if sys.version_info[0] > 2:
-            self.large = b'x' * int(4.1 * 1024**3)
+            self.large = b'x' * int(2.1 * 1024**3)
             self.noop = False
         else:
             self.noop = True
@@ -20,7 +20,7 @@ class LargeArtifactTest(MetaflowTest):
     def step_end(self):
         import sys
         if sys.version_info[0] > 2:
-            assert_equals(self.large, b'x' * int(4.1 * 1024**3))
+            assert_equals(self.large, b'x' * int(2.1 * 1024**3))
 
     @steps(1, ['all'])
     def step_all(self):
@@ -32,4 +32,4 @@ class LargeArtifactTest(MetaflowTest):
         if not noop and sys.version_info[0] > 2:
             checker.assert_artifact('end',
                                     'large',
-                                    b'x' * int(4.1 * 1024**3))
+                                    b'x' * int(2.1 * 1024**3))


### PR DESCRIPTION
Reduce file size from 4g to 2g. We will bump it back up when we get to custom runners for tests.