### PR TITLE
AWS Fargate support for AWS Batch

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -97,6 +97,8 @@ if METADATA_SERVICE_AUTH_KEY is not None:
 # IAM role for AWS Batch container with Amazon S3 access 
 # (and AWS DynamoDb access for AWS StepFunctions, if enabled)
 ECS_S3_ACCESS_IAM_ROLE = from_conf('METAFLOW_ECS_S3_ACCESS_IAM_ROLE')
+# IAM role for AWS Batch container for AWS Fargate
+ECS_FARGATE_EXECUTION_ROLE = from_conf('METAFLOW_ECS_FARGATE_EXECUTION_ROLE')
 # Job queue for AWS Batch
 BATCH_JOB_QUEUE = from_conf('METAFLOW_BATCH_JOB_QUEUE')
 # Default container image for AWS Batch

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -113,6 +113,7 @@ class Batch(object):
         image,
         queue,
         iam_role=None,
+        execution_role=None,
         cpu=None,
         gpu=None,
         memory=None,
@@ -137,7 +138,8 @@ class Batch(object):
                               self.environment, step_name, [step_cli])) \
             .image(image) \
             .iam_role(iam_role) \
-            .job_def(image, iam_role) \
+            .execution_role(execution_role) \
+            .job_def(image, iam_role, queue, execution_role) \
             .cpu(cpu) \
             .gpu(gpu) \
             .memory(memory) \
@@ -174,9 +176,11 @@ class Batch(object):
         image,
         queue,
         iam_role=None,
+        execution_role=None, # for FARGATE compatibility
         cpu=None,
         gpu=None,
         memory=None,
+        platform=None,
         run_time_limit=None,
         env={},
         attrs={},
@@ -197,6 +201,7 @@ class Batch(object):
                         image,
                         queue,
                         iam_role,
+                        execution_role,
                         cpu,
                         gpu,
                         memory,

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -134,7 +134,10 @@ def kill(ctx, run_id, user, my_runs):
     "--image", help="Docker image requirement for AWS Batch. In name:version format."
 )
 @click.option(
-    "--iam_role", help="IAM role requirement for AWS Batch"
+    "--iam_role", help="IAM role requirement for AWS Batch."
+)
+@click.option(
+    "--execution_role", help="Execution role requirement for AWS Batch on Fargate."
 )
 @click.option("--cpu", help="CPU requirement for AWS Batch.")
 @click.option("--gpu", help="GPU requirement for AWS Batch.")
@@ -168,6 +171,7 @@ def step(
     executable=None,
     image=None,
     iam_role=None,
+    execution_role=None,
     cpu=None,
     gpu=None,
     memory=None,
@@ -258,6 +262,7 @@ def step(
                 image=image,
                 queue=queue,
                 iam_role=iam_role,
+                execution_role=execution_role,
                 cpu=cpu,
                 gpu=gpu,
                 memory=memory,

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -136,6 +136,8 @@ class BatchJob(object):
             job_definition['containerProperties']['executionRoleArn'] = \
                 execution_role
             job_definition['platformCapabilities'] = [platform]
+            job_definition['containerProperties']['networkConfiguration'] = \
+                {'assignPublicIp': 'ENABLED'}
         
         # check if job definition already exists
         def_name = 'metaflow_%s' % \

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -135,7 +135,7 @@ class BatchJob(object):
                     'environment variable.')
             job_definition['containerProperties']['executionRoleArn'] = \
                 execution_role
-            job_definition['platformCapabilities'] = [platform]
+            job_definition['platformCapabilities'] = ['FARGATE']
             job_definition['containerProperties']['networkConfiguration'] = \
                 {'assignPublicIp': 'ENABLED'}
         

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -126,7 +126,7 @@ class BatchJob(object):
                 ]
             }
         }
