### PR TITLE
Make conda_step_decorator working with an already existing environment

### DIFF
--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -56,7 +56,8 @@ class CondaStepDecorator(StepDecorator):
     name = 'conda'
     defaults = {'libraries': {},
                 'python': None,
-                'disabled': None}
+                'disabled': None,
+                'env_name': None}
 
     conda = None
     environments = None
@@ -230,6 +231,10 @@ class CondaStepDecorator(StepDecorator):
             python_path = self.metaflow_home
             if os.environ.get('PYTHONPATH') is not None:
                 python_path = os.pathsep.join([os.environ['PYTHONPATH'], python_path])
+
+            if self.attributes['env_name']:
+                self.env_id = self.attributes['env_name']
+
             cli_args.env['PYTHONPATH'] = python_path
             cli_args.env['_METAFLOW_CONDA_ENV'] = self.env_id
             cli_args.entrypoint[0] = self.conda.python(self.env_id)


### PR DESCRIPTION
Probably we will have to iterate on this PR but right now it would already have the functionality, we should add anyway some checks that when the `env_name` parameter exists the others (`libraries` and `python`) are not used, attached example that works :blush:

```python
from metaflow import FlowSpec, step, conda, conda_base


class DummyFlow(FlowSpec):
    """Start of our ML process
    """
    @step
    def start(self):
        """Start of our ML process
        """
        print('Welcome to your ML pipeline flow! \N{grinning face}')

        self.next(self.test_conda)

    @conda(env_name='h2o_engine')
    @step
    def test_conda(self):
        """Checks `h2o_engine` libraries 
        """
        import sklearn
        import pandas as pd

        print(sklearn.__version__)
        print(pd.__version__)

        self.next(self.end)

    @step
    def end(self):
        """
        Last step in the flow, says goodbye.
        """
        print('Goodbye!.')


if __name__ == '__main__':
    DummyFlow()
```

Outputs:

```shell
>> python hello_world.py --environment=conda run
../metaflow/metaflow/__init__.py
Metaflow 2.0.5.post17+gitbf7688c executing DummyFlow for user:scalderp
Validating your flow...
    The graph looks good!
Running pylint...
    Pylint is happy!
2020-06-22 18:47:28.657 Bootstrapping conda environment...(this could take a few minutes)
2020-06-22 18:47:32.229 Workflow starting (run-id 1592844452223327):
2020-06-22 18:47:33.514 [1592844452223327/start/1 (pid 9040)] Task is starting.
2020-06-22 18:47:34.098 [1592844452223327/start/1 (pid 9040)] ../metaflow/metaflow/__init__.py
2020-06-22 18:47:34.205 [1592844452223327/start/1 (pid 9040)] Welcome to your ML pipeline flow! 😀
2020-06-22 18:47:34.207 [1592844452223327/start/1 (pid 9040)] Task finished successfully.
2020-06-22 18:47:35.457 [1592844452223327/test_conda/2 (pid 9059)] Task is starting.
2020-06-22 18:47:36.930 [1592844452223327/test_conda/2 (pid 9059)] dentro /home/scalderp/anaconda3/envs/h2o_engine/lib/python3.6/site-packages/metaflow/__init__.py
2020-06-22 18:47:37.138 [1592844452223327/test_conda/2 (pid 9059)] /home/scalderp/anaconda3/envs/h2o_engine/lib/python3.6/site-packages/metaflow/__init__.py
2020-06-22 18:47:37.138 [1592844452223327/test_conda/2 (pid 9059)] 0.23.1
2020-06-22 18:47:37.138 [1592844452223327/test_conda/2 (pid 9059)] 1.0.4
2020-06-22 18:47:37.141 [1592844452223327/test_conda/2 (pid 9059)] Task finished successfully.
2020-06-22 18:47:38.403 [1592844452223327/end/3 (pid 9075)] Task is starting.
2020-06-22 18:47:38.966 [1592844452223327/end/3 (pid 9075)] ../metaflow/metaflow/__init__.py
2020-06-22 18:47:39.059 [1592844452223327/end/3 (pid 9075)] Goodbye!.
2020-06-22 18:47:39.062 [1592844452223327/end/3 (pid 9075)] Task finished successfully.
2020-06-22 18:47:39.063 Done!

```

I hope it's useful and we can work from here!