### PR TITLE
allow to mount host volumes in AWS Batch

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -164,7 +164,8 @@ class Batch(object):
         max_swap=None,
         swappiness=None,
         env={},
-        attrs={}
+        attrs={},
+        host_volumes=None,
     ):
         job_name = self._job_name(
             attrs.get('metaflow.user'),
@@ -186,7 +187,7 @@ class Batch(object):
             .execution_role(execution_role) \
             .job_def(image, iam_role,
                 queue, execution_role, shared_memory,
-                max_swap, swappiness) \
+                max_swap, swappiness, host_volumes=host_volumes) \
             .cpu(cpu) \
             .gpu(gpu) \
             .memory(memory) \
@@ -244,6 +245,7 @@ class Batch(object):
         shared_memory=None,
         max_swap=None,
         swappiness=None,
+        host_volumes=None,
         env={},
         attrs={},
         ):
@@ -272,8 +274,9 @@ class Batch(object):
                         shared_memory,
                         max_swap,
                         swappiness,
-                        env,
-                        attrs
+                        env=env,
+                        attrs=attrs,
+                        host_volumes=host_volumes
         )
         self.job = job.execute()
 

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -169,6 +169,7 @@ def kill(ctx, run_id, user, my_runs):
 @click.option("--swappiness", help="Swappiness requirement for AWS Batch.")
 #TODO: Maybe remove it altogether since it's not used here
 @click.option('--ubf-context', default=None, type=click.Choice([None]))
+@click.option('--mount-host-volumes', default=None)
 @click.pass_context
 def step(
     ctx,
@@ -187,6 +188,7 @@ def step(
     shared_memory=None,
     max_swap=None,
     swappiness=None,
+    host_volumes=None,
     **kwargs
 ):
     def echo(msg, stream='stderr', batch_id=None):
@@ -294,7 +296,8 @@ def step(
                 max_swap=max_swap,
                 swappiness=swappiness,
                 env=env,
-                attrs=attrs
+                attrs=attrs,
+                host_volumes=host_volumes,
             )
     except Exception as e:
         print(e)

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -99,7 +99,8 @@ class BatchDecorator(StepDecorator):
         'execution_role': ECS_FARGATE_EXECUTION_ROLE,
         'shared_memory': None,
         'max_swap': None,
-        'swappiness': None
+        'swappiness': None,
+        'host_volumes': None,
     }
     package_url = None
     package_sha = None

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -613,7 +613,8 @@ class StepFunctions(object):
                         max_swap=resources['max_swap'],
                         swappiness=resources['swappiness'],
                         env=env,
-                        attrs=attrs
+                        attrs=attrs,
+                        host_volumes=resources['host_volumes'],
                 ) \
                 .attempts(total_retries + 1)
 


### PR DESCRIPTION
# What does this PR do?

Adds an option to `@batch` decorator to mount host volumes inside the container. `@batch(mount_host_volumes="/mnt/")`. This way, `/mnt` from host will be mounted at `/mnt` inside the container. This (partially) addresses #441

In this release this is considered an _advanced_ feature due to less friendly UX and the fact that troubleshooting this requires a decent knowledge of AWS Batch. 

I've tested this on Batch and Step Functions and it seems to work!


## Potential improvements in future PRs, not included here

* First class support for [per-job EFS mounts](https://aws.amazon.com/blogs/hpc/introducing-support-for-per-job-amazon-efs-volumes-in-aws-batch/). Not included this because the configuration is pretty hairy, needs some extra thinking. However, you should be able to use this PR as is to expose EFS volumes mounted at host to containers, as described [here](https://aws.amazon.com/premiumsupport/knowledge-center/batch-mount-efs/).

* Support for customizing mount points inside a container. Right now `/mnt` from host always gets mounted as `/mnt` inside the container.