### PR TITLE
Revert usage of shlex for Python2 (not compatible)

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -408,7 +408,7 @@ def _attach_decorators_to_step(step, decospecs):
     from .plugins import STEP_DECORATORS
     decos = {decotype.name: decotype for decotype in STEP_DECORATORS}
     for decospec in decospecs:
-        deconame = decospec.split(':')[0]
+        deconame = decospec.strip("'").split(':')[0]
         if deconame not in decos:
             raise UnknownStepDecoratorException(deconame)
         # Attach the decorator to step if it doesn't have the decorator

--- a/metaflow/util.py
+++ b/metaflow/util.py
@@ -8,7 +8,6 @@ from functools import wraps
 from io import BytesIO
 from itertools import takewhile
 import re
-import shlex
 
 from metaflow.exception import MetaflowUnknownUser, MetaflowInternalError
 
@@ -39,6 +38,7 @@ try:
         def __str__(self):
             return self.path
 
+    from pipes import quote as _quote
 except:
     # python3
     unicode_type = str
@@ -49,6 +49,7 @@ except:
     def unquote_bytes(x):
         return unquote(to_unicode(x))
 
+    from shlex import quote as _quote
 
 class TempDir(object):
     # Provide a temporary directory since Python 2.7 does not have it inbuilt
@@ -304,7 +305,7 @@ def dict_to_cli_options(params):
                         yield value
                     else:
                         # Otherwise, assume it is a literal value and quote it safely
-                        yield shlex.quote(value)
+                        yield _quote(value)
 
 
 # This function is imported from https://github.com/cookiecutter/whichcraft


### PR DESCRIPTION
Allow quoted values in decospec (due to aforementioned quote)