### PR TITLE
Improve module aliasing for metaflow_custom

### DIFF
--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -53,8 +53,12 @@ else:
     # Something random so there is no syntax error
     ModuleSpec = None
 
+
 class _LazyLoader(object):
     # This _LazyLoader implements the Importer Protocol defined in PEP 302
+    # TODO: Need to move to find_spec, exec_module and create_module as
+    # find_module and load_module are deprecated
+
     def __init__(self, handled):
         # Modules directly loaded (this is either new modules or overrides of existing ones)
         self._handled = handled if handled else {}
@@ -63,12 +67,23 @@ class _LazyLoader(object):
         # the over-ridden module
         self._tempexcluded = set()
 
+        # This is used when loading a module alias to load any submodule
+        self._alias_to_orig = {}
+
     def find_module(self, fullname, path=None):
         if fullname in self._tempexcluded:
             return None
         if fullname in self._handled or \
                 (fullname.endswith('._orig') and fullname[:-6] in self._handled):
             return self
+        name_parts = fullname.split('.')
+        if len(name_parts) > 1 and name_parts[-1] != '_orig':
+            # We check if we had an alias created for this module and if so,
+            # we are going to load it to properly fully create aliases all
+            # the way down.
+            parent_name = '.'.join(name_parts[:-1])
+            if parent_name in self._alias_to_orig:
+                return self
         return None
 
     def load_module(self, fullname):
@@ -80,27 +95,37 @@ class _LazyLoader(object):
                 "Attempting to load '%s' -- loading shadowed modules in Metaflow "
                 "Custom is only supported in Python 3.4+" % fullname)
         to_import = self._handled.get(fullname, None)
-        # We see if we are shadowing an existing module and, if so, we
-        # will keep track of the module we are shadowing so that it
-        # may be loaded if needed. We basically will create a ._orig submodule
-        # of sorts. This functionality only works for Python 3.4+. For anything
-        # below this, we do not create the _orig module so loading it will
-        # result in ModuleNotFound
-        if self._can_handle_orig_module() and not fullname.endswith('._orig'):
-            try:
-                # We exclude this module temporarily from what we handle to
-                # revert back to the non-shadowing mode of import
-                self._tempexcluded.add(fullname)
-                spec = importlib.util.find_spec(fullname)
-                self._handled["%s._orig" % fullname] = spec
-            finally:
-                self._tempexcluded.remove(fullname)
+
+        # If to_import is None, two cases:
+        #  - we are loading a ._orig module
+        #  - OR we are loading a submodule
+        if to_import is None:
+            if fullname.endswith('._orig'):
+                try:
+                    # We exclude this module temporarily from what we handle to
+                    # revert back to the non-shadowing mode of import
+                    self._tempexcluded.add(fullname)
+                    to_import = importlib.util.find_spec(fullname)
+                finally:
+                    self._tempexcluded.remove(fullname)
+            else:
+                name_parts = fullname.split('.')
+                submodule = name_parts[-1]
+                parent_name = '.'.join(name_parts[:-1])
+                to_import = '.'.join(
+                    [self._alias_to_orig[parent_name], submodule])
 
         if isinstance(to_import, str):
-            to_import = importlib.import_module(to_import)
-            sys.modules[fullname] = to_import
+            try:
+                to_import_mod = importlib.import_module(to_import)
+            except ImportError:
+                raise ImportError(
+                    "No module found '%s' (aliasing %s)" % (fullname, to_import))
+            sys.modules[fullname] = to_import_mod
+            self._alias_to_orig[fullname] = to_import_mod.__name__
         elif isinstance(to_import, types.ModuleType):
             sys.modules[fullname] = to_import
+            self._alias_to_orig[fullname] = to_import.__name__
         elif self._can_handle_orig_module() and isinstance(to_import, ModuleSpec):
             # This loads modules that end in _orig
             m = importlib.util.module_from_spec(to_import)


### PR DESCRIPTION
This patch makes module aliasing work properly by only creating one instance of the module (with different names).