### PR TITLE
Remove millisecond information from run timestamps

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -338,7 +338,7 @@ class MetaflowObject(object):
             raise MetaflowInternalError(msg="Unknown type: %s" % self._NAME)
 
         self._created_at = time.strftime(
-            '%Y-%m-%dT%H:%M:%S.%fZ', time.gmtime(self._object['ts_epoch']//1000))
+            '%Y-%m-%dT%H:%M:%SZ', time.gmtime(self._object['ts_epoch']//1000))
 
         self._tags = frozenset(chain(self._object.get('system_tags') or [],
                                      self._object.get('tags') or []))


### PR DESCRIPTION
This removes the millisecond information from `created_at` and `finished_at` because `%f` directive is not compatible with `time`.

Fixes #224 