### PR TITLE
Dereference symlinks when packaging

### DIFF
--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -96,7 +96,7 @@ class MetaflowPackage(object):
             return tarinfo
 
         buf = BytesIO()
-        with tarfile.TarFile(fileobj=buf, mode='w') as tar:
+        with tarfile.TarFile(fileobj=buf, mode='w', dereference=True) as tar:
             self._add_info(tar)
             for path, arcname in self.path_tuples():
                 tar.add(path, arcname=arcname,


### PR DESCRIPTION
As a user of metaflow, I would like to share external libraries among flows in different folders without code duplication. 

symlinks provide a solution but not when packaging and running --with batch, because the TarFile are keeping the symlinks as such instead of dereferencing when packaging.