### PR TITLE
Remove METAFLOW_ATTEMPT

### DIFF
--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -947,8 +947,6 @@ class Worker(object):
                                       self.task.ubf_context)
         env.update(args.get_env())
         env['PYTHONUNBUFFERED'] = 'x'
-        # the env vars are needed by the test framework, nothing else
-        env['_METAFLOW_ATTEMPT'] = str(self.task.retries)
         # NOTE bufsize=1 below enables line buffering which is required
         # by read_logline() below that relies on readline() not blocking
         # print('running', args)

--- a/test/core/metaflow_test/formatter.py
+++ b/test/core/metaflow_test/formatter.py
@@ -79,7 +79,7 @@ class FlowFormatter(object):
             tags.extend(tag.split('(')[0] for tag in step.tags)
 
         yield 0, '# -*- coding: utf-8 -*-'
-        yield 0, 'from metaflow import FlowSpec, step, Parameter, project, IncludeFile, JSONType'
+        yield 0, 'from metaflow import FlowSpec, step, Parameter, project, IncludeFile, JSONType, current'
         yield 0, 'from metaflow_test import assert_equals, '\
                                            'assert_exception, '\
                                            'ExpectationFailed, '\

--- a/test/core/tests/tag_catch.py
+++ b/test/core/tests/tag_catch.py
@@ -1,5 +1,7 @@
 
 from metaflow_test import MetaflowTest, ExpectationFailed, steps, tag
+from metaflow import current
+
 
 class TagCatchTest(MetaflowTest):
     PRIORITY = 2
@@ -8,7 +10,7 @@ class TagCatchTest(MetaflowTest):
     @steps(0, ['start'])
     def step_start(self):
         import os, sys
-        self.test_attempt = int(os.environ['_METAFLOW_ATTEMPT'])
+        self.test_attempt = current.retry_count
         sys.stdout.write('stdout testing logs %d\n' % self.test_attempt)
         sys.stderr.write('stderr testing logs %d\n' % self.test_attempt)
         if self.test_attempt < 3:
@@ -20,7 +22,7 @@ class TagCatchTest(MetaflowTest):
     @steps(0, ['foreach-split'])
     def step_split(self):
         import os
-        if os.environ['_METAFLOW_ATTEMPT'] == '2':
+        if current.retry_count == 2:
             self.this_is_split = True
         else:
             raise TestRetry()
@@ -29,7 +31,7 @@ class TagCatchTest(MetaflowTest):
     @steps(0, ['join'])
     def step_join(self):
         import os
-        if os.environ['_METAFLOW_ATTEMPT'] == '2':
+        if current.retry_count == 2:
             self.test_attempt = inputs[0].test_attempt
         else:
             raise TestRetry()


### PR DESCRIPTION
It is no longer necessary to have this workaround for tests, as this info is available in the `current` object.