### PR TITLE
Tensorflow parallel decorator

### DIFF
--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -136,6 +136,7 @@ from .test_unbounded_foreach_decorator import (
 )
 from .conda.conda_step_decorator import CondaStepDecorator
 from .cards.card_decorator import CardDecorator
+from .frameworks.pytorch import PytorchParallelDecorator
 
 
 STEP_DECORATORS = _merge_lists(
@@ -151,6 +152,7 @@ STEP_DECORATORS = _merge_lists(
         StepFunctionsInternalDecorator,
         CondaStepDecorator,
         ParallelDecorator,
+        PytorchParallelDecorator,
         InternalTestUnboundedForeachDecorator,
     ],
     _ext_plugins.STEP_DECORATORS,

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -137,6 +137,7 @@ from .test_unbounded_foreach_decorator import (
 from .conda.conda_step_decorator import CondaStepDecorator
 from .cards.card_decorator import CardDecorator
 from .frameworks.pytorch import PytorchParallelDecorator
+from .frameworks.tensorflow import TensorflowParallelDecorator
 
 
 STEP_DECORATORS = _merge_lists(
@@ -153,6 +154,7 @@ STEP_DECORATORS = _merge_lists(
         CondaStepDecorator,
         ParallelDecorator,
         PytorchParallelDecorator,
+        TensorflowParallelDecorator,
         InternalTestUnboundedForeachDecorator,
     ],
     _ext_plugins.STEP_DECORATORS,

--- a/metaflow/plugins/frameworks/pytorch.py
+++ b/metaflow/plugins/frameworks/pytorch.py
@@ -1,0 +1,39 @@
+import inspect
+import subprocess
+import pickle
+import tempfile
+import os
+import sys
+from metaflow import current
+from metaflow.plugins.parallel_decorator import ParallelDecorator
+
+
+class PytorchParallelDecorator(ParallelDecorator):
+    name = "pytorch_parallel"
+    defaults = {"master_port": None}
+    IS_PARALLEL = True
+
+    def task_decorate(
+        self, step_func, flow, graph, retry_count, max_user_code_retries, ubf_context
+    ):
+        return super().task_decorate(
+            step_func, flow, graph, retry_count, max_user_code_retries, ubf_context
+        )
+
+    def setup_distributed_env(self, flow):
+        setup_torch_distributed(self.attributes["master_port"])
+
+
+def setup_torch_distributed(master_port=None):
+    """
+    Set up environment variables for PyTorch's distributed (DDP).
+    """
+    # Choose port depending on run id to reduce probability of collisions, unless
+    # provided by the user.
+    master_port = master_port or (51000 + abs(int(current.run_id)) % 10000)
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["MASTER_ADDR"] = current.parallel.main_ip
+    os.environ["NODE_RANK"] = str(current.parallel.node_index)
+    os.environ["WORLD_SIZE"] = str(current.parallel.num_nodes)
+    os.environ["NUM_NODES"] = str(current.parallel.num_nodes)
+    os.environ["PL_TORCH_DISTRIBUTED_BACKEND"] = "gloo"  # NCCL crashes on aws batch!

--- a/metaflow/plugins/frameworks/tensorflow.py
+++ b/metaflow/plugins/frameworks/tensorflow.py
@@ -1,0 +1,82 @@
+from metaflow.plugins.parallel_decorator import ParallelDecorator
+import os
+import json
+import socket
+import time
+import random
+
+
+class TensorflowParallelDecorator(ParallelDecorator):
+    name = "tensorflow_parallel"
+    defaults = {}
+    IS_PARALLEL = True
+
+    def task_decorate(
+        self, step_func, flow, graph, retry_count, max_user_code_retries, ubf_context
+    ):
+        return super().task_decorate(
+            step_func, flow, graph, retry_count, max_user_code_retries, ubf_context
+        )
+
+    def setup_distributed_env(self, flow):
+        setup_tf_distributed(flow)
+
+
+def setup_tf_distributed(run):
+    """
+    Exchange address and port information of TensorFlow distributed participants.
+    This is done via
+    """
+    from metaflow import current, S3
+
+    print(
+        "Setup Tensorflow distributed, using S3 to rendezvous. Number of nodes: %d"
+        % current.parallel.num_nodes
+    )
+    num_nodes = current.parallel.num_nodes
+    node_index = current.parallel.node_index
+    local_ip = socket.gethostbyname_ex(socket.gethostname())[-1][0]
+    s3 = S3(run=run)
+
+    # Create a port id based on run id and node index to avoid clashes if the
+    # workers run on same machine
+    my_port = 40000 + (int(current.run_id) % 100) * 100 + node_index
+    info_dict = {"node": node_index, "address": "{}:{}".format(local_ip, my_port)}
+    key = os.path.join("tf_nodes", "node_{}.json".format(node_index))
+    s3.put(key, json.dumps(info_dict))
+
+    # Then poll for others
+    all_workers = {node_index: info_dict}
+    while len(all_workers) < num_nodes:
+        print(
+            "Got information for {} workers out of {}".format(
+                len(all_workers), num_nodes
+            )
+        )
+
+        for other_node in range(num_nodes):
+            if other_node not in all_workers:
+                node_key = os.path.join("tf_nodes", "node_{}.json".format(other_node))
+                node_info = s3.get(node_key, return_missing=True)  # use get_many
+                if node_info.exists:
+                    print(
+                        "Tensorflow parallel init: Found information for node {}".format(
+                            other_node
+                        )
+                    )
+                    all_workers[other_node] = json.loads(node_info.blob)
+                    print(all_workers)
+                print(
+                    "Tensorflow parallel init: Could not load {}, trying soon again...".format(
+                        node_key
+                    )
+                )
+
+        time.sleep(4.0 + random.random() * 3.0)
+
+    my_task = {"type": "worker", "index": node_index}
+    cluster = {
+        "worker": [all_workers[node_id]["address"] for node_id in range(num_nodes)]
+    }
+    json_config = json.dumps({"cluster": cluster, "task": my_task})
+    os.environ["TF_CONFIG"] = json_config

--- a/test/core/metaflow_extensions/frameworks/pytorch_parallel_test_flow.py
+++ b/test/core/metaflow_extensions/frameworks/pytorch_parallel_test_flow.py
@@ -1,0 +1,78 @@
+from metaflow import FlowSpec, step, batch, current, pytorch_parallel, Parameter
+
+
+class PytorchParallelTest(FlowSpec):
+    """
+    Test flow to test @pytorch_parallel.
+    """
+
+    num_parallel = Parameter(
+        "num_parallel", help="Number of nodes in cluster", default=3
+    )
+
+    @step
+    def start(self):
+        self.next(self.parallel_step, num_parallel=self.num_parallel)
+
+    @pytorch_parallel
+    @step
+    def parallel_step(self):
+        """
+        Run a simple torch parallel program where each node creates a 3 x 3 tensor
+        with each entry equaling their rank + 1. Then, all reduce is called to sum the
+        tensors up.
+        """
+        import torch
+        import torch.distributed as dist
+
+        # Run very simple parallel pytorch program
+        dist.init_process_group(
+            "gloo",
+            rank=current.parallel.node_index,
+            world_size=current.parallel.num_nodes,
+        )
+
+        # Each node creates a 3x3 matrix with values corresponding to their rank + 1
+        my_tensor = torch.ones(3, 3) * (dist.get_rank() + 1)
+        assert int(my_tensor[0, 0]) == current.parallel.node_index + 1
+
+        # Then sum the tensors up
+        print("Reducing tensor", my_tensor)
+        dist.all_reduce(my_tensor, op=dist.ReduceOp.SUM)
+        print("Result:", my_tensor)
+
+        # Assert the values are as expected
+        for i in range(3):
+            for j in range(3):
+                assert int(my_tensor[i, j]) == sum(
+                    range(1, current.parallel.num_nodes + 1)
+                )
+        dist.destroy_process_group()
+
+        self.node_index = current.parallel.node_index
+        self.num_nodes = current.parallel.num_nodes
+        self.reduced_tensor_value = int(my_tensor[0, 0])
+
+        self.next(self.multinode_end)
+
+    @step
+    def multinode_end(self, inputs):
+        """
+        Check the validity of the parallel execution.
+        """
+        j = 0
+        for input in inputs:
+            assert input.node_index == j
+            assert input.num_nodes == self.num_parallel
+            assert input.reduced_tensor_value == sum(range(1, input.num_nodes + 1))
+            j += 1
+        assert j == self.num_parallel
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+if __name__ == "__main__":
+    PytorchParallelTest()

--- a/test/core/metaflow_extensions/frameworks/tensorflow_parallel_test_flow.py
+++ b/test/core/metaflow_extensions/frameworks/tensorflow_parallel_test_flow.py
@@ -1,0 +1,95 @@
+from metaflow import FlowSpec, step, batch, current, tensorflow_parallel, Parameter
+import tensorflow as tf
+import json
+import os
+
+
+class TensorflowParallelTest(FlowSpec):
+    """
+    Test flow to test @tensorflow_parallel.
+    """
+
+    num_parallel = Parameter(
+        "num_parallel", help="Number of nodes in cluster", default=3
+    )
+
+    @step
+    def start(self):
+        self.next(self.parallel_step, num_parallel=self.num_parallel)
+
+    @tensorflow_parallel
+    @step
+    def parallel_step(self):
+        """
+        Run a simple tensorflow parallel program
+        """
+        train()
+
+        self.node_index = current.parallel.node_index
+        self.num_nodes = current.parallel.num_nodes
+
+        self.next(self.multinode_end)
+
+    @step
+    def multinode_end(self, inputs):
+        """
+        Check the validity of the parallel execution.
+        """
+        j = 0
+        for input in inputs:
+            assert input.node_index == j
+            assert input.num_nodes == self.num_parallel
+            j += 1
+        assert j == self.num_parallel
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+def train():
+    tf_config = json.loads(os.environ["TF_CONFIG"])
+    num_workers = len(tf_config["cluster"]["worker"])
+
+    strategy = tf.distribute.MultiWorkerMirroredStrategy()
+    per_worker_batch_size = 4
+    global_batch_size = per_worker_batch_size * num_workers
+    multi_worker_dataset = dummy_dataset(global_batch_size)
+
+    with strategy.scope():
+        multi_worker_model = create_keras_model()
+    multi_worker_model.fit(multi_worker_dataset, epochs=1, steps_per_epoch=4)
+
+
+def create_keras_model():
+    model = tf.keras.Sequential(
+        [tf.keras.layers.InputLayer(input_shape=(1, 1)), tf.keras.layers.Dense(1)]
+    )
+    model.compile(
+        loss=tf.keras.losses.MeanAbsoluteError(),
+        optimizer=tf.keras.optimizers.SGD(learning_rate=0.001),
+        metrics=["accuracy"],
+    )
+    return model
+
+
+def dummy_dataset(batch_size):
+    import numpy as np
+
+    (x_train, y_train) = np.random.rand(100, 1), np.random.rand(100, 1) + 0.5
+    # The `x` arrays are in uint8 and have values in the [0, 255] range.
+    # You need to convert them to float32 with values in the [0, 1] range.
+    x_train = x_train / np.float32(255)
+    y_train = y_train.astype(np.int64)
+    train_dataset = (
+        tf.data.Dataset.from_tensor_slices((x_train, y_train))
+        .shuffle(60000)
+        .repeat()
+        .batch(batch_size)
+    )
+    return train_dataset
+
+
+if __name__ == "__main__":
+    TensorflowParallelTest()

--- a/test/core/tests/card_timeout.py
+++ b/test/core/tests/card_timeout.py
@@ -10,7 +10,9 @@ class CardTimeoutTest(MetaflowTest):
 
     PRIORITY = 2
 
-    @tag('card(type="test_timeout_card",timeout=10,options=dict(timeout=20),save_errors=False)')
+    @tag(
+        'card(type="test_timeout_card",timeout=10,options=dict(timeout=20),save_errors=False)'
+    )
     @steps(0, ["start"])
     def step_start(self):
         from metaflow import current


### PR DESCRIPTION
@tensorflow_parallel

Note that this is stacked on top of #871 and thus includes also its commits.

Tensorflow has more involved handshaking than pytorch. We use S3 files to exchange information of each node's address and port. In the future, this could be rewritten to use a simple tcp server to exchange the info.

Simple test flow:

```
 python test/core/metaflow_extensions/frameworks/tensorflow_parallel_test_flow.py --no-pylint run
```