### PR TITLE
Representation change for `task.exception`

### DIFF
--- a/metaflow/exception.py
+++ b/metaflow/exception.py
@@ -30,6 +30,9 @@ class MetaflowExceptionWrapper(Exception):
 
     def __setstate__(self, state):
         self.__dict__ = state
+    
+    def __repr__(self):
+        return str(self)
 
     def __str__(self):
         if self.stacktrace:

--- a/test/core/tests/task_exception.py
+++ b/test/core/tests/task_exception.py
@@ -1,0 +1,26 @@
+from metaflow_test import MetaflowTest, ExpectationFailed, steps
+
+
+
+class TaskExceptionTest(MetaflowTest):
+    """
+    Test that an artifact defined in the first step
+    is available in all steps downstream.
+    """
+    PRIORITY = 1
+    SHOULD_FAIL = True
+
+    @steps(0, ['singleton-end'],required=True)
+    def step_start(self):
+        raise KeyError('Something has went wrong')
+
+    @steps(2, ['all'])
+    def step_all(self):
+        pass
+
+    def check_results(self, flow, checker):
+        run = checker.get_run()
+        if run is not None:
+            for task in run['end']:
+                assert_equals('KeyError' in str(task.exception), True)
+                assert_equals(task.exception.exception,"'Something has went wrong'")

--- a/test/core/tests/task_exception.py
+++ b/test/core/tests/task_exception.py
@@ -4,8 +4,7 @@ from metaflow_test import MetaflowTest, ExpectationFailed, steps
 
 class TaskExceptionTest(MetaflowTest):
     """
-    Test that an artifact defined in the first step
-    is available in all steps downstream.
+    A test to validate if exceptions are stored and retrieved correctly
     """
     PRIORITY = 1
     SHOULD_FAIL = True

--- a/test/core/tests/task_exception.py
+++ b/test/core/tests/task_exception.py
@@ -9,9 +9,9 @@ class TaskExceptionTest(MetaflowTest):
     PRIORITY = 1
     SHOULD_FAIL = True
 
-    @steps(0, ['singleton-end'],required=True)
+    @steps(0, ['singleton-end'], required=True)
     def step_start(self):
-        raise KeyError('Something has went wrong')
+        raise KeyError('Something has gone wrong')
 
     @steps(2, ['all'])
     def step_all(self):
@@ -22,4 +22,4 @@ class TaskExceptionTest(MetaflowTest):
         if run is not None:
             for task in run['end']:
                 assert_equals('KeyError' in str(task.exception), True)
-                assert_equals(task.exception.exception,"'Something has went wrong'")
+                assert_equals(task.exception.exception,"'Something has gone wrong'")


### PR DESCRIPTION
- Added Repr to fix error representation problem
- Added a test case to ensure this code works as expected. 
- Based on #677 