### PR TITLE
host_volumes for batch now takes an array instead of a csv

### DIFF
--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -169,7 +169,7 @@ def kill(ctx, run_id, user, my_runs):
 @click.option("--swappiness", help="Swappiness requirement for AWS Batch.")
 #TODO: Maybe remove it altogether since it's not used here
 @click.option('--ubf-context', default=None, type=click.Choice([None]))
-@click.option('--mount-host-volumes', default=None)
+@click.option('--host-volumes', multiple=True)
 @click.pass_context
 def step(
     ctx,

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -191,10 +191,9 @@ class BatchJob(object):
                         ['linuxParameters']['maxSwap'] = int(max_swap)
 
         if host_volumes:
-            volume_paths = host_volumes.split(',')
             job_definition['containerProperties']['volumes'] = []
             job_definition['containerProperties']['mountPoints'] = []
-            for host_path in volume_paths:
+            for host_path in host_volumes:
                 name = host_path.replace('/', '_')
                 job_definition['containerProperties']['volumes'].append(
                     {'name': name, 'host': {'sourcePath': host_path}}


### PR DESCRIPTION
You can now do this:
```python
@batch(host_volumes=['/home', '/var/log'])
```