### PR TITLE
Bug fix for AWS Step Functions on AWS Fargate

### DIFF
--- a/metaflow/plugins/aws/step_functions/dynamo_db_client.py
+++ b/metaflow/plugins/aws/step_functions/dynamo_db_client.py
@@ -1,3 +1,4 @@
+import os
 import requests
 from metaflow.metaflow_config import SFN_DYNAMO_DB_TABLE
 
@@ -63,6 +64,10 @@ class DynamoDbClient(object):
         return response['Item']['parent_task_ids_for_foreach_join']['SS']
 
     def _get_instance_region(self):
+        region = os.environ.get('AWS_REGION')
+        # region is available as an env variable in AWS Fargate but not in EC2
+        if region is not None:
+            return region
         metadata_url = "http://169.254.169.254/latest/meta-data/placement/availability-zone/"
         r = requests.get(
             url = metadata_url


### PR DESCRIPTION
AWS Fargate doesn't support instance metadata as EC2 does, but exposes
all the metadata needed as env variables thankfully