### PR TITLE
print 'environment bootstrapped' when environment is set to conda

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -662,7 +662,6 @@ def before_run(obj, tags, decospecs):
         decorators._attach_decorators(obj.flow, decospecs)
         obj.graph = FlowGraph(obj.flow.__class__)
     obj.check(obj.graph, obj.flow, obj.environment, pylint=obj.pylint)
-    #obj.environment.init_environment(obj.logger)
 
     if obj.datastore.datastore_root is None:
         obj.datastore.datastore_root = \
@@ -791,7 +790,6 @@ def start(ctx,
 
     ctx.obj.environment = [e for e in ENVIRONMENTS + [MetaflowEnvironment]
                            if e.TYPE == environment][0](ctx.obj.flow)
-    ctx.obj.environment.validate_environment(echo)
 
     ctx.obj.datastore = DATASTORES[datastore]
     ctx.obj.datastore_root = datastore_root

--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -32,6 +32,7 @@ class MetaflowPackage(object):
                 deco.package_init(flow,
                                   step.__name__,
                                   environment)
+        environment.validate_environment(echo)
         self.blob, self.sha = self._make()
 
     def _walk(self, root, exclude_hidden=True):

--- a/metaflow/plugins/conda/conda_environment.py
+++ b/metaflow/plugins/conda/conda_environment.py
@@ -23,6 +23,10 @@ class CondaEnvironment(MetaflowEnvironment):
         echo("Bootstrapping conda environment..." +
             "(this could take a few minutes)")
 
+    def validate_environment(self, echo):
+        # Print a message for now
+        echo("Environment bootstrapped")
+
     def decospecs(self):
         # Apply conda decorator to all steps
         return ('conda', )


### PR DESCRIPTION
addresses #446 

print it as part of the `validate_environment` call.