### PR TITLE
Fix an issue with load_artifacts when several artifacts have the same…

### DIFF
--- a/metaflow/datastore/content_addressed_store.py
+++ b/metaflow/datastore/content_addressed_store.py
@@ -118,7 +118,8 @@ class ContentAddressedStore(object):
 
         Returns
         -------
-        Returns an iterator of (string, bytes) tuples
+        Returns an iterator of (string, bytes) tuples; the iterator will return the keys
+        in the same order as the input argument.
         """
         load_paths = []
         for key in keys:

--- a/metaflow/datastore/datastore_storage.py
+++ b/metaflow/datastore/datastore_storage.py
@@ -262,5 +262,7 @@ class DataStoreStorage(object):
 
             Note that the file at `path` may no longer be accessible outside of
             the scope of the returned object.
+
+            Note that the order of the iterator will be the same as the input paths.
         """
         raise NotImplementedError

--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -338,7 +338,6 @@ class TaskDataStore(object):
                 "load artifacts" % self._path
             )
         to_load = []
-        sha_to_names = {}
         for name in names:
             info = self._info.get(name)
             # We use gzip+pickle-v2 as this is the oldest/most compatible.
@@ -353,15 +352,13 @@ class TaskDataStore(object):
                     "Python 3.4 or later is required to load artifact '%s'" % name
                 )
             else:
-                sha = self._objects[name]
-                sha_to_names[sha] = name
-                to_load.append(sha)
+                to_load.append(self._objects[name])
         # At this point, we load what we don't have from the CAS
         # We assume that if we have one "old" style artifact, all of them are
         # like that which is an easy assumption to make since artifacts are all
         # stored by the same implementation of the datastore for a given task.
-        for sha, blob in self._ca_store.load_blobs(to_load):
-            yield sha_to_names[sha], pickle.loads(blob)
+        for name, (_, blob) in zip(names, self._ca_store.load_blobs(to_load)):
+            yield name, pickle.loads(blob)
 
     @require_mode("r")
     def get_artifact_sizes(self, names):


### PR DESCRIPTION
… hash

Incorrect results could be returned from load_artifacts when multiple
artifacts hash to the same value and are all requested at the same
time.