### PR TITLE
(R) Change tutorial decorators to new wrappers

### DIFF
--- a/R/inst/tutorials/04-helloaws/helloaws.R
+++ b/R/inst/tutorials/04-helloaws/helloaws.R
@@ -3,7 +3,7 @@
 
 library(metaflow)
 
-# This is the 'start' step. All flows must have a step named 
+# This is the 'start' step. All flows must have a step named
 # 'start' that is the first step in the flow.
 start <- function(self){
     message("HelloAWS is starting.")
@@ -13,25 +13,25 @@ start <- function(self){
 # A step for metaflow to introduce itself.
 hello <- function(self){
     self$message <- "We're on the cloud! Metaflow says: Hi!"
-    print(self$message) 
+    print(self$message)
     message("Using metadata provider: ", get_metadata())
 }
 
-# This is the 'end' step. All flows must have an 'end' step, 
+# This is the 'end' step. All flows must have an 'end' step,
 # which is the last step in the flow.
 end <- function(self){
     message("HelloAWS is all done.")
 }
 
 metaflow("HelloAWSFlow") %>%
-    step(step = "start", 
-         r_function = start, 
+    step(step = "start",
+         r_function = start,
          next_step = "hello") %>%
-    step(step = "hello", 
-         decorator("retry", times=2),
-         decorator("batch", cpu=2, memory=2048),
-         r_function = hello,  
+    step(step = "hello",
+         retry(times=2),
+         batch(cpu=2, memory=2048),
+         r_function = hello,
          next_step = "end") %>%
-    step(step = "end", 
-         r_function = end) %>% 
+    step(step = "end",
+         r_function = end) %>%
     run()


### PR DESCRIPTION
Follows on from #565 

This PR changes tutorial 5 to use the new `retry` and `batch` decorators that were introduced in the previous PR. There is a corresponding PR to the docs that covers this as well as #565:

* https://github.com/Netflix/metaflow-docs/pull/11

Sorry about the changed lines --- my IDE removes trailing whitespace. 