### PR TITLE
Throw an exception if invalid tags are input

### DIFF
--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -646,6 +646,12 @@ class StepFunctions(object):
                  '--task-id %s' % task_id_params]
             # Assign tags to run objects.
             if self.tags:
+                import shlex
+                invalid_tags = [tag for tag in self.tags if shlex.quote(tag) != tag]
+                if invalid_tags:
+                    raise MetaflowException("Step functions doesn't support "\
+                                            "tags with special characters "\
+                                            "currently: %s" % invalid_tags[0])
                 params.extend('--tag %s' % tag for tag in self.tags)
 
             # If the start step gets retried, we must be careful not to 


### PR DESCRIPTION
We will probably not be able to pass tags with special characters in them easily via CLI, so this is a safety guard for that:
E.g: '!,a,list of,#tags,with,,special:characters or "ravi's"