### PR TITLE
Fix bug with current.paramter_names

### DIFF
--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -392,7 +392,7 @@ class MetaflowTask(object):
                     # initialize parameters (if they exist)
                     # We take Parameter values from the first input,
                     # which is always safe since parameters are read-only
-                    current._update_env({'parameter_names': self._init_parameters(inputs[0], passdown=True)})
+                    current._update_env({'parameter_names': self._init_parameters(inputs[0], passdown=False)})
 
             decorators = step_func.decorators
             for deco in decorators:

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -67,8 +67,7 @@ class MetaflowTask(object):
 
             setattr(self.flow.__class__, var,
                     property(fget=property_setter))
-            if passdown:
-                vars.append(var)
+            vars.append(var)
         if passdown:
             self.flow._datastore.passdown_partial(parameter_ds, vars)
         return vars
@@ -393,7 +392,7 @@ class MetaflowTask(object):
                     # initialize parameters (if they exist)
                     # We take Parameter values from the first input,
                     # which is always safe since parameters are read-only
-                    current._update_env({'parameter_names': self._init_parameters(inputs[0], passdown=False)})
+                    current._update_env({'parameter_names': self._init_parameters(inputs[0], passdown=True)})
 
             decorators = step_func.decorators
             for deco in decorators:

--- a/test/core/tests/param_names.py
+++ b/test/core/tests/param_names.py
@@ -1,0 +1,13 @@
+from metaflow_test import MetaflowTest, steps
+
+class ParameterNameTest(MetaflowTest):
+    PRIORITY = 1
+    PARAMETERS = {
+        "foo":{"default":1}
+    }
+
+    @steps(0, ['all'])
+    def step_all(self):
+        from metaflow import current
+        assert_equals(len(current.parameter_names),1)
+        assert_equals(current.parameter_names[0],'foo')


### PR DESCRIPTION
Without this patch, the following flow returns an empty list for `parameter_names` - 

```
from metaflow import FlowSpec,Parameter,step

class ParameterNameFlow(FlowSpec):

    x = Parameter('x',default=3,type=int)

    @step
    def start(self):
        from metaflow import current
        print(current.parameter_names)
        self.next(self.end)

    @step
    def end(self):
        print("Done Compute")

if __name__ == "__main__":
    ParameterNameFlow()
```