-        if platform == 'FARGATE':
+        if platform == 'FARGATE' or platform == 'FARGATE_SPOT':
             if execution_role is None:
                 raise BatchJobException(
                     'No AWS Fargate task execution IAM role found. Please see '
@@ -153,7 +153,7 @@ class BatchJob(object):
             response = self._client.register_job_definition(**job_definition)
         except Exception as ex:
             if type(ex).__name__ == 'ParamValidationError' and \
-                    platform == 'FARGATE':
+                    (platform == 'FARGATE' or platform == 'FARGATE_SPOT'):
                 raise BatchJobException(
                     '%s \nPlease ensure you have installed boto3>=1.16.29 if '
                     'you intend to launch AWS Batch jobs on AWS Fargate '

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -39,10 +39,15 @@ class BatchClient(object):
             for job in page['jobSummaryList']
         )
 
-    def describe_jobs(self, jobIds):
-        for jobIds in [jobIds[i:i+100] for i in range(0, len(jobIds), 100)]:
+    def describe_jobs(self, job_ids):
+        for jobIds in [job_ids[i:i+100] for i in range(0, len(job_ids), 100)]:
             for jobs in self._client.describe_jobs(jobs=jobIds)['jobs']:
                 yield jobs
+
+    def describe_job_queue(self, job_queue):
+        paginator = self._client.get_paginator('describe_job_queues').paginate(
+            jobQueues=[job_queue], maxResults=1)
+        return paginator.paginate()['jobQueues'][0] 
 
     def job(self):
         return BatchJob(self._client)
@@ -76,35 +81,81 @@ class BatchJob(object):
             )
         if 'jobDefinition' not in self.payload:
             self.payload['jobDefinition'] = \
-                self._register_job_definition(self._image, self._iam_role)
+                self._register_job_definition(self._image,
+                                              self._iam_role,
+                                              self.payload['job_queue'],
+                                              self._execution_role)
         response = self._client.submit_job(**self.payload)
         job = RunningJob(response['jobId'], self._client)
         return job.update()
 
-    def _register_job_definition(self, image, job_role):
-        def_name = 'metaflow_%s' % \
-            hashlib.sha224((image + job_role).encode('utf-8')).hexdigest()
-        payload = {'jobDefinitionName': def_name, 'status': 'ACTIVE'}
-        response = self._client.describe_job_definitions(**payload)
-        if len(response['jobDefinitions']) > 0:
-            return response['jobDefinitions'][0]['jobDefinitionArn']
-        payload = {
-            'jobDefinitionName': def_name,
+    def _register_job_definition(self,
+                                 image,
+                                 job_role,
+                                 job_queue,
+                                 execution_role):
+        # identify platform from any compute environment associated with the
+        # queue
+        response = self._client.describe_job_queues(jobQueues=[job_queue])
+        if len(response['jobQueues']) == 0:
+            raise BatchJobException('Job queue %s found.' % job_queue)
+        compute_environment = response['jobQueues'][0] \
+                                ['computeEnvironmentOrder'][0] \
+                                ['computeEnvironment']
+        response = self._client.describe_compute_environments(
+            computeEnvironments=[compute_environment])
+        platform = response['computeEnvironments'][0] \
+                        ['computeResources']['type']
+
+        # compose job definition
+        job_definition = {
             'type': 'container',
             'containerProperties': {
                 'image': image,
                 'jobRoleArn': job_role,
                 'command': ['echo', 'hello world'],
-                'memory': 4000,
-                'vcpus': 1,
-            },
+                'resourceRequirements': [
+                    {
+                        'value': '1',
+                        'type': 'VCPU'
+                    },
+                    {
+                        'value': '4096',
+                        'type': 'MEMORY'
+                    }
+                ]
+            }
         }
