### PR TITLE
Add pre-commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,12 @@ on:
     branches:
     - master
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3
   formatter:
     name: runner / black
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+      - id: check-yaml
+      - id: check-json
+  - repo: https://github.com/ambv/black
+    rev: 21.9b0
+    hooks:
+      - id: black
+        language_version: python3


### PR DESCRIPTION
This adds [pre-commit](https://pre-commit.com/) config to the repo and a GH action to run the check on PRs.

If you are a contributor, the recommendation is that you do the following (once!):
1. install pre-commit, e.g. `brew install pre-commit`
2. run `pre-commit install` in your local copy of the repo. That will install the git hook to run the checks on every commit.

From then on, you don't have to install `black` or anything, `pre-commit` will take care of it. On `git commit` you'll see either a successful run:
<img width="646" alt="Screen Shot 2021-10-28 at 7 21 46 PM" src="https://user-images.githubusercontent.com/3689/139363072-c951db4f-b50d-4e0c-a9c9-03281ae8b029.png">

Or, if the formatting wasn't correct, pre-commit will fix things for you (you'll have to run `git commit` again after reviewing the changes)

<img width="698" alt="Screen Shot 2021-10-28 at 7 21 38 PM" src="https://user-images.githubusercontent.com/3689/139363155-0abfe339-9f8b-4ec9-a98c-289f65ce65ea.png">
