### PR TITLE
Introduce @project decorator

### DIFF
--- a/metaflow/metadata/metadata.py
+++ b/metaflow/metadata/metadata.py
@@ -4,6 +4,7 @@ import time
 from collections import namedtuple
 from datetime import datetime
 
+from metaflow.current import current
 from metaflow.exception import MetaflowInternalError
 from metaflow.util import get_username, resolve_identity
 
@@ -461,6 +462,9 @@ class MetadataProvider(object):
             tags.append('metaflow_r_version:' + env['metaflow_r_version'])
         if 'r_version_code' in env:
             tags.append('r_version:' + env['r_version_code'])
+        if 'project_name' in current:
+            tags.append('project:' + current.project_name)
+            tags.append('project_branch:' + current.branch_name)
         return tags
 
     def _register_code_package_metadata(self, run_id, step_name, task_id):

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -91,7 +91,11 @@ METADATA_PROVIDERS = _merge_lists(
 # imports from the metaflow package.
 from .conda.conda_flow_decorator import CondaFlowDecorator
 from .aws.step_functions.schedule_decorator import ScheduleDecorator
-FLOW_DECORATORS = _merge_lists([CondaFlowDecorator, ScheduleDecorator], ext_plugins.FLOW_DECORATORS, 'name')
+from .project_decorator import ProjectDecorator
+FLOW_DECORATORS = _merge_lists([CondaFlowDecorator,
+                                ScheduleDecorator,
+                                ProjectDecorator],
+                            ext_plugins.FLOW_DECORATORS, 'name')
 
 
 # Sidecars

--- a/metaflow/plugins/aws/step_functions/event_bridge_client.py
+++ b/metaflow/plugins/aws/step_functions/event_bridge_client.py
@@ -1,5 +1,8 @@
+import base64
 import json
 from hashlib import sha1
+
+from metaflow.util import to_bytes, to_unicode
 
 class EventBridgeClient(object):
 
@@ -58,11 +61,15 @@ class EventBridgeClient(object):
             ]
         )
 
-# Unfortunately the Event Bridge rule names are restricted to 64 characters.
 def format(name):
+    # AWS Event Bridge has a limit of 64 chars for rule names.
+    # We truncate the rule name if the computed name is greater
+    # than 64 chars and append a hashed suffix to ensure uniqueness.
     if len(name) > 64:
-        name_hash = sha1(name.encode('utf-8')).hexdigest()
+        name_hash = to_unicode(
+                        base64.b32encode(
+                            sha1(to_bytes(name)).digest()))[:16].lower()
         # construct an 64 character long rule name
-        return '%s_%s' % (name[:23], name_hash)
+        return '%s-%s' % (name[:47], name_hash)
     else:
         return name

--- a/metaflow/plugins/aws/step_functions/event_bridge_client.py
+++ b/metaflow/plugins/aws/step_functions/event_bridge_client.py
@@ -29,7 +29,6 @@ class EventBridgeClient(object):
         return self.name
 
     def _disable(self):
-        print(self.name)
         try:
             self._client.disable_rule(
                 Name=self.name

--- a/metaflow/plugins/aws/step_functions/event_bridge_client.py
+++ b/metaflow/plugins/aws/step_functions/event_bridge_client.py
@@ -1,12 +1,12 @@
 import json
-
+from hashlib import sha1
 
 class EventBridgeClient(object):
 
     def __init__(self, name):
         from ..aws_client import get_aws_client
         self._client = get_aws_client('events')
-        self.name = name
+        self.name = format(name)
 
     def cron(self, cron):
         self.cron = cron
@@ -26,8 +26,10 @@ class EventBridgeClient(object):
             self._disable()
         else:
             self._set()
+        return self.name
 
     def _disable(self):
+        print(self.name)
         try:
             self._client.disable_rule(
                 Name=self.name
@@ -56,3 +58,12 @@ class EventBridgeClient(object):
                 }
             ]
         )
+
+# Unfortunately the Event Bridge rule names are restricted to 64 characters.
+def format(name):
+    if len(name) > 64:
+        name_hash = sha1(name.encode('utf-8')).hexdigest()
+        # construct an 64 character long rule name
+        return '%s_%s' % (name[:23], name_hash)
+    else:
+        return name

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -45,7 +45,8 @@ class StepFunctions(object):
                  namespace=None,
                  username=None,
                  max_workers=None,
