### PR TITLE
Fix s3_put_object retries in datastore/s3.py. Also fail gracefully if boto3 is not installed

### DIFF
--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -28,7 +28,13 @@ except:
     from urllib.parse import urlparse
 
 from metaflow.datastore.util.s3util import get_s3_client
-from botocore.exceptions import ClientError
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+    boto_found = True
+except:
+    boto_found = False
 
 NUM_S3OP_RETRIES = 8
 
@@ -201,6 +207,9 @@ class S3(object):
 
             tmproot: (optional) Root path for temporary files (default: '.')
         """
+
+        if not boto_found:
+            raise MetaflowException("You need to install 'boto3' in order to use S3.")
 
         if run:
             # 1. use a (current) run ID with optional customizations

--- a/test/core/tests/s3_failure.py
+++ b/test/core/tests/s3_failure.py
@@ -1,0 +1,43 @@
+from metaflow_test import MetaflowTest, ExpectationFailed, steps
+
+class S3FailureTest(MetaflowTest):
+    """
+    Test that S3 failures are handled correctly.
+    """
+    PRIORITY = 1
+
+    HEADER = """
+import os
+
+os.environ['TEST_S3_RETRY'] = '1'
+"""
+
+    @steps(0, ['singleton-start'], required=True)
+    def step_start(self):
+        # we need a unique artifact for every run which we can reconstruct
+        # independently in the start and end tasks
+        from metaflow import current
+        self.x = '%s/%s' % (current.flow_name, current.run_id)
+
+    @steps(0, ['end'])
+    def step_end(self):
+        from metaflow import current
+        run_id = '%s/%s' % (current.flow_name, current.run_id)
+        assert_equals(self.x, run_id)
+
+    @steps(1, ['all'])
+    def step_all(self):
+        pass
+
+    def check_results(self, flow, checker):
+        run = checker.get_run()
+        if run:
+            # we should see TEST_S3_RETRY error in the logs
+            # when --datastore=s3
+            checker.assert_log('start',
+                               'stderr',
+                               'TEST_S3_RETRY',
+                               exact_match=False)
+        run_id = 'S3FailureTestFlow/%s' % checker.run_id
+        checker.assert_artifact('start', 'x', run_id)
+        checker.assert_artifact('end', 'x', run_id)


### PR DESCRIPTION
Uploads were not retried correctly since the buffer status was
not reset after the first attempt which led to an "IO on closed file"
error or an empty file being written to S3

Supersedes #234 