### PR TITLE
Make --namespace= behave as promised

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -616,7 +616,7 @@ def run(obj,
         user_namespace=None,
         **kwargs):
 
-    if namespace is not None:
+    if user_namespace is not None:
         namespace(user_namespace or None)
     before_run(obj, tags, decospecs + obj.environment.decospecs())
 

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -703,8 +703,8 @@ class StepFunctions(object):
             step.append('--split-index $METAFLOW_SPLIT_INDEX')
         if self.tags:
             step.extend('--tag %s' % tag for tag in self.tags)
-        if self.namespace:
-            step.append('--namespace %s' % self.namespace)
+        if self.namespace is not None:
+            step.append('--namespace=%s' % self.namespace)
         cmds.append(' '.join(entrypoint + top_level + step))
         return ' && '.join(cmds)
 

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -740,10 +740,18 @@ class CLIArgs(object):
 
     def get_args(self):
         def options(mapping):
+            """ Map a dictionary of options to a list of command-line arguments.
+
+            Values assigned to boolean values are assumed boolean flags. List values
+            are converted to repeated CLI arguments.
+
+            >>> list(options({"foo": True, "bar": False, "baz": "", "qux": ["a", "b"]}))
+            ["--foo", "--baz", "", "--qux", "a", "--qux", "b"]
+            """
             for k, v in mapping.items():
                 values = v if isinstance(v, list) else [v]
                 for value in values:
-                    if value:
+                    if value is not None and value is not False:
                         yield '--%s' % k
                         if not isinstance(value, bool):
                             yield to_unicode(value)


### PR DESCRIPTION
The help string for `--namespace` [says](https://github.com/Netflix/metaflow/blob/de527ab8da63fa4a5895d5f6b032728769838f0a/metaflow/cli.py#L602-L607) you can pass an empty string, and it would have the same effect as `namespace(None)`.

However, it looks like this setting is never propagated to `step` command. That is, scheduler does not pass `--namespace` flag to the step process, and then namespace defaults back to username.

I have tested this in local mode and with `@batch` 