### PR TITLE
Fixed batch related bug in convergence.

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -235,9 +235,12 @@ class Batch(object):
                     ' specified and no valid & enabled queue found.'
                 )
         job = self.create_job(
+                        flow_name,
                         step_name,
+                        run_id,
+                        task_id,
                         step_cli,
-                        task_spec,
+                        attempt,
                         code_package_sha,
                         code_package_url,
                         code_package_ds,


### PR DESCRIPTION
There was a bug in `batch.py`; this small patch fixes it. 

The following was the bug: the `self.create_job` function is given as task_spec when the function doesn't take a `task_spec` as an input. 