### PR TITLE
fix an issue with aws region check in dynamodb client

### DIFF
--- a/metaflow/plugins/aws/step_functions/dynamo_db_client.py
+++ b/metaflow/plugins/aws/step_functions/dynamo_db_client.py
@@ -1,7 +1,4 @@
-import json
-import os
 import requests
-
 from metaflow.metaflow_config import SFN_DYNAMO_DB_TABLE
 
 
@@ -66,16 +63,13 @@ class DynamoDbClient(object):
         return response['Item']['parent_task_ids_for_foreach_join']['SS']
 
     def _get_instance_region(self):
-        try:
-            r = requests.post(
-                url = "http://169.254.169.254/latest/meta-data/placement/availability-zone/"
-            )
-            if r.status_code != 200:
-                raise RuntimeError("Failed to query AWS region from " +
+        r = requests.get(
+            url = "http://169.254.169.254/latest/meta-data/placement/availability-zone/"
+        )
+
+        if r.status_code != 200:
+            raise RuntimeError("Failed to query AWS region from " +
                         "http://169.254.169.254/latest/meta-data/placement/availability-zone/\n" +
                         "Error code: " + str(r.status_code))
-            return r.text[:-1]
-        except Exception as e:
-            print(repr(e))
-            raise RuntimeError("Failed to query AWS region from " +
-                        "http://169.254.169.254/latest/meta-data/placement/availability-zone/")
+
+        return r.text[:-1]

--- a/metaflow/plugins/aws/step_functions/dynamo_db_client.py
+++ b/metaflow/plugins/aws/step_functions/dynamo_db_client.py
@@ -63,13 +63,13 @@ class DynamoDbClient(object):
         return response['Item']['parent_task_ids_for_foreach_join']['SS']
 
     def _get_instance_region(self):
+        metadata_url = "http://169.254.169.254/latest/meta-data/placement/availability-zone/"
         r = requests.get(
-            url = "http://169.254.169.254/latest/meta-data/placement/availability-zone/"
+            url = metadata_url
         )
 
         if r.status_code != 200:
-            raise RuntimeError("Failed to query AWS region from " +
-                        "http://169.254.169.254/latest/meta-data/placement/availability-zone/\n" +
-                        "Error code: " + str(r.status_code))
+            raise RuntimeError("Failed to query instance metadata. Url [%s]" % metadata_url +
+                        " Error code [%s]" % str(r.status_code))
 
         return r.text[:-1]


### PR DESCRIPTION
Replace the `curl` function call with requests in case `curl` does not exist in a custom image.