-        response = self._client.register_job_definition(**payload)
+        if platform == 'FARGATE':
+            if execution_role is None:
+                raise BatchJobException(
+                    'No AWS Fargate task execution IAM role found. Please see '
+                    'https://docs.aws.amazon.com/batch/latest/userguide/execution-IAM-role.html '
+                    'and set the role as METAFLOW_ECS_FARGATE_EXECUTION_ROLE '
+                    'environment variable.')
+            job_definition['containerProperties']['executionRoleArn'] = \
+                execution_role
+            job_definition['platformCapabilities'] = [platform]
+        
+        # check if job definition already exists
+        def_name = 'metaflow23_%s' % \
+            hashlib.sha224(str(job_definition).encode('utf-8')).hexdigest()
+        payload = {'jobDefinitionName': def_name, 'status': 'ACTIVE'}
+        response = self._client.describe_job_definitions(**payload)
+        if len(response['jobDefinitions']) > 0:
+            return response['jobDefinitions'][0]['jobDefinitionArn']
+
+        # else create a job definition
+        job_definition['jobDefinitionName'] = def_name
+        response = self._client.register_job_definition(**job_definition)
         return response['jobDefinitionArn']
 
-    def job_def(self, image, iam_role):
+    def job_def(self, image, iam_role, job_queue, execution_role):
         self.payload['jobDefinition'] = \
-            self._register_job_definition(image, iam_role)
+            self._register_job_definition(image,
+                                          iam_role,
+                                          job_queue,
+                                          execution_role)
         return self
 
     def job_name(self, job_name):
@@ -123,6 +174,10 @@ class BatchJob(object):
         self._iam_role = iam_role
         return self
 
+    def execution_role(self, execution_role):
+        self._execution_role = execution_role
+        return self
+
     def command(self, command):
         if 'command' not in self.payload['containerOverrides']:
             self.payload['containerOverrides']['command'] = []
@@ -133,14 +188,22 @@ class BatchJob(object):
         if not (isinstance(cpu, (int, unicode, basestring)) and int(cpu) > 0):
             raise BatchJobException(
                 'Invalid CPU value ({}); it should be greater than 0'.format(cpu))
-        self.payload['containerOverrides']['vcpus'] = int(cpu)
+        if 'resourceRequirements' not in self.payload['containerOverrides']:
+            self.payload['containerOverrides']['resourceRequirements'] = []
+        self.payload['containerOverrides']['resourceRequirements'].append(
+            {'value' : str(cpu), 'type': 'VCPU'}
+        )
         return self
 
     def memory(self, mem):
         if not (isinstance(mem, (int, unicode, basestring)) and int(mem) > 0):
             raise BatchJobException(
                 'Invalid memory value ({}); it should be greater than 0'.format(mem))
-        self.payload['containerOverrides']['memory'] = int(mem)
+        if 'resourceRequirements' not in self.payload['containerOverrides']:
+            self.payload['containerOverrides']['resourceRequirements'] = []
+        self.payload['containerOverrides']['resourceRequirements'].append(
+            {'value' : str(mem), 'type': 'MEMORY'}
+        )
         return self
 
     def gpu(self, gpu):

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -12,6 +12,7 @@ except NameError:
     basestring = str
 
 from metaflow.exception import MetaflowException
+from metaflow.metaflow_config import AWS_SANDBOX_ENABLED
 
 class BatchClient(object):
     def __init__(self):
@@ -96,16 +97,22 @@ class BatchJob(object):
                                  execution_role):
         # identify platform from any compute environment associated with the
         # queue
