### PR TITLE
Add check for empty describe_jobs response for AWS Batch

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -327,7 +327,7 @@ class BatchJob(object):
         return self
 
 class Throttle(object):
-    def __init__(self, delta_in_secs=1, num_tries=1):
+    def __init__(self, delta_in_secs=1, num_tries=20):
         self.delta_in_secs = delta_in_secs
         self.num_tries = num_tries
         self._now = None

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -327,7 +327,7 @@ class BatchJob(object):
         return self
 
 class Throttle(object):
-    def __init__(self, delta_in_secs=1, num_tries=20):
+    def __init__(self, delta_in_secs=1, num_tries=1):
         self.delta_in_secs = delta_in_secs
         self.num_tries = num_tries
         self._now = None
@@ -381,7 +381,15 @@ class RunningJob(object):
             if code == 429 or code >= 500:
                 raise TriableException(err)
             raise err
-        self._apply(data['jobs'][0])
+        # There have been sporadic reports of empty responses to the
+        # batch.describe_jobs API call, which can potentially happen if the
+        # batch.submit_job API call is not strongly consistent(¯\_(ツ)_/¯).
+        # We add a check here to guard against that. The `update()` call
+        # will ensure that we poll `batch.describe_jobs` until we get a
+        # satisfactory response at least once through out the lifecycle of
+        # the job.
+        if len(data['jobs']) == 1:
+            self._apply(data['jobs'][0])
 
     def update(self):
         self._update()

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from collections import defaultdict, deque
 import random
 import select


### PR DESCRIPTION
It seems that the response for describe_jobs could be empty,
particularly when the job has been just launched. Although, I
haven't been able to replicate the issue on my end, a handful of
Metaflow users seem to have run into it. When such an issue happens,
this PR happily ignores the response and tries again.