### PR TITLE
from metaflow.sidecar_messages import Message for line 13

### DIFF
--- a/metaflow/plugins/debug_logger.py
+++ b/metaflow/plugins/debug_logger.py
@@ -1,5 +1,7 @@
 import sys
 
+from metaflow.sidecar_messages import Message
+
 
 class DebugEventLogger(object):
     TYPE = 'debugLogger'


### PR DESCRIPTION
An _undefined name_ in a type hint.

As done at https://github.com/Netflix/metaflow/blob/master/metaflow/plugins/debug_monitor.py#L5 for line 27.

$ `BUILTINS=assert_equals,assert_exception,inputs,is_resumed,NUM_FOREACH,NUM_LINES,ResumeFromHere,TestRetry`
$ `flake8 . --builtins=$BUILTINS --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./metaflow/metaflow/plugins/debug_logger.py:11:9: F821 undefined name 'Message'
        # type: (Message) -> None
        ^
```