### PR TITLE
Exit early if no log_stream is generated for AWS Batch job

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -333,6 +333,8 @@ class RunningJob(object):
             elif not self.is_done:
                 self.wait_for_running()
 
+        if log_stream is None:
+            return 
         exception = None
         for i in range(self.NUM_RETRIES + 1):
             try:


### PR DESCRIPTION
When IAM perms are incorrectly assigned, AWS Batch will be unable to
generate an AWS CloudWatch log stream. In those instances, we should
short circuit and return the actual error message.