### PR TITLE
Revert "Conda environment now returns the information from the default environment (#291)"

### DIFF
--- a/metaflow/plugins/conda/conda_environment.py
+++ b/metaflow/plugins/conda/conda_environment.py
@@ -99,12 +99,3 @@ class CondaEnvironment(MetaflowEnvironment):
             'explicit': info[env_id]['explicit'],
             'deps': info[env_id]['deps']}
         return new_info
-
-    def get_environment_info(self):
-        # We want to simply wrap the default environment, not necessarily the base class
-        # environment so we specifically call that one
-        from ...plugins import ENVIRONMENTS
-        from metaflow.metaflow_config import DEFAULT_ENVIRONMENT
-        base_env = [e for e in ENVIRONMENTS + [MetaflowEnvironment]
-            if e.TYPE == DEFAULT_ENVIRONMENT][0](self.flow)
-        return base_env.get_environment_info()


### PR DESCRIPTION
This reverts commit 1c0f4bd03581ea57e6b994ff382e59901f49d139.

The commit was initially dependent on another commit which has not yet been merged. We will re-push this commit once the other commit has also been merged.