### PR TITLE
Checks embed URL param and adds it as a class

### DIFF
--- a/metaflow/plugins/cards/ui/src/App.svelte
+++ b/metaflow/plugins/cards/ui/src/App.svelte
@@ -11,9 +11,13 @@
   import Main from "./components/main.svelte";
   import Modal from "./components/modal.svelte";
   import Nav from "./components/aside-nav.svelte";
+
+  // Set the `embed` class to hide the `aside` if specified in the URL
+  const urlParams = new URLSearchParams(window.location.search);
+  let embed = Boolean(urlParams.get('embed'))
 </script>
 
-<div class="container mf-card">
+<div class="container mf-card" class:embed>
   <Aside>
     <Nav pageHierarchy={utils.getPageHierarchy($cardData?.components)} />
   </Aside>


### PR DESCRIPTION
## To test

* `cd metaflow/plugins/cards/ui`
* `yarn dev`
* Go to `http://localhost:5000`
* Add an `embed` parameter to the URL

<img width="764" alt="Screen Shot 2021-12-21 at 2 54 24 PM" src="https://user-images.githubusercontent.com/93726128/147002454-6966318f-7569-4764-bbfb-da71370248f6.png">

<img width="864" alt="Screen Shot 2021-12-21 at 2 54 34 PM" src="https://user-images.githubusercontent.com/93726128/147002458-693f8988-93fd-4913-a2d5-edf43a00fe36.png">
