### PR TITLE
Remove unused module + enhance code patterns

### DIFF
--- a/metaflow/mflog/mflog.py
+++ b/metaflow/mflog/mflog.py
@@ -1,6 +1,5 @@
 import heapq
 import re
-import sys
 import time
 import uuid
 
@@ -41,23 +40,23 @@ MISSING_TIMESTAMP_STR = MISSING_TIMESTAMP.strftime(ISOFORMAT)
 if time.timezone == 0:
     # the local timezone is UTC (common on servers). Don't waste time
     # on conversions
-    def utc_to_local(x): return x
+    utc_to_local = lambda x: x
 else:
-    # Check python version to determine how to convert to local time
-    if sys.version_info[0] == 2:
-        # Python 2
+    try:
+        # python3
+        from datetime import timezone
+
+        def utc_to_local(utc_dt):
+            return utc_dt.replace(tzinfo=timezone.utc).astimezone(tz=None)
+
+    except ImportError:
+        # python2
         import calendar
 
         def utc_to_local(utc_dt):
             timestamp = calendar.timegm(utc_dt.timetuple())
             local_dt = datetime.fromtimestamp(timestamp)
             return local_dt.replace(microsecond=utc_dt.microsecond)
-    else:
-        # Python 3
-        from datetime import timezone
-
-        def utc_to_local(utc_dt): return utc_dt.replace(
-            tzinfo=timezone.utc).astimezone(tz=None)
 
 
 def decorate(source, line, version=VERSION, now=None, lineid=None):

--- a/metaflow/mflog/mflog.py
+++ b/metaflow/mflog/mflog.py
@@ -5,7 +5,6 @@ import uuid
 
 from datetime import datetime
 from collections import namedtuple
-from metaflow.exception import MetaflowException
 from metaflow.util import to_bytes, to_fileobj, to_unicode
 
 VERSION = b"0"

--- a/metaflow/mflog/mflog.py
+++ b/metaflow/mflog/mflog.py
@@ -1,7 +1,8 @@
+import heapq
 import re
 import time
 import uuid
-import heapq
+
 from datetime import datetime
 from collections import namedtuple
 from metaflow.exception import MetaflowException
@@ -40,7 +41,7 @@ MISSING_TIMESTAMP_STR = MISSING_TIMESTAMP.strftime(ISOFORMAT)
 if time.timezone == 0:
     # the local timezone is UTC (common on servers). Don't waste time
     # on conversions
-    utc_to_local = lambda x: x
+    def utc_to_local(x): return x
 else:
     try:
         # python3


### PR DESCRIPTION
This PR targets this issue: https://github.com/Netflix/metaflow/issues/848

What's new:

- Import modules with respect to alphabetical order
- Remove unused module `MetaflowException`
- Elegantly check the Python version to know what modules to import
    - Use a more explicit `LBYL` instead of `EAPF`