### PR TITLE
Allow CLI args that are falsy but not False or None

### DIFF
--- a/metaflow/cli_args.py
+++ b/metaflow/cli_args.py
@@ -55,17 +55,22 @@ class CLIArgs(object):
     @staticmethod
     def _options(mapping):
         for k, v in mapping.items():
-            if v:
-                # we need special handling for 'with' since it is a reserved
-                # keyword in Python, so we call it 'decospecs' in click args
-                if k == "decospecs":
-                    k = "with"
-                k = k.replace("_", "-")
-                v = v if isinstance(v, (list, tuple, set)) else [v]
-                for value in v:
-                    yield "--%s" % k
-                    if not isinstance(value, bool):
-                        yield to_unicode(value)
+            
+            # None or False arguments are ignored
+            # v needs to be explicitly False, not falsy, eg. 0 is an acceptable value
+            if v is None or v is False:
+                continue
+
+            # we need special handling for 'with' since it is a reserved
+            # keyword in Python, so we call it 'decospecs' in click args
+            if k == "decospecs":
+                k = "with"
+            k = k.replace("_", "-")
+            v = v if isinstance(v, (list, tuple, set)) else [v]
+            for value in v:
+                yield "--%s" % k
+                if not isinstance(value, bool):
+                    yield to_unicode(value)
 
 
 cli_args = CLIArgs()

--- a/metaflow/cli_args.py
+++ b/metaflow/cli_args.py
@@ -55,7 +55,7 @@ class CLIArgs(object):
     @staticmethod
     def _options(mapping):
         for k, v in mapping.items():
-            
+
             # None or False arguments are ignored
             # v needs to be explicitly False, not falsy, eg. 0 is an acceptable value
             if v is None or v is False:

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -910,17 +910,22 @@ class CLIArgs(object):
         # TODO: Make one with dict_to_cli_options; see cli_args.py for more detail
         def _options(mapping):
             for k, v in mapping.items():
-                if v:
-                    # we need special handling for 'with' since it is a reserved
-                    # keyword in Python, so we call it 'decospecs' in click args
-                    if k == "decospecs":
-                        k = "with"
-                    k = k.replace("_", "-")
-                    v = v if isinstance(v, (list, tuple, set)) else [v]
-                    for value in v:
-                        yield "--%s" % k
-                        if not isinstance(value, bool):
-                            yield to_unicode(value)
+
+                # None or False arguments are ignored
+                # v needs to be explicitly False, not falsy, eg. 0 is an acceptable value
+                if v is None or v is False:
+                    continue
+
+                # we need special handling for 'with' since it is a reserved
+                # keyword in Python, so we call it 'decospecs' in click args
+                if k == "decospecs":
+                    k = "with"
+                k = k.replace("_", "-")
+                v = v if isinstance(v, (list, tuple, set)) else [v]
+                for value in v:
+                    yield "--%s" % k
+                    if not isinstance(value, bool):
+                        yield to_unicode(value)
 
         args = list(self.entrypoint)
         args.extend(_options(self.top_level_options))


### PR DESCRIPTION
closes #748

Currently, Metaflow CLI argument values that are "falsy" are ignored. The intention --- I believe --- is to omit CLI arguments that are `False`. This has the undesired consequence of also ignoring CLI arguments like `--gpu 0`, which arises from `@batch(gpu=0)`. The proposed solution explicitly ignores values in which `v is None or v is False`, allowing falsy values like `0` to go through.

Thank you to @romain-intel for help with this PR.

I couldn't find any existing tests around this functionality. I'd be happy to add a unit test if required, although I would be grateful for where this would fit into the Metaflow test suite.