### PR TITLE
Follow symlinks when packaging

### DIFF
--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -37,7 +37,7 @@ class MetaflowPackage(object):
     def _walk(self, root, exclude_hidden=True):
         root = to_unicode(root)  # handle files/folder with non ascii chars
         prefixlen = len('%s/' % os.path.dirname(root))
-        for path, dirs, files in os.walk(root):
+        for path, dirs, files in os.walk(root, followlinks=True):
             if exclude_hidden and '/.' in path:
                 continue
             # path = path[2:] # strip the ./ prefix


### PR DESCRIPTION
As a user of metaflow, I would like to share external libraries among flows in different folders without code duplication.

symlinks to package folders provide a solution but not when packaging and running --with batch, because the os.walk is not following symlinks when packaging.