### PR TITLE
Add resource tags to AWS Batch jobs

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -111,10 +111,10 @@ BATCH_CONTAINER_REGISTRY = from_conf("METAFLOW_BATCH_CONTAINER_REGISTRY")
 BATCH_METADATA_SERVICE_URL = from_conf('METAFLOW_SERVICE_INTERNAL_URL', METADATA_SERVICE_URL)
 BATCH_METADATA_SERVICE_HEADERS = METADATA_SERVICE_HEADERS
 
-# Assign tags to AWS Batch jobs. Set to False by default since it
-# requires `Batch:TagResource` permissions which may not be available
+# Assign resource tags to AWS Batch jobs. Set to False by default since
+# it requires `Batch:TagResource` permissions which may not be available
 # in all Metaflow deployments. Hopefully, some day we can flip the
-# default to True
+# default to True.
 BATCH_EMIT_TAGS = from_conf("METAFLOW_BATCH_EMIT_TAGS", False)
 
 ###

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -111,6 +111,12 @@ BATCH_CONTAINER_REGISTRY = from_conf("METAFLOW_BATCH_CONTAINER_REGISTRY")
 BATCH_METADATA_SERVICE_URL = from_conf('METAFLOW_SERVICE_INTERNAL_URL', METADATA_SERVICE_URL)
 BATCH_METADATA_SERVICE_HEADERS = METADATA_SERVICE_HEADERS
 
+# Assign tags to AWS Batch jobs. Set to False by default since it
+# requires `Batch:TagResource` permissions which may not be available
+# in all Metaflow deployments. Hopefully, some day we can flip the
+# default to True
+BATCH_EMIT_TAGS = from_conf("METAFLOW_BATCH_EMIT_TAGS", False)
+
 ###
 # AWS Step Functions configuration
 ###

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -219,7 +219,7 @@ class Batch(object):
             for key in ['metaflow.flow_name', 'metaflow.run_id',
                             'metaflow.step_name', 'metaflow.version', 
                             'metaflow.run_id.$', 'metaflow.user',
-                            'metaflow.owner']:
+                            'metaflow.owner', 'metaflow.production_token']:
                 if key in attrs:
                     job.tag(key, attrs.get(key))
         return job

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -214,6 +214,12 @@ class Batch(object):
         if attrs:
             for key, value in attrs.items():
                 job.parameter(key, value)
+        # Tags for AWS Batch job (for say cost attribution)
+        for key in ['metaflow.flow_name', 'metaflow.run_id',
+                        'metaflow.step_name', 'metaflow.version', 
+                        'metaflow.run_id.$']:
+            if key in attrs:
+                job.tag(key, attrs.get(key))
         return job
 
     def launch_job(

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -11,7 +11,7 @@ from requests.exceptions import HTTPError
 from metaflow.exception import MetaflowException, MetaflowInternalError
 from metaflow.metaflow_config import BATCH_METADATA_SERVICE_URL, DATATOOLS_S3ROOT, \
     DATASTORE_LOCAL_DIR, DATASTORE_SYSROOT_S3, DEFAULT_METADATA, \
-    BATCH_METADATA_SERVICE_HEADERS
+    BATCH_METADATA_SERVICE_HEADERS, BATCH_EMIT_TAGS
 from metaflow import util
 
 from .batch_client import BatchClient
@@ -215,11 +215,13 @@ class Batch(object):
             for key, value in attrs.items():
                 job.parameter(key, value)
         # Tags for AWS Batch job (for say cost attribution)
-        for key in ['metaflow.flow_name', 'metaflow.run_id',
-                        'metaflow.step_name', 'metaflow.version', 
-                        'metaflow.run_id.$']:
-            if key in attrs:
-                job.tag(key, attrs.get(key))
+        if BATCH_EMIT_TAGS:
+            for key in ['metaflow.flow_name', 'metaflow.run_id',
+                            'metaflow.step_name', 'metaflow.version', 
+                            'metaflow.run_id.$', 'metaflow.user',
+                            'metaflow.owner']:
+                if key in attrs:
+                    job.tag(key, attrs.get(key))
         return job
 
     def launch_job(

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -319,6 +319,10 @@ class BatchJob(object):
         self.payload['timeout']['attemptDurationSeconds'] = timeout_in_secs
         return self
 
+    def tag(self, key, value):
+        self.payload['tags'][key] = str(value)
+        return self
+
     def parameter(self, key, value):
         self.payload['parameters'][key] = str(value)
         return self

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -139,7 +139,10 @@ class BatchJob(object):
                         'type': 'MEMORY'
                     }
                 ]
-            }
+            },
+            # This propagates the AWS Batch resource tags to the underlying
+            # ECS tasks.
+            'propagateTags': True
         }
 
         if platform == 'FARGATE' or platform == 'FARGATE_SPOT':

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -813,7 +813,8 @@ class State(object):
             .parameter('RetryStrategy', 
                 to_pascalcase(job.payload['retryStrategy'])) \
             .parameter('Timeout', 
-                to_pascalcase(job.payload['timeout']))
+                to_pascalcase(job.payload['timeout'])) \
+            .parameter('Tags', job.payload['tags'])
         return self
 
     def dynamo_db(self, table_name, primary_key, values):

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -813,8 +813,10 @@ class State(object):
             .parameter('RetryStrategy', 
                 to_pascalcase(job.payload['retryStrategy'])) \
             .parameter('Timeout', 
-                to_pascalcase(job.payload['timeout'])) \
-            .parameter('Tags', job.payload['tags'])
+                to_pascalcase(job.payload['timeout']))
+        # tags may not be present in all scenarios
+        if 'tags' in job.payload:
+            self.parameter('Tags', job.payload['tags'])
         return self
 
     def dynamo_db(self, table_name, primary_key, values):


### PR DESCRIPTION
This PR assumes that `Batch:TagResource` is whitelisted for the role which submits the AWS Batch job.

Gated on env var - `METAFLOW_BATCH_EMIT_TAGS`