### PR TITLE
Close datastore after task_finished has been invoked

### DIFF
--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -496,10 +496,6 @@ class MetaflowTask(object):
             output.save_metadata({'task_end': {}})
             output.persist(self.flow)
 
-            # this writes a success marker indicating that the
-            # "transaction" is done
-            output.done()
-
             # final decorator hook: The task results are now
             # queryable through the client API / datastore
             for deco in decorators:
@@ -509,6 +505,10 @@ class MetaflowTask(object):
                                    self.flow._task_ok,
                                    retry_count,
                                    max_user_code_retries)
+
+            # this writes a success marker indicating that the
+            # "transaction" is done
+            output.done()
 
             # terminate side cars
             logger.terminate()


### PR DESCRIPTION
task_finished may have some business with datastore, so we should
close the datastore after task_finished has been invoked and not
before