### PR TITLE
[Breaking] Modify return type of created_at/finished_at to datetime

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from datetime import datetime
 import os
 import time
 import tarfile

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -343,8 +343,7 @@ class MetaflowObject(object):
         else:
             raise MetaflowInternalError(msg="Unknown type: %s" % self._NAME)
 
-        self._created_at = time.strftime(
-            '%Y-%m-%dT%H:%M:%SZ', time.gmtime(self._object['ts_epoch']//1000))
+        self._created_at = datetime.fromtimestamp(self._object['ts_epoch']/1000.0)
 
         self._tags = frozenset(chain(self._object.get('system_tags') or [],
                                      self._object.get('tags') or []))

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 from datetime import datetime
 import os
-import time
 import tarfile
 import json
 from collections import namedtuple


### PR DESCRIPTION
Metaflow Client currently returns a string for `created_at` and `finished_at` properties. This PR changes the response type to a more appropriate Datetime object.