### PR TITLE
Do not override cov params if rcfile is set

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 import sys
 import traceback
 from datetime import datetime
@@ -845,10 +846,11 @@ def start(ctx,
 
     if coverage:
         from coverage import Coverage
+        no_covrc = "COVERAGE_RCFILE" not in os.environ
         cov = Coverage(data_suffix=True,
                        auto_data=True,
-                       source=['metaflow'],
-                       branch=True)
+                       source=['metaflow'] if no_covrc else None,
+                       branch=True if no_covrc else None)
         cov.start()
 
     cli_args._set_top_kwargs(ctx.params)


### PR DESCRIPTION
Proof of concept fix for #650

Caveats/Notes:
- The way this PR uses in os.environ does not appear to follow the library's conventions
- Logic avoids setting "source" and "branch" when initializing coverage if a coverage rc file is configured.   The other parameters are not conditional based on the presence of a coverage rcfile because those settings either can not be set by a coverage rcfile or are not configured in the same way
- A more complete solution might look into the coverage rcfile to validate that "branch" and "source" were configured but this would more tightly couple with coverage.py which seems like it might be a bad idea