### PR TITLE
Add run.exceptions to easily iterate all exceptions of a run.

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -1418,6 +1418,16 @@ class Run(MetaflowObject):
 
         return end_step.task
 
+    @property
+    def exceptions(self):
+        """
+        Returns all the exceptions - if any - that occured during the execution.
+        """
+        exceptions = []
+        for step in self.steps():
+            exceptions.extend(task.exception for task in step.tasks() if task.exception)
+        return exceptions
+
 
 class Flow(MetaflowObject):
     """


### PR DESCRIPTION
Add a convenience function to quickly get all exceptions that occured during a run. Since run already has property "successful", it would be nice to include the reasons for failure as well.

Tested in the jupyter notebook:
```

for run in Flow('PlayListFlow').runs():
    if run.successful:
        print("Playlist generated on %s" % run.finished_at)
        print("Playlist for movies in genre '%s'" % run.data.genre)
        if run.data.playlist:
            print("Top Pick: '%s'" % run.data.playlist[0])
        print('\n')
    else:
        # For failed runs, you can see the exception(s) that occured.
        print("*** Run failed", run)
        for exception in run.exceptions:
            print(exception)
```