### PR TITLE
@awslambda decorator

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -234,7 +234,7 @@ class StepDecorator(Decorator):
         """
         pass
 
-    def package_init(self, flow, step_name, environment):
+    def package_init(self, flow, step_name, environment, logger):
         """
         Called to determine package components
         """

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -193,6 +193,22 @@ KUBERNETES_CONTAINER_REGISTRY = (
     from_conf("METAFLOW_KUBERNETES_CONTAINER_REGISTRY") or DEFAULT_CONTAINER_REGISTRY
 )
 #
+# AWS Lambda configuration
+###
+LAMBDA_ROLE_ARN = from_conf("METAFLOW_LAMBDA_ROLE_ARN")
+
+LAMBDA_CONTAINER_IMAGE = (
+    from_conf("METAFLOW_LAMBDA_CONTAINER_IMAGE") or DEFAULT_CONTAINER_IMAGE
+)
+
+LAMBDA_CONTAINER_REGISTRY = (
+    from_conf("METAFLOW_LAMBDA_CONTAINER_REGISTRY") or DEFAULT_CONTAINER_REGISTRY
+)
+
+# This limit is used to retry lambda execution when we're throttled by AWS due to
+# being close to the parallel execution limit. This does *not* affect how much we
+# retry if the step itself has failed.
+LAMBDA_THROTTLE_RETRIES = int(from_conf("METAFLOW_LAMBDA_THROTTLE_RETRIES", 20))
 
 ###
 # Conda configuration

--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -48,7 +48,7 @@ class MetaflowPackage(object):
         environment.init_environment(echo)
         for step in flow:
             for deco in step.decorators:
-                deco.package_init(flow, step.__name__, environment)
+                deco.package_init(flow, step.__name__, environment, echo)
         self.blob = self._make()
 
     def _walk(self, root, exclude_hidden=True, addl_suffixes=None):

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -98,6 +98,7 @@ def get_plugin_cli():
     from .aws.batch import batch_cli
     from .aws.eks import kubernetes_cli
     from .aws.step_functions import step_functions_cli
+    from .aws.awslambda import lambda_cli
     from .cards import card_cli
 
     return _ext_plugins.get_plugin_cli() + [
@@ -106,6 +107,7 @@ def get_plugin_cli():
         card_cli.cli,
         kubernetes_cli.cli,
         step_functions_cli.cli,
+        lambda_cli.cli,
     ]
 
 
@@ -134,9 +136,10 @@ from .test_unbounded_foreach_decorator import (
     InternalTestUnboundedForeachDecorator,
     InternalTestUnboundedForeachInput,
 )
+from .aws.awslambda.lambda_decorator import LambdaDecorator
+
 from .conda.conda_step_decorator import CondaStepDecorator
 from .cards.card_decorator import CardDecorator
-
 
 STEP_DECORATORS = _merge_lists(
     [
@@ -152,6 +155,7 @@ STEP_DECORATORS = _merge_lists(
         CondaStepDecorator,
         ParallelDecorator,
         InternalTestUnboundedForeachDecorator,
+        LambdaDecorator,
     ],
     _ext_plugins.STEP_DECORATORS,
     "name",

--- a/metaflow/plugins/aws/aws_utils.py
+++ b/metaflow/plugins/aws/aws_utils.py
@@ -50,3 +50,35 @@ def get_docker_registry(image_uri):
     if registry is not None:
         registry = registry.rstrip("/")
     return registry
+
+
+def compute_resource_attributes(decos, compute_deco, resource_defaults):
+    """
+    Compute resource values taking into account defaults, the values specified
+    in the compute decorator (like @batch or @kubernetes) directly, and
+    resources specified via @resources decorator.
+
+    Returns a dictionary of resource attr -> value (str).
+    """
+    assert compute_deco is not None
+
+    # Use the value from resource_defaults by default
+    result = {k: v for k, v in resource_defaults.items()}
+
+    for deco in decos:
+        # If resource decorator is used
+        if deco.name == "resources":
+            for k, v in deco.attributes.items():
+                # ..we use the larger of @resources and @batch attributes
+                my_val = compute_deco.attributes.get(k)
+                if not (my_val is None and v is None):
+                    result[k] = str(max(int(my_val or 0), int(v or 0)))
+            return result
+
+    # If there is no resources decorator, values from compute_deco override
+    # the defaults.
+    for k, v in resource_defaults.items():
+        if compute_deco.attributes.get(k):
+            result[k] = str(compute_deco.attributes[k])
+
+    return result

--- a/metaflow/plugins/aws/awslambda/lambda_cli.py
+++ b/metaflow/plugins/aws/awslambda/lambda_cli.py
@@ -1,0 +1,224 @@
+import os
+import sys
+
+import click
+import traceback
+
+from metaflow import R, util
+from metaflow.exception import METAFLOW_EXIT_DISALLOW_RETRY
+from metaflow.datastore import FlowDataStore
+from metaflow.metadata.util import (
+    sync_local_metadata_from_datastore,
+)
+from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
+
+from .lambda_runner import LambdaRunner, LambdaRuntimeException
+from metaflow.mflog import TASK_LOG_SOURCE
+
+
+class CommonTaskAttrs:
+    def __init__(
+        self,
+        flow_name,
+        run_id,
+        step_name,
+        task_id,
+        attempt,
+        user,
+        version,
+    ):
+        self.flow_name = flow_name
+        self.step_name = step_name
+        self.run_id = run_id
+        self.task_id = task_id
+        self.attempt = attempt
+        self.user = user
+        self.version = version
+
+    def to_dict(self, key_prefix):
+        attrs = {
+            key_prefix + "flow_name": self.flow_name,
+            key_prefix + "step_name": self.step_name,
+            key_prefix + "run_id": self.run_id,
+            key_prefix + "task_id": self.task_id,
+            key_prefix + "retry_count": str(self.attempt),
+            key_prefix + "version": self.version,
+        }
+        if self.user is not None:
+            attrs[key_prefix + "user"] = self.user
+        return attrs
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.group(help="Commands related to AWS Lambda.")
+def awslambda():
+    pass
+
+
+@awslambda.command(
+    help="Execute a single task using AWS Lambda. This command "
+    "calls the top-level step command inside a AWS Lambda "
+    "job with the given options. Typically you do not "
+    "call this command directly; it is used internally "
+    "by Metaflow."
+)
+@click.argument("step-name")
+@click.argument("code-package-sha")
+@click.argument("code-package-url")
+@click.option("--run-id", help="Passed to the top-level 'step'.")
+@click.option("--task-id", help="Passed to the top-level 'step'.")
+@click.option("--lambda-arn", help="Lambda ARN")
+@click.option("--lambda-name", help="Lambda name")
+@click.option("--input-paths", help="Passed to the top-level 'step'.")
+@click.option("--split-index", help="Passed to the top-level 'step'.")
+@click.option("--clone-path", help="Passed to the top-level 'step'.")
+@click.option("--clone-run-id", help="Passed to the top-level 'step'.")
+@click.option(
+    "--tag", multiple=True, default=None, help="Passed to the top-level 'step'."
+)
+@click.option("--namespace", default=None, help="Passed to the top-level 'step'.")
+@click.option("--retry-count", default=0, help="Passed to the top-level 'step'.")
+@click.option(
+    "--max-user-code-retries", default=0, help="Passed to the top-level 'step'."
+)
+@click.pass_context
+def step(
+    ctx,
+    step_name,
+    code_package_sha,
+    code_package_url,
+    lambda_arn,
+    lambda_name,
+    **kwargs
+):
+    # type: (...) -> None
+
+    def echo_without_prefix(msg, err):
+        ctx.obj.echo_always(msg, err=err)
+
+    if R.use_r():
+        entrypoint = R.entrypoint()
+    else:
+        executable = ctx.obj.environment.executable(step_name)
+        entrypoint = "%s -u %s" % (executable, os.path.basename(sys.argv[0]))
+
+    top_args = " ".join(util.dict_to_cli_options(ctx.parent.parent.params))
+
+    step_args = " ".join(util.dict_to_cli_options(kwargs))
+    step_cli = u"{entrypoint} {top_args} step {step} {step_args}".format(
+        entrypoint=entrypoint, top_args=top_args, step=step_name, step_args=step_args
+    )
+    node = ctx.obj.graph[step_name]
+
+    retry_count = kwargs.get("retry_count", 0)
+
+    common_attrs = CommonTaskAttrs(
+        flow_name=ctx.obj.flow.name,
+        step_name=step_name,
+        run_id=kwargs["run_id"],
+        task_id=kwargs["task_id"],
+        attempt=retry_count,
+        user=util.get_username(),
+        version=ctx.obj.environment.get_environment_info()["metaflow_version"],
+    )
+
+    env_deco = [deco for deco in node.decorators if deco.name == "environment"]
+    if env_deco:
+        env = env_deco[0].attributes["vars"]
+    else:
+        env = {}
+
+    def echo_with_prefix(msg, err):  # type: (str, bool) -> None
+        ctx.obj.echo_always(
+            "[%s] %s"
+            % (
+                lambda_name,
+                msg,
+            ),
+            err=err,
+        )
+
+    runner = LambdaRunner(
+        datastore=ctx.obj.flow_datastore,
+        environment=ctx.obj.environment,
+        lambda_arn=lambda_arn,
+        name=lambda_name,
+    )
+
+    ds = ctx.obj.flow_datastore.get_task_datastore(
+        mode="w",
+        run_id=kwargs["run_id"],
+        step_name=step_name,
+        task_id=kwargs["task_id"],
+        attempt=int(retry_count),
+    )
+    stdout_location = ds.get_log_location(TASK_LOG_SOURCE, "stdout")
+    stderr_location = ds.get_log_location(TASK_LOG_SOURCE, "stderr")
+
+    def _sync_metadata():
+        if ctx.obj.metadata.TYPE == "local":
+            sync_local_metadata_from_datastore(
+                DATASTORE_LOCAL_DIR,
+                ctx.obj.flow_datastore.get_task_datastore(
+                    kwargs["run_id"], step_name, kwargs["task_id"]
+                ),
+            )
+
+    try:
+        with ctx.obj.monitor.measure("metaflow.awslambda.launch"):
+            return_code = runner.run(
+                step_name,
+                step_cli,
+                code_package_sha,
+                code_package_url,
+                ctx.obj.flow_datastore.TYPE,
+                env=env,
+                attrs=common_attrs.to_dict(key_prefix="metaflow."),
+                echo=echo_without_prefix,
+                stdout_location=stdout_location,
+                stderr_location=stderr_location,
+                task_id=kwargs["task_id"],
+                run_id=kwargs["run_id"],
+                attempt=str(retry_count),
+                flow_name=ctx.obj.flow.name,
+            )
+            task_datastore = FlowDataStore(
+                ctx.obj.flow.name,
+                ctx.obj.environment,
+                ctx.obj.metadata,
+                ctx.obj.event_logger,
+                ctx.obj.monitor,
+            ).get_task_datastore(kwargs["run_id"], step_name, kwargs["task_id"])
+            _sync_metadata()
+            if return_code != 0:
+                sys.exit(1)
+    except LambdaRuntimeException as e:
+        echo_with_prefix(
+            "Lambda runtime exception (possibly an issue with the container image)",
+            True,
+        )
+        echo_with_prefix(str(e), True)
+        task_datastore = FlowDataStore(
+            ctx.obj.flow.name,
+            ctx.obj.environment,
+            ctx.obj.metadata,
+            ctx.obj.event_logger,
+            ctx.obj.monitor,
+        ).get_task_datastore(kwargs["run_id"], step_name, kwargs["task_id"])
+        _sync_metadata()
+        sys.exit(METAFLOW_EXIT_DISALLOW_RETRY)
+    except Exception as e:
+        traceback.print_exc()
+        task_datastore = FlowDataStore(
+            ctx.obj.flow.name,
+            ctx.obj.environment,
+            ctx.obj.metadata,
+            ctx.obj.event_logger,
+            ctx.obj.monitor,
+        ).get_task_datastore(kwargs["run_id"], step_name, kwargs["task_id"])
+        _sync_metadata()
+        sys.exit(METAFLOW_EXIT_DISALLOW_RETRY)

--- a/metaflow/plugins/aws/awslambda/lambda_decorator.py
+++ b/metaflow/plugins/aws/awslambda/lambda_decorator.py
@@ -1,0 +1,322 @@
+import os
+import sys
+
+from metaflow import R
+
+from metaflow.decorators import Decorator, StepDecorator
+from metaflow.exception import MetaflowException
+from metaflow.plugins.aws.awslambda.lambda_runner import LAMBDA_MAX_MEMORY_MB
+from metaflow.plugins.aws.batch.batch_decorator import (
+    BatchDecorator,
+    ResourcesDecorator,
+)
+from metaflow.metadata.util import sync_local_metadata_to_datastore
+from metaflow.plugins.conda.conda_step_decorator import CondaStepDecorator
+from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task
+from .lambda_runner import ensure_lambda, lambda_name
+from metaflow.sidecar import SidecarSubProcess
+from metaflow.metadata import MetaDatum
+from ..aws_utils import get_docker_registry, compute_resource_attributes
+
+
+if sys.version_info > (3, 0):
+    from typing import TYPE_CHECKING, Dict, List, Optional, Callable
+
+    if TYPE_CHECKING:
+        from metaflow.runtime import CLIArgs
+        from metaflow.graph import FlowGraph
+        from metaflow.package import MetaflowPackage
+        from metaflow.flowspec import FlowSpec
+        from metaflow.datastore import FlowDataStore
+        from metaflow.datastore.task_datastore import TaskDataStore
+        from metaflow.metaflow_environment import MetaflowEnvironment
+        from metaflow.event_logger import EventLogger
+
+from metaflow.metaflow_config import (
+    LAMBDA_CONTAINER_REGISTRY,
+    LAMBDA_CONTAINER_IMAGE,
+    LAMBDA_ROLE_ARN,
+    DATASTORE_LOCAL_DIR,
+)
+
+DEFAULT_TIMEOUT_SECONDS = 900
+LAMBDA_DEFAULT_MEMORY_MB = 4096
+
+
+class LambdaException(MetaflowException):
+    headline = "AWS Lambda error"
+
+
+class LambdaDecorator(StepDecorator):
+    """
+    The decorator is called @awslambda to avoid confusion, since "lambda" is a reserved
+    word in Python.
+    """
+
+    name = "awslambda"
+    defaults = {
+        "image": None,
+        "memory": None,
+        "refresh_image": False,
+    }
+    resource_defaults = {
+        "memory": "4096",
+    }
+
+    package_url = None  # type: Optional[str]
+    package_sha = None  # type: Optional[str]
+    memory_mb = LAMBDA_DEFAULT_MEMORY_MB  # type: int
+    run_time_limit = None  # type: Optional[int]
+    ds_root = None  # type: Optional[str]
+    lambda_arn = None  # type: Optional[str]
+    lambda_name = None  # type: Optional[str]
+
+    def __init__(self, attributes=None, statically_defined=False):
+        super(LambdaDecorator, self).__init__(attributes, statically_defined)
+
+        if not self.attributes["image"]:
+            # If metaflow-config specifies a docker image, just use that.
+            if LAMBDA_CONTAINER_IMAGE:
+                self.attributes["image"] = LAMBDA_CONTAINER_IMAGE
+            # If metaflow-config doesn't specify a docker image, throw an error.
+            # Unlike with other platforms, AWS Lambda needs a special image
+            # and it has to be uploaded in users ECR repo, so we cannot provide
+            # a good default here.
+            else:
+                raise LambdaException(
+                    "The *@awslambda* decorator requires either image parameter or "
+                    "METAFLOW_LAMBDA_CONTAINER_IMAGE to be set to a lambda container image uri"
+                )
+        if not get_docker_registry(self.attributes["image"]):
+            if LAMBDA_CONTAINER_REGISTRY:
+                self.attributes["image"] = "%s/%s" % (
+                    LAMBDA_CONTAINER_REGISTRY.rstrip("/"),
+                    self.attributes["image"],
+                )
+
+    def step_init(
+        self,
+        flow,  # type: "FlowSpec"
+        graph,  # type : "FlowGraph"
+        step,  # type: str
+        decos,  # type: List[Decorator]
+        environment,  # type: "MetaflowEnvironment"
+        flow_datastore,  # type: "FlowDataStore"
+        logger,  # type: "Callable[[str], None]"
+    ):
+        if flow_datastore.TYPE != "s3":
+            raise LambdaException("The *@awslambda* decorator requires --datastore=s3.")
+
+        self.logger = logger
+        self.environment = environment
+        self.step = step
+        self.flow_datastore = flow_datastore
+
+        for deco in decos:
+            if isinstance(deco, CondaStepDecorator):
+                raise LambdaException(
+                    "*@awslambda* doesn't support using @conda. "
+                    "We recommend using custom container images to manage"
+                    " dependencies instead"
+                )
+
+            if isinstance(deco, BatchDecorator):
+                raise LambdaException(
+                    "You can't use @batch and *@awslambda* at the same time"
+                )
+
+        resource_attrs = compute_resource_attributes(
+            decos, self, self.resource_defaults
+        )
+        if int(resource_attrs["memory"]) > LAMBDA_MAX_MEMORY_MB:
+            raise LambdaException(
+                "{r} cannot exceed {max_v} for *@awslambda* (currently set to {v})".format(
+                    r="memory", max_v=LAMBDA_MAX_MEMORY_MB, v=resource_attrs["memory"]
+                )
+            )
+
+        # ignore all other resource attrs, we only support setting memory for lambda
+        self.memory_mb = int(resource_attrs["memory"])
+
+        # Run time limit more than 15m is effectively ignored
+        self.run_time_limit = min(
+            get_run_time_limit_for_task(decos),
+            900,
+        )
+
+        if self.run_time_limit < 10:
+            raise LambdaException(
+                "The timeout for step *{step}* should be at "
+                "least 10 seconds for execution on AWS Lambda".format(step=step)
+            )
+
+    def runtime_step_cli(
+        self,
+        cli_args,  # type: "CLIArgs"
+        retry_count,  # type: int
+        max_user_code_retries,  # type: int
+        ubf_context,
+    ):
+        # After all attempts to run the user code have failed, we don't need
+        # Lambda anymore. We can execute possible fallback code locally, so we'll
+        # leave args as is
+        if retry_count <= max_user_code_retries:
+            cli_args.commands = ["awslambda", "step"]
+            cli_args.command_args.append(self.package_sha)
+            cli_args.command_args.append(self.package_url)
+            cli_args.command_options["lambda_arn"] = self.lambda_arn
+            cli_args.command_options["lambda_name"] = self.lambda_name
+            if not R.use_r():
+                cli_args.entrypoint[0] = sys.executable
+
+    @classmethod
+    def _save_package_once(
+        cls,
+        flow_datastore,  # type: "FlowDataStore"
+        package,  # type: "MetaflowPackage"
+    ):
+        if cls.package_url is None:
+            cls.package_url, cls.package_sha = flow_datastore.save_data(
+                [package.blob], len_hint=1
+            )[0]
+
+    def package_init(
+        self,
+        flow,  # type: "FlowSpec"
+        step_name,  # type: str
+        environment,  # type: "MetaflowEnvironment"
+        echo,  # type: Callable[..., None]
+    ):
+        # self.step_init(..) should've run by now and populated this and other
+        # attributes. This assert makes mypy happy as it cannot infer that statically.
+        assert self.run_time_limit is not None
+
+        self.lambda_name = lambda_name(
+            self.memory_mb, self.run_time_limit, self.attributes["image"]
+        )
+
+        def echo_with_prefix(msg, err):  # type: (str, bool) -> None
+            echo(
+                "[awslambda decorator] %s" % (msg,),
+                err=err,
+            )
+
+        if LAMBDA_ROLE_ARN is None:
+            raise LambdaException(
+                "The *@lambda* decorator requires METAFLOW_LAMBDA_ROLE_ARN to be set to a "
+                "lambda role arn"
+            )
+
+        self.lambda_arn = ensure_lambda(
+            name=self.lambda_name,
+            memory_mb=self.memory_mb,
+            timeout_seconds=self.run_time_limit,
+            role_arn=LAMBDA_ROLE_ARN,
+            image_uri=self.attributes["image"],
+            refresh_image=self.attributes["refresh_image"],
+            echo=echo_with_prefix,
+        )
+
+    def runtime_init(
+        self,
+        flow,  # type: "FlowSpec"
+        graph,  # type: "FlowGraph"
+        package,  # type: "MetaflowPackage"
+        run_id,  # type: str
+    ):
+        self.flow = flow
+        self.graph = graph
+        self.package = package
+        self.run_id = run_id
+
+    def runtime_task_created(
+        self,
+        task_datastore,  # type: "TaskDataStore"
+        task_id,  # type: str
+        split_index,  # type: Optional[int]
+        input_paths,  # type: List[str]
+        is_cloned,  # type: bool
+        ubf_context,
+    ):
+        if not is_cloned:
+            self._save_package_once(self.flow_datastore, self.package)
+
+    def task_pre_step(
+        self,
+        step_name,
+        task_datastore,
+        metadata,
+        run_id,
+        task_id,
+        flow,
+        graph,
+        retry_count,
+        max_retries,
+        ubf_context,
+        inputs,
+    ):
+        self.metadata = metadata
+        self.task_datastore = task_datastore
+
+        meta = {}
+        if "AWS_LAMBDA_FUNCTION_NAME" in os.environ:
+            meta["aws-lambda-function-name"] = os.environ["AWS_LAMBDA_FUNCTION_NAME"]
+            meta["aws-lambda-log-group-name"] = os.environ["AWS_LAMBDA_LOG_GROUP_NAME"]
+            meta["aws-lambda-log-stream-name"] = os.environ[
+                "AWS_LAMBDA_LOG_STREAM_NAME"
+            ]
+            meta["aws-lambda-execution-env"] = os.environ["AWS_EXECUTION_ENV"]
+
+            # Unlike the above vars, this is set by our own code in entrypoint.py
+            meta["aws-lambda-request-id"] = os.environ["LAMBDA_REQUEST_ID"]
+
+            entries = [
+                MetaDatum(field=k, value=v, type=k, tags=[]) for k, v in meta.items()
+            ]
+
+            # Register book-keeping metadata for debugging.
+            metadata.register_metadata(run_id, step_name, task_id, entries)
+            self._save_logs_sidecar = SidecarSubProcess("save_logs_periodically")
+
+    def task_post_step(
+        self, step_name, flow, graph, retry_count, max_user_code_retries
+    ):
+        # task_post_step may run locally if fallback is activated for @catch
+        # decorator.
+        if "AWS_LAMBDA_FUNCTION_NAME" in os.environ:
+            # If `local` metadata is configured, we would need to copy task
+            # execution metadata from the AWS Batch container to user's
+            # local file system after the user code has finished execution.
+            # This happens via datastore as a communication bridge.
+            if self.metadata.TYPE == "local":
+                # Note that the datastore is *always* Amazon S3 (see
+                # runtime_task_created function).
+                sync_local_metadata_to_datastore(
+                    DATASTORE_LOCAL_DIR, self.task_datastore
+                )
+
+    def task_exception(
+        self, exception, step_name, flow, graph, retry_count, max_user_code_retries
+    ):
+        # task_exception may run locally if fallback is activated for @catch
+        # decorator.
+        if "AWS_LAMBDA_FUNCTION_NAME" in os.environ:
+            # If `local` metadata is configured, we would need to copy task
+            # execution metadata from the AWS Batch container to user's
+            # local file system after the user code has finished execution.
+            # This happens via datastore as a communication bridge.
+            if self.metadata.TYPE == "local":
+                # Note that the datastore is *always* Amazon S3 (see
+                # runtime_task_created function).
+                sync_local_metadata_to_datastore(
+                    DATASTORE_LOCAL_DIR, self.task_datastore
+                )
+
+    def task_finished(
+        self, step_name, flow, graph, is_task_ok, retry_count, max_retries
+    ):
+        try:
+            self._save_logs_sidecar.kill()
+        except:
+            # Best effort kill
+            pass

--- a/metaflow/plugins/aws/awslambda/lambda_runner.py
+++ b/metaflow/plugins/aws/awslambda/lambda_runner.py
@@ -1,0 +1,381 @@
+import sys
+import hashlib
+import json
+import shlex
+
+from threading import Thread
+
+from metaflow.datatools.s3tail import S3Tail
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from metaflow.exception import MetaflowException
+
+from metaflow.mflog import (
+    export_mflog_env_vars,
+    capture_output_to_mflog,
+    tail_logs,
+    BASH_SAVE_LOGS,
+)
+
+from metaflow.metaflow_config import (
+    LAMBDA_THROTTLE_RETRIES,
+)
+
+if sys.version_info > (3, 0):
+    from typing import TYPE_CHECKING, Callable, Dict, Optional
+
+    if TYPE_CHECKING:
+        from metaflow.metaflow_environment import MetaflowEnvironment
+
+from metaflow.plugins.aws.aws_client import get_aws_client
+
+LAMBDA_MAX_MEMORY_MB = 10240
+
+from metaflow.metaflow_config import (
+    DATASTORE_SYSROOT_S3,
+    DATATOOLS_S3ROOT,
+    METADATA_SERVICE_HEADERS,
+    METADATA_SERVICE_URL,
+    DEFAULT_METADATA,
+)
+
+
+class LambdaRuntimeException(MetaflowException):
+    headline = "Error while setting up AWS Lambda environment"
+
+
+class LogTailer(Thread):
+
+    _stop_flag = False
+
+    def __init__(
+        self,
+        stdout_location,  # type: str
+        stderr_location,  # type: str
+        echo,  # type: Callable[[str, bool], None]
+        prefix,  # type: str
+    ):
+        """
+        Parameters
+        ----------
+        echo : Callable[str]
+            Printer function to call for each log line
+        """
+        self._stdout_tail = S3Tail(stdout_location)
+        self._stderr_tail = S3Tail(stderr_location)
+
+        self._echo = echo
+        self._prefix = prefix
+        super(LogTailer, self).__init__()
+        self.daemon = True
+
+    def stop_tail(self):
+        self._stop_flag = True
+
+    def run(self):
+        tail_logs(
+            prefix=self._prefix,
+            stdout_tail=self._stdout_tail,
+            stderr_tail=self._stderr_tail,
+            echo=self._echo,
+            has_log_updates=lambda: not self._stop_flag,
+        )
+
+
+def lambda_name(memory_mb, timeout_seconds, image_uri):
+    """Construct lambda name based on hashed resources"""
+    res_hash = hashlib.sha256(
+        str(memory_mb).encode("utf8")
+        + str(timeout_seconds).encode("utf8")
+        + image_uri.encode("utf8")
+    ).hexdigest()[:10]
+
+    # We append unhashed resource values here for a bit more debuggability
+    return "-".join(["mflambda", res_hash, str(memory_mb), str(timeout_seconds)])
+
+
+def ensure_lambda(
+    name,  # type: str
+    timeout_seconds,  # type: int
+    memory_mb,  # type: int
+    role_arn,
+    image_uri,
+    refresh_image,  # type: bool
+    echo,  # type: Callable[[str, bool], None]
+):
+    # type: (...) -> str
+    """
+    Make sure Lambda for the step exists. If it does, but resources or timeout
+    configuration is not what we expect, update the lambda configuration.
+
+    Return lambda ARN.
+    """
+
+    client = get_aws_client("lambda")
+
+    return _maybe_update_lambda(
+        client,
+        name,
+        timeout_seconds,
+        memory_mb,
+        role_arn,
+        image_uri,
+        refresh_image,
+        echo=echo,
+    )
+
+
+def _maybe_update_lambda(
+    client,
+    name,
+    timeout_seconds,  # type: int
+    memory_size,  # type: float
+    role_arn,
+    image_uri,
+    refresh_image,  # type: bool
+    echo,  # type: Callable[[str, bool], None]
+):
+    # type: (...) -> str
+    """
+    This does all the necessary AWS API Calls to update or create Lambda. Returns
+    Lambda ARN.
+    """
+    try:
+        # Get current function configuration
+        info = client.get_function(FunctionName=name)
+
+        # If refresh_image is set, force update function code.
+        if refresh_image:
+            echo("Updating image for %s.." % name, False)
+            client.update_function_code(
+                FunctionName=name,
+                ImageUri=image_uri,
+            )
+            waiter = client.get_waiter("function_updated")
+            waiter.wait(FunctionName=name)
+
+        return info["Configuration"]["FunctionArn"]
+    except client.exceptions.ResourceNotFoundException:
+        pass
+
+    # If function does not exist, create it
+    echo("Creating worker Lambda %s..." % name, False)
+    try:
+        response = client.create_function(
+            FunctionName=name,
+            Role=role_arn,
+            PackageType="Image",
+            Timeout=timeout_seconds,
+            MemorySize=memory_size,
+            Code={
+                "ImageUri": image_uri,
+            },
+        )
+    except client.exceptions.InvalidParameterValueException as e:
+        raise LambdaRuntimeException(e.response["Error"]["Message"])
+
+    waiter = client.get_waiter("function_active")
+    waiter.wait(FunctionName=name)
+    return response["FunctionArn"]
+
+
+class LambdaRunner:
+    def __init__(
+        self,
+        datastore,
+        environment,  # type: "MetaflowEnvironment"
+        lambda_arn,  # type: str
+        name,  # type: str
+    ):
+        config = Config(
+            retries={
+                "max_attempts": LAMBDA_THROTTLE_RETRIES,
+            }
+        )
+        self._lambda_client = get_aws_client("lambda", params=dict(config=config))
+        self._environment = environment
+        self._datastore = datastore
+        self._lambda_arn = lambda_arn
+        self._name = name
+
+    def _build_task_command(
+        self,
+        code_package_url,
+        step_cmds,
+        flow_name,
+        step_name,
+        run_id,
+        task_id,
+        attempt,
+        stdout_path,
+        stderr_path,
+        logs_dir,
+    ):
+        mflog_expr = export_mflog_env_vars(
+            flow_name=flow_name,
+            run_id=run_id,
+            step_name=step_name,
+            task_id=task_id,
+            retry_count=attempt,
+            datastore_type=self._datastore.TYPE,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+        )
+        init_cmds = self._environment.get_package_commands(code_package_url)
+        init_expr = " && ".join(init_cmds)
+        step_expr = " && ".join(
+            [
+                capture_output_to_mflog(a)
+                for a in (self._environment.bootstrap_commands(step_name) + step_cmds)
+            ]
+        )
+
+        # Construct an entry point that
+        # 1) initializes the mflog environment (mflog_expr)
+        # 2) bootstraps a metaflow environment (init_expr)
+        # 3) executes a task (step_expr)
+
+        # The `true` command is to make sure that the generated command
+        # plays well with docker containers which have entrypoint set as
+        # eval $@
+        cmd_str = "true && mkdir -p %s && %s && %s && %s; " % (
+            logs_dir,
+            mflog_expr,
+            init_expr,
+            step_expr,
+        )
+        # After the task has finished, we save its exit code (fail/success)
+        # and persist the final logs. The whole entrypoint should exit
+        # with the exit code (c) of the task.
+        #
+        # Note that if step_expr OOMs, this tail expression is never executed.
+        # We lose the last logs in this scenario.
+        #
+        # TODO: Find a way to capture hard exit logs in Kubernetes.
+        cmd_str += "c=$?; %s; exit $c" % BASH_SAVE_LOGS
+        return shlex.split('bash -c "%s"' % cmd_str)
+
+    def run(
+        self,
+        step_name,
+        step_cli,
+        code_package_sha,
+        code_package_url,
+        code_package_ds,
+        env,  # type: Dict[str, str]
+        attrs,  # type: Dict[str, str]
+        echo,  # type: Callable[[str, bool], None]
+        stdout_location,  # type: str
+        stderr_location,  # type: str
+        flow_name,  # type: str
+        attempt,  # type: str
+        task_id,  # type: str
+        run_id,  # type: str
+    ):
+        # type: (...) -> int
+
+        lambda_event = {
+            "args": self._build_task_command(
+                code_package_url=code_package_url,
+                step_name=step_name,
+                step_cmds=[step_cli],
+                flow_name=flow_name,
+                task_id=task_id,
+                attempt=attempt,
+                run_id=run_id,
+                stdout_path="$(pwd)/logs/stdout.log",
+                stderr_path="$(pwd)/logs/stderr.log",
+                logs_dir="$(pwd)/logs",
+            ),
+            "shell": False,
+            "env": {
+                "METAFLOW_DEFAULT_DATASTORE": "s3",
+                "METAFLOW_CODE_DS": code_package_ds,
+                "METAFLOW_CODE_SHA": code_package_sha,
+                "METAFLOW_CODE_URL": code_package_url,
+                "METAFLOW_DATASTORE_SYSROOT_S3": DATASTORE_SYSROOT_S3,
+                "METAFLOW_DATATOOLS_S3ROOT": DATATOOLS_S3ROOT,
+                "METAFLOW_USER": attrs["metaflow.user"],
+            },
+            "parameters": {},
+        }
+
+        if METADATA_SERVICE_URL:
+            lambda_event["env"]["METAFLOW_SERVICE_URL"] = METADATA_SERVICE_URL
+        if METADATA_SERVICE_HEADERS:
+            lambda_event["env"]["METAFLOW_SERVICE_HEADERS"] = json.dumps(
+                METADATA_SERVICE_HEADERS
+            )
+        if DEFAULT_METADATA:
+            lambda_event["env"]["METAFLOW_DEFAULT_METADATA"] = DEFAULT_METADATA
+
+        for name, value in env.items():
+            lambda_event["env"][name] = value
+
+        if attrs:
+            for key, value in attrs.items():
+                lambda_event["parameters"][key] = value
+
+        log_tailer = LogTailer(
+            stdout_location,
+            stderr_location,
+            echo=echo,
+            prefix="[%s] " % self._name,
+        )
+        log_tailer.start()
+
+        config = Config(
+            retries={
+                "max_attempts": 1,  # We don't want boto to auto-retry the invocation
+                # instead we'll rely on our scheduling logic to
+                # do the retries.
+            },
+            read_timeout=930,  # 15m30s, enough for the max lambda duration.
+            # Without this, Invoke call may fail due to socket
+            # timeout.
+        )
+        lambda_invoke_client = get_aws_client("lambda", params=dict(config=config))
+
+        try:
+            result = lambda_invoke_client.invoke(
+                FunctionName=self._lambda_arn,
+                InvocationType="RequestResponse",
+                Payload=json.dumps(lambda_event).encode("utf8"),
+            )
+        except ClientError as error:
+            # When lambda isn't invoked for a while, it becomes "inactive". Then
+            # the next invocation will return a transient error and trigger
+            # aws to "reactivate" the lambda. So we wait and then try again.
+            if error.response["Error"]["Code"] == "CodeArtifactUserPendingException":
+                waiter = lambda_invoke_client.get_waiter("function_active")
+                echo(
+                    "Waiting for worker Lambda %s to become active..." % self._name,
+                    False,
+                )
+                waiter.wait(FunctionName=self._name)
+                result = lambda_invoke_client.invoke(
+                    FunctionName=self._lambda_arn,
+                    InvocationType="RequestResponse",
+                    Payload=json.dumps(lambda_event).encode("utf8"),
+                )
+            else:
+                raise
+        log_tailer.stop_tail()
+        log_tailer.join()
+        parsed_result = json.loads(result["Payload"].read())
+
+        if (
+            "errorMessage" in parsed_result
+            and "errorType" in parsed_result
+            and parsed_result["errorType"].startswith("Runtime.")
+        ):
+            # Runtime error, no point in retrying so raise the exception
+            raise LambdaRuntimeException(parsed_result["errorMessage"])
+        elif (
+            "errorMessage" in parsed_result
+            and "Task timed out" in parsed_result["errorMessage"]
+        ):
+            # Lambda timeout, return non-zero code so that the task will be retried
+            echo("[%s] %s " % (self._name, parsed_result["errorMessage"]), True)
+            return 1
+        return parsed_result["return_code"]

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -24,7 +24,7 @@ from metaflow.sidecar import SidecarSubProcess
 from metaflow.unbounded_foreach import UBF_CONTROL
 
 from .batch import BatchException
-from ..aws_utils import get_docker_registry
+from ..aws_utils import compute_resource_attributes, get_docker_registry
 
 
 class BatchDecorator(StepDecorator):
@@ -87,9 +87,9 @@ class BatchDecorator(StepDecorator):
 
     name = "batch"
     defaults = {
-        "cpu": "1",
-        "gpu": "0",
-        "memory": "4096",
+        "cpu": None,
+        "gpu": None,
+        "memory": None,
         "image": None,
         "queue": BATCH_JOB_QUEUE,
         "iam_role": ECS_S3_ACCESS_IAM_ROLE,
@@ -98,6 +98,11 @@ class BatchDecorator(StepDecorator):
         "max_swap": None,
         "swappiness": None,
         "host_volumes": None,
+    }
+    resource_defaults = {
+        "cpu": "1",
+        "gpu": "0",
+        "memory": "4096",
     }
     package_url = None
     package_sha = None
@@ -144,14 +149,10 @@ class BatchDecorator(StepDecorator):
         self.environment = environment
         self.step = step
         self.flow_datastore = flow_datastore
-        for deco in decos:
-            if isinstance(deco, ResourcesDecorator):
-                for k, v in deco.attributes.items():
-                    # We use the larger of @resources and @batch attributes
-                    # TODO: Fix https://github.com/Netflix/metaflow/issues/467
-                    my_val = self.attributes.get(k)
-                    if not (my_val is None and v is None):
-                        self.attributes[k] = str(max(int(my_val or 0), int(v or 0)))
+
+        self.attributes.update(
+            compute_resource_attributes(decos, self, self.resource_defaults)
+        )
 
         # Set run time limit for the AWS Batch job.
         self.run_time_limit = get_run_time_limit_for_task(decos)

--- a/metaflow/plugins/aws/eks/kubernetes_decorator.py
+++ b/metaflow/plugins/aws/eks/kubernetes_decorator.py
@@ -18,7 +18,7 @@ from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task
 from metaflow.sidecar import SidecarSubProcess
 
 from .kubernetes import KubernetesException
-from ..aws_utils import get_docker_registry
+from ..aws_utils import get_docker_registry, compute_resource_attributes
 
 
 class KubernetesDecorator(StepDecorator):
@@ -61,9 +61,10 @@ class KubernetesDecorator(StepDecorator):
 
     name = "kubernetes"
     defaults = {
-        "cpu": "1",
-        "memory": "4096",
-        "disk": "10240",
+        "cpu": None,
+        "memory": None,
+        "disk": None,
+        "gpu": None,
         "image": None,
         "service_account": None,
         "secrets": None,  # e.g., mysecret
@@ -71,6 +72,12 @@ class KubernetesDecorator(StepDecorator):
         "gpu": "0",
         # "shared_memory": None,
         "namespace": None,
+    }
+    resource_defaults = {
+        "cpu": "1",
+        "memory": "4096",
+        "disk": "10240",
+        "gpu": "0",
     }
     package_url = None
     package_sha = None
@@ -121,15 +128,11 @@ class KubernetesDecorator(StepDecorator):
         self.environment = environment
         self.step = step
         self.flow_datastore = flow_datastore
-        for deco in decos:
-            if isinstance(deco, ResourcesDecorator):
-                for k, v in deco.attributes.items():
-                    # We use the larger of @resources and @k8s attributes
-                    # TODO: Fix https://github.com/Netflix/metaflow/issues/467
-                    my_val = self.attributes.get(k)
-                    if not (my_val is None and v is None):
-                        self.attributes[k] = str(max(int(my_val or 0), int(v or 0)))
+        self.attributes.update(
+            compute_resource_attributes(decos, self, self.resource_defaults)
+        )
 
+        for deco in decos:
             if getattr(deco, "IS_PARALLEL", False):
                 raise KubernetesException(
                     "Kubernetes decorator does not support parallel execution yet."

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -24,6 +24,7 @@ from metaflow import R
 from .step_functions_client import StepFunctionsClient
 from .event_bridge_client import EventBridgeClient
 from ..batch.batch import Batch
+from ..aws_utils import compute_resource_attributes
 
 from metaflow.mflog import capture_output_to_mflog
 
@@ -621,8 +622,13 @@ class StepFunctions(object):
 
         # Resolve AWS Batch resource requirements.
         batch_deco = [deco for deco in node.decorators if deco.name == "batch"][0]
-        resources = batch_deco.attributes
-
+        resources = {}
+        resources.update(batch_deco.attributes)
+        resources.update(
+            compute_resource_attributes(
+                node.decorators, batch_deco, batch_deco.resource_defaults
+            )
+        )
         # Resolve retry strategy.
         user_code_retries, total_retries = self._get_retries(node)
 

--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -297,7 +297,7 @@ class CondaStepDecorator(StepDecorator):
         self.base_attributes = self._get_base_attributes()
         os.environ["PYTHONNOUSERSITE"] = "1"
 
-    def package_init(self, flow, step, environment):
+    def package_init(self, flow, step, environment, echo):
         if self.is_enabled():
             self._prepare_step_environment(step, self.local_root)
 


### PR DESCRIPTION
This is a PR to implement https://github.com/Netflix/metaflow/issues/358 , stacked on top of #810 

### What works
You can decorate steps with `@awslambda` and they will run on Lambda. It is pretty quick, just a few seconds spin-up time, so the user experience is much better than AWS Batch. Logs are collected and streamed properly.

`@awslambda` respects `@resource`, `@retry` and `@timeout` decorators.

You can also specify a custom docker image like this:
```python
@awslambda(image="1234.dkr.ecr.us-west-2.amazonaws.com/my-image:latest")
def my_step(self):
    ...
```
The image must be pushed to a ECR registry, public images are not supported by AWS Lambda.

### Not supported in this PR
..but could be done as future improvements:

* No integration with Step Functions. It would be nice if one could write mixed Batch+Lambda workflows and deploy them to Step, but this is not implemented here (you'll get a nice error message)
* `@conda` is not supported (you'll get a nice error message). The reason is that Lambdas only get .5 GB of writable disk space. It could probably technically work for smallish conda deps, but even installing Pandas bumps into that limit, so I figured better to disable this altogether. What we could implement instead in a future PR, is to build and push a custom docker image for each `@conda` step, since Lambda supports docker images up to 10GB in size.

### How to give it a try
For now the setup is somewhat involved, hopefully we'll automate away most of this:
1. In your AWS account, create a ECR repo to hold the docker image for Lambda. 
2. Run `Makefile` from https://github.com/Netflix/metaflow-tools/pull/29 to build the image and push it to the repo. 
3. Create a Lambda IAM role that has access to Metaflow S3 bucket.
4. Set `METAFLOW_LAMBDA_ROLE_ARN` env var to lambda role ARN created in step 4
5. Set `METAFLOW_LAMBDA_CONTAINER_IMAGE` to the docker image URI from step (2)

### Other Limitations
There are a couple of limitations with Lambdas that I don't think can be addressed nicely:
1. AWS provides no way to cancel Lambda execution. If we want to support that, we'd have to invent something awkward with sending termination signal to Lambda via SQS or something. For now lambdas will always run to completion.
2. AWS provides no built-in way to invoke a function asynchronously and poll for the invocation to finish. You can either call it synchronously, but that's potentially a 15 minute API call. Or invoke it asynchronously, but you have to invent your own mechanism for it to signal completion via another service. For now this implementation sticks with the former approach but it has some downsides, for example you need to make sure the HTTP connection doesn't time out.

