### PR TITLE
continue removing python2 from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,5 +73,3 @@ jobs:
       run: |
         cd R/tests
         Rscript run_tests.R
-
-

--- a/metaflow/_vendor/click/_compat.py
+++ b/metaflow/_vendor/click/_compat.py
@@ -270,7 +270,6 @@ if PY2:
             value = value.decode(get_filesystem_encoding(), "replace")
         return value
 
-
 else:
     import io
 
@@ -724,7 +723,6 @@ if WIN:
                 colorama.win32.STDOUT
             ).srWindow
             return win.Right - win.Left, win.Bottom - win.Top
-
 
 else:
 

--- a/metaflow/_vendor/click/_termui_impl.py
+++ b/metaflow/_vendor/click/_termui_impl.py
@@ -459,7 +459,9 @@ class Editor(object):
             environ = None
         try:
             c = subprocess.Popen(
-                '{} "{}"'.format(editor, filename), env=environ, shell=True,
+                '{} "{}"'.format(editor, filename),
+                env=environ,
+                shell=True,
             )
             exit_code = c.wait()
             if exit_code != 0:
@@ -563,11 +565,11 @@ def open_url(url, wait=False, locate=False):
 
 
 def _translate_ch_to_exc(ch):
-    if ch == u"\x03":
+    if ch == "\x03":
         raise KeyboardInterrupt()
-    if ch == u"\x04" and not WIN:  # Unix-like, Ctrl+D
+    if ch == "\x04" and not WIN:  # Unix-like, Ctrl+D
         raise EOFError()
-    if ch == u"\x1a" and WIN:  # Windows, Ctrl+Z
+    if ch == "\x1a" and WIN:  # Windows, Ctrl+Z
         raise EOFError()
 
 
@@ -614,13 +616,12 @@ if WIN:
             func = msvcrt.getwch
 
         rv = func()
-        if rv in (u"\x00", u"\xe0"):
+        if rv in ("\x00", "\xe0"):
             # \x00 and \xe0 are control characters that indicate special key,
             # see above.
             rv += func()
         _translate_ch_to_exc(rv)
         return rv
-
 
 else:
     import tty

--- a/metaflow/_vendor/click/globals.py
+++ b/metaflow/_vendor/click/globals.py
@@ -36,7 +36,7 @@ def pop_context():
 
 
 def resolve_color_default(color=None):