-                 workflow_timeout=None):
+                 workflow_timeout=None,
+                 is_project=False):
         self.name = name
         self.graph = graph
         self.flow = flow

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -539,7 +539,7 @@ class StepFunctions(object):
         env['METAFLOW_RUN_ID'] = attrs['metaflow.run_id.$']
         env['METAFLOW_PRODUCTION_TOKEN'] = self.production_token
         env['SFN_STATE_MACHINE'] = self.name
-        env['METAFLOW_SFN_USER'] = attrs['metaflow.owner']
+        env['METAFLOW_OWNER'] = attrs['metaflow.owner']
         # Can't set `METAFLOW_TASK_ID` due to lack of run-scoped identifiers.
         # We will instead rely on `AWS_BATCH_JOB_ID` as the task identifier.
         # Can't set `METAFLOW_RETRY_COUNT` either due to integer casting issue.

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -80,7 +80,7 @@ class StepFunctions(object):
             # format and push to the user for a better UX, someday.
             return 'This workflow triggers automatically '\
                 'via a cron schedule *%s* defined in AWS EventBridge.' \
-                % self.name
+                % self.event_bridge_rule
         else:
             return 'No triggers defined. '\
                 'You need to launch this workflow manually.'
@@ -130,11 +130,11 @@ class StepFunctions(object):
                                                    "using *metaflow configure "
                                                    "aws* on your terminal.")
         try:
-            EventBridgeClient(self.name) \
-                .cron(self._cron) \
-                .role_arn(EVENTS_SFN_ACCESS_IAM_ROLE) \
-                .state_machine_arn(self._state_machine_arn) \
-                .schedule()
+            self.event_bridge_rule = EventBridgeClient(self.name) \
+                                        .cron(self._cron) \
+                                        .role_arn(EVENTS_SFN_ACCESS_IAM_ROLE) \
+                                        .state_machine_arn(self._state_machine_arn) \
+                                        .schedule()
         except Exception as e:
             raise StepFunctionsSchedulingException(repr(e))
 

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -237,7 +237,6 @@ def resolve_token(name,
                   is_project):
 
     # 1) retrieve the previous deployment, if one exists
