### PR TITLE
add conda bin path to PATH env variable

### DIFF
--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -230,6 +230,12 @@ class CondaStepDecorator(StepDecorator):
             python_path = self.metaflow_home
             if os.environ.get('PYTHONPATH') is not None:
                 python_path = os.pathsep.join([os.environ['PYTHONPATH'], python_path])
+
+            env_path = os.path.dirname(self.conda.python(self.env_id))
+            if os.environ.get('PATH') is not None:
+                env_path = os.pathsep.join([env_path, os.environ['PATH']])
+            
+            cli_args.env['PATH'] = env_path
             cli_args.env['PYTHONPATH'] = python_path
             cli_args.env['_METAFLOW_CONDA_ENV'] = self.env_id
             cli_args.entrypoint[0] = self.conda.python(self.env_id)


### PR DESCRIPTION
add conda bin path to PATH environment variable so that we can use binaries installed by conda directly in the steps. 