### PR TITLE
Fix typos

### DIFF
--- a/metaflow/datastore/s3.py
+++ b/metaflow/datastore/s3.py
@@ -4,7 +4,6 @@ S3 storage
 Store data in S3
 """
 import os
-import sys
 import json
 import gzip
 from io import BytesIO
@@ -17,7 +16,7 @@ except:
     from urllib.parse import urlparse
 
 from .. import metaflow_config
-from .datastore import MetaflowDataStore, DataException, only_if_not_done
+from .datastore import MetaflowDataStore, only_if_not_done
 from ..metadata import MetaDatum
 from .util.s3util import aws_retry, get_s3_client
 
@@ -54,7 +53,7 @@ class S3DataStore(MetaflowDataStore):
             with self.monitor.measure("metaflow.s3.get_object"):
                 self.s3.download_fileobj(url.netloc, url.path.lstrip('/'), buf)
         else:
-           self.s3.download_fileobj(url.netloc, url.path.lstrip('/'), buf) 
+            self.s3.download_fileobj(url.netloc, url.path.lstrip('/'), buf)
         if return_buf:
             buf.seek(0)
             return buf

--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -184,7 +184,7 @@ class S3(object):
                  run=None,
                  s3root=None):
         """
-        Initialize a new context for S3 operations. This object is based used as
+        Initialize a new context for S3 operations. This object is used as
         a context manager for a with statement.
 
         There are two ways to initialize this object depending whether you want
@@ -490,7 +490,7 @@ class S3(object):
 
             try:
                 self._one_boto_op(_head, url)
-            except MetaflowS3NotFound as err:
+            except MetaflowS3NotFound:
                 self._one_boto_op(_upload, url)    
             return url
 


### PR DESCRIPTION
This PR removes an extra word from a docstring, adds a missing indentation space, and removes a couple unused imports from the `s3` modules.