### PR TITLE
Fix issue with IncludeFile caused in 2.1.0

### DIFF
--- a/metaflow/includefile.py
+++ b/metaflow/includefile.py
@@ -11,10 +11,11 @@ from shutil import move
 
 import click
 
+from . import parameters
 from .datastore.datastore import TransformableObject
 from .exception import MetaflowException
 from .metaflow_config import DATATOOLS_LOCALROOT, DATATOOLS_SUFFIX
-from .parameters import context_proto, DeployTimeField, Parameter
+from .parameters import DeployTimeField, Parameter
 from .util import to_unicode
 
 try:
@@ -226,8 +227,8 @@ class FilePathClass(click.ParamType):
             self.fail(err)
         if file_type is None:
             # Here, we need to store the file
-            param_ctx = context_proto._replace(parameter_name=self.parameter_name)
-            return LocalFile(self._is_text, self._encoding, value)(param_ctx)
+            return LocalFile(
+                self._is_text, self._encoding, value)(parameters.context_proto)
         else:
             # We will just store the URL in the datastore along with text/encoding info
             return Uploader.encode_url(

--- a/test/core/metaflow_test/__init__.py
+++ b/test/core/metaflow_test/__init__.py
@@ -93,7 +93,7 @@ class MetaflowCheck(object):
     def cli_options(self):
         return sys.argv[3:]
 
-    def assert_artifact(step, name, value):
+    def assert_artifact(step, name, value, fields=None):
         raise NotImplementedError()
 
     def artifact_dict(step, name):

--- a/test/core/metaflow_test/__init__.py
+++ b/test/core/metaflow_test/__init__.py
@@ -72,6 +72,7 @@ def assert_exception(func, exception):
 class MetaflowTest(object):
     PRIORITY = 999999999
     PARAMETERS = {}
+    INCLUDE_FILES = {}
     HEADER = ""
 
     def check_results(self, flow, checker):

--- a/test/core/metaflow_test/formatter.py
+++ b/test/core/metaflow_test/formatter.py
@@ -78,7 +78,7 @@ class FlowFormatter(object):
             tags.extend(tag.split('(')[0] for tag in step.tags)
 
         yield 0, '# -*- coding: utf-8 -*-'
-        yield 0, 'from metaflow import FlowSpec, step, Parameter, JSONType'
+        yield 0, 'from metaflow import FlowSpec, step, Parameter, IncludeFile, JSONType'
         yield 0, 'from metaflow_test import assert_equals, '\
                                            'assert_exception, '\
                                            'ExpectationFailed, '\
@@ -94,6 +94,10 @@ class FlowFormatter(object):
         for var, parameter in self.test.PARAMETERS.items():
             kwargs = ['%s=%s' % (k, v) for k, v in parameter.items()]
             yield 1, '%s = Parameter("%s", %s)' % (var, var, ','.join(kwargs))
+
+        for var, include in self.test.INCLUDE_FILES.items():
+            kwargs = ['%s=%s' % (k, v) for k, v in include.items()]
+            yield 1, '%s = IncludeFile("%s", %s)' % (var, var, ','.join(kwargs))
 
         for name, node in self.graphspec['graph'].items():
             step = self._choose_step(name, node)

--- a/test/core/tests/basic_include.py
+++ b/test/core/tests/basic_include.py
@@ -1,0 +1,70 @@
+from metaflow_test import MetaflowTest, ExpectationFailed, steps
+
+
+class BasicIncludeTest(MetaflowTest):
+    PRIORITY = 1
+    INCLUDE_FILES = {
+        'myfile_txt': {'default': "'./reg.txt'"},
+        'myfile_utf8': {'default': "'./utf8.txt'", 'encoding': "'utf8'"},
+        'myfile_binary': {'default': "'./utf8.txt'", 'is_text': False},
+        'myfile_overriden': {'default': "'./reg.txt'"}
+    }
+    HEADER = """
+import codecs
+import os
+os.environ['METAFLOW_RUN_MYFILE_OVERRIDEN'] = './override.txt'
+
+with open('reg.txt', mode='w') as f:
+    f.write("Regular Text File")
+with codecs.open('utf8.txt', mode='w', encoding='utf8') as f:
+    f.write(u"UTF Text File \u5e74")
+with open('override.txt', mode='w') as f:
+    f.write("Override Text File")
+"""
+
+    @steps(0, ['all'])
+    def step_all(self):
+        assert_equals("Regular Text File", self.myfile_txt)
+        assert_equals(u"UTF Text File \u5e74", self.myfile_utf8)
+        assert_equals(
+            u"UTF Text File \u5e74".encode(encoding='utf8'), self.myfile_binary)
+        assert_equals("Override Text File", self.myfile_overriden)
+
+        try:
+            # Include files should be immutable
+            self.myfile_txt = 5
+            raise ExpectationFailed(AttributeError, 'nothing')
+        except AttributeError:
+            pass
+
+    def check_results(self, flow, checker):
+        for step in flow:
+            checker.assert_artifact(
+                step.name,
+                'myfile_txt',
+                None,
+                fields={'type': 'uploader-v1',
+                        'is_text': True,
+                        'encoding': None})
+            checker.assert_artifact(
+                step.name,
+                'myfile_utf8',
+                None,
+                fields={'type': 'uploader-v1',
+                        'is_text': True,
+                        'encoding': 'utf8'})
+            checker.assert_artifact(
+                step.name,
+                'myfile_binary',
+                None,
+                fields={'type': 'uploader-v1',
+                        'is_text': False,
+                        'encoding': None})
+            checker.assert_artifact(
+                step.name,
+                'myfile_overriden',
+                None,
+                fields={'type': 'uploader-v1',
+                        'is_text': True,
+                        'encoding': None})
+


### PR DESCRIPTION
In some cases, overriding the default IncludeFile value would cause a crash.
This fixes this issue and adds tests to test this condition