### PR TITLE
Fix timestamp issue for python2 in s3

### DIFF
--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -31,7 +31,7 @@ except:
     # python3
     from urllib.parse import urlparse
 
-from .s3util import get_s3_client, read_in_chunks
+from .s3util import get_s3_client, read_in_chunks, get_timestamp
 
 try:
     import boto3
@@ -496,7 +496,7 @@ class S3(object):
                 "content_type": resp["ContentType"],
                 "metadata": resp["Metadata"],
                 "size": resp["ContentLength"],
-                "last_modified": resp["LastModified"].timestamp(),
+                "last_modified": get_timestamp(resp["LastModified"]),
             }
 
         info_results = None
@@ -605,7 +605,7 @@ class S3(object):
                 return {
                     "content_type": resp["ContentType"],
                     "metadata": resp["Metadata"],
-                    "last_modified": resp["LastModified"].timestamp(),
+                    "last_modified": get_timestamp(resp["LastModified"]),
                 }
             return None
 

--- a/metaflow/datatools/s3op.py
+++ b/metaflow/datatools/s3op.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 # multiprocessing.Pool because https://bugs.python.org/issue31886
 from metaflow.util import TempDir, url_quote, url_unquote
 from metaflow.multicore_utils import parallel_map
-from metaflow.datatools.s3util import aws_retry, read_in_chunks
+from metaflow.datatools.s3util import aws_retry, read_in_chunks, get_timestamp
 
 NUM_WORKERS_DEFAULT = 64
 
@@ -120,7 +120,7 @@ def worker(result_file_name, queue, mode):
                 "size": head["ContentLength"],
                 "content_type": head["ContentType"],
                 "metadata": head["Metadata"],
-                "last_modified": head["LastModified"].timestamp(),
+                "last_modified": get_timestamp(head["LastModified"]),
             }
         except client_error as err:
             error_code = normalize_client_error(err)
@@ -192,7 +192,9 @@ def worker(result_file_name, queue, mode):
                             if resp["Metadata"] is not None:
                                 args["metadata"] = resp["Metadata"]
                             if resp["LastModified"]:
-                                args["last_modified"] = resp["LastModified"].timestamp()
+                                args["last_modified"] = get_timestamp(
+                                    resp["LastModified"]
+                                )
                             json.dump(args, f)
                         # Finally, we push out the size to the result_pipe since
                         # the size is used for verification and other purposes and

--- a/metaflow/datatools/s3util.py
+++ b/metaflow/datatools/s3util.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from datetime import datetime
 import random
 import time
 import sys
@@ -78,3 +79,10 @@ def read_in_chunks(dst, src, src_sz, max_chunk_size):
         # separately
         dst.write(buf)
         remaining -= len(buf)
+
+
+def get_timestamp(dt):
+    """
+    Python2 compatible way to compute the timestamp (seconds since 1/1/1970)
+    """
+    return (dt.replace(tzinfo=None) - datetime(1970, 1, 1)).total_seconds()


### PR DESCRIPTION
Thanks to @romain-intel 's integration tests, he noticed that the #778 had a bug for python2:  datetime had .timestamp() function only since python 3.3.

This PR replaces the .timestamp() with a get_timestamp() function that calculates the timestamp using datetime operations.

Test with both py2 and py3:
```
Python 2.7.15 | packaged by conda-forge | (default, Mar  5 2020, 14:58:04) 
[GCC Clang 9.0.1 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from metaflow import S3
>>> s3 = S3()
>>> info = s3.info_many(['s3://aapo-mf-test/mnist/t10k-labels-idx1-ubyte.gz', 's3://aapo-mf-test/mnist/train-labels-idx1-ubyte.gz'])
>>> info[0].last_modified, info[1].last_modified
(1632312604.0, 1632312562.0)
>>> 


(py2) MacBook-Pro-5:metaflow akyrola$ conda activate metaflow_dev
(metaflow_dev) MacBook-Pro-5:metaflow akyrola$ aws-vault exec mfdeveloper --  python
Python 3.9.7 | packaged by conda-forge | (default, Sep 14 2021, 01:18:03) 
[Clang 11.1.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from metaflow import S3
>>> s3 = S3()
>>> info = s3.info_many(['s3://aapo-mf-test/mnist/t10k-labels-idx1-ubyte.gz', 's3://aapo-mf-test/mnist/train-labels-idx1-ubyte.gz'])
>>> info[0].last_modified, info[1].last_modified
```