### PR TITLE
Support dictionaries as decorator arguments

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -1,6 +1,7 @@
 import inspect
 import os
 import sys
+import json
 import traceback
 from datetime import datetime
 from functools import wraps
@@ -1033,7 +1034,9 @@ def _reconstruct_cli(params):
                 v = [v]
             for value in v:
                 yield "--%s" % k
-                if not isinstance(value, bool):
+                if isinstance(value, dict):
+                    yield json.dumps(value)
+                elif not isinstance(value, bool):
                     yield str(value)
 
 

--- a/metaflow/cli_args.py
+++ b/metaflow/cli_args.py
@@ -14,6 +14,7 @@
 # done in one place.
 
 from .util import to_unicode
+import json
 
 
 class CLIArgs(object):
@@ -55,7 +56,6 @@ class CLIArgs(object):
     @staticmethod
     def _options(mapping):
         for k, v in mapping.items():
-
             # None or False arguments are ignored
             # v needs to be explicitly False, not falsy, eg. 0 is an acceptable value
             if v is None or v is False:
@@ -69,7 +69,9 @@ class CLIArgs(object):
             v = v if isinstance(v, (list, tuple, set)) else [v]
             for value in v:
                 yield "--%s" % k
-                if not isinstance(value, bool):
+                if isinstance(value, dict):
+                    yield json.dumps(value)
+                elif not isinstance(value, bool):
                     yield to_unicode(value)
 
 

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -931,7 +931,6 @@ class CLIArgs(object):
         # TODO: Make one with dict_to_cli_options; see cli_args.py for more detail
         def _options(mapping):
             for k, v in mapping.items():
-
                 # None or False arguments are ignored
                 # v needs to be explicitly False, not falsy, eg. 0 is an acceptable value
                 if v is None or v is False:
@@ -945,7 +944,9 @@ class CLIArgs(object):
                 v = v if isinstance(v, (list, tuple, set)) else [v]
                 for value in v:
                     yield "--%s" % k
-                    if not isinstance(value, bool):
+                    if isinstance(value, dict):
+                        yield json.dumps(value)
+                    elif not isinstance(value, bool):
                         yield to_unicode(value)
 
         args = list(self.entrypoint)

--- a/metaflow/util.py
+++ b/metaflow/util.py
@@ -3,6 +3,7 @@ import shutil
 import sys
 import tempfile
 import zlib
+import json
 import base64
 from functools import wraps
 from io import BytesIO
@@ -318,7 +319,9 @@ def dict_to_cli_options(params):
                 v = [v]
             for value in v:
                 yield "--%s" % k
-                if not isinstance(value, bool):
+                if isinstance(value, dict):
+                    yield json.dumps(value)
+                elif not isinstance(value, bool):
                     value = to_unicode(value)
 
                     # Of the value starts with $, assume the caller wants shell variable


### PR DESCRIPTION
(previously #744)

There seems to be several places where we convert arguments to strings, I'm not 100% sure how they are all used. Need this for K8S as some parameters there can be somewhat more complex than just strings.

Without this, if you add a new decorator with an argument that takes a dictionary or list-of-dictionaries, Metaflow will trigger the subprocess like this:

```bash
python ./helloworld1.py ...  --myarg {'key': 'key1',  'value': 'value1'} ...
```

After this change, the argument will be passed as JSON instead, so it can be parsed by the subprocess easily:
```bash
python ./helloworld1.py ...  --myarg {"key": "key1",  "value": "value1"} ...
```