### PR TITLE
Parse environment variables passed from CLI

### DIFF
--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -249,7 +249,7 @@ def step(
 
     env_deco = [deco for deco in node.decorators if deco.name == "environment"]
     if env_deco:
-        env = env_deco[0].attributes["vars"]
+        env = env_deco[0].vars_dict()
     else:
         env = {}
 

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -388,7 +388,7 @@ class StepFunctions(object):
                         if deco.name == 'environment']
         env = {}
         if env_deco:
-            env = env_deco[0].attributes['vars']
+            env = env_deco[0].vars_dict()
 
         if node.name == 'start':
             # Initialize parameters for the flow in the `start` step.

--- a/metaflow/plugins/environment_decorator.py
+++ b/metaflow/plugins/environment_decorator.py
@@ -27,6 +27,9 @@ class EnvironmentDecorator(StepDecorator):
     name = 'environment'
     defaults = {'vars': {}}
 
+    def step_init(self, flow, graph, step_name, decorators, environment, datastore, logger):
+        self.attributes["vars"] = self.vars_dict().items()
+
     def vars_dict(self):
         vars = self.attributes["vars"]
         if isinstance(vars, str):  # env specified using --with will be a string that we must parse

--- a/metaflow/plugins/environment_decorator.py
+++ b/metaflow/plugins/environment_decorator.py
@@ -39,10 +39,8 @@ class EnvironmentDecorator(StepDecorator):
 
             except Exception as e:
                 raise ValueError(
-                    f"Encountered a problem parsing stringified @environment vars attribute as a dict: {e}"
+                    "Encountered a problem parsing stringified @environment vars attribute as a dict: {}".format(e)
                 )
-
-            logger.debug(f"Parsed stringified @environment vars attribute to dict with keys: {vars_dict.keys()}")
             self.attributes["vars"] = vars_dict
 
 

--- a/metaflow/plugins/environment_decorator.py
+++ b/metaflow/plugins/environment_decorator.py
@@ -27,7 +27,7 @@ class EnvironmentDecorator(StepDecorator):
     name = 'environment'
     defaults = {'vars': {}}
 
-    def step_init(self, flow, graph, step_name, decorators, environment, datastore, logger):
+    def vars_dict(self):
         vars = self.attributes["vars"]
         if isinstance(vars, str):  # env specified using --with will be a string that we must parse
             try:
@@ -41,8 +41,9 @@ class EnvironmentDecorator(StepDecorator):
                 raise ValueError(
                     "Encountered a problem parsing stringified @environment vars attribute as a dict: {}".format(e)
                 )
-            self.attributes["vars"] = vars_dict
-
+            return vars_dict
+        else:
+            return vars
 
     def runtime_step_cli(self, cli_args, retry_count, max_user_code_retries, ubf_context):
-        cli_args.env.update(self.attributes['vars'].items())
+        cli_args.env.update(self.vars_dict().items())

--- a/metaflow/plugins/environment_decorator.py
+++ b/metaflow/plugins/environment_decorator.py
@@ -27,5 +27,24 @@ class EnvironmentDecorator(StepDecorator):
     name = 'environment'
     defaults = {'vars': {}}
 
+    def step_init(self, flow, graph, step_name, decorators, environment, datastore, logger):
+        vars = self.attributes["vars"]
+        if isinstance(vars, str):  # env specified using --with will be a string that we must parse
+            try:
+                vars_dict = {}
+                pairs = vars.split(",")
+                for pair in pairs:
+                    k, v = pair.split(":")
+                    vars_dict[k] = v
+
+            except Exception as e:
+                raise ValueError(
+                    f"Encountered a problem parsing stringified @environment vars attribute as a dict: {e}"
+                )
+
+            logger.debug(f"Parsed stringified @environment vars attribute to dict with keys: {vars_dict.keys()}")
+            self.attributes["vars"] = vars_dict
+
+
     def runtime_step_cli(self, cli_args, retry_count, max_user_code_retries, ubf_context):
         cli_args.env.update(self.attributes['vars'].items())

--- a/metaflow/plugins/environment_decorator.py
+++ b/metaflow/plugins/environment_decorator.py
@@ -1,7 +1,7 @@
 import os
 
-from metaflow.exception import MetaflowException
 from metaflow.decorators import StepDecorator
+from metaflow.exception import MetaflowException
 
 
 class EnvironmentDecorator(StepDecorator):
@@ -27,19 +27,15 @@ class EnvironmentDecorator(StepDecorator):
     name = 'environment'
     defaults = {'vars': {}}
 
-    def step_init(self, flow, graph, step_name, decorators, environment, datastore, logger):
-        self.attributes["vars"] = self.vars_dict().items()
-
     def vars_dict(self):
         env_vars = self.attributes["vars"]
-        env_vars = env_vars.lstrip("{").rstrip("}") # strip brackets
         if isinstance(vars, str):  # env specified using --with will be a string that we must parse
             try:
                 vars_dict = {}
                 pairs = env_vars.split(",")
                 for pair in pairs:
                     k, v = pair.split(":", 1) # split on the first colon only
-                    vars_dict[k.strip()] = v.strip()
+                    vars_dict[k] = v
 
             except Exception as e:
                 raise ValueError(

--- a/metaflow/plugins/environment_decorator.py
+++ b/metaflow/plugins/environment_decorator.py
@@ -29,7 +29,7 @@ class EnvironmentDecorator(StepDecorator):
 
     def vars_dict(self):
         env_vars = self.attributes["vars"]
-        if isinstance(vars, str):  # env specified using --with will be a string that we must parse
+        if isinstance(env_vars, str):  # env specified using --with will be a string that we must parse
             try:
                 vars_dict = {}
                 pairs = env_vars.split(",")

--- a/metaflow/plugins/environment_decorator.py
+++ b/metaflow/plugins/environment_decorator.py
@@ -31,14 +31,15 @@ class EnvironmentDecorator(StepDecorator):
         self.attributes["vars"] = self.vars_dict().items()
 
     def vars_dict(self):
-        vars = self.attributes["vars"]
+        env_vars = self.attributes["vars"]
+        env_vars = env_vars.lstrip("{").rstrip("}") # strip brackets
         if isinstance(vars, str):  # env specified using --with will be a string that we must parse
             try:
                 vars_dict = {}
-                pairs = vars.split(",")
+                pairs = env_vars.split(",")
                 for pair in pairs:
-                    k, v = pair.split(":")
-                    vars_dict[k] = v
+                    k, v = pair.split(":", 1) # split on the first colon only
+                    vars_dict[k.strip()] = v.strip()
 
             except Exception as e:
                 raise ValueError(
@@ -46,7 +47,7 @@ class EnvironmentDecorator(StepDecorator):
                 )
             return vars_dict
         else:
-            return vars
+            return env_vars
 
     def runtime_step_cli(self, cli_args, retry_count, max_user_code_retries, ubf_context):
         cli_args.env.update(self.vars_dict().items())


### PR DESCRIPTION
Right now if one attempted to pass environment variables to the `@environment` decorator using the following type of syntax:
```
python workflow/myflow.py --with environment:vars=FOO:$(FOO),BAR:$(BAR)
```
vars would incorrectly register as a string rather than parsing the the contents as a dict. 

This PR enables parsing of environment for the environment decorator which are passed using --with
