### PR TITLE
Use mflog redirect_stream wrapper correctly with Step Functions

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -62,8 +62,9 @@ class Batch(object):
         step_expr = " && ".join(
             [
                 capture_output_to_mflog(a)
-                for a in (environment.bootstrap_commands(step_name) + step_cmds)
+                for a in (environment.bootstrap_commands(step_name))
             ]
+            + step_cmds
         )
 
         # construct an entry point that
@@ -287,7 +288,7 @@ class Batch(object):
                 )
         job = self.create_job(
             step_name,
-            step_cli,
+            capture_output_to_mflog(step_cli),
             task_spec,
             code_package_sha,
             code_package_url,

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -11,7 +11,7 @@ from metaflow import R
 from metaflow.exception import CommandException, METAFLOW_EXIT_DISALLOW_RETRY
 from metaflow.metadata.util import sync_local_metadata_from_datastore
 from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
-from metaflow.mflog import TASK_LOG_SOURCE
+from metaflow.mflog import TASK_LOG_SOURCE, capture_output_to_mflog
 
 from .batch import Batch, BatchKilledException
 
@@ -263,7 +263,7 @@ def step(
         with ctx.obj.monitor.measure("metaflow.aws.batch.launch_job"):
             batch.launch_job(
                 step_name,
-                step_cli,
+                capture_output_to_mflog(step_cli),
                 task_spec,
                 code_package_sha,
                 code_package_url,

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -25,6 +25,8 @@ from .step_functions_client import StepFunctionsClient
 from .event_bridge_client import EventBridgeClient
 from ..batch.batch import Batch
 
+from metaflow.mflog import capture_output_to_mflog
+
 
 class StepFunctionsException(MetaflowException):
     headline = "AWS Step Functions error"
@@ -701,11 +703,16 @@ class StepFunctions(object):
             param_file = "".join(
                 random.choice(string.ascii_lowercase) for _ in range(10)
             )
-            export_params = (
-                "python -m "
-                "metaflow.plugins.aws.step_functions.set_batch_environment "
-                "parameters %s && . `pwd`/%s" % (param_file, param_file)
+            export_params = " && ".join(
+                [
+                    capture_output_to_mflog(
+                        "python -m metaflow.plugins.aws.step_functions.set_batch_environment parameters %s"
+                        % param_file
+                    ),
+                    ". `pwd`/%s" % param_file,
+                ]
             )
+
             params = (
                 entrypoint
                 + top_opts
@@ -737,7 +744,7 @@ class StepFunctions(object):
             cmd = "if ! %s >/dev/null 2>/dev/null; then %s && %s; fi" % (
                 " ".join(exists),
                 export_params,
-                " ".join(params),
+                capture_output_to_mflog(" ".join(params)),
             )
             cmds.append(cmd)
             paths = "sfn-${METAFLOW_RUN_ID}/_parameters/%s" % (task_id_params)
@@ -746,7 +753,7 @@ class StepFunctions(object):
             parent_tasks_file = "".join(
                 random.choice(string.ascii_lowercase) for _ in range(10)
             )
-            export_parent_tasks = (
+            export_parent_tasks = capture_output_to_mflog(
                 "python -m "
                 "metaflow.plugins.aws.step_functions.set_batch_environment "
                 "parent_tasks %s && . `pwd`/%s" % (parent_tasks_file, parent_tasks_file)
@@ -787,7 +794,7 @@ class StepFunctions(object):
             step.extend("--tag %s" % tag for tag in self.tags)
         if self.namespace is not None:
             step.append("--namespace=%s" % self.namespace)
-        cmds.append(" ".join(entrypoint + top_level + step))
+        cmds.append(capture_output_to_mflog(" ".join(entrypoint + top_level + step)))
         return " && ".join(cmds)
 
 


### PR DESCRIPTION
In the current version, SFN command line is constructed incorrectly. This PR fixes that. The problem exists since #801. 

## Background

Before #801, we used internal function `bash_capture_logs(bash_expr)` that would construct some creative bash to capture output of `bash_expr` to mflog. However, since this implementation used [bash process substitution](https://tldp.org/LDP/abs/html/process-sub.html), it wouldn't work on AWS Lambda. Therefore it was replaced with another implementation, that would kick off a wrapper subprocess via `python -m metaflow.mflog.redirect_streams ...`.

As part of this, the internal function `bash_capture_logs(bash_expr)` was replaced with `capture_output_to_mflog(command_and_args)` that would do the necessary wrapping. However, the new implementation would no longer be able to wrap an _arbitrary_ bash expression; only command invocations were wrapped correctly.

This works fine with AWS Batch plugin since it only needs to wrap an invocation of `metaflow task` CLI command. It wouldn't work with SFN where a more involved bash expression needs to be executed as an entry point of the task. 

## Solution

This PR slightly changes the semantics of `Batch.create_job(..)`, method that is used by both SFN and "pure" Batch plugin to construct the Batch job definition:
* before, it would take care of wrapping whatever is passed in the `step_cli` parameter in mflog redirects (by adding `python -m metaflow.mflog.redirect_streams ...` where necessary).
* after this change, the _caller_ is responsible to do the wrapping when constructing the value for `step_cli` 

That allows SFN plugin to correctly sprinkle invocations of `python -m metaflow.mflog.redirect_streams ...` in the complex bash expression it constructs.