### PR TITLE
Refactor @resources decorator

### DIFF
--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -96,7 +96,7 @@ from .timeout_decorator import TimeoutDecorator
 from .environment_decorator import EnvironmentDecorator
 from .retry_decorator import RetryDecorator
 from .resources_decorator import ResourcesDecorator
-from .aws.batch.batch_decorator import BatchDecorator, ResourcesDecorator
+from .aws.batch.batch_decorator import BatchDecorator
 from .aws.step_functions.step_functions_decorator \
                 import StepFunctionsInternalDecorator
 from .test_unbounded_foreach_decorator\

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -95,6 +95,7 @@ from .catch_decorator import CatchDecorator
 from .timeout_decorator import TimeoutDecorator
 from .environment_decorator import EnvironmentDecorator
 from .retry_decorator import RetryDecorator
+from .resources_decorator import ResourcesDecorator
 from .aws.batch.batch_decorator import BatchDecorator, ResourcesDecorator
 from .aws.step_functions.step_functions_decorator \
                 import StepFunctionsInternalDecorator

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -10,6 +10,7 @@ from metaflow.datastore.datastore import TransformableObject
 from metaflow.datastore.util.s3util import get_s3_client
 from metaflow.decorators import StepDecorator
 from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
+from metaflow.plugins import ResourcesDecorator
 from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task
 from metaflow.metadata import MetaDatum
 
@@ -30,83 +31,57 @@ except:  # noqa E722
     from urllib.parse import urlparse
 
 
