### PR TITLE
Fix a race condition when querying for artifacts of a running task

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -972,7 +972,7 @@ class Task(MetaflowObject):
             Container of all DataArtifacts produced by this task
         """
         arts = list(self)
-        obj = namedtuple('MetaflowArtifacts', [art.id for art in self])
+        obj = namedtuple('MetaflowArtifacts', [art.id for art in arts])
         return obj._make(arts)
 
     @property


### PR DESCRIPTION
In some cases, requesting the artifacts through `.artifacts` of a running
task may return an error. This patch addresses this issue