### PR TITLE
Fix return type of task.environment_info

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -1056,7 +1056,7 @@ class Task(MetaflowObject):
         if not env_type:
             return None
         env = [m for m in ENVIRONMENTS + [MetaflowEnvironment] if m.TYPE == env_type][0]
-        return env.get_client_info(self.path_components[0], self.metadata_dict)
+        return env.get_info(self.path_components[0], self.metadata_dict)
 
     def _load_log(self, stream):
         log_location = self.metadata_dict.get('log_location_%s' % stream)

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -61,7 +61,7 @@ class MetaflowEnvironment(object):
         return []
 
     @classmethod
-    def get_client_info(cls, flow_name, metadata):
+    def get_info(cls, flow_name, metadata):
         """
         Environment may customize the information returned to the client about the environment
 
@@ -74,9 +74,9 @@ class MetaflowEnvironment(object):
 
         Returns
         -------
-        str : Information printed and returned to the user
+        dict : Information for the environment
         """
-        return "Local environment"
+        return {'type': MetaflowEnvironment.TYPE}
 
     def get_package_commands(self, code_package_url):
         cmds = [BASH_MFLOG,


### PR DESCRIPTION
!!Breaking Change!!
The return type of task.environment_info fluctuated between a
string and a dict depending on the actual environment.

As a follow-up we need to fix the schema of the returned object.