### PR TITLE
fix: legacy log access

### DIFF
--- a/metaflow/client/filecache.py
+++ b/metaflow/client/filecache.py
@@ -77,7 +77,7 @@ class FileCache(object):
 
         ds_cls = self._get_datastore_storage_impl(ds_type)
         ds_root = ds_cls.path_join(*ds_cls.path_split(location)[:-5])
-        cache_id = self._flow_ds_type(ds_type, ds_root, flow_name)
+        cache_id = self._flow_ds_id(ds_type, ds_root, flow_name)
 
         token = '%s.cached' % sha1(os.path.join(
             run_id, step_name, task_id, '%s_log' % logtype).\


### PR DESCRIPTION
fix remaining `_flow_ds_type` occurrences to the renamed `_flow_ds_id`

accessing legacy style logs with
```
task = Task("pathspec/to/task")
taks.stdout
```
is broken with v2.4.1, but still works with 2.4.0 