### PR TITLE
Properly handle error messages in `_version` metadata call

### DIFF
--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -261,7 +261,7 @@ class ServiceMetadataProvider(MetadataProvider):
             raise MetaflowException('Missing Metaflow Service URL. '
                 'Specify with METAFLOW_SERVICE_URL environment variable')
         path = 'ping/'
-        url = os.path.join(cls.INFO, path.lstrip('/'))
+        url = os.path.join(cls.INFO, path)
         for i in range(METADATA_SERVICE_NUM_RETRIES):
             try:
                 if monitor:

--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -260,7 +260,8 @@ class ServiceMetadataProvider(MetadataProvider):
         if cls.INFO is None:
             raise MetaflowException('Missing Metaflow Service URL. '
                 'Specify with METAFLOW_SERVICE_URL environment variable')
-        url = os.path.join(cls.INFO, 'ping')
+        path = 'ping/'
+        url = os.path.join(cls.INFO, path.lstrip('/'))
         for i in range(METADATA_SERVICE_NUM_RETRIES):
             try:
                 if monitor:


### PR DESCRIPTION
The error handling logic was missing a reference to `path`
resulting in the issue outlined in #472