### PR TITLE
Move from cStringIO.StringIO to BytesIO for more consistency.

### DIFF
--- a/metaflow/datastore/util/s3tail.py
+++ b/metaflow/datastore/util/s3tail.py
@@ -1,16 +1,13 @@
 
+from io import BytesIO
 from .s3util import aws_retry, get_s3_client
 
 try:
     # python2
     from urlparse import urlparse
-    import cStringIO
-    BytesIO = cStringIO.StringIO
 except:
     # python3
     from urllib.parse import urlparse
-    import io
-    BytesIO = io.BytesIO
 
 class S3Tail(object):
     def __init__(self, s3url):

--- a/metaflow/includefile.py
+++ b/metaflow/includefile.py
@@ -19,14 +19,9 @@ from .util import to_unicode
 
 try:
     # python2
-    import cStringIO
-    BytesIO = cStringIO.StringIO
-
     from urlparse import urlparse
 except:
     # python3
-    BytesIO = io.BytesIO
-
     from urllib.parse import urlparse
 
 # TODO: This local "client" and the general notion of dataclients should probably
@@ -323,7 +318,7 @@ class Uploader():
                                     'large to be properly handled by Python 2.7' % path)
         sha = sha1(cur_obj.current()).hexdigest()
         path = os.path.join(self._client_class.get_root_from_config(logger, True), flow_name, sha)
-        buf = BytesIO()
+        buf = io.BytesIO()
         with gzip.GzipFile(
                 fileobj=buf, mode='wb', compresslevel=3) as f:
             f.write(cur_obj.current())

--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -3,20 +3,12 @@ import sys
 import tarfile
 import json
 from hashlib import sha1
+from io import BytesIO
 from itertools import chain
 
 from .metaflow_config import DEFAULT_SUFFIXES
 from .util import to_unicode
 from . import R
-
-try:
-    # python2
-    import cStringIO
-    BytesIO = cStringIO.StringIO
-except:
-    # python3
-    import io
-    BytesIO = io.BytesIO
 
 DEFAULT_SUFFIXES_LIST = DEFAULT_SUFFIXES.split(',')
 

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -12,6 +12,8 @@ import fcntl
 import time
 import select
 import subprocess
+
+from io import BytesIO
 from functools import partial
 
 from . import get_namespace
@@ -26,14 +28,6 @@ from .debug import debug
 from .decorators import flow_decorators
 
 from .util import to_unicode, compress_list
-try:
-    # python2
-    import cStringIO
-    BytesIO = cStringIO.StringIO
-except:
-    # python3
-    import io
-    BytesIO = io.BytesIO
 
 MAX_WORKERS=16
 MAX_NUM_SPLITS=100

--- a/metaflow/util.py
+++ b/metaflow/util.py
@@ -5,6 +5,7 @@ import tempfile
 import zlib
 import base64
 from functools import wraps
+from io import BytesIO
 from itertools import takewhile
 import re
 
@@ -12,8 +13,6 @@ from metaflow.exception import MetaflowUnknownUser, MetaflowInternalError
 
 try:
     # python2
-    import cStringIO
-    BytesIO = cStringIO.StringIO
     unicode_type = unicode
     bytes_type = str
     from urllib import quote, unquote
@@ -32,8 +31,6 @@ try:
 
 except:
     # python3
-    import io
-    BytesIO = io.BytesIO
     unicode_type = str
     bytes_type = bytes
     from urllib.parse import quote, unquote


### PR DESCRIPTION
This change only affects Python2; Python3 was already using BytesIO