### PR TITLE
K8S: better error handling for evicted pods

### DIFF
--- a/metaflow/plugins/aws/eks/kubernetes_client.py
+++ b/metaflow/plugins/aws/eks/kubernetes_client.py
@@ -580,8 +580,19 @@ class RunningJob(object):
                     # If pod status is dirty, check for newer status
                     self._pod = self._fetch_pod()
                 if self._pod:
+                    pod_status = self._pod["status"]
+                    if pod_status.get("container_statuses") is None:
+                        # We're done, but no container_statuses is set
+                        # This can happen when the pod is evicted
+                        return None, ": ".join(
+                                filter(
+                                    None,
+                                    [pod_status.get("reason"), pod_status.get("message")],
+                                )
+                            )
+
                     for k, v in (
-                        self._pod["status"]
+                        pod_status
                         .get("container_statuses", [{}])[0]
                         .get("state", {})
                         .items()


### PR DESCRIPTION
From testing on our EKS cluster, it turns out `container_statuses` can sometimes be None for a failed pod. It looks like it happens when the pod was assigned to a node, haven't had a chance to start the containers yet, and gets evicted. In that case current version fails with a non-descriptive error ("NoneType not subsciptable" and a stack trace). This PR adds a handler for this case and prints a nicer error message, derived from `V1PodStatus.reason`:
```
...
2021-09-21 20:27:10.659 [6617/start/117133 (pid 14120)] Kubernetes error:
2021-09-21 20:27:10.660 [6617/start/117133 (pid 14120)] Evicted: Pod The node had condition: [DiskPressure]. . This could be a transient error. Use @retry to retry.
2021-09-21 20:27:10.760 [6617/start/117133 (pid 14120)]
```

This condition is somewhat tricky to repro without running the full test suite, so for reference, here's how V1PodStatus looks like in those cases, as returned by K8S API:
```python
    ...
    "status": {
        "conditions": None,
        "container_statuses": None,
        "ephemeral_container_statuses": None,
        "host_ip": None,
        "init_container_statuses": None,
        "message": "Pod The node had condition: [DiskPressure]. ",
        "nominated_node_name": None,
        "phase": "Failed",
        "pod_ip": None,
        "pod_i_ps": None,
        "qos_class": None,
        "reason": "Evicted",
        "start_time": datetime.datetime(2021, 9, 17, 2, 26, 4, tzinfo=tzlocal()),
    },
```