### PR TITLE
Get rid of  _METAFLOW_RESUMED_RUN in tests

### DIFF
--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -949,9 +949,6 @@ class Worker(object):
         env['PYTHONUNBUFFERED'] = 'x'
         # the env vars are needed by the test framework, nothing else
         env['_METAFLOW_ATTEMPT'] = str(self.task.retries)
-        if self.task.clone_run_id:
-            env['_METAFLOW_RESUMED_RUN'] = '1'
-            env['_METAFLOW_RESUME_ORIGIN_RUN_ID'] = str(self.task.clone_run_id)
         # NOTE bufsize=1 below enables line buffering which is required
         # by read_logline() below that relies on readline() not blocking
         # print('running', args)

--- a/test/core/metaflow_test/__init__.py
+++ b/test/core/metaflow_test/__init__.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from metaflow.exception import MetaflowException
+from metaflow import current
 
 def steps(prio, quals, required=False):
     def wrapper(f):
@@ -50,10 +51,10 @@ class TestRetry(MetaflowException):
                                         "Testing retry...")
 
 def is_resumed():
-    return '_METAFLOW_RESUMED_RUN' in os.environ
+    return current.origin_run_id is not None
 
 def origin_run_id_for_resume():
-    return os.environ['_METAFLOW_RESUME_ORIGIN_RUN_ID']
+    return current.origin_run_id
 
 def assert_equals(expected, got):
     if expected != got:


### PR DESCRIPTION
According to @savingoyal this hack is no longer necessary (it was introduced before this info was available in `metaflow.current`). The hack also does not work on Batch or AWS Lambda