-class ResourcesDecorator(StepDecorator):
-    """
-    Step decorator to specify the resources needed when executing this step.
-    This decorator passes this information along to Batch when requesting resources
-    to execute this step.
-    This decorator is ignored if the execution of the step does not happen on Batch.
-    To use, annotate your step as follows:
-    ```
-    @resources(cpu=32)
-    @step
-    def myStep(self):
-        ...
-    ```
-    Parameters
-    ----------
-    cpu : int
-        Number of CPUs required for this step. Defaults to 1
-    gpu : int
-        Number of GPUs required for this step. Defaults to 0
-    memory : int
-        Memory size (in MB) required for this step. Defaults to 4096
-    shared_memory : int
-        The value for the size (in MiB) of the /dev/shm volume for this step.
-        This parameter maps to the --shm-size option to docker run .
-    """
-    name = 'resources'
-    defaults = {
-        'cpu': '1',
-        'gpu': '0',
-        'memory': '4096',
-        'shared_memory': None
-    }
-
 class BatchDecorator(StepDecorator):
     """
-    Step decorator to specify that this step should execute on Batch.
-    This decorator indicates that your step should execute on Batch. Note that you can
-    apply this decorator automatically to all steps using the ```--with batch``` argument
-    when calling run. Step level decorators are overrides and will force a step to execute
-    on Batch regardless of the ```--with``` specification.
+    Step decorator to specify that this step should execute on AWS Batch.
+    
+    This decorator indicates that your step should execute on AWS Batch. Note 
+    that you can apply this decorator automatically to all steps using the 
+    ```--with batch``` argument when calling run/resume. Step level decorators 
+    within the code are overrides and will force a step to execute on AWS Batch
+    regardless of the ```--with``` specification.
+    
     To use, annotate your step as follows:
     ```
     @batch
     @step
-    def myStep(self):
+    def my_step(self):
         ...
     ```
     Parameters
     ----------
     cpu : int
-        Number of CPUs required for this step. Defaults to 1. If @resources is also
-        present, the maximum value from all decorators is used
-    gpu : int
-        Number of GPUs required for this step. Defaults to 0. If @resources is also
-        present, the maximum value from all decorators is used
-    memory : int
-        Memory size (in MB) required for this step. Defaults to 4096. If @resources is
+        Number of CPUs required for this step. Defaults to 1. If @resources is
         also present, the maximum value from all decorators is used
+    gpu : int
+        Number of GPUs required for this step. Defaults to 0. If @resources is
+        also present, the maximum value from all decorators is used
+    memory : int
+        Memory size (in MB) required for this step. Defaults to 4096. If 
+        @resources is also present, the maximum value from all decorators is
+        used
     image : string
-        Image to use when launching on AWS Batch. If not specified, a default image mapping to
-        the current version of Python is used
+        Docker image to use when launching on AWS Batch. If not specified, a 
+        default docker image mapping to the current version of Python is used
     queue : string
-        Queue to submit the job to. Defaults to the one determined by the environment variable
-        METAFLOW_BATCH_JOB_QUEUE
+        AWS Batch Job Queue to submit the job to. Defaults to the one 
+        specified by the environment variable METAFLOW_BATCH_JOB_QUEUE
     iam_role : string
-        IAM role that AWS Batch can use to access Amazon S3. Defaults to the one determined by the environment
-        variable METAFLOW_ECS_S3_ACCESS_IAM_ROLE
+        AWS IAM role that AWS Batch container uses to access AWS cloud resources
+        (Amazon S3, Amazon DynamoDb, etc). Defaults to the one specified by the
+        environment variable METAFLOW_ECS_S3_ACCESS_IAM_ROLE
     execution_role : string
-        IAM role that AWS Batch can use to trigger AWS Fargate tasks. Defaults to the one determined by the environment
-        variable METAFLOW_ECS_FARGATE_EXECUTION_ROLE https://docs.aws.amazon.com/batch/latest/userguide/execution-IAM-role.html
+        AWS IAM role that AWS Batch can use to trigger AWS Fargate tasks. 
+        Defaults to the one determined by the environment variable 
+        METAFLOW_ECS_FARGATE_EXECUTION_ROLE https://docs.aws.amazon.com/batch/latest/userguide/execution-IAM-role.html
     shared_memory : int
         The value for the size (in MiB) of the /dev/shm volume for this step.
         This parameter maps to the --shm-size option to docker run.
     max_swap : int
-        The total amount of swap memory (in MiB) a container can use for this step.
-        This parameter is translated to the --memory-swap option to docker run
-        where the value is the sum of the container memory plus the max_swap value.
+        The total amount of swap memory (in MiB) a container can use for this 
+        step. This parameter is translated to the --memory-swap option to 
+        docker run where the value is the sum of the container memory plus the 
+        max_swap value.
     swappiness : int
         This allows you to tune memory swappiness behavior for this step.
         A swappiness value of 0 causes swapping not to happen unless absolutely

--- a/metaflow/plugins/resources_decorator.py
+++ b/metaflow/plugins/resources_decorator.py
@@ -1,0 +1,39 @@
+from metaflow.decorators import StepDecorator
+
+
+class ResourcesDecorator(StepDecorator):
+    """
+    Step decorator to specify the resources needed when executing this step.
+    
+    This decorator passes this information along to container orchestrator
+    (AWS Batch, Kubernetes, etc.) when requesting resources to execute this
+    step.
+    
+    This decorator is ignored if the execution of the step happens locally.
+    
+    To use, annotate your step as follows:
+    ```
+    @resources(cpu=32)
+    @step
+    def my_step(self):
+        ...
+    ```
+    Parameters
+    ----------
+    cpu : int
+        Number of CPUs required for this step. Defaults to 1
+    gpu : int
+        Number of GPUs required for this step. Defaults to 0
+    memory : int
+        Memory size (in MB) required for this step. Defaults to 4096
+    shared_memory : int
+        The value for the size (in MiB) of the /dev/shm volume for this step.
+        This parameter maps to the --shm-size option to docker run .
+    """
+    name = 'resources'
+    defaults = {
+        'cpu': '1',
+        'gpu': '0',
+        'memory': '4096',
+        'shared_memory': None
+    }


### PR DESCRIPTION
@resources decorator is shared by all compute related decorators -
@batch, @lambda, @k8s, @titus. This patch moves it out of
batch_decorator.py so that other decorators can cleanly reference
it.