-    """"Internal helper to get the default value of the color flag.  If a
+    """ "Internal helper to get the default value of the color flag.  If a
     value is passed it's returned unchanged, otherwise it's looked up from
     the current context.
     """

--- a/metaflow/_vendor/click/utils.py
+++ b/metaflow/_vendor/click/utils.py
@@ -234,9 +234,9 @@ def echo(message=None, file=None, nl=True, err=False, color=None):
         message = text_type(message)
 
     if nl:
-        message = message or u""
+        message = message or ""
         if isinstance(message, text_type):
-            message += u"\n"
+            message += "\n"
         else:
             message += b"\n"
 

--- a/metaflow/_vendor/importlib_metadata/__init__.py
+++ b/metaflow/_vendor/importlib_metadata/__init__.py
@@ -30,7 +30,7 @@ from ._compat import (
     PyPy_repr,
     unique_ordered,
     str,
-    )
+)
 from importlib import import_module
 from itertools import starmap
 
@@ -39,17 +39,17 @@ __metaclass__ = type
 
 
 __all__ = [
-    'Distribution',
-    'DistributionFinder',
-    'PackageNotFoundError',
-    'distribution',
-    'distributions',
-    'entry_points',
-    'files',
-    'metadata',
-    'requires',
-    'version',
-    ]
+    "Distribution",
+    "DistributionFinder",
+    "PackageNotFoundError",
+    "distribution",
+    "distributions",
+    "entry_points",
+    "files",
+    "metadata",
+    "requires",
+    "version",
+]
 
 
 class PackageNotFoundError(ModuleNotFoundError):
@@ -61,13 +61,13 @@ class PackageNotFoundError(ModuleNotFoundError):
 
     @property
     def name(self):
-        name, = self.args
+        (name,) = self.args
         return name
 
 
 class EntryPoint(
-        PyPy_repr,
-        collections.namedtuple('EntryPointBase', 'name value group')):
+    PyPy_repr, collections.namedtuple("EntryPointBase", "name value group")
+):
     """An entry point as defined by Python packaging conventions.
 
     See `the packaging docs on entry points
@@ -76,10 +76,10 @@ class EntryPoint(
     """
 
     pattern = re.compile(
-        r'(?P<module>[\w.]+)\s*'
-        r'(:\s*(?P<attr>[\w.]+)\s*)?'
-        r'((?P<extras>\[.*\])\s*)?$'
-        )
+        r"(?P<module>[\w.]+)\s*"
+        r"(:\s*(?P<attr>[\w.]+)\s*)?"
+        r"((?P<extras>\[.*\])\s*)?$"
+    )
     """
     A regular expression describing the syntax for an entry point,
     which might look like:
@@ -102,24 +102,24 @@ class EntryPoint(
         return the named object.
         """
         match = self.pattern.match(self.value)
-        module = import_module(match.group('module'))
-        attrs = filter(None, (match.group('attr') or '').split('.'))
+        module = import_module(match.group("module"))
+        attrs = filter(None, (match.group("attr") or "").split("."))
         return functools.reduce(getattr, attrs, module)
 
     @property
     def module(self):
         match = self.pattern.match(self.value)
-        return match.group('module')
+        return match.group("module")
 
     @property
     def attr(self):
         match = self.pattern.match(self.value)
-        return match.group('attr')
+        return match.group("attr")
 
     @property
     def extras(self):
         match = self.pattern.match(self.value)
-        return list(re.finditer(r'\w+', match.group('extras') or ''))
+        return list(re.finditer(r"\w+", match.group("extras") or ""))
 
     @classmethod
     def _from_config(cls, config):
@@ -127,11 +127,11 @@ class EntryPoint(
             cls(name, value, group)
             for group in config.sections()
             for name, value in config.items(group)
-            ]
+        ]
 
     @classmethod
     def _from_text(cls, text):
-        config = ConfigParser(delimiters='=')
+        config = ConfigParser(delimiters="=")
         # case sensitive: https://stackoverflow.com/q/1611799/812183
         config.optionxform = str
         try:
@@ -151,18 +151,18 @@ class EntryPoint(
         return (
             self.__class__,
             (self.name, self.value, self.group),
-            )
+        )
 
 
 class PackagePath(pathlib.PurePosixPath):
     """A reference to a path in a package"""
 
-    def read_text(self, encoding='utf-8'):
+    def read_text(self, encoding="utf-8"):
         with self.locate().open(encoding=encoding) as stream:
             return stream.read()
 
     def read_binary(self):
-        with self.locate().open('rb') as stream:
+        with self.locate().open("rb") as stream:
             return stream.read()
 
     def locate(self):
@@ -172,10 +172,10 @@ class PackagePath(pathlib.PurePosixPath):
 
 class FileHash:
     def __init__(self, spec):
-        self.mode, _, self.value = spec.partition('=')
+        self.mode, _, self.value = spec.partition("=")
 
     def __repr__(self):
-        return '<FileHash mode: {} value: {}>'.format(self.mode, self.value)
+        return "<FileHash mode: {} value: {}>".format(self.mode, self.value)
 
 
 class Distribution:
@@ -224,14 +224,13 @@ class Distribution:
         :context: A ``DistributionFinder.Context`` object.
         :return: Iterable of Distribution objects for all packages.
         """
-        context = kwargs.pop('context', None)
+        context = kwargs.pop("context", None)
         if context and kwargs:
             raise ValueError("cannot accept context and kwargs")
         context = context or DistributionFinder.Context(**kwargs)
         return itertools.chain.from_iterable(
-            resolver(context)
-            for resolver in cls._discover_resolvers()
-            )
+            resolver(context) for resolver in cls._discover_resolvers()
+        )
 
     @staticmethod
     def at(path):
@@ -246,20 +245,20 @@ class Distribution:
     def _discover_resolvers():
         """Search the meta_path for resolvers."""
         declared = (
-            getattr(finder, 'find_distributions', None)
-            for finder in sys.meta_path
-            )
+            getattr(finder, "find_distributions", None) for finder in sys.meta_path
+        )
         return filter(None, declared)
 
     @classmethod
-    def _local(cls, root='.'):
+    def _local(cls, root="."):
         from pep517 import build, meta
+
         system = build.compat_system(root)
         builder = functools.partial(
             meta.build,
             source_dir=root,
             system=system,
-            )
+        )
         return PathDistribution(zipp.Path(meta.build_as_zip(builder)))
 
     @property
@@ -270,23 +269,23 @@ class Distribution:
         metadata.  See PEP 566 for details.
         """
         text = (
-            self.read_text('METADATA')
-            or self.read_text('PKG-INFO')
+            self.read_text("METADATA")
+            or self.read_text("PKG-INFO")
             # This last clause is here to support old egg-info files.  Its
             # effect is to just end up using the PathDistribution's self._path
             # (which points to the egg-info file) attribute unchanged.
-            or self.read_text('')
-            )
+            or self.read_text("")
+        )
         return email_message_from_string(text)
 
     @property
     def version(self):
         """Return the 'Version' metadata for the distribution package."""
-        return self.metadata['Version']
+        return self.metadata["Version"]
 
     @property
     def entry_points(self):
-        return EntryPoint._from_text(self.read_text('entry_points.txt'))
+        return EntryPoint._from_text(self.read_text("entry_points.txt"))
 
     @property
     def files(self):
@@ -314,7 +313,7 @@ class Distribution:
         """
         Read the lines of RECORD
         """
-        text = self.read_text('RECORD')
+        text = self.read_text("RECORD")
         return text and text.splitlines()
 
     def _read_files_egginfo(self):
@@ -322,7 +321,7 @@ class Distribution:
         SOURCES.txt might contain literal commas, so wrap each line
         in quotes.
         """
-        text = self.read_text('SOURCES.txt')
+        text = self.read_text("SOURCES.txt")
         return text and map('"{}"'.format, text.splitlines())
 
     @property
@@ -332,27 +331,28 @@ class Distribution:
         return reqs and list(reqs)
 
     def _read_dist_info_reqs(self):
-        return self.metadata.get_all('Requires-Dist')
+        return self.metadata.get_all("Requires-Dist")
 
     def _read_egg_info_reqs(self):
-        source = self.read_text('requires.txt')
+        source = self.read_text("requires.txt")
         return source and self._deps_from_requires_text(source)
 
     @classmethod
     def _deps_from_requires_text(cls, source):
         section_pairs = cls._read_sections(source.splitlines())
         sections = {
-            section: list(map(operator.itemgetter('line'), results))
-            for section, results in
-            itertools.groupby(section_pairs, operator.itemgetter('section'))
-            }
+            section: list(map(operator.itemgetter("line"), results))
+            for section, results in itertools.groupby(
+                section_pairs, operator.itemgetter("section")
+            )
+        }
         return cls._convert_egg_info_reqs_to_simple_reqs(sections)
 
     @staticmethod
     def _read_sections(lines):
         section = None
         for line in filter(None, lines):
-            section_match = re.match(r'\[(.*)\]$', line)
+            section_match = re.match(r"\[(.*)\]$", line)
             if section_match:
                 section = section_match.group(1)
                 continue
@@ -369,16 +369,17 @@ class Distribution:
         requirement. This method converts the former to the
         latter. See _test_deps_from_requires_text for an example.
         """
+
         def make_condition(name):
             return name and 'extra == "{name}"'.format(name=name)
 
         def parse_condition(section):
-            section = section or ''
-            extra, sep, markers = section.partition(':')
+            section = section or ""
+            extra, sep, markers = section.partition(":")
             if extra and markers:
-                markers = '({markers})'.format(markers=markers)
+                markers = "({markers})".format(markers=markers)
             conditions = list(filter(None, [markers, make_condition(extra)]))
-            return '; ' + ' and '.join(conditions) if conditions else ''
+            return "; " + " and ".join(conditions) if conditions else ""
 
         for section, deps in sections.items():
             for dep in deps:
@@ -419,7 +420,7 @@ class DistributionFinder(MetaPathFinder):
             Typically refers to Python package paths and defaults
             to ``sys.path``.
             """
-            return vars(self).get('path', sys.path)
+            return vars(self).get("path", sys.path)
 
     @abc.abstractmethod
     def find_distributions(self, context=Context()):
@@ -447,7 +448,7 @@ class FastPath:
 
     def children(self):
         with suppress(Exception):
-            return os.listdir(self.root or '.')
+            return os.listdir(self.root or ".")
         with suppress(Exception):
             return self.zip_children()
         return []
@@ -457,41 +458,38 @@ class FastPath:
         names = zip_path.root.namelist()
         self.joinpath = zip_path.joinpath
 
-        return unique_ordered(
-            child.split(posixpath.sep, 1)[0]
-            for child in names
-            )
+        return unique_ordered(child.split(posixpath.sep, 1)[0] for child in names)
 
     def search(self, name):
         return (
             self.joinpath(child)
             for child in self.children()
             if name.matches(child, self.base)
-            )
+        )
 
 
 class Prepared:
     """
     A prepared search for metadata on a possibly-named package.
     """
+
     normalized = None
-    suffixes = '.dist-info', '.egg-info'
-    exact_matches = [''][:0]
+    suffixes = ".dist-info", ".egg-info"
+    exact_matches = [""][:0]
 
     def __init__(self, name):
         self.name = name
         if name is None:
             return
         self.normalized = self.normalize(name)
-        self.exact_matches = [
-            self.normalized + suffix for suffix in self.suffixes]
+        self.exact_matches = [self.normalized + suffix for suffix in self.suffixes]
 
     @staticmethod
     def normalize(name):
         """
         PEP 503 normalization plus dashes as underscores.
         """
-        return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')
+        return re.sub(r"[-_.]+", "-", name).lower().replace("-", "_")
 
     @staticmethod
     def legacy_normalize(name):
@@ -499,30 +497,30 @@ class Prepared:
         Normalize the package name as found in the convention in
         older packaging tools versions and specs.
         """
-        return name.lower().replace('-', '_')
+        return name.lower().replace("-", "_")
 
     def matches(self, cand, base):
         low = cand.lower()
         pre, ext = os.path.splitext(low)
-        name, sep, rest = pre.partition('-')
+        name, sep, rest = pre.partition("-")
         return (
             low in self.exact_matches
-            or ext in self.suffixes and (
-                not self.normalized or
-                name.replace('.', '_') == self.normalized
-                )
+            or ext in self.suffixes
+            and (not self.normalized or name.replace(".", "_") == self.normalized)
             # legacy case:
-            or self.is_egg(base) and low == 'egg-info'
-            )
+            or self.is_egg(base)
+            and low == "egg-info"
+        )
 
     def is_egg(self, base):
-        normalized = self.legacy_normalize(self.name or '')
-        prefix = normalized + '-' if normalized else ''
-        versionless_egg_name = normalized + '.egg' if self.name else ''
+        normalized = self.legacy_normalize(self.name or "")
+        prefix = normalized + "-" if normalized else ""
+        versionless_egg_name = normalized + ".egg" if self.name else ""
         return (
             base == versionless_egg_name
             or base.startswith(prefix)
-            and base.endswith('.egg'))
+            and base.endswith(".egg")
+        )
 
 
 @install
@@ -549,9 +547,8 @@ class MetadataPathFinder(NullFinder, DistributionFinder):
     def _search_paths(cls, name, paths):
         """Find metadata directories in paths heuristically."""
         return itertools.chain.from_iterable(
-            path.search(Prepared(name))
-            for path in map(FastPath, paths)
-            )
+            path.search(Prepared(name)) for path in map(FastPath, paths)
+        )
 
 
 class PathDistribution(Distribution):
@@ -564,9 +561,15 @@ class PathDistribution(Distribution):
         self._path = path
 
     def read_text(self, filename):
-        with suppress(FileNotFoundError, IsADirectoryError, KeyError,
-                      NotADirectoryError, PermissionError):
-            return self._path.joinpath(filename).read_text(encoding='utf-8')
+        with suppress(
+            FileNotFoundError,
+            IsADirectoryError,
+            KeyError,
+            NotADirectoryError,
+            PermissionError,
+        ):
+            return self._path.joinpath(filename).read_text(encoding="utf-8")
+
     read_text.__doc__ = Distribution.read_text.__doc__
 
     def locate_file(self, path):
@@ -614,15 +617,11 @@ def entry_points():
 
     :return: EntryPoint objects for all installed packages.
     """
-    eps = itertools.chain.from_iterable(
-        dist.entry_points for dist in distributions())
-    by_group = operator.attrgetter('group')
+    eps = itertools.chain.from_iterable(dist.entry_points for dist in distributions())
+    by_group = operator.attrgetter("group")
     ordered = sorted(eps, key=by_group)
     grouped = itertools.groupby(ordered, by_group)
-    return {
-        group: tuple(eps)
-        for group, eps in grouped
-        }
+    return {group: tuple(eps) for group, eps in grouped}
 
 
 def files(distribution_name):

--- a/metaflow/_vendor/importlib_metadata/_compat.py
+++ b/metaflow/_vendor/importlib_metadata/_compat.py
@@ -10,6 +10,7 @@ if sys.version_info > (3,):  # pragma: nocover
     import builtins
     from configparser import ConfigParser
     import contextlib
+
     FileNotFoundError = builtins.FileNotFoundError
     IsADirectoryError = builtins.IsADirectoryError
     NotADirectoryError = builtins.NotADirectoryError
@@ -21,12 +22,13 @@ else:  # pragma: nocover
     from itertools import imap as map  # type: ignore
     from itertools import ifilterfalse as filterfalse
     import contextlib2 as contextlib
+
     FileNotFoundError = IOError, OSError
     IsADirectoryError = IOError, OSError
     NotADirectoryError = IOError, OSError
     PermissionError = IOError, OSError
 
-str = type('')
+str = type("")
 
 suppress = contextlib.suppress
 
@@ -44,16 +46,25 @@ except (NameError, AttributeError):  # pragma: nocover
 if sys.version_info >= (3,):  # pragma: nocover
     from importlib.abc import MetaPathFinder
 else:  # pragma: nocover
+
     class MetaPathFinder(object):
         __metaclass__ = abc.ABCMeta
 
 
 __metaclass__ = type
 __all__ = [
-    'install', 'NullFinder', 'MetaPathFinder', 'ModuleNotFoundError',
-    'pathlib', 'ConfigParser', 'map', 'suppress', 'FileNotFoundError',
-    'NotADirectoryError', 'email_message_from_string',
-    ]
+    "install",
+    "NullFinder",
+    "MetaPathFinder",
+    "ModuleNotFoundError",
+    "pathlib",
+    "ConfigParser",
+    "map",
+    "suppress",
+    "FileNotFoundError",
+    "NotADirectoryError",
+    "email_message_from_string",
+]
 
 
 def install(cls):
@@ -77,11 +88,12 @@ def disable_stdlib_finder():
     See #91 for more background for rationale on this sketchy
     behavior.
     """
+
     def matches(finder):
-        return (
-            getattr(finder, '__module__', None) == '_frozen_importlib_external'
-            and hasattr(finder, 'find_distributions')
-            )
+        return getattr(
+            finder, "__module__", None
+        ) == "_frozen_importlib_external" and hasattr(finder, "find_distributions")
+
     for finder in filter(matches, sys.meta_path):  # pragma: nocover
         del finder.find_distributions
 
@@ -91,6 +103,7 @@ class NullFinder:
     A "Finder" (aka "MetaClassFinder") that never finds any modules,
     but may find distributions.
     """
+
     @staticmethod
     def find_spec(*args, **kwargs):
         return None
@@ -112,10 +125,8 @@ def py2_message_from_string(text):  # nocoverpy3
 
 
 email_message_from_string = (
-    py2_message_from_string
-    if sys.version_info < (3,) else
-    email.message_from_string
-    )
+    py2_message_from_string if sys.version_info < (3,) else email.message_from_string
+)
 
 
 class PyPy_repr:
@@ -123,14 +134,16 @@ class PyPy_repr:
     Override repr for EntryPoint objects on PyPy to avoid __iter__ access.
     Ref #97, #102.
     """
-    affected = hasattr(sys, 'pypy_version_info')
+
+    affected = hasattr(sys, "pypy_version_info")
 
     def __compat_repr__(self):  # pragma: nocover
         def make_param(name):
             value = getattr(self, name)
-            return '{name}={value!r}'.format(**locals())
-        params = ', '.join(map(make_param, self._fields))
-        return 'EntryPoint({params})'.format(**locals())
+            return "{name}={value!r}".format(**locals())
+
+        params = ", ".join(map(make_param, self._fields))
+        return "EntryPoint({params})".format(**locals())
 
     if affected:  # pragma: nocover
         __repr__ = __compat_repr__
@@ -148,5 +161,4 @@ def unique_everseen(iterable):  # pragma: nocover
         yield element
 
 
-unique_ordered = (
-    unique_everseen if sys.version_info < (3, 7) else dict.fromkeys)
+unique_ordered = unique_everseen if sys.version_info < (3, 7) else dict.fromkeys

--- a/metaflow/_vendor/zipp.py
+++ b/metaflow/_vendor/zipp.py
@@ -12,7 +12,7 @@ else:
     OrderedDict = dict
 
 
-__all__ = ['Path']
+__all__ = ["Path"]
 
 
 def _parents(path):
@@ -93,7 +93,7 @@ class CompleteDirs(zipfile.ZipFile):
         as a directory (with the trailing slash).
         """
         names = self._name_set()
-        dirname = name + '/'
+        dirname = name + "/"
         dir_match = name not in names and dirname in names
         return dirname if dir_match else name
 
@@ -110,7 +110,7 @@ class CompleteDirs(zipfile.ZipFile):
             return cls(_pathlib_compat(source))
 
         # Only allow for FastLookup when supplied zipfile is read-only
-        if 'r' not in source.mode:
+        if "r" not in source.mode:
             cls = CompleteDirs
 
         source.__class__ = cls
@@ -240,7 +240,7 @@ class Path:
         self.root = FastLookup.make(root)
         self.at = at
 
-    def open(self, mode='r', *args, pwd=None, **kwargs):
+    def open(self, mode="r", *args, pwd=None, **kwargs):
         """
         Open this entry as text or binary following the semantics
         of ``pathlib.Path.open()`` by passing arguments through
@@ -249,10 +249,10 @@ class Path:
         if self.is_dir():
             raise IsADirectoryError(self)
         zip_mode = mode[0]
-        if not self.exists() and zip_mode == 'r':
+        if not self.exists() and zip_mode == "r":
             raise FileNotFoundError(self)
         stream = self.root.open(self.at, zip_mode, pwd=pwd)
-        if 'b' in mode:
+        if "b" in mode:
             if args or kwargs:
                 raise ValueError("encoding args invalid for binary operation")
             return stream
@@ -279,11 +279,11 @@ class Path:
         return pathlib.Path(self.root.filename).joinpath(self.at)
 
     def read_text(self, *args, **kwargs):
-        with self.open('r', *args, **kwargs) as strm:
+        with self.open("r", *args, **kwargs) as strm:
             return strm.read()
 
     def read_bytes(self):
-        with self.open('rb') as strm:
+        with self.open("rb") as strm:
             return strm.read()
 
     def _is_child(self, path):
@@ -323,7 +323,7 @@ class Path:
     def parent(self):
         if not self.at:
             return self.filename.parent
-        parent_at = posixpath.dirname(self.at.rstrip('/'))
+        parent_at = posixpath.dirname(self.at.rstrip("/"))
         if parent_at:
-            parent_at += '/'
+            parent_at += "/"
         return self._next(parent_at)

--- a/metaflow/client/filecache.py
+++ b/metaflow/client/filecache.py
@@ -23,7 +23,6 @@ if sys.version_info[0] >= 3 and sys.version_info[1] >= 2:
     def od_move_to_end(od, key):
         od.move_to_end(key)
 
-
 else:
     # Not very efficient but works and most people are on 3.2+
     def od_move_to_end(od, key):
@@ -320,7 +319,7 @@ class FileCache(object):
 
     def _garbage_collect(self):
         now = time.time()
-        while self._objects and self._total > self._max_size * 1024 ** 2:
+        while self._objects and self._total > self._max_size * 1024**2:
             if now - self._objects[0][0] < NEW_FILE_QUARANTINE:
                 break
             ctime, size, path = self._objects.pop(0)

--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -327,7 +327,7 @@ class S3(object):
             else:
                 prefix = os.path.join(prefix, run.parent.id, run.id)
 
-            self._s3root = u"s3://%s" % os.path.join(bucket, prefix.strip("/"))
+            self._s3root = "s3://%s" % os.path.join(bucket, prefix.strip("/"))
         elif s3root:
             # 2. use an explicit S3 prefix
             parsed = urlparse(to_unicode(s3root))
@@ -928,7 +928,7 @@ class S3(object):
                 os.unlink(tmp.name)
             self._s3_client.reset_client()
             # add some jitter to make sure retries are not synchronized
-            time.sleep(2 ** i + random.randint(0, 10))
+            time.sleep(2**i + random.randint(0, 10))
         raise MetaflowS3Exception(
             "S3 operation failed.\n" "Key requested: %s\n" "Error: %s" % (url, error)
         )
@@ -1042,6 +1042,6 @@ class S3(object):
                     elif ex.returncode == s3op.ERROR_URL_ACCESS_DENIED:
                         raise MetaflowS3AccessDenied(err_out)
                     print("Error with S3 operation:", err_out)
-                    time.sleep(2 ** i + random.randint(0, 10))
+                    time.sleep(2**i + random.randint(0, 10))
 
         return None, err_out

--- a/metaflow/datatools/s3op.py
+++ b/metaflow/datatools/s3op.py
@@ -78,7 +78,7 @@ ERROR_LOCAL_FILE_NOT_FOUND = 10
 
 
 def format_triplet(prefix, url="", local=""):
-    return u" ".join(url_quote(x).decode("utf-8") for x in (prefix, url, local))
+    return " ".join(url_quote(x).decode("utf-8") for x in (prefix, url, local))
 
 
 # I can't understand what's the right way to deal
@@ -306,10 +306,10 @@ def process_urls(mode, urls, verbose, num_workers):
 
 
 def with_unit(x):
-    if x > 1024 ** 3:
-        return "%.1fGB" % (x / 1024.0 ** 3)
-    elif x > 1024 ** 2:
-        return "%.1fMB" % (x / 1024.0 ** 2)
+    if x > 1024**3:
+        return "%.1fGB" % (x / 1024.0**3)
+    elif x > 1024**2:
+        return "%.1fMB" % (x / 1024.0**2)
     elif x > 1024:
         return "%.1fKB" % (x / 1024.0)
     else:
@@ -476,8 +476,8 @@ def generate_local_path(url, suffix=None):
     fname = quoted.split(b"/")[-1].replace(b".", b"_").replace(b"-", b"_")
     sha = sha1(quoted).hexdigest()
     if suffix:
-        return u"-".join((sha, fname.decode("utf-8"), suffix))
-    return u"-".join((sha, fname.decode("utf-8")))
+        return "-".join((sha, fname.decode("utf-8"), suffix))
+    return "-".join((sha, fname.decode("utf-8")))
 
 
 def parallel_op(op, lst, num_workers):

--- a/metaflow/datatools/s3util.py
+++ b/metaflow/datatools/s3util.py
@@ -58,7 +58,7 @@ def aws_retry(f):
                 last_exc = ex
                 # exponential backoff for real failures
                 if not (TEST_S3_RETRY and i == 0):
-                    time.sleep(2 ** i + random.randint(0, 5))
+                    time.sleep(2**i + random.randint(0, 5))
         raise last_exc
 
     return retry_wrapper

--- a/metaflow/includefile.py
+++ b/metaflow/includefile.py
@@ -126,9 +126,9 @@ class Local(object):
 
     def _path(self, key):
         key = to_unicode(key)
-        if key.startswith(u"local://"):
+        if key.startswith("local://"):
             return key[8:]
-        elif key[0] != u"/":
+        elif key[0] != "/":
             if current.is_running_flow:
                 raise MetaflowLocalURLException(
                     "Specify Local(run=self) when you use Local inside a running "
@@ -145,7 +145,7 @@ class Local(object):
 
     def get(self, key=None, return_missing=False):
         p = self._path(key)
-        url = u"local://%s" % p
+        url = "local://%s" % p
         if not os.path.isfile(p):
             if return_missing:
                 p = None
@@ -159,7 +159,7 @@ class Local(object):
             Local._makedirs(os.path.dirname(p))
             with open(p, "wb") as f:
                 f.write(obj)
-        return u"local://%s" % p
+        return "local://%s" % p
 
 
 # From here on out, this is the IncludeFile implementation.
@@ -190,7 +190,7 @@ class LocalFile:
                 )
             path = decoded_value["url"]
         for prefix, handler in DATACLIENTS.items():
-            if path.startswith(u"%s://" % prefix):
+            if path.startswith("%s://" % prefix):
                 return True, Uploader(handler), None
         try:
             with open(path, mode="r") as _:

--- a/metaflow/metadata/heartbeat.py
+++ b/metaflow/metadata/heartbeat.py
@@ -49,7 +49,7 @@ class MetadataHeartBeat(object):
                 retry_counter = 0
             except HeartBeatException as e:
                 retry_counter = retry_counter + 1
-                time.sleep(4 ** retry_counter)
+                time.sleep(4**retry_counter)
 
     def heartbeat(self):
         if self.hb_url is not None:

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -201,7 +201,7 @@ def step(
     if num_parallel and num_parallel > 1:
         # For multinode, we need to add a placeholder that can be mutated by the caller
         step_args += " [multinode-args]"
-    step_cli = u"{entrypoint} {top_args} step {step} {step_args}".format(
+    step_cli = "{entrypoint} {top_args} step {step} {step_args}".format(
         entrypoint=entrypoint,
         top_args=top_args,
         step=step_name,

--- a/metaflow/plugins/aws/eks/kubernetes_cli.py
+++ b/metaflow/plugins/aws/eks/kubernetes_cli.py
@@ -153,7 +153,7 @@ def step(
         )
         time.sleep(minutes_between_retries * 60)
 
-    step_cli = u"{entrypoint} {top_args} step {step} {step_args}".format(
+    step_cli = "{entrypoint} {top_args} step {step} {step_args}".format(
         entrypoint="%s -u %s" % (executable, os.path.basename(sys.argv[0])),
         top_args=" ".join(util.dict_to_cli_options(ctx.parent.parent.params)),
         step=step_name,

--- a/metaflow/plugins/cards/card_modules/chevron/renderer.py
+++ b/metaflow/plugins/cards/card_modules/chevron/renderer.py
@@ -23,7 +23,6 @@ if sys.version_info[0] == 3:
     def unicode(x, y):
         return x
 
-
 else:  # python 2
     python3 = False
     unicode_type = unicode

--- a/metaflow/plugins/env_escape/data_transferer.py
+++ b/metaflow/plugins/env_escape/data_transferer.py
@@ -165,7 +165,6 @@ if sys.version_info[0] >= 3:
     def _load_invalidunicode(obj_type, transferer, json_annotation, json_obj):
         return _load_simple(str, transferer, json_annotation, json_obj)
 
-
 else:
 
     @_register_dumper((str,))

--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -376,7 +376,7 @@ class ServiceMetadataProvider(MetadataProvider):
                         resp.status_code,
                         resp.text,
                     )
-            time.sleep(2 ** i)
+            time.sleep(2**i)
 
         if resp:
             raise ServiceException(
@@ -423,7 +423,7 @@ class ServiceMetadataProvider(MetadataProvider):
                         resp.status_code,
                         resp.text,
                     )
-            time.sleep(2 ** i)
+            time.sleep(2**i)
         if resp:
             raise ServiceException(
                 "Metadata request (%s) failed (code %s): %s"

--- a/metaflow/plugins/test_unbounded_foreach_decorator.py
+++ b/metaflow/plugins/test_unbounded_foreach_decorator.py
@@ -111,11 +111,11 @@ class InternalTestUnboundedForeachDecorator(StepDecorator):
             cmd = cli_args.step_command(
                 executable, script, step_name, step_kwargs=kwargs
             )
-            step_cli = u" ".join(cmd)
+            step_cli = " ".join(cmd)
             # Print cmdline for execution. Doesn't work without the temporary
             # unicode object while using `print`.
             print(
-                u"[${cwd}] Starting split#{split} with cmd:{cmd}".format(
+                "[${cwd}] Starting split#{split} with cmd:{cmd}".format(
                     cwd=os.getcwd(), split=i, cmd=step_cli
                 )
             )

--- a/test/core/tests/basic_include.py
+++ b/test/core/tests/basic_include.py
@@ -26,9 +26,9 @@ with open('override.txt', mode='w') as f:
     @steps(0, ["all"])
     def step_all(self):
         assert_equals("Regular Text File", self.myfile_txt)
-        assert_equals(u"UTF Text File \u5e74", self.myfile_utf8)
+        assert_equals("UTF Text File \u5e74", self.myfile_utf8)
         assert_equals(
-            u"UTF Text File \u5e74".encode(encoding="utf8"), self.myfile_binary
+            "UTF Text File \u5e74".encode(encoding="utf8"), self.myfile_binary
         )
         assert_equals("Override Text File", self.myfile_overriden)
 

--- a/test/core/tests/basic_log.py
+++ b/test/core/tests/basic_log.py
@@ -14,7 +14,7 @@ class BasicLogTest(MetaflowTest):
         import sys
 
         msg1 = "stdout: A regular message.\n"
-        msg2 = u"stdout: A message with unicode: \u5e74\n"
+        msg2 = "stdout: A message with unicode: \u5e74\n"
         sys.stdout.write(msg1)
         if not sys.stdout.encoding:
             sys.stdout.write(msg2.encode("utf8"))
@@ -22,7 +22,7 @@ class BasicLogTest(MetaflowTest):
             sys.stdout.write(msg2)
 
         msg3 = "stderr: A regular message.\n"
-        msg4 = u"stderr: A message with unicode: \u5e74\n"
+        msg4 = "stderr: A message with unicode: \u5e74\n"
         sys.stderr.write(msg3)
         if not sys.stderr.encoding:
             sys.stderr.write(msg4.encode("utf8"))
@@ -35,11 +35,11 @@ class BasicLogTest(MetaflowTest):
 
     def check_results(self, flow, checker):
         msg1 = "stdout: A regular message.\n"
-        msg2 = u"stdout: A message with unicode: \u5e74\n"
+        msg2 = "stdout: A message with unicode: \u5e74\n"
         stdout_combined_msg = "".join([msg1, msg2, ""])
 
         msg3 = "stderr: A regular message.\n"
-        msg4 = u"stderr: A message with unicode: \u5e74\n"
+        msg4 = "stderr: A message with unicode: \u5e74\n"
         stderr_combined_msg = "".join([msg3, msg4, ""])
 
         for step in flow:

--- a/test/core/tests/basic_tags.py
+++ b/test/core/tests/basic_tags.py
@@ -31,11 +31,11 @@ class BasicTagTest(MetaflowTest):
         # test crazy unicode and spaces in tags
         # these tags must be set with --tag option in contexts.json
         tags = (
-            u"project:basic_tag",
-            u"project_branch:user.tester",
-            u"user:%s" % os.environ.get("METAFLOW_USER"),
-            u"刺身 means sashimi",
-            u"multiple tags should be ok",
+            "project:basic_tag",
+            "project_branch:user.tester",
+            "user:%s" % os.environ.get("METAFLOW_USER"),
+            "刺身 means sashimi",
+            "multiple tags should be ok",
         )
         for tag in tags:
             # test different namespaces: one is a system-tag,

--- a/test/core/tests/large_artifact.py
+++ b/test/core/tests/large_artifact.py
@@ -16,7 +16,7 @@ class LargeArtifactTest(MetaflowTest):
         import sys
 
         if sys.version_info[0] > 2:
-            self.large = b"x" * int(4.1 * 1024 ** 3)
+            self.large = b"x" * int(4.1 * 1024**3)
             self.noop = False
         else:
             self.noop = True
@@ -26,7 +26,7 @@ class LargeArtifactTest(MetaflowTest):
         import sys
 
         if sys.version_info[0] > 2:
-            assert_equals(self.large, b"x" * int(4.1 * 1024 ** 3))
+            assert_equals(self.large, b"x" * int(4.1 * 1024**3))
 
     @steps(1, ["all"])
     def step_all(self):
@@ -37,4 +37,4 @@ class LargeArtifactTest(MetaflowTest):
 
         noop = next(iter(checker.artifact_dict("end", "noop").values()))["noop"]
         if not noop and sys.version_info[0] > 2:
-            checker.assert_artifact("end", "large", b"x" * int(4.1 * 1024 ** 3))
+            checker.assert_artifact("end", "large", b"x" * int(4.1 * 1024**3))

--- a/test/data/s3/s3_data.py
+++ b/test/data/s3/s3_data.py
@@ -36,7 +36,7 @@ BASIC_METADATA = {
     "complex": (
         "text/plain",
         {
-            "utf8-data": u"\u523a\u8eab/means sashimi",
+            "utf8-data": "\u523a\u8eab/means sashimi",
             "with-weird-chars": "Space and !@#<>:/-+=&%",
         },
     ),
@@ -44,7 +44,7 @@ BASIC_METADATA = {
 
 BASIC_RANGE_INFO = {
     "from_beg": (0, 16),  # From beginning
-    "exceed_end": (0, 10 * 1024 ** 3),  # From beginning, should fetch full file
+    "exceed_end": (0, 10 * 1024**3),  # From beginning, should fetch full file
     "middle": (5, 10),  # From middle
     "end": (None, -5),  # Fetch from end
     "till_end": (5, None),  # Fetch till end
@@ -61,7 +61,7 @@ BASIC_DATA = [
     # a basic sanity check
     (
         "3_small_files",
-        {"empty_file": 0, "kb_file": 1024, "mb_file": 1024 ** 2, "missing_file": None},
+        {"empty_file": 0, "kb_file": 1024, "mb_file": 1024**2, "missing_file": None},
     ),
     # S3 paths can be longer than the max allowed filename on Linux
     (
@@ -90,27 +90,27 @@ BASIC_DATA = [
     (
         "crazypath",
         {
-            u"crazy spaces": 34,
-            u"\x01\xff": 64,
-            u"\u523a\u8eab/means sashimi": 33,
-            u"crazy-!.$%@2_()\"'": 100,
-            u" /cra._:zy/\x01\x02/p a t h/$this/!!is()": 1000,
-            u"crazy missing :(": None,
+            "crazy spaces": 34,
+            "\x01\xff": 64,
+            "\u523a\u8eab/means sashimi": 33,
+            "crazy-!.$%@2_()\"'": 100,
+            " /cra._:zy/\x01\x02/p a t h/$this/!!is()": 1000,
+            "crazy missing :(": None,
         },
     ),
 ]
 
 BIG_DATA = [
     # test a file > 4GB
-    ("5gb_file", {"5gb_file": 5 * 1024 ** 3}),
+    ("5gb_file", {"5gb_file": 5 * 1024**3}),
     # ensure that e.g. paged listings work correctly with many keys
     ("3000_files", {str(i): i for i in range(3000)}),
 ]
 
 # Large file to use for benchmark, must be in BASIC_DATA or BIG_DATA
 BENCHMARK_SMALL_FILE = ("3000_files", {"1": 1})
-BENCHMARK_MEDIUM_FILE = ("3_small_files", {"mb_file": 1024 ** 2})
-BENCHMARK_LARGE_FILE = ("5gb_file", {"5gb_file": 5 * 1024 ** 3})
+BENCHMARK_MEDIUM_FILE = ("3_small_files", {"mb_file": 1024**2})
+BENCHMARK_LARGE_FILE = ("5gb_file", {"5gb_file": 5 * 1024**3})
 
 BENCHMARK_SMALL_ITER_MAX = 10001
 BENCHMARK_MEDIUM_ITER_MAX = 501
@@ -382,7 +382,7 @@ def pytest_many_prefixes_case():
 def pytest_put_strings_case(meta=None):
     put_prefix = os.path.join(S3ROOT, PUT_PREFIX)
     data = [
-        u"unicode: \u523a\u8eab means sashimi",
+        "unicode: \u523a\u8eab means sashimi",
         b"bytes: \x00\x01\x02",
         "just a string",
     ]

--- a/test/unit/test_compute_resource_attributes.py
+++ b/test/unit/test_compute_resource_attributes.py
@@ -33,14 +33,11 @@ def test_compute_resource_attributes():
     ) == {"cpu": "1", "memory": "100"}
 
     # take largest of @resources and @batch if both are present
-    assert (
-        compute_resource_attributes(
-            [MockDeco("resources", {"cpu": "2"})],
-            MockDeco("batch", {"cpu": 1}),
-            {"cpu": "3"},
-        )
-        == {"cpu": "2"}
-    )
+    assert compute_resource_attributes(
+        [MockDeco("resources", {"cpu": "2"})],
+        MockDeco("batch", {"cpu": 1}),
+        {"cpu": "3"},
+    ) == {"cpu": "2"}
 
 
 def test_compute_resource_attributes_string():
@@ -52,31 +49,22 @@ def test_compute_resource_attributes_string():
     ) == {"cpu": "1"}
 
     # use string value from deco if set (default is None)
-    assert (
-        compute_resource_attributes(
-            [],
-            MockDeco("batch", {"instance_type": "p3.xlarge"}),
-            {"cpu": "1", "instance_type": None},
-        )
-        == {"cpu": "1", "instance_type": "p3.xlarge"}
-    )
+    assert compute_resource_attributes(
+        [],
+        MockDeco("batch", {"instance_type": "p3.xlarge"}),
+        {"cpu": "1", "instance_type": None},
+    ) == {"cpu": "1", "instance_type": "p3.xlarge"}
 
     # use string value from deco if set (default is not None)
-    assert (
-        compute_resource_attributes(
-            [],
-            MockDeco("batch", {"instance_type": "p3.xlarge"}),
-            {"cpu": "1", "instance_type": "p4.xlarge"},
-        )
-        == {"cpu": "1", "instance_type": "p3.xlarge"}
-    )
+    assert compute_resource_attributes(
+        [],
+        MockDeco("batch", {"instance_type": "p3.xlarge"}),
+        {"cpu": "1", "instance_type": "p4.xlarge"},
+    ) == {"cpu": "1", "instance_type": "p3.xlarge"}
 
     # use string value from defaults if @batch has it set to None
-    assert (
-        compute_resource_attributes(
-            [],
-            MockDeco("batch", {"instance_type": None}),
-            {"cpu": "1", "instance_type": "p4.xlarge"},
-        )
-        == {"cpu": "1", "instance_type": "p4.xlarge"}
-    )
+    assert compute_resource_attributes(
+        [],
+        MockDeco("batch", {"instance_type": None}),
+        {"cpu": "1", "instance_type": "p4.xlarge"},
+    ) == {"cpu": "1", "instance_type": "p4.xlarge"}

--- a/test_runner
+++ b/test_runner
@@ -3,10 +3,7 @@
 set -o errexit -o nounset -o pipefail
 
 install_deps() {
-  for version in 2 3;
-  do
-    python$version -m pip install . 
-  done
+  python3 -m pip install .
 }
 
 run_tests() {


### PR DESCRIPTION
**Update**: Partly superceded by #867, but removes a few more vestigial Python 2 configurations.

----

Fixes https://github.com/Netflix/metaflow/issues/668; opening partly for discussion.

This may have to wait for Metaflow 3.x; @villelaitila mentioned that long-running Metaflow services may exist where upgrading them (to a new version that removes Python 2), but not their clients, could cause breakage if those clients try to do Python 2 things.

I'm not familiar enough with what services like that may exist, or whether anyone is likely to run into that situation. Interested in others' thoughts!

This was factored out of #612.