### PR TITLE
[R] serialize all the things with qs

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -19,6 +19,7 @@ BugReports: https://github.com/Netflix/metaflow/issues
 Imports:
     magrittr,
     R6,
+    qs,
     reticulate (>= 1.10),
     digest (>= 0.4.0)
 Suggests:

--- a/R/R/utils.R
+++ b/R/R/utils.R
@@ -1,33 +1,10 @@
-simple_type <- function(obj) {
-  if (is.atomic(obj)) {
-    return(TRUE)
-  } else if (is.list(obj)) {
-    if ("data.table" %in% class(obj)) {
-      return(FALSE)
-    }
-
-    for (item in obj) {
-      if (!simple_type(item)) {
-        return(FALSE)
-      }
-    }
-    return(TRUE)
-  } else {
-    return(FALSE)
-  }
-}
-
 #' Helper utility to serialize R object to metaflow
 #' data format
 #'
 #' @param object object to serialize
 #' @return metaflow data format object
 mf_serialize <- function(object) {
-  if (simple_type(object)) {
-    return(object)
-  } else {
-    return(serialize(object, NULL))
-  }
+  qs::qserialize(object)
 }
 
 #' Helper utility to deserialize objects from metaflow
@@ -36,21 +13,11 @@ mf_serialize <- function(object) {
 #' @param object object to deserialize
 #' @return R object
 mf_deserialize <- function(object) {
-  r_obj <- object
-
   if (is.raw(object)) {
-    # for bytearray try to unserialize
-    tryCatch(
-      {
-        r_obj <- object %>% unserialize()
-      },
-      error = function(e) {
-        r_obj <- object
-      }
-    )
+    qs::qdeserialize(object)
+  } else {
+    object
   }
-
-  return(r_obj)
 }
 
 #' Overload getter for self object


### PR DESCRIPTION
@savingoyal @jasonge27 

Currently passing complex R objects to and fro leads to weird results; below is a simple flow demonstrating this with bootstrap sampling from the rsample package:

```
library(metaflow)
start <- function(self){
    suppressPackageStartupMessages(library(rsample))
    self$data <- bootstraps(mtcars)
}
end <- function(self){
    suppressPackageStartupMessages(library(rsample))
    print(self$data)
}

metaflow("HelloFlow") %>%
    step(step = "start", 
         r_function = start, 
         next_step = "end") %>%
    step(step = "end", 
         r_function = end) %>% 
    run()
```

With some mangled results coming back out:

```Metaflow 2.2.0 executing HelloFlow for user:bryangalvin
Validating your flow...
    The graph looks good!
2021-01-30 00:14:56.162 Workflow starting (run-id 1611994496156093):
2021-01-30 00:14:56.168 [1611994496156093/start/1 (pid 7539)] Task is starting.
2021-01-30 00:14:59.277 [1611994496156093/start/1 (pid 7539)] Task finished successfully.
2021-01-30 00:14:59.286 [1611994496156093/end/2 (pid 7561)] Task is starting.
2021-01-30 00:15:02.258 [1611994496156093/end/2 (pid 7561)]                                                                                                                                                                                          splits
2021-01-30 00:15:02.258 [1611994496156093/end/2 (pid 7561)] 1    <environment: 0x7fb423d26d18>, 9, 28, 24, 15, 4, 24, 32, 5, 30, 29, 15, 14, 17, 4, 19, 11, 17, 18, 18, 7, 30, 5, 27, 11, 19, 25, 22, 6, 24, 28, 22, 6, TRUE, <environment: 0x7fb423d32838>
2021-01-30 00:15:02.258 [1611994496156093/end/2 (pid 7561)] 2   <environment: 0x7fb424067920>, 27, 1, 10, 10, 10, 7, 13, 3, 7, 28, 15, 31, 27, 15, 16, 16, 12, 13, 29, 13, 12, 12, 15, 13, 11, 5, 10, 21, 1, 27, 2, 26, TRUE, <environment: 0x7fb424075aa8>
2021-01-30 00:15:02.258 [1611994496156093/end/2 (pid 7561)] 3         <environment: 0x7fb42407d610>, 5, 11, 8, 5, 11, 23, 9, 7, 10, 22, 10, 19, 1, 15, 4, 15, 2, 2, 1, 9, 31, 17, 28, 14, 21, 18, 7, 4, 14, 32, 15, 23, TRUE, <environment: 0x7fb423d33258>
2021-01-30 00:15:02.258 [1611994496156093/end/2 (pid 7561)] 4  <environment: 0x7fb423d3cdf8>, 19, 21, 22, 19, 16, 23, 32, 15, 23, 17, 24, 32, 26, 13, 10, 21, 21, 13, 11, 6, 1, 15, 2, 21, 11, 28, 10, 2, 21, 7, 9, 17, TRUE, <environment: 0x7fb423d44a40>
2021-01-30 00:15:02.259 [1611994496156093/end/2 (pid 7561)] 5    <environment: 0x7fb423d50448>, 25, 27, 16, 2, 3, 16, 24, 7, 23, 30, 17, 17, 23, 32, 24, 3, 8, 15, 29, 30, 17, 4, 18, 9, 22, 21, 31, 13, 23, 3, 16, 13, TRUE, <environment: 0x7fb423d57f78>```

```
This PR just swaps out the base R functions for serialization with [the pretty amazing qs package](https://github.com/traversc/qs) and instead of letting reticulate handle basic conversions it will serialize everything. I can add some memory benchmarks later on but this has the nice added effect of reducing the memory footprint of by ~50% vs the base R functions. I've been using this internally at the LA Times for a few weeks and haven't hit any corner cases, and especially important to tidymodels aficionados @mdneuzerling) since just about everything is a list column in that world. This adds a dependency on qs but would argue its well worth it since this issue made it near impossible to use metaflow without extreme care about what objects you're passing around.

Finally below is the output from the same minimal flow using qs:


```
Metaflow 2.2.0 executing HelloFlow for user:bryangalvin
Validating your flow...
    The graph looks good!
2021-01-30 00:09:06.716 Workflow starting (run-id 1611994146711075):
2021-01-30 00:09:06.722 [1611994146711075/start/1 (pid 6605)] Task is starting.
2021-01-30 00:09:09.612 [1611994146711075/start/1 (pid 6605)] Task finished successfully.
2021-01-30 00:09:09.620 [1611994146711075/end/2 (pid 6627)] Task is starting.
2021-01-30 00:09:12.408 [1611994146711075/end/2 (pid 6627)] # Bootstrap sampling
2021-01-30 00:09:12.517 [1611994146711075/end/2 (pid 6627)] # A tibble: 25 x 2
2021-01-30 00:09:12.551 [1611994146711075/end/2 (pid 6627)]    splits          id
2021-01-30 00:09:12.551 [1611994146711075/end/2 (pid 6627)]    <list>          <chr>
2021-01-30 00:09:12.552 [1611994146711075/end/2 (pid 6627)]  1 <split [32/13]> Bootstrap01
2021-01-30 00:09:12.552 [1611994146711075/end/2 (pid 6627)]  2 <split [32/11]> Bootstrap02
2021-01-30 00:09:12.552 [1611994146711075/end/2 (pid 6627)]  3 <split [32/12]> Bootstrap03
2021-01-30 00:09:12.552 [1611994146711075/end/2 (pid 6627)]  4 <split [32/11]> Bootstrap04
2021-01-30 00:09:12.552 [1611994146711075/end/2 (pid 6627)]  5 <split [32/12]> Bootstrap05
2021-01-30 00:09:12.553 [1611994146711075/end/2 (pid 6627)]  6 <split [32/9]>  Bootstrap06
2021-01-30 00:09:12.553 [1611994146711075/end/2 (pid 6627)]  7 <split [32/13]> Bootstrap07
2021-01-30 00:09:12.553 [1611994146711075/end/2 (pid 6627)]  8 <split [32/10]> Bootstrap08
2021-01-30 00:09:12.553 [1611994146711075/end/2 (pid 6627)]  9 <split [32/12]> Bootstrap09
2021-01-30 00:09:12.553 [1611994146711075/end/2 (pid 6627)] 10 <split [32/12]> Bootstrap10
2021-01-30 00:09:12.553 [1611994146711075/end/2 (pid 6627)] # … with 15 more rows
```