### PR TITLE
Orient flow graph images from top to bottom

### DIFF
--- a/metaflow/graph.py
+++ b/metaflow/graph.py
@@ -248,7 +248,6 @@ class FlowGraph(object):
                       '  shape = "record" ];'.format(node, type=nodetype)
 
         return "digraph {0.name} {{\n"\
-               "rankdir=LR;\n"\
                "{nodes}\n"\
                "{edges}\n"\
                "}}".format(self,


### PR DESCRIPTION
It is hard to read the flow graph images of longer flows. This is because the node labels and graph edges are oriented in the same direction (horizontally), making the images long and thin. In contrast, orienting flow graphs from top to bottom allows more nodes to fit on a screen, making them easier to read.

I've attached two visualizations of the same toy flow, a "before" image (`left-to-right.png`) and an "after" image (`top-to-bottom.png`). Squeezing them into this PR text box unfairly accentuates the issue, because there is limited horizontal space an unlimited vertical space, but if you click through to the images, you'll see what I mean.

No worries if the left-to-right layout was a conscious decision and there's a benefit to it that I've not considered. I'd be happy to just close out the PR if so.

![left-to-right](https://user-images.githubusercontent.com/6373515/120723779-414b1200-c487-11eb-9cd6-b5cb31fcdcfa.png)
![top-to-bottom](https://user-images.githubusercontent.com/6373515/120723786-44460280-c487-11eb-8d5d-f471d000d7b1.png)