-    #TODO - Check existing deployment with is_project enabled
     workflow = StepFunctions.get_existing_deployment(name)
     if workflow is None:
         obj.echo("It seems this is the first time you are deploying *%s* to "

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -1,4 +1,5 @@
 import click
+from hashlib import sha1
 import json
 import re
 from distutils.version import LooseVersion
@@ -9,7 +10,7 @@ from metaflow.exception import MetaflowException, MetaflowInternalError
 from metaflow.datastore.datastore import TransformableObject
 from metaflow.package import MetaflowPackage
 from metaflow.plugins import BatchDecorator
-from metaflow.util import get_username
+from metaflow.util import get_username, to_bytes
 
 from .step_functions import StepFunctions
 from .production_token import load_token, store_token, new_token
@@ -124,9 +125,11 @@ def create(obj,
         obj.echo_always(flow.to_json(), err=False, no_bold=True)
     else:
         flow.deploy(log_execution_history)
-        obj.echo("Workflow *{name}* pushed to "
+        obj.echo("State Machine *{state_machine}* "
+                 "for flow *{name}* pushed to "
                  "AWS Step Functions successfully.\n"
-                    .format(name=obj.state_machine_name), 
+                    .format(state_machine=obj.state_machine_name,
+                            name=current.flow_name), 
                  bold=True)
 
         flow.schedule()

--- a/metaflow/plugins/project_decorator.py
+++ b/metaflow/plugins/project_decorator.py
@@ -1,0 +1,90 @@
+from metaflow.exception import MetaflowException
+from metaflow.decorators import FlowDecorator
+from metaflow import current
+from metaflow.util import get_username
+
+import re
+
+# be careful when changing these limits. Other systems that see
+# these names may rely on these limits
+VALID_NAME_RE = '[^a-z0-9_]'
+VALID_NAME_LEN = 128
+
+class ProjectDecorator(FlowDecorator):
+    name = 'project'
+    defaults = {'name': None}
+
+    options = {
+        'production': dict(
+            is_flag=True,
+            default=False,
+            show_default=True,
+            help="Use the @project's production branch. To "
+                 "use a custom branch, use --branch."),
+        'branch': dict(
+            default=None,
+            show_default=False,
+            help="Use the given branch name under @project. "
+                 "The default is the user name if --production is "
+                 "not specified.")
+    }
+
+    def flow_init(self, flow, graph, environment, logger, echo, options):
+        self._option_values = options
+        project_name = self.attributes.get('name')
+        project_flow_name, branch_name = format_name(flow.name,
+                                                     project_name,
+                                                     options['production'],
+                                                     options['branch'],
+                                                     get_username())
+        echo("Project flow name: *%s*\n" % project_flow_name,
+             fg='magenta',
+             highlight='green')
+        is_user_branch = options['branch'] is None and not options['production']
+        current._update_env({'project_name': project_name,
+                             'branch_name': branch_name,
+                             'is_user_branch': is_user_branch,
+                             'is_production': options['production'],
+                             'project_flow_name': project_flow_name})
+
+    def get_top_level_options(self):
+        return list(self._option_values.items())
+
+def format_name(flow_name,
+                project_name,
+                deploy_prod,
+                given_branch,
+                user_name):
+
+    if not project_name:
+        # an empty string is not a valid project name
+        raise MetaflowException("@project needs a name. "
+                                "Try @project(name='some_name')")
+    elif re.search(VALID_NAME_RE, project_name):
+        raise MetaflowException("The @project name must contain only "
+                                "lowercase alphanumeric characters "
+                                "and underscores.")
+    elif len(project_name) > VALID_NAME_LEN:
+        raise MetaflowException("The @project name must be shorter than "
+                                "%d characters." % VALID_NAME_LEN)
+
+    if given_branch and deploy_prod:
+        raise MetaflowException("Specify either --deploy_prod or --branch.")
+
+    if given_branch:
+        if re.search(VALID_NAME_RE, given_branch):
+            raise MetaflowException("The branch name must contain only "
+                                    "lowercase alphanumeric characters "
+                                    "and underscores.")
+        elif len(given_branch) > VALID_NAME_LEN:
+            raise MetaflowException("Branch name is too long. "
+                                    "The maximum is %d characters."\
+                                    % VALID_NAME_LEN)
+
+        branch = 'test.%s' % given_branch
+    elif deploy_prod:
+        branch = 'prod'
+    else:
+        branch = 'user.%s' % user_name
+
+    return '.'.join((project_name, branch, flow_name)), branch

--- a/metaflow/plugins/project_decorator.py
+++ b/metaflow/plugins/project_decorator.py
@@ -73,9 +73,6 @@ def format_name(flow_name,
         raise MetaflowException("The @project name must be shorter than "
                                 "%d characters." % VALID_NAME_LEN)
 
-    if given_branch and deploy_prod:
-        raise MetaflowException("Specify either --production or --branch.")
-
     if given_branch:
         if re.search(VALID_NAME_RE, given_branch):
             raise MetaflowException("The branch name must contain only "
@@ -85,8 +82,10 @@ def format_name(flow_name,
             raise MetaflowException("Branch name is too long. "
                                     "The maximum is %d characters."\
                                     % VALID_NAME_LEN)
-
-        branch = 'test.%s' % given_branch
+        if deploy_prod:
+            branch = 'prod.%s' % given_branch
+        else:
+            branch = 'test.%s' % given_branch
     elif deploy_prod:
         branch = 'prod'
     else:

--- a/metaflow/plugins/project_decorator.py
+++ b/metaflow/plugins/project_decorator.py
@@ -91,8 +91,8 @@ def format_name(flow_name,
         branch = 'prod'
     else:
         # For AWS Step Functions, we set the branch to the value of
-        # environment variable `METAFLOW_SFN_USER`, since AWS Step Functions
+        # environment variable `METAFLOW_OWNER`, since AWS Step Functions
         # has no notion of user name.
-        branch = 'user.%s' % os.environ.get('METAFLOW_SFN_USER', user_name)
+        branch = 'user.%s' % os.environ.get('METAFLOW_OWNER', user_name)
 
     return '.'.join((project_name, branch, flow_name)), branch

--- a/metaflow/plugins/project_decorator.py
+++ b/metaflow/plugins/project_decorator.py
@@ -46,6 +46,9 @@ class ProjectDecorator(FlowDecorator):
                                                      options['branch'],
                                                      get_username())
         is_user_branch = options['branch'] is None and not options['production']
+        echo("Project: *%s*, Branch: *%s*" % (project_name, branch_name),
+             fg='magenta',
+             highlight='green')
         current._update_env({'project_name': project_name,
                              'branch_name': branch_name,
                              'is_user_branch': is_user_branch,

--- a/test/core/metaflow_test/formatter.py
+++ b/test/core/metaflow_test/formatter.py
@@ -79,7 +79,7 @@ class FlowFormatter(object):
             tags.extend(tag.split('(')[0] for tag in step.tags)
 
         yield 0, '# -*- coding: utf-8 -*-'
-        yield 0, 'from metaflow import FlowSpec, step, Parameter, IncludeFile, JSONType'
+        yield 0, 'from metaflow import FlowSpec, step, Parameter, project, IncludeFile, JSONType'
         yield 0, 'from metaflow_test import assert_equals, '\
                                            'assert_exception, '\
                                            'ExpectationFailed, '\

--- a/test/core/tests/basic_tags.py
+++ b/test/core/tests/basic_tags.py
@@ -6,6 +6,7 @@ class BasicTagTest(MetaflowTest):
     Test that tags are assigned properly.
     """
     PRIORITY = 2
+    HEADER = "@project(name='basic_tag')"
 
     @steps(0, ['all'])
     def step_all(self):
@@ -25,7 +26,9 @@ class BasicTagTest(MetaflowTest):
         flow_obj = run.parent
         # test crazy unicode and spaces in tags
         # these tags must be set with --tag option in contexts.json
-        tags = (u'user:%s' % os.environ.get('METAFLOW_USER'),
+        tags = (u'project:basic_tag',
+                u'project_branch:user.tester',
+                u'user:%s' % os.environ.get('METAFLOW_USER'),
                 u'刺身 means sashimi',
                 u'multiple tags should be ok')
         for tag in tags:

--- a/test/core/tests/dynamic_parameters.py
+++ b/test/core/tests/dynamic_parameters.py
@@ -1,4 +1,3 @@
-
 from metaflow_test import MetaflowTest, ExpectationFailed, steps
 
 class DynamicParameterTest(MetaflowTest):
@@ -14,6 +13,8 @@ os.environ['METAFLOW_RUN_NONDEFAULT_PARAM'] = 'False'
 
 def str_func(ctx):
     import os
+    from metaflow import current
+    assert_equals(current.project_name, 'dynamic_parameters_project')
     assert_equals(ctx.parameter_name, 'str_param')
     assert_equals(ctx.flow_name, 'DynamicParameterTestFlow')
     assert_equals(ctx.user_name, os.environ['METAFLOW_USER'])
@@ -29,6 +30,8 @@ def str_func(ctx):
 def json_func(ctx):
     import json
     return json.dumps({'a': [8]})
+
+@project(name='dynamic_parameters_project')
 """
 
     @steps(0, ['singleton'], required=True)

--- a/test/core/tests/project_branch.py
+++ b/test/core/tests/project_branch.py
@@ -1,0 +1,22 @@
+from metaflow_test import MetaflowTest, ExpectationFailed, steps, tag
+
+class ProjectBranchTest(MetaflowTest):
+    PRIORITY = 1
+
+    HEADER = """
+import os
+
+os.environ['METAFLOW_BRANCH'] = 'this_is_a_test_branch'
+@project(name='project_branch')
+"""
+
+    @steps(0, ['singleton'], required=True)
+    def step_single(self):
+        pass
+
+    @steps(1, ['all'])
+    def step_all(self):
+        from metaflow import current
+        assert_equals(current.branch_name, 'test.this_is_a_test_branch')
+        assert_equals(current.project_flow_name,
+                      'project_branch.test.this_is_a_test_branch.ProjectBranchTestFlow')

--- a/test/core/tests/project_production.py
+++ b/test/core/tests/project_production.py
@@ -1,0 +1,22 @@
+from metaflow_test import MetaflowTest, ExpectationFailed, steps, tag
+
+class ProjectProductionTest(MetaflowTest):
+    PRIORITY = 1
+
+    HEADER = """
+import os
+
+os.environ['METAFLOW_PRODUCTION'] = 'True'
+@project(name='project_prod')
+"""
+
+    @steps(0, ['singleton'], required=True)
+    def step_single(self):
+        pass
+
+    @steps(1, ['all'])
+    def step_all(self):
+        from metaflow import current
+        assert_equals(current.branch_name, 'prod')
+        assert_equals(current.project_flow_name,
+                      'project_prod.prod.ProjectProductionTestFlow')


### PR DESCRIPTION
This PR introduces @project decorator to help users manage multiple Metaflow flows (especially on AWS Step Functions). 

[Documentation](https://docs.google.com/document/d/1NDFrPhi5-zuUkuayDg3K277-yry8Nup2fxhQGgWGzLI/edit?usp=sharing)

I will introduce namespace-aware triggering of flows in a separate PR.