### PR TITLE
PEP8: Avoid bare `except:`

### DIFF
--- a/metaflow/parameters.py
+++ b/metaflow/parameters.py
@@ -11,7 +11,7 @@ from .exception import ParameterFieldFailed,\
 try:
     # Python2
     strtype = basestring
-except:
+except NameError:
     # Python3
     strtype = str
 

--- a/metaflow/util.py
+++ b/metaflow/util.py
@@ -39,7 +39,7 @@ try:
             return self.path
 
     from pipes import quote as _quote
-except:
+except NameError:
     # python3
     unicode_type = str
     bytes_type = bytes


### PR DESCRIPTION
Do not use bare `except:`, it also catches unexpected events like memory errors, interrupts, system exit, and so on. Prefer `except Exception:`. If you’re sure what you’re doing, be explicit and write `except BaseException:`.

https://realpython.com/the-most-diabolical-python-antipattern/
https://www.python.org/dev/peps/pep-0008/

$ `BUILTINS=assert_equals,assert_exception,inputs,is_resumed,NUM_FOREACH,NUM_LINES,ResumeFromHere,TestRetry`
$ `flake8 . --builtins=$BUILTINS --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./metaflow/metaflow/parameters.py:13:15: F821 undefined name 'basestring'
    strtype = basestring
              ^
./metaflow/metaflow/util.py:16:20: F821 undefined name 'unicode'
    unicode_type = unicode
                   ^
```