### PR TITLE
Handle hyphens in parameter names for AWS Step Functions executions

### DIFF
--- a/metaflow/parameters.py
+++ b/metaflow/parameters.py
@@ -249,17 +249,8 @@ def set_parameters(flow, kwargs):
         seen.add(norm)
 
     flow._success = True
-    # Impose length constraints on parameter names as some backend systems
-    # impose limits on environment variables (which are used to implement
-    # parameters)
-    parameter_list_length = 0
-    num_parameters = 0
     for var, param in flow._get_parameters():
         val = kwargs[param.name.replace('-', '_').lower()]
-        # Account for the parameter values to unicode strings or integer
-        # values. And the name to be a unicode string.
-        parameter_list_length += len((param.name + str(val)).encode("utf-8"))
-        num_parameters += 1
         # Support for delayed evaluation of parameters. This is used for
         # includefile in particular
         if callable(val):

--- a/metaflow/plugins/aws/step_functions/set_batch_environment.py
+++ b/metaflow/plugins/aws/step_functions/set_batch_environment.py
@@ -10,8 +10,11 @@ def export_parameters(output_file):
     params.update(input)
     with open(output_file, 'w') as f:
         for k in params:
+            # Replace `-` with `_` is parameter names since `-` isn't an
+            # allowed character for environment variables. cli.py will
+            # correctly translate the replaced `-`s.
             f.write('export METAFLOW_INIT_%s=%s\n' %
-                (k.upper(), json.dumps(params[k])))
+                (k.upper().replace('-', '_'), json.dumps(params[k])))
     os.chmod(output_file, 509)
 
 def export_parent_task_ids(output_file):

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -286,13 +286,15 @@ def resolve_token(name,
 @click.pass_obj
 def trigger(obj, **kwargs):
     def _convert_value(param):
-        v = kwargs.get(param.name)
-        return json.dumps(v) if param.kwargs.get('type') == JSONType else \
-            v() if callable(v) else v
+        # Swap `-` with `_` in parameter name to match click's behavior
+        val = kwargs.get(param.name.replace('-', '_').lower())
+        return json.dumps(val) if param.kwargs.get('type') == JSONType else \
+            val() if callable(val) else val
 
     params = {param.name: _convert_value(param)
               for _, param in obj.flow._get_parameters()
-                if kwargs.get(param.name) is not None}
+                if kwargs.get(param.name.replace('-', '_').lower()) is not None}
+
     response = StepFunctions.trigger(obj.state_machine_name, params)
 
     id = response['executionArn'].split(':')[-1]


### PR DESCRIPTION
Prior to this PR, an invocation like `python flow.py step-functions create --foo-bar 42` will result in an error. Metaflow behind the scenes relies on environment variables to correctly pass parameters to various steps. The environment variables, unfortunately, can't have hyphens in the name - this PR accounts for that behavior and fixes the issue.