### PR TITLE
Refactor @batch decorator

### DIFF
--- a/metaflow/plugins/aws/aws_utils.py
+++ b/metaflow/plugins/aws/aws_utils.py
@@ -1,0 +1,108 @@
+import os
+import re
+import tarfile
+
+from distutils.dir_util import copy_tree
+try:
+    # python2
+    from urlparse import urlparse
+except:  # noqa E722
+    # python3
+    from urllib.parse import urlparse
+
+from metaflow import util
+from metaflow.datastore import MetaflowDataStore
+from metaflow.datastore.local import LocalDataStore
+from metaflow.datastore.util.s3util import get_s3_client
+
+def sync_metadata_to_S3(metadata_local_dir, datastore_root, retry_count):
+    with util.TempDir() as td:
+        tar_file_path = os.path.join(td, 'metadata.tgz')
+        with tarfile.open(tar_file_path, 'w:gz') as tar:
+            tar.add(metadata_local_dir)
+        # Upload metadata to Amazon S3.
+        with open(tar_file_path, 'rb') as f:
+            s3, _ = get_s3_client()
+            url = urlparse(
+                        os.path.join(
+                            datastore_root,
+                            MetaflowDataStore.filename_with_attempt_prefix(
+                                'metadata.tgz',
+                                retry_count)))
+            s3.upload_fileobj(f, url.netloc, url.path.lstrip('/'))  
+
+def sync_metadata_from_S3(metadata_local_dir, datastore_root, retry_count):
+    def echo_none(*args, **kwargs):
+        pass
+    url = urlparse(
+                os.path.join(
+                    datastore_root,
+                    MetaflowDataStore.filename_with_attempt_prefix(
+                        'metadata.tgz',
+                        retry_count)))
+    s3, err = get_s3_client()
+    try:
+        s3.head_object(Bucket=url.netloc, Key=url.path.lstrip('/'))
+        with util.TempDir() as td:
+            tar_file_path = os.path.join(td, 'metadata.tgz')
+            with open(tar_file_path, 'wb') as f:
+                s3.download_fileobj(url.netloc, url.path.lstrip('/'), f)
+            with tarfile.open(tar_file_path, 'r:gz') as tar:
+                tar.extractall(td)
+            copy_tree(
+                os.path.join(td, metadata_local_dir),
+                LocalDataStore.get_datastore_root_from_config(echo_none),
+                update=True)
+    except err as e:
+        # Metadata sync is best effort.
+        pass
+
+def get_docker_registry(image_uri):
+    """
+    Explanation:
+        (.+?(?:[:.].+?)\/)? - [GROUP 0] REGISTRY
+            .+?                 - A registry must start with at least one character
+            (?:[:.].+?)\/       - A registry must have ":" or "." and end with "/"
+            ?                   - Make a registry optional
+        (.*?)               - [GROUP 1] REPOSITORY
+            .*?                 - Get repository name until separator
+        (?:[@:])?           - SEPARATOR
+            ?:                  - Don't capture separator
+            [@:]                - The separator must be either "@" or ":"
+            ?                   - The separator is optional
+        ((?<=[@:]).*)?      - [GROUP 2] TAG / DIGEST
+            (?<=[@:])           - A tag / digest must be preceeded by "@" or ":"
+            .*                  - Capture rest of tag / digest
+            ?                   - A tag / digest is optional
+    Examples:
+        image
+            - None
+            - image
+            - None
+        example/image
+            - None
+            - example/image
+            - None
+        example/image:tag
+            - None
+            - example/image
+            - tag
+        example.domain.com/example/image:tag
+            - example.domain.com/
+            - example/image
+            - tag
+        123.123.123.123:123/example/image:tag
+            - 123.123.123.123:123/
+            - example/image
+            - tag
+        example.domain.com/example/image@sha256:45b23dee0
+            - example.domain.com/
+            - example/image
+            - sha256:45b23dee0
+    """
+
+    pattern = re.compile(r"^(.+?(?:[:.].+?)\/)?(.*?)(?:[@:])?((?<=[@:]).*)?$")
+    registry, repository, tag = pattern.match(image_uri).groups()
+    if registry is not None:
+        registry = registry.rstrip("/")
+    return registry

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -467,53 +467,6 @@ class RunningJob(object):
         if not self.is_running and not self.is_done:
             BatchWaiter(self._client).wait_for_running(self.id)
 
