### PR TITLE
A couple run_tests tweaks

### DIFF
--- a/test/core/metaflow_test/formatter.py
+++ b/test/core/metaflow_test/formatter.py
@@ -140,7 +140,10 @@ class FlowFormatter(object):
                                 'branch=True, '\
                                 'omit=["check_flow.py", '\
                                       '"test_flow.py", '\
-                                      '"*/click/*"])'
+                                      '"*/click/*", '\
+                                      '"*/site-packages/*", '\
+                                      '"*/core/metaflow_custom/*", '\
+                                      '"*/core/metaflow_test/*"])'
         yield 0, 'cov.start()'
         yield 0, 'import sys'
         yield 0, 'from metaflow_test import assert_equals, new_checker'


### PR DESCRIPTION
A few tweaks that didn't seem to deserve separate PRs.

1. Exclude more stuff from coverage
2. Copy `metaflow_test` module to the temp dir so it gets included into the code package. Without this, tests fail on AWS Lambda (as `metaflow_test` is not available to the step code )
3. Add `--inherit-env` option that makes run_tests.py pass its own env to the test (off by default).