### PR TITLE
Add optional kubernetes dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setup(name='metaflow',
         'boto3',
         'pylint'
       ],
+      extras_require = {
+        'kubernetes': ['kubernetes']
+      },
       tests_require = [
         'coverage'
       ])


### PR DESCRIPTION
Install metaflow with `pip install metaflow[kubernetes]`
to avoid "ModuleNotFoundError: No module named 'kubernetes'" error
when use kubernetes plugin.