### PR TITLE
Set minimum version of digest dependency to 0.6.19

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     magrittr,
     R6,
     reticulate (>= 1.10),
-    digest
+    digest (>= 0.6.19)
 Suggests:
     cli,
     lubridate,

--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     magrittr,
     R6,
     reticulate (>= 1.10),
-    digest (>= 0.6.19)
+    digest (>= 0.4.0)
 Suggests:
     cli,
     lubridate,

--- a/R/R/step.R
+++ b/R/R/step.R
@@ -31,9 +31,12 @@ step <- function(flow, ..., step, r_function = NULL, foreach = NULL, join = FALS
   }
   if (!is.null(r_function)) {
     function_name <- as.character(substitute(r_function))
-    function_hash <- digest::digest(deparse(r_function), algo = "sha256")
-    trunc_function_hash <- substr(function_hash, 1, 16)
-    if (length(function_name) > 1) { # likely an anonymous function
+    # If r_function is anonymous then function_name will be a vector of its
+    # components. In this case we give the function a pseudonym prefixed by the
+    # step name and suffixed with a hash of the function.
+    if (length(function_name) > 1) { 
+      function_hash <- digest::digest(deparse(r_function), algo = "sha256")
+      trunc_function_hash <- substr(function_hash, 1, 16)
       function_name <- paste(step, "function", trunc_function_hash, sep = "_")
     }
     body(r_function) <- wrap_function(r_function)

--- a/R/R/step.R
+++ b/R/R/step.R
@@ -31,9 +31,10 @@ step <- function(flow, ..., step, r_function = NULL, foreach = NULL, join = FALS
   }
   if (!is.null(r_function)) {
     function_name <- as.character(substitute(r_function))
-    function_hash <- digest::digest(deparse(r_function), algo = "spookyhash")
+    function_hash <- digest::digest(deparse(r_function), algo = "sha256")
+    trunc_function_hash <- substr(function_hash, 1, 16)
     if (length(function_name) > 1) { # likely an anonymous function
-      function_name <- paste(step, "function", function_hash, sep = "_")
+      function_name <- paste(step, "function", trunc_function_hash, sep = "_")
     }
     body(r_function) <- wrap_function(r_function)
     if (join) {

--- a/R/tests/testthat/test-step.R
+++ b/R/tests/testthat/test-step.R
@@ -93,7 +93,7 @@ test_that("we can define a step with an anonymous function", {
       step = "anonymous",
       r_function = function(step) step$x <- 3 
     )
-  expected_function_name <- "anonymous_function_7542958bbcd6fa74bdf17e888b956426"
+  expected_function_name <- "anonymous_function_616fb45ef54cbfa9"
   functions <- flow$get_functions()
   expect_true(expected_function_name %in% names(functions))
 })


### PR DESCRIPTION
Addresses issue #313.

Version 0.6.19 (2019-05-20) of the `digest` package was the earliest to support the `spookyhash` algorithm.