### PR TITLE
fix argument type handling for host_volumes when used with --with and SFN

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -253,6 +253,8 @@ class BatchJob(object):
         if host_volumes:
             job_definition["containerProperties"]["volumes"] = []
             job_definition["containerProperties"]["mountPoints"] = []
+            if isinstance(host_volumes, str):
+                host_volumes = [host_volumes]
             for host_path in host_volumes:
                 name = host_path.replace("/", "_").replace(".", "_")
                 job_definition["containerProperties"]["volumes"].append(


### PR DESCRIPTION
### The problem

There is a somewhat obscure difference in a way list attributes are handled between SFN and "standalone" AWS Batch. If the attribute is a list of strings, but the user passes a single string instead, it is implicitly converted to a single-item list when we convert attributes to command-line args for `batch_cli.py` and they are parsed back to Python objects by `click`. However, that conversion does not happen when used with SFN. 

### Short term fix
Support both single strings and lists for `host_volumes`

### A longer term fix
A proper solution would be to more explicitly support list attributes in decospec parser used for `--with`, and have unit tests for that. Right now it just kinda happens to (mostly) work. 

