### PR TITLE
Conda _call_conda should print the stderr in case of error  

### DIFF
--- a/metaflow/plugins/conda/conda.py
+++ b/metaflow/plugins/conda/conda.py
@@ -182,7 +182,6 @@ class Conda(object):
                 raise CondaException(err)
             except (TypeError, ValueError) as ve:
                 pass
-            print("***", e.output)
             raise CondaException(
                 'command \'{cmd}\' returned error ({code}): {output}, stderr={stderr}'
                     .format(cmd=e.cmd, code=e.returncode, output=e.output, stderr=e.stderr))

--- a/metaflow/plugins/conda/conda.py
+++ b/metaflow/plugins/conda/conda.py
@@ -40,7 +40,7 @@ class Conda(object):
             raise InvalidEnvironmentException('Conda channel \'conda-forge\' '
                                               'is required. Specify it with CONDA_CHANNELS '
                                               'environment variable.')
-    
+
     def create(self,
                step_name,
                env_id,
@@ -129,14 +129,14 @@ class Conda(object):
 
     def _install_order(self, env_id):
         cmd = ['list', '--name', env_id, '--explicit']
-        response = self._call_conda(cmd).decode('utf-8') 
+        response = self._call_conda(cmd).decode('utf-8')
         emit = False
         result = []
         for line in response.splitlines():
             if emit:
                 result.append(line.split('/')[-1])
             if not emit and line == '@EXPLICIT':
-                emit = True  
+                emit = True
         return result
 
     def _deps(self, env_id):
@@ -170,8 +170,8 @@ class Conda(object):
             if disable_safety_checks:
                 env['CONDA_SAFETY_CHECKS'] = 'disabled'
             return subprocess.check_output(
-                [self._bin] + args, 
-                stderr = open(os.devnull, 'wb'),
+                [self._bin] + args,
+                stderr = subprocess.PIPE,
                 env = dict(os.environ, **env)).strip()
         except subprocess.CalledProcessError as e:
             try:
@@ -182,9 +182,10 @@ class Conda(object):
                 raise CondaException(err)
             except (TypeError, ValueError) as ve:
                 pass
+            print("***", e.output)
             raise CondaException(
-                'command \'{cmd}\' returned error ({code}): {output}'
-                    .format(cmd=e.cmd, code=e.returncode, output=e.output))
+                'command \'{cmd}\' returned error ({code}): {output}, stderr={stderr}'
+                    .format(cmd=e.cmd, code=e.returncode, output=e.output, stderr=e.stderr))
 
 
 class CondaLock(object):


### PR DESCRIPTION
Was having trouble with the conda environment, and Metaflow's error was just unhelpfully:
   
When running...

`
python3 04-playlist-plus/playlist.py --environment=conda run --hint "Data Science"
`

Conda ran into an error while setting up environment.:
`    command '['/Users/akyrola/opt/miniconda3/bin/conda', 'info']' returned error (1): b''
`
With this PR, the error is printed clearly:

    Conda ran into an error while setting up environment.:
`    command '['/Users/akyrola/opt/miniconda3/bin/conda', 'info']' returned error (1): b'', stderr=b'Traceback (most recent call last):\n  File "/Users/akyrola/opt/miniconda3/bin/conda", line 12, in <module>\n    from conda.cli import main\nModuleNotFoundError: No module named \'conda\'\n'`

Work with both py2 and py3.


Looks like my editor automatically did some whitespace cleanign up. Let me know if i should remove those from commit.