### PR TITLE
Allow dots in paths in host_volumes parameter for AWS Batch

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -194,7 +194,7 @@ class BatchJob(object):
             job_definition['containerProperties']['volumes'] = []
             job_definition['containerProperties']['mountPoints'] = []
             for host_path in host_volumes:
-                name = host_path.replace('/', '_')
+                name = host_path.replace('/', '_').replace('.', '_')
                 job_definition['containerProperties']['volumes'].append(
                     {'name': name, 'host': {'sourcePath': host_path}}
                 )


### PR DESCRIPTION
## What does this do

When we mount volumes from host, we need to specify volume "name". That name is really not used for anything except to refer to the volume within Batch Job Definition. We generate that name by sanitizing the original path (for a bit more debuggability). Turns out we don't sanitize enough since dots are not allowed in it. Before this fix, if you did `@batch(host_volumes="/path/with/.dot")` it would fail to execute on Batch.