### PR TITLE
Add instructions to tutorial 6 for execution inside a conda environment

### DIFF
--- a/metaflow/tutorials/04-playlist-plus/README.md
+++ b/metaflow/tutorials/04-playlist-plus/README.md
@@ -11,11 +11,10 @@ isolated and reproducible environments for individual steps.**
 - Metaflow's conda based dependency management.
 
 #### Before playing this episode:
-This tutorial requires the 'conda' package manager to be installed with the
-conda-forge channel added.
-
-1. Download Miniconda at https://docs.conda.io/en/latest/miniconda.html
-2. ```conda config --add channels conda-forge```
+1. This tutorial requires the 'conda' package manager to be installed with the
+   conda-forge channel added.
+   a. Download Miniconda at https://docs.conda.io/en/latest/miniconda.html
+   b. ```conda config --add channels conda-forge```
 
 #### To play this episode:
 1. ```cd metaflow-tutorials```

--- a/metaflow/tutorials/05-helloaws/README.md
+++ b/metaflow/tutorials/05-helloaws/README.md
@@ -12,8 +12,13 @@ use the client to access information about any flow from anywhere.**
 - retry decorator.
 
 #### Before playing this episode:
-1. Configure your sandbox: https://docs.metaflow.org/metaflow-on-aws/metaflow-sandbox
-2. ```python -m pip install notebook```
+1. ```python -m pip install notebook```
+2. This tutorial requires access to compute and storage resources on AWS, which
+   can be configured by 
+   a. Following the instructions at 
+      https://docs.metaflow.org/metaflow-on-aws/deploy-to-aws or
+   b. Requesting a sandbox at 
+      https://docs.metaflow.org/metaflow-on-aws/metaflow-sandbox
 
 #### To play this episode:
 1. ```cd metaflow-tutorials```

--- a/metaflow/tutorials/06-statistics-redux/README.md
+++ b/metaflow/tutorials/06-statistics-redux/README.md
@@ -9,7 +9,10 @@ behavior with additional arguments, like '--max-workers'. For this example,
 'max-workers' is used to limit the number of parallel genre specific statistics
 computations.
 You can then access the data artifacts (even the local CSV file) from anywhere
-because the data is being stored in AWS S3.**
+because the data is being stored in AWS S3.
+This tutorial uses `pandas` which may not be available in your environment. 
+Use the 'conda' package manager with the `conda-forge` channel added to run 
+this tutorial in any environment**
 
 #### Showcasing:
 - '--with batch' command line option

--- a/metaflow/tutorials/06-statistics-redux/README.md
+++ b/metaflow/tutorials/06-statistics-redux/README.md
@@ -15,15 +15,27 @@ because the data is being stored in AWS S3.**
 - '--with batch' command line option
 - '--max-workers' command line option
 - Accessing data locally or remotely
+- Metaflow's conda based dependency management.
+
 
 #### Before playing this episode:
-1. Configure your sandbox: https://docs.metaflow.org/metaflow-on-aws/metaflow-sandbox
-2. ```python -m pip install pandas```
-3. ```python -m pip install notebook```
-4. ```python -m pip install matplotlib```
+1. ```python -m pip install pandas```
+2. ```python -m pip install notebook```
+3. ```python -m pip install matplotlib```
+4. This tutorial requires the 'conda' package manager to be installed with the
+   conda-forge channel added.
+   a. Download Miniconda at https://docs.conda.io/en/latest/miniconda.html
+   b. ```conda config --add channels conda-forge```
+5. This tutorial requires access to compute and storage resources on AWS, which
+   can be configured by 
+   a. Following the instructions at 
+      https://docs.metaflow.org/metaflow-on-aws/deploy-to-aws or
+   b. Requesting a sandbox at 
+      https://docs.metaflow.org/metaflow-on-aws/metaflow-sandbox
+
 
 #### To play this episode:
 1. ```cd metaflow-tutorials```
-2. ```python 02-statistics/stats.py --with batch run --max-workers 4```
+2. ```python 02-statistics/stats.py --environment conda run --with batch --max-workers 4 --with conda:python=3.7,libraries="{pandas:0.24.2}"```
 3. ```jupyter-notebook 06-statistics-redux/stats.ipynb```
 4. Open 'stats.ipynb' in your remote Sagemaker notebook

--- a/metaflow/tutorials/07-worldview/README.md
+++ b/metaflow/tutorials/07-worldview/README.md
@@ -7,8 +7,13 @@ monitor all of your Metaflow flows.**
 - The metaflow client API.
 
 #### Before playing this episode:
-1. Configure your sandbox: https://docs.metaflow.org/metaflow-on-aws/metaflow-sandbox
-2. ```python -m pip install notebook```
+1. ```python -m pip install notebook```
+2. This tutorial requires access to compute and storage resources on AWS, which
+   can be configured by 
+   a. Following the instructions at 
+      https://docs.metaflow.org/metaflow-on-aws/deploy-to-aws or
+   b. Requesting a sandbox at 
+      https://docs.metaflow.org/metaflow-on-aws/metaflow-sandbox
 
 #### To play this episode:
 1. ```cd metaflow-tutorials```


### PR DESCRIPTION
Some users might not have access to pandas within the docker container
executing their AWS Batch job. The situation is different for sandbox
accounts since the image bundles in pandas by default.

Added a command line flag to enable conda and pandas for all executions