### PR TITLE
Set namespace to None in example notebook

### DIFF
--- a/metaflow/tutorials/05-helloaws/helloaws.ipynb
+++ b/metaflow/tutorials/05-helloaws/helloaws.ipynb
@@ -22,7 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from metaflow import Flow, get_metadata\n",
+    "from metaflow import Flow, get_metadata, namespace\n",
     "print(\"Current metadata provider: %s\" % get_metadata())"
    ]
   },
@@ -39,6 +39,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set namespace to None to search over all namespaces\n",
+    "namespace(None)\n",
     "run = Flow('HelloAWSFlow').latest_successful_run\n",
     "print(\"Using run: %s\" % str(run))\n",
     "print(run.data.message)"

--- a/metaflow/tutorials/06-statistics-redux/stats.ipynb
+++ b/metaflow/tutorials/06-statistics-redux/stats.ipynb
@@ -22,7 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from metaflow import Flow, get_metadata\n",
+    "from metaflow import Flow, get_metadata, namespace\n",
     "import matplotlib.pyplot as plt\n",
     "print(\"Current metadata provider: %s\" % get_metadata())"
    ]
@@ -40,6 +40,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set namespace to None to search over all namespaces\n",
+    "namespace(None)\n",
     "run = Flow('MovieStatsFlow').latest_successful_run\n",
     "print(\"Using run: %s\" % str(run))"
    ]

--- a/metaflow/tutorials/07-worldview/worldview.ipynb
+++ b/metaflow/tutorials/07-worldview/worldview.ipynb
@@ -62,6 +62,8 @@
    "source": [
     "import time\n",
     "\n",
+     "# Set namespace to None to search over all namespaces\n",
+    "namespace(None)\n",
     "flow = Flow('HelloAWSFlow')\n",
     "runs = list(flow.runs())\n",
     "print(\"HelloAWSFlow:\")\n",

--- a/metaflow/tutorials/07-worldview/worldview.ipynb
+++ b/metaflow/tutorials/07-worldview/worldview.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "import time\n",
     "\n",
-     "# Set namespace to None to search over all namespaces\n",
+    "# Set namespace to None to search over all namespaces\n",
     "namespace(None)\n",
     "flow = Flow('HelloAWSFlow')\n",
     "runs = list(flow.runs())\n",

--- a/metaflow/tutorials/07-worldview/worldview.ipynb
+++ b/metaflow/tutorials/07-worldview/worldview.ipynb
@@ -22,7 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from metaflow import Metaflow, Flow, get_metadata\n",
+    "from metaflow import Metaflow, Flow, get_metadata, namespace\n",
     "print(\"Current metadata provider: %s\" % get_metadata())"
    ]
   },
@@ -39,6 +39,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set namespace to None to search over all namespaces\n",
+    "namespace(None)\n",
     "for flow in Metaflow():\n",
     "    run = flow.latest_run\n",
     "    print(\"{:<15} Last run: {} Successful: {}\".\\\n",


### PR DESCRIPTION
Setting namespace to None. A common scenario is where the user
copies to contents of the notebook into a sagemaker notebook and executes
the code snippets. That would fail, because the sagemaker notebook runs
with user:ec2-user. Setting the namespace to None allows us to bypass this
issue and provide a better user experience.