### PR TITLE
Use the first environments directory instead of conda_prefix

### DIFF
--- a/metaflow/plugins/conda/conda.py
+++ b/metaflow/plugins/conda/conda.py
@@ -141,7 +141,7 @@ class Conda(object):
         return None
 
     def _env_lock_file(self, env_id):
-        return os.path.join(self._info()['conda_prefix'], 'mf_env-creation.lock')
+        return os.path.join(self._info()['envs_dirs'][0], 'mf_env-creation.lock')
 
     def _call_conda(self, args, architecture=None):
         try:


### PR DESCRIPTION
The conda_prefix folder is not always writable, so creating a lock there can fail.
On the other hand, conda's first entry in "envs_dirs" should always be writable.

Fix #179