### PR TITLE
Address another issue with load_artifacts

### DIFF
--- a/metaflow/datastore/content_addressed_store.py
+++ b/metaflow/datastore/content_addressed_store.py
@@ -118,8 +118,8 @@ class ContentAddressedStore(object):
 
         Returns
         -------
-        Returns an iterator of (string, bytes) tuples; the iterator will return the keys
-        in the same order as the input argument.
+        Returns an iterator of (string, bytes) tuples; the iterator may return keys
+        in a different order than were passed in.
         """
         load_paths = []
         for key in keys:
@@ -133,7 +133,8 @@ class ContentAddressedStore(object):
                 load_paths.append((key, path))
 
         with self._storage_impl.load_bytes([p for _, p in load_paths]) as loaded:
-            for (key, _), (_, file_path, meta) in zip(load_paths, loaded):
+            for (path_key, file_path, meta) in loaded:
+                key = self._storage_impl.path_split(path_key)[-1]
                 # At this point, we either return the object as is (if raw) or
                 # decode it according to the encoding version
                 with open(file_path, "rb") as f:

--- a/metaflow/datastore/datastore_storage.py
+++ b/metaflow/datastore/datastore_storage.py
@@ -238,7 +238,7 @@ class DataStoreStorage(object):
         """
         raise NotImplementedError
 
-    def load_bytes(self, paths):
+    def load_bytes(self, keys):
         """
         Gets objects from the datastore
 
@@ -248,21 +248,24 @@ class DataStoreStorage(object):
 
         Parameters
         ----------
-        paths : List[string]
-            Paths to fetch
+        keys : List[string]
+            Keys to fetch
 
         Returns
         -------
         CloseAfterUse :
             A CloseAfterUse which should be used in a with statement. The data
-            in the CloseAfterUse will be an iterator over (key, path, metadata)
-            tuples. Path and metadata will be None if the key was missing.
+            in the CloseAfterUse will be an iterator over (key, file_path, metadata)
+            tuples. File_path and metadata will be None if the key was missing.
             Metadata will be None if no metadata is present; otherwise it is
             a dictionary of metadata associated with the object.
 
-            Note that the file at `path` may no longer be accessible outside of
+            Note that the file at `file_path` may no longer be accessible outside of
             the scope of the returned object.
 
-            Note that the order of the iterator will be the same as the input paths.
+            The order of items in the list is not to be relied on (ie: rely on the key
+            in the returned tuple and not on the order of the list). This function will,
+            however, return as many elements as passed in even in the presence of
+            duplicate keys.
         """
         raise NotImplementedError


### PR DESCRIPTION
When an artifact is present in the blob cache, load_blobs would return
things out of order and load_artifacts would therefore return the wrong
blob for the artifact name.

This patch hopefully addresses this issue fully and also adds a small
optimization whereas blobs are not requested multiple times if they are
identical.

Fixes #819 .