### PR TITLE
Throw a pretty error when metaflow fails to fetch the code package

### DIFF
--- a/metaflow/environment.py
+++ b/metaflow/environment.py
@@ -88,8 +88,12 @@ class MetaflowEnvironment(object):
                     "echo \'Downloading code package.\'; "
                     "%s -m awscli s3 cp %s job.tar >/dev/null && \
                         echo \'Code package downloaded.\' && break; "
-                    "sleep 10; i=$((i+1));"
+                    "sleep 10; i=$((i+1)); "
                 "done " % (self._python(), code_package_url),
+                "if [ $i -gt 5 ]; then "
+                    "echo \'Failed to download code package from %s "
+                    "after 6 tries. Exiting...\' && exit 1; "
+                "fi" % code_package_url,
                 "tar xf job.tar"
                 ]
         return cmds

--- a/metaflow/environment.py
+++ b/metaflow/environment.py
@@ -89,7 +89,7 @@ class MetaflowEnvironment(object):
                     "%s -m awscli s3 cp %s job.tar >/dev/null && \
                         echo \'Code package downloaded.\' && break; "
                     "sleep 10; i=$((i+1)); "
-                "done " % (self._python(), code_package_url),
+                "done" % (self._python(), code_package_url),
                 "if [ $i -gt 5 ]; then "
                     "echo \'Failed to download code package from %s "
                     "after 6 tries. Exiting...\' && exit 1; "


### PR DESCRIPTION
In some situations, the user might be left wondering where
exactly the code package is being fetched from, when such fetches
fail, making it harder to debug.

Closes #232 