### PR TITLE
Remove the propagation of PYTHONPATH in the Conda environment

### DIFF
--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -300,8 +300,6 @@ class CondaStepDecorator(StepDecorator):
                          ubf_context):
         if self.is_enabled(ubf_context) and 'batch' not in cli_args.commands:
             python_path = self.metaflow_home
-            if os.environ.get('PYTHONPATH') is not None:
-                python_path = os.pathsep.join([os.environ['PYTHONPATH'], python_path])
             if self.addl_paths is not None:
                 addl_paths = os.pathsep.join(self.addl_paths)
                 python_path = os.pathsep.join([addl_paths, python_path])


### PR DESCRIPTION
Previously, Conda would use the pre-existing PYTHONPATH to add it to
its own PYTHONPATH thereby allowing packages outside Conda to override
packages within Conda which made running locally and remotely different.
This also breaks the Conda reproducibility argument.