### PR TITLE
Python 2 compatibility fixes

### DIFF
--- a/metaflow/mflog/save_logs_periodically.py
+++ b/metaflow/mflog/save_logs_periodically.py
@@ -8,14 +8,6 @@ from metaflow.metaflow_profile import profile
 from metaflow.sidecar import SidecarSubProcess
 from . import update_delay, BASH_SAVE_LOGS_ARGS
 
-class SaveLogsPeriodically(object):
-
-    def __init__(self):
-        self._sidecar = SidecarSubProcess("save_logs_periodically")
-
-    def shutdown(self):
-        self._sidecar.kill()
-
 class SaveLogsPeriodicallySidecar(object):
 
     def __init__(self):

--- a/metaflow/mflog/tee.py
+++ b/metaflow/mflog/tee.py
@@ -2,14 +2,24 @@ import sys
 from .mflog import decorate
 
 # This script is similar to the command-line utility 'tee':
-# It reads stdin line by line and writes the lines to stodut
+# It reads stdin line by line and writes the lines to stdout
 # and a file. In contrast to 'tee', this script formats each
 # line with mflog-style structure.
 
 if __name__ == '__main__':
     SOURCE = sys.argv[1].encode('ascii')
+
     with open(sys.argv[2], mode='ab', buffering=0) as f:
-        for line in sys.stdin.buffer:
-            decorated = decorate(SOURCE, line)
-            f.write(decorated)
-            sys.stdout.buffer.write(line)
+        if sys.version_info < (3, 0):
+            # Python 2
+            for line in iter(sys.stdin.readline, ''):
+                # https://bugs.python.org/issue3907
+                decorated = decorate(SOURCE, line)
+                f.write(decorated)
+                sys.stdout.write(line)
+        else:
+            # Python 3
+            for line in sys.stdin.buffer:
+                decorated = decorate(SOURCE, line)
+                f.write(decorated)
+                sys.stdout.buffer.write(line)

--- a/metaflow/sidecar.py
+++ b/metaflow/sidecar.py
@@ -59,6 +59,10 @@ class SidecarSubProcess(object):
                 (platform.system() == 'Darwin' and sys.version_info < (3, 0)):
                 # if on darwin and running python 2 disable sidecars
                 # there is a bug with importing poll from select in some cases
+                #
+                # TODO: Python 2 shipped by Anaconda allows for 
+                # `from select import poll`. We can consider enabling sidecars
+                # for that distribution if needed at a later date.
                 self.__poller = NullPoller()
 
         else:
@@ -138,4 +142,4 @@ class SidecarSubProcess(object):
                 self.logger(repr(ex))
 
     def logger(self, msg):
-        print("metaflow logger: " + msg, file=sys.stderr)
+        print("metaflow sidecar logger: " + msg, file=sys.stderr)

--- a/metaflow/sidecar.py
+++ b/metaflow/sidecar.py
@@ -90,6 +90,8 @@ class SidecarSubProcess(object):
     def __start_subprocess(self, cmdline):
         for i in range(3):
             try:
+                # Set stdout=sys.stdout & stderr=sys.stderr
+                # to print to console the output of sidecars.
                 return subprocess.Popen(cmdline,
                                         stdin=subprocess.PIPE,
                                         stdout=open(os.devnull, 'w'),

--- a/metaflow/sidecar_messages.py
+++ b/metaflow/sidecar_messages.py
@@ -1,11 +1,10 @@
 import json
-from enum import IntEnum
 
 # Define message enums
-class MessageTypes(IntEnum):
-    SHUTDOWN = 1
-    LOG_EVENT = 2
-
+# Unfortunately we can't use enums because they are not supported
+# officially in Python2
+class MessageTypes(object):
+    SHUTDOWN, LOG_EVENT = range(1, 3)
 
 class Message(object):
 
@@ -20,9 +19,5 @@ class Message(object):
         }
         return json.dumps(msg)+"\n"
 
-
 def deserialize(json_msg):
-    parsed_json_msg = json.loads(json_msg)
-    return Message(MessageTypes(parsed_json_msg['msg_type']),
-                   parsed_json_msg['payload'])
-
+    return Message(**json.loads(json_msg))


### PR DESCRIPTION
1. Sidecars were borked on Python 2 since there is no native enum functionality in stdlib.
2. Mflog was borked on Python 2 as well since tee was assuming that it was launched using Python 3.
3. Remove some dead-code in MFlog implementation.