-    @property
-    def log_stream_name(self):
-        return self.info['container'].get('logStreamName')
-
-    def logs(self):
-        def get_log_stream(job):
-            log_stream_name = job.log_stream_name
-            if log_stream_name:
-                return BatchLogs('/aws/batch/job', log_stream_name, sleep_on_no_data=1)
-            else:
-                return None
-
-        log_stream = None
-        while True:
-            if self.is_running or self.is_done or self.is_crashed:
-                log_stream = get_log_stream(self)
-                break
-            elif not self.is_done:
-                self.wait_for_running()
-
-        if log_stream is None:
-            return 
-        exception = None
-        for i in range(self.NUM_RETRIES + 1):
-            try:
-                check_after_done = 0
-                for line in log_stream:
-                    if not line:
-                        if self.is_done:
-                            if check_after_done > 1:
-                                return
-                            check_after_done += 1
-                        else:
-                            pass
-                    else:
-                        i = 0
-                        yield line
-                return
-            except Exception as ex:
-                exception = ex
-                if self.is_crashed:
-                    break
-                #sys.stderr.write(repr(ex) + '\n')
-                if i < self.NUM_RETRIES:
-                    time.sleep(2 ** i + random.randint(0, 5))
-        raise BatchJobException(repr(exception))
-
     def kill(self):
         if not self.is_done:
             self._client.terminate_job(
@@ -571,55 +524,3 @@ class BatchWaiter(object):
         self._waiter.create_waiter_with_client('JobRunning', model, self._client).wait(
             jobs=[job_id]
         )
-
-class BatchLogs(object):
-    def __init__(self, group, stream, pos=0, sleep_on_no_data=0):
-        from ..aws_client import get_aws_client
-        self._client = get_aws_client('logs')
-        self._group = group
-        self._stream = stream
-        self._pos = pos
-        self._sleep_on_no_data = sleep_on_no_data
-        self._buf = deque()
-        self._token = None
-
-    def _get_events(self):
-        try:
-            if self._token:
-                response = self._client.get_log_events(
-                    logGroupName=self._group,
-                    logStreamName=self._stream,
-                    startTime=self._pos,
-                    nextToken=self._token,
-                    startFromHead=True,
-                )
-            else:
-                response = self._client.get_log_events(
-                    logGroupName=self._group,
-                    logStreamName=self._stream,
-                    startTime=self._pos,
-                    startFromHead=True,
-                )
-            self._token = response['nextForwardToken']
-            return response['events']
-        except self._client.exceptions.ResourceNotFoundException as e:
-            # The logs might be delayed by a bit, so we can simply try
-            # again next time.
-            return []
-
-    def __iter__(self):
-        while True:
-            self._fill_buf()
-            if len(self._buf) == 0:
-                yield ''
-                if self._sleep_on_no_data > 0:
-                    select.poll().poll(self._sleep_on_no_data * 1000)
-            else:
-                while self._buf:
-                    yield self._buf.popleft()
-
-    def _fill_buf(self):
-        events = self._get_events()
-        for event in events:
-            self._buf.append(event['message'])
-            self._pos = event['timestamp']


### PR DESCRIPTION
Some basic housekeeping for `batch_decorator.py` to share code snippets with the `@k8s` decorator.

Also includes a bug fix with `task_*`. Given the semantics of `@catch` - the fallback step executes locally to handle hard crashes - `task_*` may execute locally so any AWS Batch specific code needs to be guarded.