### PR TITLE
Fixing two R error messages

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: metaflow
 Type: Package
 Title: Metaflow for R-Lang
-Version: 2.3.0
+Version: 2.3.1
 Author: Jason Ge [aut] <jge@netflix.com>, 
   Savin Goyal [aut, cre] <savin@netflix.com>,
   David Neuzerling [ctb] <david@neuzerling.com>

--- a/R/R/package.R
+++ b/R/R/package.R
@@ -22,5 +22,5 @@ set_global_variable <- function(key, val, pos = 1) {
 #' @export
 metaflow <- function(cls, ...) {
   set_global_variable(cls, Flow$new(cls, list(...)))
-  get(cls)
+  get(cls, pos = 1)
 }

--- a/R/R/step.R
+++ b/R/R/step.R
@@ -26,6 +26,15 @@ step <- function(flow, ..., step, r_function = NULL, foreach = NULL, join = FALS
 identifiers; they can contain letters, numbers, and underscores, although they
 cannot begin with a number.")
   }
+
+  # To identify trailing commas, we look for empty symbols in the function
+  # call. We can generate an empty symbol with `substitute()`.
+  if (any(as.list(match.call()) == substitute())) {
+    stop(
+      "No decorators have been provided.
+  Is there a trailing comma in your step definition?"
+    )
+  }
   decorators <- add_decorators(list(...))
   if (!is.null(decorators)) {
     decorators <- paste0(space(4), decorators)

--- a/R/tests/testthat/test-decorators.R
+++ b/R/tests/testthat/test-decorators.R
@@ -7,19 +7,19 @@ test_that("error on duplicate arguments", {
 
 test_that("decorator arguments parsed correctly", {
   skip_if_no_metaflow()
-  
+
   actual <- decorator_arguments(list(cpu = 10))
   expected <- "cpu=10"
   expect_equal(actual, expected)
-  
+
   actual <- decorator_arguments(list(memory = 60000, cpu = 10))
   expected <- "memory=60000, cpu=10"
   expect_equal(actual, expected)
-  
+
   actual <- decorator_arguments(list(memory = 60000, image = NULL))
   expected <- "memory=60000, image=None"
   expect_equal(actual, expected)
-  
+
   actual <- decorator_arguments(list(abc = "red panda"), .convert_args = FALSE)
   expected <- "abc=red panda" # invalid Python because we're not converting
   expect_equal(actual, expected)
@@ -56,5 +56,17 @@ test_that("decorator with unnamed arguments errors", {
   expect_error(
     decorator("batch", memoy = 60000, 8),
     "All arguments to a decorator must be named"
+  )
+})
+
+test_that("trailing comma in step definition gives a good error message", {
+  expect_error(
+    step(
+      metaflow("TrailingCommaFlow"),
+      step = "start",
+      r_function = NULL,
+      next_step = "end",
+    ),
+    "trailing comma"
   )
 })

--- a/R/tests/testthat/test-flow.R
+++ b/R/tests/testthat/test-flow.R
@@ -1,5 +1,7 @@
 context("test-flow.R")
 
+teardown(if ("sqrt" %in% names(.GlobalEnv)) rm("sqrt", envir = .GlobalEnv))
+
 test_that("header() formatted correctly", {
   skip_if_no_metaflow()
   actual <- header("TestFlow")
@@ -87,4 +89,12 @@ test_that("get_functions() works", {
     }
   )
   expect_equal(actual, expected)
+})
+
+test_that("flow names are assigned to global environment", {
+  expect_false("sqrt" %in% names(.GlobalEnv))
+  step(metaflow("sqrt"), step = "start")
+  expect_true("sqrt" %in% names(.GlobalEnv))
+  expect_s3_class(get("sqrt", envir = .GlobalEnv), "Flow")
+  expect_equal(base::sqrt(4), 2)
 })


### PR DESCRIPTION
This PR addresses two minor errors in Metaflow R that have been annoying me.

## Trailing commas in step definitions

When a user accidentally leaves a trailing comma in the definition of a step, they get an unhelpful error message that doesn't really describe the problem:

```r
step(
    flow = metaflow("TrailingComma"),
    step = "start",
)

Error in lapply(decorators, is.decorator) : 
  argument is missing, with no default
```

Trailing commas aren't allowed in R, but this one slips by because the function accepts `...` additional arguments (intended to be decorators). I put a check in place that looks for trailing commas, which show up in function calls as empty symbols. It still returns an error, but I'd argue it's a much better error message:

```
No decorators have been provided.
  Is there a trailing comma in your step definition?
```

## Flows returned from wrong environment

Defining a flow places the flow in the global environment. However, the `metaflow` function doesn't ensure that the flow is then returned from the global environment:
```
metaflow <- function(cls, ...) {
  set_global_variable(cls, Flow$new(cls, list(...)))
  get(cls)
}
```

I _think_ this happens because even though the global environment is first on the `search()` path, the `get` in this function definition is probably starting from the `metaflow` namespace. In any case, I fixed this by changing the above to `get(cls, pos = 1)`.

This popped up for me when I would define a flow with the name "test", in which case `metaflow("test")` would return the _function_ `metaflow::test`. In the test case I've implemented, I use `metaflow("sqrt")` instead, which conflicts with `base::sqrt`.