-        response = self._client.describe_job_queues(jobQueues=[job_queue])
-        if len(response['jobQueues']) == 0:
-            raise BatchJobException('Job queue %s found.' % job_queue)
-        compute_environment = response['jobQueues'][0] \
-                                ['computeEnvironmentOrder'][0] \
-                                ['computeEnvironment']
-        response = self._client.describe_compute_environments(
-            computeEnvironments=[compute_environment])
-        platform = response['computeEnvironments'][0] \
-                        ['computeResources']['type']
+        if AWS_SANDBOX_ENABLED:
+            # within the Metaflow sandbox, we can't execute the
+            # describe_job_queues directive for AWS Batch to detect compute
+            # environment platform, so let's just default to EC2 for now.
+            platform = "EC2"
+        else:
+            response = self._client.describe_job_queues(jobQueues=[job_queue])
+            if len(response['jobQueues']) == 0:
+                raise BatchJobException('Job queue %s found.' % job_queue)
+            compute_environment = response['jobQueues'][0] \
+                                    ['computeEnvironmentOrder'][0] \
+                                    ['computeEnvironment']
+            response = self._client.describe_compute_environments(
+                computeEnvironments=[compute_environment])
+            platform = response['computeEnvironments'][0] \
+                            ['computeResources']['type']
 
         # compose job definition
         job_definition = {

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -197,7 +197,7 @@ class BatchJob(object):
         return self
 
     def cpu(self, cpu):
-        if not (isinstance(cpu, (int, unicode, basestring)) and int(cpu) > 0):
+        if not (isinstance(cpu, (int, unicode, basestring, float)) and float(cpu) > 0):
             raise BatchJobException(
                 'Invalid CPU value ({}); it should be greater than 0'.format(cpu))
         if 'resourceRequirements' not in self.payload['containerOverrides']:

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -17,7 +17,8 @@ from metaflow import R
 
 from .batch import Batch, BatchException
 from metaflow.metaflow_config import ECS_S3_ACCESS_IAM_ROLE, BATCH_JOB_QUEUE, \
-                    BATCH_CONTAINER_IMAGE, BATCH_CONTAINER_REGISTRY
+                    BATCH_CONTAINER_IMAGE, BATCH_CONTAINER_REGISTRY, \
+                    ECS_FARGATE_EXECUTION_ROLE
 
 try:
     # python2
@@ -53,7 +54,7 @@ class ResourcesDecorator(StepDecorator):
     defaults = {
         'cpu': '1',
         'gpu': '0',
-        'memory': '4000',
+        'memory': '4096',
     }
 
 class BatchDecorator(StepDecorator):
@@ -82,23 +83,27 @@ class BatchDecorator(StepDecorator):
         Memory size (in MB) required for this step. Defaults to 4000. If @resources is
         also present, the maximum value from all decorators is used
     image : string
-        Image to use when launching on Batch. If not specified, a default image mapping to
+        Image to use when launching on AWS Batch. If not specified, a default image mapping to
         the current version of Python is used
     queue : string
         Queue to submit the job to. Defaults to the one determined by the environment variable
         METAFLOW_BATCH_JOB_QUEUE
     iam_role : string
-        IAM role that Batch can use to access S3. Defaults to the one determined by the environment
+        IAM role that AWS Batch can use to access Amazon S3. Defaults to the one determined by the environment
         variable METAFLOW_ECS_S3_ACCESS_IAM_ROLE
+    execution_role : string
+        IAM role that AWS Batch can use to trigger AWS Fargate tasks. Defaults to the one determined by the environment
+        variable METAFLOW_ECS_FARGATE_EXECUTION_ROLE https://docs.aws.amazon.com/batch/latest/userguide/execution-IAM-role.html
     """
     name = 'batch'
     defaults = {
         'cpu': '1',
         'gpu': '0',
-        'memory': '4000',
+        'memory': '4096',
         'image': None,
         'queue': BATCH_JOB_QUEUE,
-        'iam_role': ECS_S3_ACCESS_IAM_ROLE
+        'iam_role': ECS_S3_ACCESS_IAM_ROLE,
+        'execution_role': ECS_FARGATE_EXECUTION_ROLE
     }
     package_url = None
     package_sha = None

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -575,6 +575,7 @@ class StepFunctions(object):
                         image=resources['image'],
                         queue=resources['queue'],
                         iam_role=resources['iam_role'],
+                        execution_role=resources['execution_role'],
                         cpu=resources['cpu'],
                         gpu=resources['gpu'],
                         memory=resources['memory'],


### PR DESCRIPTION
Introduces support for executing AWS Batch tasks on top of AWS Fargate
compute platform.

1. Add a new environment variable - METAFLOW_ECS_FARGATE_EXECUTION_ROLE
to track ecsTaskExecutionRole for the Batch container and Fargate agent.
Can also be specified by the `execution-role` attribute in `@batch`.
2. Auto-detects the platform type from the assigned job queue to the step
3. Works with AWS Step Functions as well as local execution.