### PR TITLE
Fix ordering of custom parameters in help text

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -1,9 +1,8 @@
-import os
-import sys
 import inspect
+import sys
 import traceback
-from functools import wraps
 from datetime import datetime
+from functools import wraps
 
 import click
 

--- a/metaflow/parameters.py
+++ b/metaflow/parameters.py
@@ -227,7 +227,7 @@ def add_custom_parameters(deploy_mode=False):
     # deploy_mode determines whether deploy-time functions should or should
     # not be evaluated for this command
     def wrapper(cmd):
-        for arg in parameters:
+        for arg in parameters[::-1]:
             kwargs = arg.option_kwargs(deploy_mode)
             cmd.params.insert(0, click.Option(('--' + arg.name,), **kwargs))
         return cmd

--- a/metaflow/parameters.py
+++ b/metaflow/parameters.py
@@ -227,6 +227,8 @@ def add_custom_parameters(deploy_mode=False):
     # deploy_mode determines whether deploy-time functions should or should
     # not be evaluated for this command
     def wrapper(cmd):
+        # Iterate over parameters in reverse order so cmd.params lists options
+        # in the order they are defined in the FlowSpec subclass
         for arg in parameters[::-1]:
             kwargs = arg.option_kwargs(deploy_mode)
             cmd.params.insert(0, click.Option(('--' + arg.name,), **kwargs))


### PR DESCRIPTION
With this change, the help text output by:
```
python my_flow.py run --help
```
will list custom options in the intended order.

Custom parameters are iteratively inserted into the front of the command parameters list. Doing so in reverse preserves the order in which they are defined in the `FlowSpec`.