### PR TITLE
Handle log indenting in metaflow

### DIFF
--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -828,7 +828,7 @@ class Worker(object):
 
     def write(self, msg, buf):
         buf.write(msg)
-        text = msg.strip().decode(self._encoding, errors='replace')
+        text = msg.rstrip().decode(self._encoding, errors='replace')
         self.task.log(text, pid=self._proc.pid)
 
     def read_logline(self, fd):


### PR DESCRIPTION
Logs might have leading whitespaces which are currently being removed from the user-visible logs on console.

Addresses #223