### PR TITLE
Remove unused code in BatchJob.execute()

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -85,16 +85,6 @@ class BatchJob(object):
             raise BatchJobException(
                 "Unable to launch AWS Batch job. No IAM role specified."
             )
-        if "jobDefinition" not in self.payload:
-            self.payload["jobDefinition"] = self._register_job_definition(
-                self._image,
-                self._iam_role,
-                self.payload["job_queue"],
-                self._execution_role,
-                self._shared_memory,
-                self._max_swap,
-                self._swappiness,
-            )
 
         # Multinode
         if getattr(self, "num_parallel", 0) > 1:


### PR DESCRIPTION
`execute()` is only called [here](https://github.com/Netflix/metaflow/blob/master/metaflow/plugins/aws/batch/batch.py#L321:L321), but that code calls `create_job()` right before that, which in turn calls `job_def()`, which populates `jobDefinition` in `self.payload`.

The unused code inside `if` has been broken for a while anyway: over the last few months, two more required parameters were added to `_register_job_definition()`, namely `num_parallel` and `host_volumes`. That's how I noticed it is not used -- pylance type checker highlighted it for me as an error.