### PR TITLE
`origin-task-id` in `Task` metadata and `origin_pathspec` property in `Task` object

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -533,7 +533,7 @@ def step(
         ubf_context,
     )
     if clone_only:
-        task.clone_only(step_name, run_id, task_id, clone_only)
+        task.clone_only(step_name, run_id, task_id, clone_only, retry_count)
     else:
         task.run_step(
             step_name,

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -1504,7 +1504,6 @@ class Step(MetaflowObject):
         str
             Pathspec of the origin step or None
         """
-        task = self.task
         runorig = self.parent.origin_pathspec
         if runorig is None:
             return None

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -312,7 +312,7 @@ class MetaflowObject(object):
     path_components : List[string]
         Components of the pathspec
     origin_pathspec : str
-        Pathspec of the `Run`/`Step`/`Task`, the current MetaflowObject has been cloned from
+        Pathspec of the `Run`/`Step`/`Task`, the current MetaflowObject has been cloned from or None if not a cloned object
     """
 
     _NAME = "base"

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -312,7 +312,7 @@ class MetaflowObject(object):
     path_components : List[string]
         Components of the pathspec
     origin_pathspec : str
-        Pathspec of the `Run`/`Step`/`Task` a MetaflowObject has been cloned from
+        Pathspec of the `Run`/`Step`/`Task`, the current MetaflowObject has been cloned from
     """
 
     _NAME = "base"

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -946,7 +946,7 @@ class Task(MetaflowObject):
         Returns
         -------
         str
-            Pathspec of the origin task
+            Pathspec of the origin task or None
         """
         origin_task_id = None
         origin_run_id = None

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -575,7 +575,9 @@ class MetaflowObject(object):
             if latest_step:
                 # If we had a step
                 task = latest_step.task
-                origin_run_id = [m.value for m in task.metadata if m.name == "origin-run-id"]
+                origin_run_id = [
+                    m.value for m in task.metadata if m.name == "origin-run-id"
+                ]
                 if origin_run_id:
                     origin_pathspec = "%s/%s" % (self.parent.id, origin_run_id[0])
         else:
@@ -583,7 +585,10 @@ class MetaflowObject(object):
             if parent_pathspec:
                 my_id = self.id
                 if self._NAME == "task":
-                    origin_task_id = [m.value for m in self.metadata if m.name == "origin-task-id"]
+                    origin_task_id = [
+                        m.value for m in self.metadata if m.name == "origin-task-id"
+                    ]
+
                 if origin_task_id:
                     my_id = origin_task_id[0]
                 else:

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -576,7 +576,7 @@ class MetaflowObject(object):
                 # If we had a step
                 task = latest_step.task
                 origin_run_id = [m.value for m in task.metadata if m.name == "origin-run-id"]
-                if origin_run_id
+                if origin_run_id:
                     origin_pathspec = "%s/%s" % (self.parent.id, origin_run_id[0])
         else:
             parent_pathspec = self.parent.origin_pathspec if self.parent else None

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -939,6 +939,30 @@ class Task(MetaflowObject):
         ]
 
     @property
+    def origin_pathspec(self):
+        """
+        Pathspec of the origin task that the current task was cloned from.
+
+        Returns
+        -------
+        str
+            Pathspec of the origin task
+        """
+        origin_task_id = None
+        origin_run_id = None
+        for metadata in self.metadata:
+            if metadata.name == "origin-task-id":
+                origin_task_id = metadata.value
+            elif metadata.name == "origin-run-id":
+                origin_run_id = metadata.value
+        if origin_task_id is None:
+            return None
+
+        step_name = self.parent.id
+        flow_name = self.parent.parent.parent.id
+        return "%s/%s/%s/%s" % (flow_name, origin_run_id, step_name, origin_task_id)
+
+    @property
     def metadata_dict(self):
         """
         Dictionary mapping metadata names (keys) and their associated values.

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -584,15 +584,15 @@ class MetaflowObject(object):
             parent_pathspec = self.parent.origin_pathspec if self.parent else None
             if parent_pathspec:
                 my_id = self.id
+                origin_task_id = None
                 if self._NAME == "task":
                     origin_task_id = [
                         m.value for m in self.metadata if m.name == "origin-task-id"
                     ]
-
-                if origin_task_id:
-                    my_id = origin_task_id[0]
-                else:
-                    my_id = None
+                    if origin_task_id:
+                        my_id = origin_task_id[0]
+                    else:
+                        my_id = None
                 if my_id is not None:
                     origin_pathspec = "%s/%s" % (parent_pathspec, my_id)
         return origin_pathspec

--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -111,8 +111,6 @@ class TaskDataStore(object):
         self._attempt = attempt
         self._metadata = flow_datastore.metadata
         self._parent = flow_datastore
-        self._origin_task_id = None
-        self._origin_run_id = None
 
         # The GZIP encodings are for backward compatibility
         self._encodings = {"pickle-v2", "gzip+pickle-v2"}
@@ -555,25 +553,6 @@ class TaskDataStore(object):
         )
 
         if self._metadata:
-            origin_task_metadata = []
-            if self._origin_task_id is not None:
-                origin_task_metadata.extend(
-                    [
-                        MetaDatum(
-                            field="origin-task-id",
-                            value=str(self._origin_task_id),
-                            type="origin-task-id",
-                            tags=["attempt_id:{0}".format(self._attempt)],
-                        ),
-                        MetaDatum(
-                            field="origin-run-id",
-                            value=str(self._origin_run_id),
-                            type="origin-run-id",
-                            tags=["attempt_id:{0}".format(self._attempt)],
-                        ),
-                    ]
-                )
-
             self._metadata.register_metadata(
                 self._run_id,
                 self._step_name,
@@ -585,8 +564,7 @@ class TaskDataStore(object):
                         type="attempt-done",
                         tags=["attempt_id:{0}".format(self._attempt)],
                     )
-                ]
-                + origin_task_metadata,
+                ],
             )
             artifacts = [
                 DataArtifact(
@@ -620,8 +598,6 @@ class TaskDataStore(object):
         """
         self._objects = origin._objects
         self._info = origin._info
