### PR TITLE
Support step-functions --with ... cli format

### DIFF
--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -9,7 +9,6 @@ from metaflow.datastore.datastore import TransformableObject
 from metaflow.package import MetaflowPackage
 from metaflow.plugins import BatchDecorator
 from metaflow.util import get_username
-from metaflow.graph import FlowGraph
 
 from .step_functions import StepFunctions
 from .production_token import load_token, store_token, new_token
@@ -172,7 +171,6 @@ def make_flow(obj,
 
     # Attach AWS Batch decorator to the flow
     decorators._attach_decorators(obj.flow, [BatchDecorator.name])
-    obj.graph = FlowGraph(obj.flow.__class__)
     decorators._init_step_decorators(
             obj.flow, obj.graph, obj.environment, obj.datastore, obj.logger)
 

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -9,6 +9,7 @@ from metaflow.datastore.datastore import TransformableObject
 from metaflow.package import MetaflowPackage
 from metaflow.plugins import BatchDecorator
 from metaflow.util import get_username
+from metaflow.graph import FlowGraph
 
 from .step_functions import StepFunctions
 from .production_token import load_token, store_token, new_token
@@ -72,6 +73,12 @@ def step_functions(obj):
               default=None,
               type=int,
               help="Workflow timeout in seconds.")
+@click.option('--with',
+              'decospecs',
+              multiple=True,
+              help="Add a decorator to all steps. You can specify this "
+                   "option multiple times to attach multiple decorators "
+                   "in steps.")
 @click.pass_obj
 def create(obj,
            tags=None,
@@ -81,7 +88,8 @@ def create(obj,
            generate_new_token=False,
            given_token=None,
            max_workers=None,
-           workflow_timeout=None):
+           workflow_timeout=None,
+           decospecs=None):
     name = state_machine_name(current.flow_name)
     obj.echo("Deploying *%s* to AWS Step Functions..." % name, bold=True)
 
@@ -100,7 +108,8 @@ def create(obj,
                      tags,
                      user_namespace,
                      max_workers,
-                     workflow_timeout)
+                     workflow_timeout,
+                     decospecs)
 
     if only_json:
         obj.echo_always(flow.to_json(), err=False, no_bold=True)
@@ -148,7 +157,8 @@ def make_flow(obj,
               tags,
               namespace,
               max_workers,
-              workflow_timeout):
+              workflow_timeout,
+              decospecs):
     datastore = obj.datastore(obj.flow.name,
                               mode='w',
                               metadata=obj.metadata,
@@ -157,8 +167,12 @@ def make_flow(obj,
     if datastore.TYPE != 's3':
         raise MetaflowException("AWS Step Functions requires --datastore=s3.")
 
+    
+    if decospecs:
+        decorators._attach_decorators(obj.flow, decospecs)
     # Attach AWS Batch decorator to the flow
     decorators._attach_decorators(obj.flow, [BatchDecorator.name])
+    obj.graph = FlowGraph(obj.flow.__class__)
     decorators._init_step_decorators(
             obj.flow, obj.graph, obj.environment, obj.datastore, obj.logger)
 

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -166,10 +166,10 @@ def make_flow(obj,
                               monitor=obj.monitor)
     if datastore.TYPE != 's3':
         raise MetaflowException("AWS Step Functions requires --datastore=s3.")
-
     
     if decospecs:
         decorators._attach_decorators(obj.flow, decospecs)
+
     # Attach AWS Batch decorator to the flow
     decorators._attach_decorators(obj.flow, [BatchDecorator.name])
     obj.graph = FlowGraph(obj.flow.__class__)


### PR DESCRIPTION
Currently, CLI decorators can only be specified as `python flow.py --with blah step-functions create` which isn't very natural. This change allows for the following specification as well - `python flow.py step-functions create --with retry:times=3` and brings it in line with how `run` behaves