### PR TITLE
Fix Python version logic that would fail with Py 4

### DIFF
--- a/metaflow/util.py
+++ b/metaflow/util.py
@@ -50,7 +50,7 @@ except NameError:
 
     from shlex import quote as _quote
 
-if sys.version_info.major >= 3 and sys.version_info.minor >= 7:
+if sys.version_info >= (3, 7):
     from collections import namedtuple
 
     namedtuple_with_defaults = namedtuple


### PR DESCRIPTION
Fix a logic error discovered by https://github.com/asottile/flake8-2020 which would treat Python 4.0, 4.1, ... 4.6 like they were ___less than___ Python 3.7.

% `flake8 . --count --select=E9,F63,F7,F82,Y --show-source --statistics`
```
./metaflow/metaflow/util.py:53:36: YTT204 `sys.version_info.minor` compared to integer (python4), compare `sys.version_info` to tuple
if sys.version_info.major >= 3 and sys.version_info.minor >= 7:
                                   ^
```