### PR TITLE
Silence tar timestamp warnings

### DIFF
--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -96,7 +96,7 @@ class MetaflowEnvironment(object):
                     "mflog \'Failed to download code package from %s "
                     "after 6 tries. Exiting...\' && exit 1; "
                 "fi" % code_package_url,
-                "tar xf job.tar",
+                "TAR_OPTIONS='--warning=no-timestamp' tar xf job.tar",
                 "mflog \'Task is starting.\'",
                 ]
         return cmds


### PR DESCRIPTION
## The Problem 
Before v1.27, gnu tar would complain about timestamps set to 0. This was fixed ([commit](https://git.savannah.gnu.org/cgit/tar.git/commit/src/extract.c?id=28b44aaa), [discussion](https://www.mail-archive.com/bug-tar@gnu.org/msg04136.html) ) but earlier versions are still used by some docker images in the wild. This results in a lot of spam in the logs, e.g. 

```
...
2021-07-26T20:34:19.879-07:00 | tar: metaflow/package.py: implausibly old time stamp 1970-01-01 00:00:00
2021-07-26T20:34:19.879-07:00 | tar: metaflow/sidecar_messages.py: implausibly old time stamp 1970-01-01 00:00:00
2021-07-26T20:34:19.879-07:00 | tar: metaflow/trace.py: implausibly old time stamp 1970-01-01 00:00:00
2021-07-26T20:34:19.879-07:00 | tar: metaflow/task.py: implausibly old time stamp 1970-01-01 00:00:00
2021-07-26T20:34:19.879-07:00 | tar: metaflow/exception.py: implausibly old time stamp 1970-01-01 00:00:00
2021-07-26T20:34:19.879-07:00 | tar: metaflow/cli_args.py: implausibly old time stamp 1970-01-01 00:00:00
...
```

## Solution

Set the tar options to ignore "implausibly old" timestamps.