### PR TITLE
Fix @local @parallel and refactor task ids

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -182,6 +182,7 @@ class Batch(object):
         attrs={},
         host_volumes=None,
         num_parallel=1,
+        parallel_task_prefix=None,
     ):
         job_name = self._job_name(
             attrs.get("metaflow.user"),
@@ -213,6 +214,7 @@ class Batch(object):
                 swappiness,
                 host_volumes=host_volumes,
                 num_parallel=num_parallel,
+                parallel_task_prefix=parallel_task_prefix,
             )
             .cpu(cpu)
             .gpu(gpu)
@@ -284,6 +286,7 @@ class Batch(object):
         swappiness=None,
         host_volumes=None,
         num_parallel=1,
+        parallel_task_prefix=None,
         env={},
         attrs={},
     ):
@@ -316,6 +319,7 @@ class Batch(object):
             attrs=attrs,
             host_volumes=host_volumes,
             num_parallel=num_parallel,
+            parallel_task_prefix=parallel_task_prefix,
         )
         self.num_parallel = num_parallel
         self.job = job.execute()

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -149,6 +149,12 @@ def kill(ctx, run_id, user, my_runs):
     type=int,
     help="Number of parallel nodes to run as a multi-node job.",
 )
+@click.option(
+    "--parallel-task-prefix",
+    default=None,
+    type=str,
+    help="Task id prefix for non-main tasks in parallel mode.",
+)
 @click.pass_context
 def step(
     ctx,
@@ -169,6 +175,7 @@ def step(
     swappiness=None,
     host_volumes=None,
     num_parallel=None,
+    parallel_task_prefix=None,
     **kwargs
 ):
     def echo(msg, stream="stderr", batch_id=None):
@@ -294,6 +301,7 @@ def step(
                 attrs=attrs,
                 host_volumes=host_volumes,
                 num_parallel=num_parallel,
+                parallel_task_prefix=parallel_task_prefix,
             )
     except Exception as e:
         traceback.print_exc()

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -112,11 +112,11 @@ class BatchJob(object):
                 self.payload["containerOverrides"]
             )
             secondary_commands = self.payload["containerOverrides"]["command"][-1]
-            # other tasks do not have control- prefix, and have the split id appended to the task -id
+            # Other tasks than the main task have their task id as the split id appended to the parallel task prefix.
+            # These tasks have been registered by the batch decorator.
             secondary_commands = secondary_commands.replace(
                 self._task_id,
-                self._task_id.replace("control-", "")
-                + "-node-$AWS_BATCH_JOB_NODE_INDEX",
+                self.parallel_task_prefix + "$AWS_BATCH_JOB_NODE_INDEX",
             )
             secondary_commands = secondary_commands.replace(
                 "ubf_control",
@@ -153,6 +153,7 @@ class BatchJob(object):
         swappiness,
         host_volumes,
         num_parallel,
+        parallel_task_prefix,
     ):
         # identify platform from any compute environment associated with the
         # queue
@@ -263,6 +264,7 @@ class BatchJob(object):
                 )
 
         self.num_parallel = num_parallel or 1
+        self.parallel_task_prefix = parallel_task_prefix
         if self.num_parallel > 1:
             job_definition["type"] = "multinode"
             job_definition["nodeProperties"] = {
@@ -321,6 +323,7 @@ class BatchJob(object):
         swappiness,
         host_volumes,
         num_parallel,
+        parallel_task_prefix,
     ):
         self.payload["jobDefinition"] = self._register_job_definition(
             image,
@@ -332,6 +335,7 @@ class BatchJob(object):
             swappiness,
             host_volumes,
             num_parallel,
+            parallel_task_prefix,
         )
         return self
 


### PR DESCRIPTION
1) Pass parallel_task_prefix from decorator to client so the task id logic is in one place only.
2) Now works with local metadata. The problem was _wait_for_mapper_tasks. There is now special version for local metadata, which uses S3 files to communicate finishing of the tasks. I could not make it work with the metadata object itself.
3) some small logging message changes for clarity.


