### PR TITLE
Refactor throttle delta and tries into config

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -117,6 +117,11 @@ BATCH_METADATA_SERVICE_HEADERS = METADATA_SERVICE_HEADERS
 # default to True.
 BATCH_EMIT_TAGS = from_conf("METAFLOW_BATCH_EMIT_TAGS", False)
 
+# To set the number of retries when throttling client.describe_jobs
+# in plugins.aws.batch.batch_client via Throttle()
+BATCH_DESCRIBE_JOBS_THROTTLE_TRIES = from_conf("BATCH_DESCRIBE_JOBS_THROTTLE_TRIES", 20)
+BATCH_DESCRIBE_JOBS_THROTTLE_DELTA = from_conf("BATCH_DESCRIBE_JOBS_THROTTLE_DELTA", 1)
+
 ###
 # AWS Step Functions configuration
 ###

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -14,6 +14,8 @@ except NameError:
 
 from metaflow.exception import MetaflowException
 from metaflow.metaflow_config import AWS_SANDBOX_ENABLED
+from metaflow.metaflow_config import BATCH_DESCRIBE_JOBS_THROTTLE_DELTA as DELTA
+from metaflow.metaflow_config import BATCH_DESCRIBE_JOBS_THROTTLE_TRIES as TRIES
 
 class BatchClient(object):
     def __init__(self):
@@ -335,9 +337,9 @@ class BatchJob(object):
         return self
 
 class Throttle(object):
-    def __init__(self, delta_in_secs=1, num_tries=20):
-        self.delta_in_secs = delta_in_secs
-        self.num_tries = num_tries
+    def __init__(self, delta_in_secs=DELTA, num_tries=TRIES):
+        self.delta_in_secs = int(delta_in_secs)  # Cast if from env variable
+        self.num_tries = int(num_tries)  # Cast if from env variable
         self._now = None
         self._reset()
 


### PR DESCRIPTION
As discussed in PR #634, to refactor the `delta_in_secs` and `num_tries` into config.

I think not too controversial, but I've added in an explicit cast to integer in the `Throttle` constructor so safeguard the case where these are set via env variables, e.g. on the command line