### PR TITLE
Upgrade pandas version in tutorials to 1.3.3

### DIFF
--- a/metaflow/tutorials/02-statistics/README.md
+++ b/metaflow/tutorials/02-statistics/README.md
@@ -6,8 +6,8 @@ later examples to improve our playlist generator. You can optionally use the
 Metaflow client to eyeball the results in a Notebook, and make some simple
 plots using the Matplotlib library.**
 
-Please note that Episode 04, a follow-on to this episode, requires Pandas version 0.24.2.
-Please make sure that you install or upgrade/downgrade to Pandas 0.24.2.
+Please note that Episode 04, a follow-on to this episode, requires Pandas version 1.3.3.
+Please make sure that you install or upgrade/downgrade to Pandas 1.3.3.
 
 #### Showcasing:
 - Fan-out over a set of parameters using Metaflow foreach.
@@ -15,7 +15,7 @@ Please make sure that you install or upgrade/downgrade to Pandas 0.24.2.
 - Plotting results in a Notebook.
 
 #### Before playing this episode:
-1. ```python -m pip install pandas==0.24.2```
+1. ```python -m pip install pandas==1.3.3```
 2. ```python -m pip install notebook```
 3. ```python -m pip install matplotlib```
 

--- a/metaflow/tutorials/04-playlist-plus/playlist.py
+++ b/metaflow/tutorials/04-playlist-plus/playlist.py
@@ -44,7 +44,7 @@ class PlayListFlow(FlowSpec):
                                 "the playlist.",
                                 default=5)
 
-    @conda(libraries={'pandas' : '0.24.2'})
+    @conda(libraries={'pandas' : '1.3.3'})
     @step
     def start(self):
         """
@@ -52,7 +52,7 @@ class PlayListFlow(FlowSpec):
         MovieStatsFlow and assign them as data artifacts in this flow.
 
         This step uses 'conda' to isolate the environment. This step will
-        always use pandas==0.24.2 regardless of what is installed on the
+        always use pandas==1.3.3 regardless of what is installed on the
         system.
 
         """
@@ -76,7 +76,7 @@ class PlayListFlow(FlowSpec):
         # Compute our two recommendation types in parallel.
         self.next(self.bonus_movie, self.genre_movies)
 
-    @conda(libraries={'editdistance': '0.5.3', 'pandas' : '0.24.2'})
+    @conda(libraries={'editdistance': '0.5.3', 'pandas' : '1.3.3'})
     @step
     def bonus_movie(self):
         """
@@ -105,14 +105,14 @@ class PlayListFlow(FlowSpec):
 
         self.next(self.join)
 
-    @conda(libraries={'pandas' : '0.24.2'})
+    @conda(libraries={'pandas' : '1.3.3'})
     @step
     def genre_movies(self):
         """
         Select the top performing movies from the use specified genre.
 
         This step uses 'conda' to isolate the environment. This step will
-        always use pandas==0.24.2 regardless of what is installed on the
+        always use pandas==1.3.3 regardless of what is installed on the
         system.
 
         """


### PR DESCRIPTION
At least on Intel Mac Big Sur, the pandas 0.24.2 installation fails with a compilation error (with pip). Perhaps we can just use 1.3.3? This works for me.

