### PR TITLE
Fix imports in datatools.s3

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -7,7 +7,6 @@ from datetime import datetime
 
 import click
 
-from . import current
 from . import lint
 from . import plugins
 from . import parameters

--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -7,7 +7,8 @@ import subprocess
 from itertools import starmap
 from tempfile import mkdtemp, NamedTemporaryFile
 
-from .. import current, FlowSpec
+from .. import FlowSpec
+from ..current import current
 from ..metaflow_config import DATATOOLS_S3ROOT
 from ..util import is_stringish,\
                    to_bytes,\


### PR DESCRIPTION
Patching import of `current` to point to the singleton object rather than the python module