### PR TITLE
Support dict and list-of-dictionary arguments for decorators

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -1,5 +1,6 @@
 import inspect
 import sys
+import json
 import traceback
 from datetime import datetime
 from functools import wraps
@@ -928,7 +929,9 @@ def _reconstruct_cli(params):
                 v = [v]
             for value in v:
                 yield '--%s' % k
-                if not isinstance(value, bool):
+                if isinstance(value, dict):
+                    yield json.dumps(value)
+                elif not isinstance(value, bool):
                     yield str(value)
 
 

--- a/metaflow/cli_args.py
+++ b/metaflow/cli_args.py
@@ -14,7 +14,7 @@
 # done in one place.
 
 from .util import to_unicode
-
+import json
 
 class CLIArgs(object):
     def __init__(self):
@@ -67,7 +67,9 @@ class CLIArgs(object):
                 v = v if isinstance(v, (list, tuple, set)) else [v]
                 for value in v:
                     yield '--%s' % k
-                    if not isinstance(value, bool):
+                    if isinstance(value, dict):
+                        yield json.dumps(value)
+                    elif not isinstance(value, bool):
                         yield to_unicode(value)
 
 cli_args = CLIArgs()

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -877,7 +877,9 @@ class CLIArgs(object):
                     v = v if isinstance(v, (list, tuple, set)) else [v]
                     for value in v:
                         yield '--%s' % k
-                        if not isinstance(value, bool):
+                        if isinstance(value, dict):
+                            yield json.dumps(value)
+                        elif not isinstance(value, bool):
                             yield to_unicode(value)
 
         args = list(self.entrypoint)

--- a/metaflow/util.py
+++ b/metaflow/util.py
@@ -3,6 +3,7 @@ import shutil
 import sys
 import tempfile
 import zlib
+import json
 import base64
 from functools import wraps
 from io import BytesIO
@@ -309,7 +310,9 @@ def dict_to_cli_options(params):
                 v = [v]
             for value in v:
                 yield '--%s' % k
-                if not isinstance(value, bool):
+                if isinstance(value, dict):
+                    yield json.dumps(value)
+                elif not isinstance(value, bool):
                     value = to_unicode(value)
 
                     # Of the value starts with $, assume the caller wants shell variable


### PR DESCRIPTION
There seems to be several places where we convert arguments to strings, I'm not 100% sure how they are all used. Need this for K8S as some parameters there can be somewhat more complex than just strings.

Without this, if you add a new decorator with an argument that takes a dictionary or list-of-dictionaries, Metaflow will trigger the subprocess like this:

```bash
python ./helloworld1.py ...  --myarg {'key': 'key1',  'value': 'value1'} ...
```

After this change, the argument will be passed as JSON instead, so it can be parsed by the subprocess easily:
```bash
python ./helloworld1.py ...  --myarg {"key": "key1",  "value": "value1"} ...
```