### PR TITLE
Capture awslogs group/region/stream in task metadata

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -261,10 +261,10 @@ class Batch(object):
 
         if self.job.is_crashed:
             msg = next(msg for msg in 
-                [self.job.reason, self.job.status_reason, 'Task crashed']
+                [self.job.reason, self.job.status_reason, 'Task crashed.']
                  if msg is not None)
             raise BatchException(
-                '%s. '
+                '%s '
                 'This could be a transient error. '
                 'Use @retry to retry.' % msg
             )

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -261,10 +261,10 @@ class Batch(object):
 
         if self.job.is_crashed:
             msg = next(msg for msg in 
-                [self.job.reason, self.job.status_reason, 'Task crashed.']
+                [self.job.reason, self.job.status_reason, 'Task crashed']
                  if msg is not None)
             raise BatchException(
-                '%s '
+                '%s. '
                 'This could be a transient error. '
                 'Use @retry to retry.' % msg
             )


### PR DESCRIPTION
AWS CloudWatch Logs related metadata can now be queried for
tasks that execute on AWS Batch

```
Step('Flow/42/a').task.metadata_dict['aws-batch-awslogs-group']
Step('Flow/42/a').task.metadata_dict['aws-batch-awslogs-region']
Step('Flow/42/a').task.metadata_dict['aws-batch-awslogs-stream']
```