### PR TITLE
Allow users to prefix SFN state machines outside Metaflow sandbox.

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -120,7 +120,7 @@ SFN_DYNAMO_DB_TABLE = from_conf("METAFLOW_SFN_DYNAMO_DB_TABLE")
 EVENTS_SFN_ACCESS_IAM_ROLE = from_conf("METAFLOW_EVENTS_SFN_ACCESS_IAM_ROLE")
 # Prefix for AWS Step Functions state machines. Set to stack name for Metaflow
 # sandbox.
-SFN_STATE_MACHINE_PREFIX = None
+SFN_STATE_MACHINE_PREFIX = from_conf("METAFLOW_SFN_STATE_MACHINE_PREFIX")
 
 ###
 # Conda configuration


### PR DESCRIPTION
This PR addresses #372 and modifies the Metaflow environment variable config to allow users to prefix Step Function state machines outside of the Metaflow AWS sandbox. It adds a new environment variable `METAFLOW_SFN_STATE_MACHINE_PREFIX` that controls this behavior but does not modify existing behavior when running in the Metaflow AWS sandbox.