### PR TITLE
Fix issue with ClientError in s3.datatools

### DIFF
--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -877,7 +877,7 @@ class S3(object):
             try:    
                 op(self._s3_client, tmp.name)
                 return tmp.name
-            except self._s3_client_error1 as err:
+            except self._s3_client_error as err:
                 error_code = s3op.normalize_client_error(err)
                 if error_code == 404:
                     raise MetaflowS3NotFound(url)

--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -52,7 +52,7 @@ RangeInfo = namedtuple_with_defaults(
     'RangeInfo', 'total_size request_offset request_length',
     defaults=(0, -1))
 
-NUM_S3OP_RETRIES = 8
+NUM_S3OP_RETRIES = 7
 
 class MetaflowS3InvalidObject(MetaflowException):
     headline = 'Not a string-like object'
@@ -872,7 +872,7 @@ class S3(object):
     def _one_boto_op(self, op, url):
         from . import s3op
         error = ''
-        for i in range(NUM_S3OP_RETRIES):
+        for i in range(NUM_S3OP_RETRIES + 1):
             tmp = NamedTemporaryFile(dir=self._tmpdir,
                                      prefix='metaflow.s3.one_file.',
                                      delete=False)
@@ -970,7 +970,7 @@ class S3(object):
             else:
                 cmdline.extend(('--%s' % key, value))
 
-        for i in range(NUM_S3OP_RETRIES):
+        for i in range(NUM_S3OP_RETRIES + 1):
             with NamedTemporaryFile(dir=self._tmpdir,
                                     mode='wb+',
                                     delete=not debug.s3client,

--- a/metaflow/datatools/s3op.py
+++ b/metaflow/datatools/s3op.py
@@ -99,7 +99,7 @@ def worker(result_file_name, queue, mode):
                 'size': head['ContentLength'],
                 'content_type': head['ContentType'],
                 'metadata': head['Metadata']}
-        except ClientError as err:
+        except client_error as err:
             error_code = normalize_client_error(err)
             if error_code == 404:
                 to_return = {'error': ERROR_URL_NOT_FOUND, 'raise_error': err}
@@ -112,7 +112,7 @@ def worker(result_file_name, queue, mode):
     with open(result_file_name, 'w') as result_file:
         try:
             from metaflow.datastore.util.s3util import get_s3_client
-            s3, _ = get_s3_client()
+            s3, client_error = get_s3_client()
             while True:
                 url, idx = queue.get()
                 if url is None:

--- a/metaflow/datatools/s3op.py
+++ b/metaflow/datatools/s3op.py
@@ -159,7 +159,7 @@ def worker(result_file_name, queue, mode):
                                 raise RuntimeError("Could not load file")
                         tmp.close()
                         os.rename(tmp.name, url.local)
-                    except ClientError as err:
+                    except client_error as err:
                         error_code = normalize_client_error(err)
                         if error_code == 404:
                             pass # We skip this
@@ -300,11 +300,12 @@ class S3Ops(object):
 
     def __init__(self):
         self.s3 = None
+        self.client_error = None
 
     def reset_client(self, hard_reset=False):
         from metaflow.datastore.util.s3util import get_s3_client
         if hard_reset or self.s3 is None:
-            self.s3, _ = get_s3_client()
+            self.s3, self.client_error = get_s3_client()
 
     @aws_retry
     def get_info(self, url):
@@ -320,7 +321,7 @@ class S3Ops(object):
                 content_type=head['ContentType'],
                 metadata=head['Metadata'],
                 range=url.range), head['ContentLength'])]
-        except ClientError as err:
+        except self.client_error as err:
             error_code = normalize_client_error(err)
             if error_code == 404:
                 return False, url, ERROR_URL_NOT_FOUND
@@ -363,7 +364,7 @@ class S3Ops(object):
             return True, prefix_url, urls
         except self.s3.exceptions.NoSuchBucket:
             return False, prefix_url, ERROR_URL_NOT_FOUND
-        except ClientError as err:
+        except self.client_error as err:
             if err.response['Error']['Code'] == 'AccessDenied':
                 return False, prefix_url, ERROR_URL_ACCESS_DENIED
             else:
@@ -768,5 +769,4 @@ def info(prefixes,
             print(format_triplet(url.prefix, url.url, url.local))
 
 if __name__ == '__main__':
-    from botocore.exceptions import ClientError
     cli(auto_envvar_prefix='S3OP')


### PR DESCRIPTION
Fix for the stack trace 

```
raise MetaflowS3Exception("Getting S3 files failed.\n"\
metaflow.datatools.s3.MetaflowS3Exception: Getting S3 files failed.
First prefix requested: ('s3://blah', None)
Error: Traceback (most recent call last):
  File "/Users/savin/Code/metaflow/metaflow/datatools/s3op.py", line 96, in op_info
    head = s3.head_object(Bucket=url.bucket, Key=url.path)
  File "/Users/savin/opt/miniconda3/lib/python3.9/site-packages/botocore/client.py", line 386, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/savin/opt/miniconda3/lib/python3.9/site-packages/botocore/client.py", line 705, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (404) when calling the HeadObject operation: Not Found
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/Users/savin/Code/metaflow/metaflow/datatools/s3op.py", line 131, in worker
    result_info = op_info(url)
  File "/Users/savin/Code/metaflow/metaflow/datatools/s3op.py", line 102, in op_info
    except ClientError as err:
NameError: name 'ClientError' is not defined
s3op failed:
Unknown error
Worker process failed (exit code 8)
```