### PR TITLE
Dynamic polling (fix `ThrottlingException`)

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -16,6 +16,7 @@ from metaflow.metaflow_config import AWS_SANDBOX_ENABLED
 
 AWS_LOG_RATELIM = 10
 
+
 class BatchClient(object):
     def __init__(self):
         from ..aws_client import get_aws_client
@@ -470,13 +471,13 @@ class RunningJob(object):
     @property
     def number_running_jobs(self):
         running_job_iter = self.client.unfinished_jobs("RUNNING")
-	return len((*running_job_iter,))
+        return len((*running_job_iter,))
 
     def logs(self):
         def get_log_stream(job):
             log_stream_name = job.log_stream_name
-	    if log_stream_name:
-		return BatchLogs(
+            if log_stream_name:
+                return BatchLogs(
                     "/aws/batch/job",
                     log_stream_name,
                     sleep_on_no_data=1 + self.number_running_jobs / AWS_LOG_RATELIM,


### PR DESCRIPTION
Introduces dynamic polling time to avoid `ThrottlingException` as described in https://github.com/Netflix/metaflow-service/issues/7#issuecomment-586043429 and https://github.com/Netflix/metaflow-service/issues/7#issuecomment-830625893. The polling time is calculated based on the number of running jobs.

* Modifies `BatchClient.unfinished_jobs` to optionally (default=don't) allow filtering by a specific job status (e.g. `RUNNING`)
* Introduce `@property RunningJob.number_running_jobs` which calls `self.client.unfinished_jobs('RUNNING')` in order to calculate the number of running jobs
* Polling time calculated as `1 + number_running_jobs / AWS_LOG_RATELIM`, where `AWS_LOG_RATELIM=10`