-        self._origin_task_id = origin.task_id
-        self._origin_run_id = origin.run_id
 
     @only_if_not_done
     @require_mode("w")

--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -111,6 +111,8 @@ class TaskDataStore(object):
         self._attempt = attempt
         self._metadata = flow_datastore.metadata
         self._parent = flow_datastore
+        self._origin_task_id = None
+        self._origin_run_id = None
 
         # The GZIP encodings are for backward compatibility
         self._encodings = {"pickle-v2", "gzip+pickle-v2"}
@@ -553,6 +555,25 @@ class TaskDataStore(object):
         )
 
         if self._metadata:
+            origin_task_metadata = []
+            if self._origin_task_id is not None:
+                origin_task_metadata.extend(
+                    [
+                        MetaDatum(
+                            field="origin-task-id",
+                            value=str(self._origin_task_id),
+                            type="origin-task-id",
+                            tags=["attempt_id:{0}".format(self._attempt)],
+                        ),
+                        MetaDatum(
+                            field="origin-run-id",
+                            value=str(self._origin_run_id),
+                            type="origin-run-id",
+                            tags=["attempt_id:{0}".format(self._attempt)],
+                        ),
+                    ]
+                )
+
             self._metadata.register_metadata(
                 self._run_id,
                 self._step_name,
@@ -564,7 +585,8 @@ class TaskDataStore(object):
                         type="attempt-done",
                         tags=["attempt_id:{0}".format(self._attempt)],
                     )
-                ],
+                ]
+                + origin_task_metadata,
             )
             artifacts = [
                 DataArtifact(
@@ -598,6 +620,8 @@ class TaskDataStore(object):
         """
         self._objects = origin._objects
         self._info = origin._info
+        self._origin_task_id = origin.task_id
+        self._origin_run_id = origin.run_id
 
     @only_if_not_done
     @require_mode("w")

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -235,7 +235,7 @@ class MetaflowTask(object):
         x._set_datastore(datastore)
         return x
 
-    def clone_only(self, step_name, run_id, task_id, clone_origin_task):
+    def clone_only(self, step_name, run_id, task_id, clone_origin_task, retry_count):
         if not clone_origin_task:
             raise MetaflowInternalError(
                 "task.clone_only needs a valid " "clone_origin_task value."
@@ -252,8 +252,27 @@ class MetaflowTask(object):
         origin = self.flow_datastore.get_task_datastore(
             origin_run_id, origin_step_name, origin_task_id
         )
-
+        metadata_tags = ["attempt_id:{0}".format(retry_count)]
         output.clone(origin)
+        self.metadata.register_metadata(
+            run_id,
+            step_name,
+            task_id,
+            [
+                MetaDatum(
+                    field="origin-task-id",
+                    value=str(origin_task_id),
+                    type="origin-task-id",
+                    tags=metadata_tags,
+                ),
+                MetaDatum(
+                    field="origin-run-id",
+                    value=str(origin_run_id),
+                    type="origin-run-id",
+                    tags=metadata_tags,
+                ),
+            ],
+        )
         output.done()
 
     def _finalize_control_task(self):

--- a/test/core/tests/resume_originpath.py
+++ b/test/core/tests/resume_originpath.py
@@ -1,0 +1,45 @@
+from metaflow_test import MetaflowTest, ExpectationFailed, steps
+
+
+class ResumeOriginPathSpec(MetaflowTest):
+    """
+    `Step.origin_pathspec` and `Run.origin_pathspec` and `Task.origin_pathspec` should be present
+
+    How does this test work:
+        - Store origin_pathspec via the current object in the start step (step that is resumed)
+        - In the checker validate the origin_pathspec stored in the start step is the same as the `Step.origin_pathspec` and `Run.origin_pathspec` and `Task.origin_pathspec`
+
+    """
+
+    RESUME = True
+    PRIORITY = 4
+    PARAMETERS = {"int_param": {"default": 123}}
+
+    @steps(0, ["start"])
+    def step_start(self):
+        from metaflow import current
+
+        self.origin_pathspec = current.pathspec
+        self.data = "start"
+
+    @steps(0, ["singleton-end"], required=True)
+    def step_end(self):
+        if not is_resumed():
+            raise ResumeFromHere()
+
+    @steps(2, ["all"])
+    def step_all(self):
+        pass
+
+    def check_results(self, flow, checker):
+        run = checker.get_run()
+        if run is not None:
+            for step in run.steps():
+                if step.id == "start":
+                    task = step.task
+                    orig_pathspec = task.data.origin_pathspec
+                    steporiginpth = "/".join(orig_pathspec.split("/")[:-1])
+                    runoriginpth = "/".join(orig_pathspec.split("/")[:-2])
+                    assert_equals(orig_pathspec, task.origin_pathspec)
+                    assert_equals(steporiginpth, step.origin_pathspec)
+                    assert_equals(runoriginpth, run.origin_pathspec)


### PR DESCRIPTION
## Context
We currently don't store `task-id` of the origin task for resumed workflows. 

## PR Changes
- Added `origin_pathspec` to metaflow client to retrieve the pathspec of the origin task. 
- Added `origin-task-id` to `Task` metadata

## Todos
- [x] Tests
- [x] `origin_pathspec` in all levels of Metaflow Client.  