### PR TITLE
(R) Return flows from the global environment in which they're defined

### DIFF
--- a/R/R/package.R
+++ b/R/R/package.R
@@ -22,5 +22,5 @@ set_global_variable <- function(key, val, pos = 1) {
 #' @export
 metaflow <- function(cls, ...) {
   set_global_variable(cls, Flow$new(cls, list(...)))
-  get(cls)
+  get(cls, pos = 1)
 }

--- a/R/tests/testthat/test-flow.R
+++ b/R/tests/testthat/test-flow.R
@@ -1,5 +1,7 @@
 context("test-flow.R")
 
+teardown(if ("sqrt" %in% names(.GlobalEnv)) rm("sqrt", envir = .GlobalEnv))
+
 test_that("header() formatted correctly", {
   skip_if_no_metaflow()
   actual <- header("TestFlow")
@@ -87,4 +89,12 @@ test_that("get_functions() works", {
     }
   )
   expect_equal(actual, expected)
+})
+
+test_that("flow names are assigned to global environment", {
+  expect_false("sqrt" %in% names(.GlobalEnv))
+  step(metaflow("sqrt"), step = "start")
+  expect_true("sqrt" %in% names(.GlobalEnv))
+  expect_s3_class(get("sqrt", envir = .GlobalEnv), "Flow")
+  expect_equal(base::sqrt(4), 2)
 })


### PR DESCRIPTION
Defining a flow places that flow in the global environment. However, the `metaflow` function doesn't ensure that the flow is then **returned** from the global environment:

```
metaflow <- function(cls, ...) {
  set_global_variable(cls, Flow$new(cls, list(...)))
  get(cls)
}
```

I _think_ this happens because even though the global environment is first on the `search()` path, the `get` in this function definition is probably starting from the `metaflow` namespace. In any case, I fixed this by changing the above to `get(cls, pos = 1)`.

This popped up for me when I would define a flow with the name "test", in which case `metaflow("test")` would return the _function_ `metaflow::test`. In the test case I've implemented, I use `metaflow("sqrt")` instead, which conflicts with `base::sqrt`.