### PR TITLE
Remove https:// for dockerhub address in comment

### DIFF
--- a/metaflow/main_cli.py
+++ b/metaflow/main_cli.py
@@ -565,7 +565,7 @@ def aws(ctx, profile):
                                  yellow(' (optional)') +
                                  ' Default Docker image repository for AWS ' +
                                  'Batch jobs. If nothing is specified, ' +
-                                 'dockerhub (https://hub.docker.com/) is ' +
+                                 'dockerhub (hub.docker.com/) is ' +
                                  'used as default.',
                                  default=\
                                     existing_env.get('METAFLOW_BATCH_CONTAINER_REGISTRY', ''),


### PR DESCRIPTION
It can confuse users. https://gitter.im/metaflow_org/community?at=5f298c7f0ff358499bd448a9