### PR TITLE
Use linux binaries in @conda when run in k8s

### DIFF
--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -193,13 +193,13 @@ class CondaStepDecorator(StepDecorator):
         # a macOS. This is needed because of gotchas around inconsistently 
         # case-(in)sensitive filesystems for macOS and linux.
         for deco in decos:
-            if deco.name == 'batch' and platform.system() == 'Darwin':
+            if deco.name in ('batch', 'kubernetes') and platform.system() == 'Darwin':
                 return True
         return False
 
     def _architecture(self, decos):
         for deco in decos:
-            if deco.name == 'batch':
+            if deco.name in ('batch', 'kubernetes'):
                 # force conda resolution for linux-64 architectures
                 return 'linux-64'
         bit = '32'
@@ -306,7 +306,9 @@ class CondaStepDecorator(StepDecorator):
                          retry_count,
                          max_user_code_retries,
                          ubf_context):
-        if self.is_enabled(ubf_context) and 'batch' not in cli_args.commands:
+        no_batch = 'batch' not in cli_args.commands
+        no_kubernetes = 'kubernetes' not in cli_args.commands
+        if self.is_enabled(ubf_context) and no_batch and no_kubernetes:
             python_path = self.metaflow_home
             if self.addl_paths is not None:
                 addl_paths = os.pathsep.join(self.addl_paths)


### PR DESCRIPTION
Conda environment should pack linux python binary when run on MacOS
to avoid an error

metaflow_PlayListFlow_osx-64_179c56284704ca8e53622f848a3df27cdd1f4327/bin/python: cannot execute binary file: Exec format error