### PR TITLE
Support very wide workflows in AWS Step Functions

### DIFF
--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -1,6 +1,7 @@
 import os
 from collections import defaultdict
 import sys
+import hashlib
 import json
 import time
 import string
@@ -217,7 +218,9 @@ class StepFunctions(object):
             # Create a `Parallel` state and assign sub workflows if the node
             # branches out.
             elif node.type == 'split-and':
-                branch_name = '&'.join(node.out_funcs)
+                branch_name = hashlib.sha224('&'.join(node.out_funcs) \
+                                     .encode('utf-8')) \
+                                     .hexdigest()
                 workflow.add_state(state.next(branch_name))
                 branch = Parallel(branch_name) \
                             .next(node.matching_join)


### PR DESCRIPTION
Very wide workflows - `split-and` might cause issues with
AWS Step Functions because of the limitation imposed on step
name size. Changing the step name for a `Parallel` task type
in AWS Step Functions to a hashed value buys us a lot of
flexibility. This is not a user-visible change since the Parallel
step is an implementation detail of the Metaflow -> SFN compilation
process