### PR TITLE
Enable state machine execution history logging for Step Functions integration

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -124,6 +124,10 @@ EVENTS_SFN_ACCESS_IAM_ROLE = from_conf("METAFLOW_EVENTS_SFN_ACCESS_IAM_ROLE")
 # Prefix for AWS Step Functions state machines. Set to stack name for Metaflow
 # sandbox.
 SFN_STATE_MACHINE_PREFIX = from_conf("METAFLOW_SFN_STATE_MACHINE_PREFIX")
+# Optional AWS CloudWatch Log Group ARN for emitting AWS Step Functions state
+# machine execution logs. This needs to be available when using the 
+# `step-functions create --log-execution-history` command.
+SFN_EXECUTION_LOG_GROUP_ARN = from_conf("METAFLOW_SFN_EXECUTION_LOG_GROUP_ARN")
 
 ###
 # Conda configuration

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -82,6 +82,10 @@ def step_functions(obj,
               default=None,
               type=int,
               help="Workflow timeout in seconds.")
+@click.option('--log-execution-history',
+              is_flag=True,
+              help="Log AWS Step Functions execution history to AWS CloudWatch "
+                   "Logs log group.")
 @click.pass_obj
 def create(obj,
            tags=None,
@@ -91,7 +95,8 @@ def create(obj,
            generate_new_token=False,
            given_token=None,
            max_workers=None,
-           workflow_timeout=None):
+           workflow_timeout=None,
+           log_execution_history=False):
     obj.echo("Deploying *%s* to AWS Step Functions..." % obj.state_machine_name,
              bold=True)
 
@@ -115,7 +120,7 @@ def create(obj,
     if only_json:
         obj.echo_always(flow.to_json(), err=False, no_bold=True)
     else:
-        flow.deploy()
+        flow.deploy(log_execution_history)
         obj.echo("Workflow *{name}* pushed to "
                  "AWS Step Functions successfully.\n"
                     .format(name=obj.state_machine_name), 


### PR DESCRIPTION
Currently, it's hard to keep track of all the execution from within AWS console
for Step Functions executions. Now, the users can pass a `--log-execution-history`
flag to `step-functions create` to pipe execution history logs to an AWS CloudWatch
Logs log group ARN denoted by the environment variable -
METAFLOW_SFN_EXECUTION_LOG_GROUP_ARN