### PR TITLE
Flush file in FileCache to fix issue where it would see an empty file

### DIFF
--- a/metaflow/client/filecache.py
+++ b/metaflow/client/filecache.py
@@ -128,6 +128,7 @@ class FileCache(object):
 
             try:
                 tmpfile.write(load_func(ds))
+                tmpfile.flush()
                 os.rename(tmpfile.name, path)
             except:  # noqa E722
                 os.unlink(tmpfile.name)


### PR DESCRIPTION
Hello, I think there's a race condition in FileCache which can cause `get_data` to return an empty file when running in local mode. The data gets written to `tmpfile` and then renamed, but isn't necessarily flushed to disk at that point (probably not until it goes out of scope at the end of the function). So another process running ever so slightly later (in my case, due to a foreach step) sees the properly named file (since they're both on the same computer sharing that data directory) which allows it to leapfrog ahead of the other process that created the so-far empty file and access it before there's any data in the file. It happens to me when looking up successful runs of other flows inside of a foreach step that's running on a single computer. Here's what the exception looked like:
```
File "/REMOVED.py", line 6, in latest_successful_run_by_tag
2021-01-27 20:37:16.718 [86/x_partition/2421 (pid 473)]     if run.successful:
2021-01-27 20:37:16.718 [86/x_partition/2421 (pid 473)]   File "/usr/local/lib/python3.6/site-packages/metaflow/client/core.py", line 1237, in successful
2021-01-27 20:37:16.718 [86/x_partition/2421 (pid 473)]     return end.successful
2021-01-27 20:37:16.718 [86/x_partition/2421 (pid 473)]   File "/usr/local/lib/python3.6/site-packages/metaflow/client/core.py", line 880, in successful
2021-01-27 20:37:16.718 [86/x_partition/2421 (pid 473)]     return self['_success'].data
2021-01-27 20:37:16.719 [86/x_partition/2421 (pid 473)]   File "/usr/local/lib/python3.6/site-packages/metaflow/client/core.py", line 680, in data
2021-01-27 20:37:16.719 [86/x_partition/2421 (pid 473)]     obj = pickle.load(f)
2021-01-27 20:37:16.719 [86/x_partition/2421 (pid 473)] EOFError: Ran out of input
```