### PR TITLE
update metaflow R install function. remove cran check from github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,16 +55,6 @@ jobs:
         R CMD INSTALL R
         Rscript -e 'install.packages(c("data.table", "caret", "glmnet", "Matrix", "rjson"), repos="https://cloud.r-project.org", Ncpus=8)'   
 
-    - name: Install latex for CRAN compatibility checks
-      if: matrix.lang == 'R' && matrix.os == 'ubuntu-latest'
-      uses: r-lib/actions/setup-tinytex@v1
-
-    - name: Check CRAN compatibility
-      if: matrix.lang == 'R' && matrix.os == 'ubuntu-latest'
-      run: |
-        cd R/
-        bash ./check_as_cran.sh
-
     - name: Execute R tests
       if: matrix.lang == 'R'
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,16 +59,6 @@ jobs:
         R CMD INSTALL R
         Rscript -e 'install.packages(c("data.table", "caret", "glmnet", "Matrix", "rjson"), repos="https://cloud.r-project.org", Ncpus=8)'   
 
-    - name: Install latex for CRAN compatibility checks
-      if: matrix.lang == 'R' && matrix.os == 'ubuntu-latest'
-      uses: r-lib/actions/setup-tinytex@v1
-
-    - name: Check CRAN compatibility
-      if: matrix.lang == 'R' && matrix.os == 'ubuntu-latest'
-      run: |
-        cd R/
-        bash ./check_as_cran.sh
-
     - name: Execute R tests
       if: matrix.lang == 'R'
       run: |

--- a/R/R/utils.R
+++ b/R/R/utils.R
@@ -266,11 +266,11 @@ test <- function() {
 }
 
 #' Install Metaflow python dependencies
-#' @param user_install Whether or not to install into the user directory for pip install. Default to TRUE. 
+#' @param user Whether or not to install into the user directory for pip install. Default to TRUE. 
 #' @param upgrade Whether or not to upgrade metaflow python package. Default to FALSE.  
 #' @export
-install <- function(user_install=TRUE, upgrade=FALSE) {
-  if (user_install){
+install <- function(user=TRUE, upgrade=FALSE) {
+  if (user){
     user_flag = "--user"
   } else {
     user_flag = ""

--- a/R/tests/test_tutorials.sh
+++ b/R/tests/test_tutorials.sh
@@ -1,5 +1,0 @@
-DIR=$(pwd)/../inst/tutorials
-cd $DIR/00-helloworld; Rscript helloworld.R 
-cd $DIR/01-playlist; Rscript playlist.R
-cd $DIR/02-statistics; Rscript statistics.R
-cd $DIR/03-playlist-redux; Rscript playlist.R


### PR DESCRIPTION
Update Metaflow R install function. Fix a problem with the argument name. 

Remove cran check from github action. CRAN check requires a proper setup of pdflatex, which is sometimes flaky on ubuntu:latest image.