### PR TITLE
fix `black .` issue

### DIFF
--- a/test/core/tests/card_timeout.py
+++ b/test/core/tests/card_timeout.py
@@ -9,8 +9,7 @@ class CardTimeoutTest(MetaflowTest):
     """
 
     PRIORITY = 2
-
-    @tag('card(type="test_timeout_card",timeout=10,options=dict(timeout=20),save_errors=False)')
+    @tag('card(type="test_timeout_card",timeout=10,options=dict(timeout=20),save_errors=False)')  # fmt: skip
     @steps(0, ["start"])
     def step_start(self):
         from metaflow import current


### PR DESCRIPTION
Rebasing #612 and friends, `black .` is showing this unrelated change. I folded it into #661 but [the CI is failing there for a reason I'm not sure is due to my changes](https://github.com/Netflix/metaflow/pull/661#issuecomment-1006693763), so I'm submitting this separately partly to see if I see the same failure here.