### PR TITLE
Fix typo in missing job queue error message

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -111,7 +111,7 @@ class BatchJob(object):
         else:
             response = self._client.describe_job_queues(jobQueues=[job_queue])
             if len(response['jobQueues']) == 0:
-                raise BatchJobException('Job queue %s found.' % job_queue)
+                raise BatchJobException('Job queue %s not found.' % job_queue)
             compute_environment = response['jobQueues'][0] \
                                     ['computeEnvironmentOrder'][0] \
                                     ['computeEnvironment']

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -112,7 +112,7 @@ class BatchJob(object):
             response = self._client.describe_job_queues(jobQueues=[job_queue])
             if len(response['jobQueues']) == 0:
                 raise BatchJobException(
-                    'AWS Batch Job queue %s not found.' % job_queue)
+                    'AWS Batch Job Queue %s not found.' % job_queue)
             compute_environment = response['jobQueues'][0] \
                                     ['computeEnvironmentOrder'][0] \
                                     ['computeEnvironment']

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -111,7 +111,8 @@ class BatchJob(object):
         else:
             response = self._client.describe_job_queues(jobQueues=[job_queue])
             if len(response['jobQueues']) == 0:
-                raise BatchJobException('Job queue %s not found.' % job_queue)
+                raise BatchJobException(
+                    'AWS Batch Job queue %s not found.' % job_queue)
             compute_environment = response['jobQueues'][0] \
                                     ['computeEnvironmentOrder'][0] \
                                     ['computeEnvironment']


### PR DESCRIPTION
Error message should read `Job Queue *not* found` instead of `Job Queue found`