### PR TITLE
fixing a bug for parsing --authorize in R SFN

### DIFF
--- a/R/R/flags.R
+++ b/R/R/flags.R
@@ -146,7 +146,7 @@ split_parameters <- function(flags) {
     "my_runs", "run_id", 
     "origin_run_id", "with", "tag",
     # step-functions subcommands and options
-    "authorize", "step_functions", 
+    "step_functions", 
     "only_json", "generate_new_token",
     "running", "succeeded", "failed", 
     "timed_out", "aborted", "namespace",

--- a/R/R/run.R
+++ b/R/R/run.R
@@ -92,7 +92,8 @@ run_cmd <- function(flow_file, ...) {
 
   if ("step_functions" %in% names(flags)) {
     sfn_cmd <- paste("step-functions", flags$step_functions)
-    for (subcommand in c("authorize", "generate_new_token", 
+    # subcommands without an argument
+    for (subcommand in c("generate_new_token", 
                          "only_json", "running", "succeeded", 
                          "failed", "timed_out", "aborted")){
       if (subcommand %in% names(flags)){
@@ -101,7 +102,8 @@ run_cmd <- function(flow_file, ...) {
       }
     }
 
-    for (subcommand in c("new_token", "tag", "namespace", 
+    # subcommands following an argument
+    for (subcommand in c("authorize", "new_token", "tag", "namespace", 
                          "max_workers", "workflow_timeout")){
       if (subcommand %in% names(flags)){
         subcommand_valid <- gsub("_", "-", subcommand)


### PR DESCRIPTION
Fixing a bug where we treated `--authorize` as an option without argument and failed to parse the token argument.