### PR TITLE
Move S3Client to s3util.py from s3.py

### DIFF
--- a/metaflow/datastore/s3_backend.py
+++ b/metaflow/datastore/s3_backend.py
@@ -3,7 +3,8 @@ import os
 
 from itertools import starmap
 
-from ..datatools.s3 import S3, S3Client, S3PutObject
+from ..datatools.s3 import S3, S3PutObject
+from ..datatools.s3util import S3Client
 from ..metaflow_config import DATASTORE_SYSROOT_S3
 from .datastore_backend import CloseAfterUse, DataStoreBackend
 

--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -29,7 +29,7 @@ except:
     # python3
     from urllib.parse import urlparse
 
-from .s3util import get_s3_client
+from .s3util import S3Client
 
 try:
     import boto3
@@ -232,27 +232,6 @@ class S3Object(object):
 
     def __repr__(self):
         return str(self)
-
-
-class S3Client(object):
-    def __init__(self):
-        self._s3_client = None
-        self._s3_error = None
-
-    @property
-    def client(self):
-        if self._s3_client is None:
-            self.reset_client()
-        return self._s3_client
-
-    @property
-    def error(self):
-        if self._s3_error is None:
-            self.reset_client()
-        return self._s3_error
-
-    def reset_client(self):
-        self._s3_client, self._s3_error = get_s3_client()
 
 
 class S3(object):

--- a/metaflow/datatools/s3util.py
+++ b/metaflow/datatools/s3util.py
@@ -18,6 +18,28 @@ def get_s3_client():
         with_error=True,
         params={'endpoint_url': S3_ENDPOINT_URL, 'verify': S3_VERIFY_CERTIFICATE })
 
+
+class S3Client(object):
+    def __init__(self):
+        self._s3_client = None
+        self._s3_error = None
+
+    @property
+    def client(self):
+        if self._s3_client is None:
+            self.reset_client()
+        return self._s3_client
+
+    @property
+    def error(self):
+        if self._s3_error is None:
+            self.reset_client()
+        return self._s3_error
+
+    def reset_client(self):
+        self._s3_client, self._s3_error = get_s3_client()
+
+
 # decorator to retry functions that access S3
 def aws_retry(f):
     def retry_wrapper(self, *args, **kwargs):


### PR DESCRIPTION
This is to make the import of S3Client from s3op (upcoming change) as cheap
as possible in terms of import time