### PR TITLE
Allow Metaflow Custom packages to define additional suffixes to package

### DIFF
--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -39,9 +39,8 @@ class MetaflowPackage(object):
         self.blob, self.sha = self._make()
 
     def _walk(self, root, exclude_hidden=True, addl_suffixes=None):
-        suffixes_to_check = self.suffixes
-        if addl_suffixes is not None:
-            suffixes_to_check = list(set().union(suffixes_to_check, addl_suffixes))
+        if addl_suffixes is None:
+            addl_suffixes = []
         root = to_unicode(root)  # handle files/folder with non ascii chars
         prefixlen = len('%s/' % os.path.dirname(root))
         for path, dirs, files in os.walk(root):
@@ -53,7 +52,7 @@ class MetaflowPackage(object):
             for fname in files:
                 if fname[0] == '.':
                     continue
-                if any(fname.endswith(suffix) for suffix in suffixes_to_check):
+                if any(fname.endswith(suffix) for suffix in self.suffixes + addl_suffixes):
                     p = os.path.join(path, fname)
                     yield p, p[prefixlen:]
 

--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -25,6 +25,10 @@ class MetaflowPackage(object):
             self.metaflow_custom_root = None
         else:
             self.metaflow_custom_root = os.path.dirname(metaflow_custom.__file__)
+            self.metaflow_custom_addl_suffixes = getattr(
+                metaflow_custom,
+                'METAFLOW_CUSTOM_PACKAGE_SUFFIXES',
+                None)
 
         environment.init_environment(echo)
         for step in flow:
@@ -34,7 +38,10 @@ class MetaflowPackage(object):
                                   environment)
         self.blob, self.sha = self._make()
 
-    def _walk(self, root, exclude_hidden=True):
+    def _walk(self, root, exclude_hidden=True, addl_suffixes=None):
+        suffixes_to_check = self.suffixes
+        if addl_suffixes is not None:
+            suffixes_to_check = list(set().union(suffixes_to_check, addl_suffixes))
         root = to_unicode(root)  # handle files/folder with non ascii chars
         prefixlen = len('%s/' % os.path.dirname(root))
         for path, dirs, files in os.walk(root):
@@ -46,7 +53,7 @@ class MetaflowPackage(object):
             for fname in files:
                 if fname[0] == '.':
                     continue
-                if any(fname.endswith(suffix) for suffix in self.suffixes):
+                if any(fname.endswith(suffix) for suffix in suffixes_to_check):
                     p = os.path.join(path, fname)
                     yield p, p[prefixlen:]
 
@@ -61,7 +68,10 @@ class MetaflowPackage(object):
             yield path_tuple
         # Metaflow customization if any
         if self.metaflow_custom_root:
-            for path_tuple in self._walk(self.metaflow_custom_root, exclude_hidden=False):
+            for path_tuple in self._walk(
+                    self.metaflow_custom_root,
+                    exclude_hidden=False,
+                    addl_suffixes=self.metaflow_custom_addl_suffixes):
                 yield path_tuple
         # the package folders for environment
         for path_tuple in self.environment.add_to_package():


### PR DESCRIPTION
This enables you to package non-python files in your metaflow_custom package
and have them included when Metaflow creates the code package.