### PR TITLE
Making `DataStorage.list_content` have consistent Behaviour

### DIFF
--- a/metaflow/datastore/local_storage.py
+++ b/metaflow/datastore/local_storage.py
@@ -82,11 +82,11 @@ class LocalStorage(DataStoreStorage):
                 for f in os.listdir(full_path):
                     if f == self.METADATA_DIR:
                         continue
-                    results.extend(
-                        [self.list_content_result(
+                    results.append(
+                        self.list_content_result(
                             path=self.path_join(path, f),
                             is_file=self.is_file(
-                                [self.path_join(path, f)])[0])]
+                                [self.path_join(path, f)])[0])
                         )        
             except FileNotFoundError as e:
                 pass


### PR DESCRIPTION
Sending this PR based on some Observations on the behavior of `DataStorage.list_content`
- When we do `S3Storage.list_content` with a file path that doesn't exist then we get an empty array as a response 
- When we do LocalStorage.list_content with a file path that doesn't exist then I get a `FileNotFoundError` . 

Ideally they should give the same response as they inherit the same abstraction. 

As a fix, I am swallowing the `FileNotFoundError` and just return an empty array with `LocalStorage.list_content`