### PR TITLE
fix: Properly treat S3_RETRY_COUNT as integer

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -79,7 +79,7 @@ S3_VERIFY_CERTIFICATE = from_conf('METAFLOW_S3_VERIFY_CERTIFICATE', None)
 # This is useful if you want to "fail fast" on S3 operations; use with caution
 # though as this may increase failures. Note that this is the number of *retries*
 # so setting it to 0 means each operation will be tried once.
-S3_RETRY_COUNT = from_conf('METAFLOW_S3_RETRY_COUNT', 7)
+S3_RETRY_COUNT = int(from_conf('METAFLOW_S3_RETRY_COUNT', 7))
 
 ###
 # Datastore local cache


### PR DESCRIPTION
**Issue** 
The s3_retry_count is read from environment variables and treated as a string. This breaks when the config value is passed to `range()` further down the line. 

**Change**
Explicitly cast the value set to S3_RETRY_COUNT in configuration to avoid such issues.