### PR TITLE
Remove pylint<2.5.0 restriction

### DIFF
--- a/metaflow/pylint_wrapper.py
+++ b/metaflow/pylint_wrapper.py
@@ -72,4 +72,7 @@ class PyLint(object):
             # Ditto for dynamically added properties in 'current'
             if "Instance of 'Current' has no" in line:
                 continue
+            # Ingore complaints of self.next not callable
+            if "self.next is not callable" in line:
+                continue
             yield line

--- a/metaflow/pylint_wrapper.py
+++ b/metaflow/pylint_wrapper.py
@@ -72,7 +72,7 @@ class PyLint(object):
             # Ditto for dynamically added properties in 'current'
             if "Instance of 'Current' has no" in line:
                 continue
-            # Ingore complaints of self.next not callable
+            # Ignore complaints of self.next not callable
             if "self.next is not callable" in line:
                 continue
             yield line

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='metaflow',
         'click>=7.0',
         'requests',
         'boto3',
-        'pylint<2.5.0'
+        'pylint'
       ],
       tests_require = [
         'coverage'


### PR DESCRIPTION
context - https://gitter.im/metaflow_org/community?at=60622af8940f1d555e277c12

Pylint barfs on `self.next` call, which can be safely ignored.