### PR TITLE
Implementation for triggering a SFN execution from the result of a previous SFN execution

### DIFF
--- a/metaflow/plugins/aws/step_functions/schedule_decorator.py
+++ b/metaflow/plugins/aws/step_functions/schedule_decorator.py
@@ -1,22 +1,73 @@
 from metaflow.decorators import FlowDecorator
+from .event_bridge_client import EventBridgeClient
+from .step_functions_client import StepFunctionsClient
+class ScheduleDefinition():
 
+    def __init__(self, schedule_obj):
+        pass
+
+    def generate_eventbridge_rule(self):
+        pass
+
+class CronScheduleDefinition(ScheduleDefinition):
+
+    def __init__(self, schedule_obj):
+        self.cron = schedule_obj
+
+    def generate_eventbridge_rule(self, name, state_machine_arn, sfn_access_role):
+        return (
+            EventBridgeClient(name)
+                .cron(self.cron)
+                .role_arn(sfn_access_role)
+                .state_machine_arn(state_machine_arn)
+                .schedule()
+        )
+
+class FlowTriggerScheduleDefinition(ScheduleDefinition):
+
+    def __init__(self, schedule_obj):
+        self.flow_name = schedule_obj
+
+    def _get_state_machine_arn(self):
+
+        flow = StepFunctionsClient().search(self.flow_name)
+
+        if flow:
+            return flow.get('stateMachineArn', None)
+        else:
+            raise Exception("Dependant State Machine Found")
+
+    def generate_eventbridge_rule(self, name, state_machine_arn, sfn_access_role):
+
+        dependant_state_machine_arn = self._get_state_machine_arn()
+
+        return (
+            EventBridgeClient(name)
+                .dependent_state_machine_arn(dependant_state_machine_arn)
+                .role_arn(sfn_access_role)
+                .state_machine_arn(state_machine_arn)
+                .schedule()
+        )
 
 class ScheduleDecorator(FlowDecorator):
     name = "schedule"
-    defaults = {"cron": None, "weekly": False, "daily": True, "hourly": False}
+    defaults = {"cron": None, "weekly": False, "daily": True, "hourly": False, "flow_name": None}
 
     def flow_init(
         self, flow, graph, environment, flow_datastore, metadata, logger, echo, options
     ):
         # Currently supports quartz cron expressions in UTC as defined in
         # https://docs.aws.amazon.com/eventbridge/latest/userguide/scheduled-events.html#cron-expressions
-        if self.attributes["cron"]:
-            self.schedule = self.attributes["cron"]
+        if self.attributes["flow_name"]:
+            self.schedule = FlowTriggerScheduleDefinition(self.attributes['flow_name'])
+        elif self.attributes["cron"]:
+            self.schedule = CronScheduleDefinition(self.attributes["cron"])
         elif self.attributes["weekly"]:
-            self.schedule = "0 0 ? * SUN *"
+            self.schedule = CronScheduleDefinition("0 0 ? * SUN *")
         elif self.attributes["hourly"]:
-            self.schedule = "0 * * * ? *"
+            self.schedule = CronScheduleDefinition("0 * * * ? *")
         elif self.attributes["daily"]:
-            self.schedule = "0 0 * * ? *"
+            self.schedule = CronScheduleDefinition("0 0 * * ? *")
         else:
-            self.schedule = None
+            print("Returned none")
+            self.schedule = CronScheduleDefinition(None)


### PR DESCRIPTION
An implementation to allow SFN Executions to be triggered from the finishing state of another SFN execution. I have been using this to trigger multiple consumer Flows when a specific Producer flow finishes. For example:

Hourly -> DataCleaningFlow 
DataCleaningFlow -> Analysis1
DataCleaningFlow -> Analysis2

This ensures that when Analysis1/2 run, they will be able to obtain the data from the DataCleaningFlow, no need to guess at when it might end.

To implement this, I've modified the @schedule annotation to take a flow_name. This could be extended to add multiple flows and wait for their state (currently only support SUCCEEDED from SFN).

Closes #837 