### PR TITLE
Addressing `max-value-size` getting used when a `file` argument is passed 

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -226,12 +226,19 @@ def output_dot(obj):
 def dump(obj, input_path, private=None, max_value_size=None, include=None, file=None):
 
     output = {}
-    if file is not None:
+    if file is not None and max_value_size is not None:
         echo(
             "max_value_size will be set to None when a file variable "
-            "is provided so that values will not get replaced"
+            "is provided so that values will not get replaced in the file"
         )
-        max_value_size = None 
+        max_value_size = None
+    elif file is None and max_value_size is None:
+        echo(
+            "max_value_size will be set to 1000 when neither file nor "
+            "max_value_size is set to prevent all information being printed "
+            "to stdout"
+        )
+        max_value_size = 1000
     kwargs = {
         "show_private": private,
         "max_value_size": max_value_size,

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -226,6 +226,12 @@ def output_dot(obj):
 def dump(obj, input_path, private=None, max_value_size=None, include=None, file=None):
 
     output = {}
+    if file is not None:
+        echo(
+            "max_value_size will be set to None when a file variable "
+            "is provided so that values will not get replaced"
+        )
+        max_value_size = None 
     kwargs = {
         "show_private": private,
         "max_value_size": max_value_size,


### PR DESCRIPTION
* adding code to alert users that when a --file argument is provided the --max-value-size gets set to None as well as updating the max_value_size var

This PR addresses issue #524 and also adds logging to let users know that the `--file` argument will override the `--max-value-size` argument when used in conjunction to prevent values getting overwritten. 