### PR TITLE
Enabling Basic Auth for communicating with Metadata Service

### DIFF
--- a/metaflow/main_cli.py
+++ b/metaflow/main_cli.py
@@ -533,6 +533,14 @@ def aws(ctx, profile):
                              default=\
                                 existing_env.get('METAFLOW_SERVICE_AUTH_KEY', ''),
                              show_default=True)
+        # Set Auth Type for the Metadata Service.
+        env['METAFLOW_METADATA_SERVICE_AUTH_TYPE'] =\
+                click.prompt(cyan('[METAFLOW_METADATA_SERVICE_AUTH_TYPE]') + 
+                             yellow(' (optional)') +
+                             ' Override API Gateway as the default auth type.',
+                             default=\
+                                existing_env.get('METAFLOW_METADATA_SERVICE_AUTH_TYPE', ''),
+                             show_default=True)
 
     # Configure AWS Batch for compute.
     if use_s3_as_datastore:

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -232,10 +232,11 @@ try:
 except ImportError as e:
     ver = sys.version_info[0] * 10 + sys.version_info[1]
     if ver >= 36:
-        # e.path is not None if the error stems from some other place than here
+        # e.name is set to the name of the package that fails to load
         # so don't error ONLY IF the error is importing this module (but do
         # error if there is a transitive import error)
-        if not (isinstance(e, ModuleNotFoundError) and e.path is None):
+        if not (isinstance(e, ModuleNotFoundError) and \
+                e.name in ['metaflow_custom', 'metaflow_custom.config']):
             print(
                 "Cannot load metaflow_custom configuration -- "
                 "if you want to ignore, uninstall metaflow_custom package")
@@ -243,9 +244,6 @@ except ImportError as e:
 else:
     # We load into globals whatever we have in extension_module
     # We specifically exclude any modules that may be included (like sys, os, etc)
-    # *except* for ones that are part of metaflow_custom (basically providing
-    # an aliasing mechanism)
-    lazy_load_custom_modules = {}
     for n, o in extension_module.__dict__.items():
         if n == 'DEBUG_OPTIONS':
             DEBUG_OPTIONS.extend(o)
@@ -254,16 +252,9 @@ else:
                     from_conf('METAFLOW_DEBUG_%s' % typ.upper())
         elif not n.startswith('__') and not isinstance(o, types.ModuleType):
             globals()[n] = o
-        elif isinstance(o, types.ModuleType) and o.__package__ and \
-                o.__package__.startswith('metaflow_custom'):
-            lazy_load_custom_modules['metaflow.%s' % n] = o
-    if lazy_load_custom_modules:
-        from metaflow import _LazyLoader
-        sys.meta_path.append(_LazyLoader(lazy_load_custom_modules))
 finally:
     # Erase all temporary names to avoid leaking things
-    for _n in ['ver', 'n', 'o', 'e', 'type', 'lazy_load_custom_modules',
-               'extension_module', '_LazyLoader']:
+    for _n in ['ver', 'n', 'o', 'e', 'extension_module']:
         try:
             del globals()[_n]
         except KeyError:

--- a/metaflow/plugins/aws/aws_client.py
+++ b/metaflow/plugins/aws/aws_client.py
@@ -4,7 +4,7 @@ cached_aws_sandbox_creds = None
 def get_aws_client(module, with_error=False, params={}):
     from metaflow.exception import MetaflowException
     from metaflow.metaflow_config import AWS_SANDBOX_ENABLED, \
-        AWS_SANDBOX_STS_ENDPOINT_URL, AWS_SANDBOX_API_KEY
+        AWS_SANDBOX_STS_ENDPOINT_URL, AWS_SANDBOX_API_KEY, METADATA_SERVICE_AUTH_TYPE
     import requests
     try:
         import boto3
@@ -18,9 +18,14 @@ def get_aws_client(module, with_error=False, params={}):
         if cached_aws_sandbox_creds is None:
             # authenticate using STS
             url = "%s/auth/token" % AWS_SANDBOX_STS_ENDPOINT_URL
-            headers = {
-                'x-api-key': AWS_SANDBOX_API_KEY
-            }
+            if METADATA_SERVICE_AUTH_TYPE == 'basic':
+                headers = {
+                    'authorization': 'Basic {key}'.format(key=AWS_SANDBOX_API_KEY)
+                }
+            elif METADATA_SERVICE_AUTH_TYPE == 'apigw':
+                headers = {
+                    'x-api-key': AWS_SANDBOX_API_KEY
+                }
             try:
                 r = requests.get(url, headers=headers)
                 r.raise_for_status()


### PR DESCRIPTION
**Summary**

After experimenting with some other frontends for Metadata service ingress, supporting basic auth as a client-side communication mechanism seems like a worthwhile exercise.

The implementation is just the addition of a 'METAFLOW_METADATA_SERVICE_AUTH_TYPE vairable, and a few small conditionals since the HTTP header title changes based on the auth type.

**Usage**

During `metaflow configure aws`, the CLI presents an option to override the default auth type ('apigw').  If you enter 'basic', it configures the client to use the 'Authorization' header, and prepends the key with "Basic" automatically.  The key it expects in the 'METADATA_SERVICE_AUTH_KEY' variable is the base64 hashed value typically used by Basic auth, `'<username>:<password>'`.

If no environment variable is set or the CLI default is accepted, Metaflow will continue to expect API Gateway.