### PR TITLE
(R) Better error message when trailing commas are used in step definitions

### DIFF
--- a/R/R/step.R
+++ b/R/R/step.R
@@ -26,6 +26,15 @@ step <- function(flow, ..., step, r_function = NULL, foreach = NULL, join = FALS
 identifiers; they can contain letters, numbers, and underscores, although they
 cannot begin with a number.")
   }
+
+  # To identify trailing commas, we look for empty symbols in the function
+  # call. We can generate an empty symbol with `substitute()`.
+  if (any(as.list(match.call()) == substitute())) {
+    stop(
+      "No decorators have been provided.
+  Is there a trailing comma in your step definition?"
+    )
+  }
   decorators <- add_decorators(list(...))
   if (!is.null(decorators)) {
     decorators <- paste0(space(4), decorators)

--- a/R/tests/testthat/test-step.R
+++ b/R/tests/testthat/test-step.R
@@ -13,6 +13,18 @@ test_that("can't define step with an invalid name", {
   )
 })
 
+test_that("trailing comma in step definition gives a good error message", {
+  expect_error(
+    step(
+      metaflow("TrailingCommaFlow"),
+      step = "start",
+      r_function = NULL,
+      next_step = "end",
+    ),
+    "trailing comma"
+  )
+})
+
 test_that("test join step", {
   skip_if_no_metaflow()
   metaflow("TestFlow") %>%


### PR DESCRIPTION
When a user accidentally leaves a trailing comma in the definition of a step, they get an unhelpful error message that doesn't really describe the problem:

```r
step(
    flow = metaflow("TrailingComma"),
    step = "start",
)
```

```
Error in lapply(decorators, is.decorator) : 
  argument is missing, with no default
```

Trailing commas aren't allowed in R, but this one slips by because the function accepts `...` additional arguments (intended to be decorators). I put a check in place that looks for trailing commas, which show up in function calls as empty symbols. It still returns an error, but I'd argue it's a much better error message:

```
No decorators have been provided.
  Is there a trailing comma in your step definition?
```