### PR TITLE
Fix issue when running on batch with local metadata

### DIFF
--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -435,6 +435,37 @@ class TaskDataStore(object):
             add_attempt,
         )
 
+    @require_mode("w")
+    def _dangerous_save_metadata_post_done(
+        self, contents, allow_overwrite=True, add_attempt=True
+    ):
+        """
+        Method identical to save_metadata BUT BYPASSES THE CHECK ON DONE
+
+        @warning This method should not be used unless you know what you are doing. This
+        will write metadata to a datastore that has been marked as done.
+
+        Currently used to re-patriate metadata in the case of a remote run and no
+        metadata service
+
+        This method requires mode 'w'
+
+        Parameters
+        ----------
+        contents : Dict[string -> JSON-ifiable objects]
+            Dictionary of metadata to store
+        allow_overwrite : boolean, optional
+            If True, allows the overwriting of the metadata, defaults to True
+        add_attempt : boolean, optional
+            If True, adds the attempt identifier to the metadata. defaults to
+            True
+        """
+        return self._save_file(
+            {k: json.dumps(v).encode("utf-8") for k, v in contents.items()},
+            allow_overwrite,
+            add_attempt,
+        )
+
     @require_mode("r")
     def load_metadata(self, names, add_attempt=True):
         """
@@ -454,7 +485,8 @@ class TaskDataStore(object):
             Results indexed by the name of the metadata loaded
         """
         return {
-            k: json.loads(v) for k, v in self._load_file(names, add_attempt).items()
+            k: json.loads(v) if v is not None else None
+            for k, v in self._load_file(names, add_attempt).items()
         }
 
     @require_mode(None)

--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -443,10 +443,15 @@ class TaskDataStore(object):
         Method identical to save_metadata BUT BYPASSES THE CHECK ON DONE
 
         @warning This method should not be used unless you know what you are doing. This
-        will write metadata to a datastore that has been marked as done.
+        will write metadata to a datastore that has been marked as done which is an
+        assumption that other parts of metaflow rely on (ie: when a datastore is marked
+        as done, it is considered to be read-only).
 
-        Currently used to re-patriate metadata in the case of a remote run and no
-        metadata service
+        Currently only used in the case when the task is executed remotely but there is
+        no (remote) metadata service configured. We therefore use the datastore to share
+        metadata between the task and the Metaflow local scheduler. Due to some other
+        constraints and the current plugin API, we could not use the regular method
+        to save metadata.
 
         This method requires mode 'w'
 

--- a/metaflow/metadata/util.py
+++ b/metaflow/metadata/util.py
@@ -16,7 +16,7 @@ def sync_local_metadata_to_datastore(metadata_local_dir, task_ds):
             tar.add(metadata_local_dir)
         blob = buf.getvalue()
         _, key = task_ds.parent_datastore.save_data([blob], len_hint=1)[0]
-        task_ds.save_metadata({"local_metadata": key})
+        task_ds._dangerous_save_metadata_post_done({"local_metadata": key})
 
 
 def sync_local_metadata_from_datastore(metadata_local_dir, task_ds):

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -269,43 +269,24 @@ class BatchDecorator(StepDecorator):
         if num_parallel > 1:
             _setup_multinode_environment()
 
-    def task_post_step(
-        self, step_name, flow, graph, retry_count, max_user_code_retries
-    ):
-        # task_post_step may run locally if fallback is activated for @catch
-        # decorator.
-        if "AWS_BATCH_JOB_ID" in os.environ:
-            # If `local` metadata is configured, we would need to copy task
-            # execution metadata from the AWS Batch container to user's
-            # local file system after the user code has finished execution.
-            # This happens via datastore as a communication bridge.
-            if self.metadata.TYPE == "local":
-                # Note that the datastore is *always* Amazon S3 (see
-                # runtime_task_created function).
-                sync_local_metadata_to_datastore(
-                    DATASTORE_LOCAL_DIR, self.task_datastore
-                )
-
-    def task_exception(
-        self, exception, step_name, flow, graph, retry_count, max_user_code_retries
-    ):
-        # task_exception may run locally if fallback is activated for @catch
-        # decorator.
-        if "AWS_BATCH_JOB_ID" in os.environ:
-            # If `local` metadata is configured, we would need to copy task
-            # execution metadata from the AWS Batch container to user's
-            # local file system after the user code has finished execution.
-            # This happens via datastore as a communication bridge.
-            if self.metadata.TYPE == "local":
-                # Note that the datastore is *always* Amazon S3 (see
-                # runtime_task_created function).
-                sync_local_metadata_to_datastore(
-                    DATASTORE_LOCAL_DIR, self.task_datastore
-                )
-
     def task_finished(
         self, step_name, flow, graph, is_task_ok, retry_count, max_retries
     ):
+
+        # task_finished may run locally if fallback is activated for @catch
+        # decorator.
+        if "AWS_BATCH_JOB_ID" in os.environ:
+            # If `local` metadata is configured, we would need to copy task
+            # execution metadata from the AWS Batch container to user's
+            # local file system after the user code has finished execution.
+            # This happens via datastore as a communication bridge.
+            if self.metadata.TYPE == "local":
+                # Note that the datastore is *always* Amazon S3 (see
+                # runtime_task_created function).
+                sync_local_metadata_to_datastore(
+                    DATASTORE_LOCAL_DIR, self.task_datastore
+                )
+
         try:
             self._save_logs_sidecar.kill()
         except:

--- a/metaflow/plugins/aws/eks/kubernetes_decorator.py
+++ b/metaflow/plugins/aws/eks/kubernetes_decorator.py
@@ -223,43 +223,23 @@ class KubernetesDecorator(StepDecorator):
             # Start MFLog sidecar to collect task logs.
             self._save_logs_sidecar = SidecarSubProcess("save_logs_periodically")
 
-    def task_post_step(
-        self, step_name, flow, graph, retry_count, max_user_code_retries
-    ):
-        # task_post_step may run locally if fallback is activated for @catch
-        # decorator.
-        if "METAFLOW_KUBERNETES_WORKLOAD" in os.environ:
-            # If `local` metadata is configured, we would need to copy task
-            # execution metadata from the AWS Batch container to user's
-            # local file system after the user code has finished execution.
-            # This happens via datastore as a communication bridge.
-            if self.metadata.TYPE == "local":
-                # Note that the datastore is *always* Amazon S3 (see
-                # runtime_task_created function).
-                sync_local_metadata_to_datastore(
-                    DATASTORE_LOCAL_DIR, self.task_datastore
-                )
-
-    def task_exception(
-        self, exception, step_name, flow, graph, retry_count, max_user_code_retries
-    ):
-        # task_exception may run locally if fallback is activated for @catch
-        # decorator.
-        if "METAFLOW_KUBERNETES_WORKLOAD" in os.environ:
-            # If `local` metadata is configured, we would need to copy task
-            # execution metadata from the AWS Batch container to user's
-            # local file system after the user code has finished execution.
-            # This happens via datastore as a communication bridge.
-            if self.metadata.TYPE == "local":
-                # Note that the datastore is *always* Amazon S3 (see
-                # runtime_task_created function).
-                sync_local_metadata_to_datastore(
-                    DATASTORE_LOCAL_DIR, self.task_datastore
-                )
-
     def task_finished(
         self, step_name, flow, graph, is_task_ok, retry_count, max_retries
     ):
+        # task_finished may run locally if fallback is activated for @catch
+        # decorator.
+        if "METAFLOW_KUBERNETES_WORKLOAD" in os.environ:
+            # If `local` metadata is configured, we would need to copy task
+            # execution metadata from the AWS Batch container to user's
+            # local file system after the user code has finished execution.
+            # This happens via datastore as a communication bridge.
+            if self.metadata.TYPE == "local":
+                # Note that the datastore is *always* Amazon S3 (see
+                # runtime_task_created function).
+                sync_local_metadata_to_datastore(
+                    DATASTORE_LOCAL_DIR, self.task_datastore
+                )
+
         try:
             self._save_logs_sidecar.kill()
         except:


### PR DESCRIPTION
Artifacts were persisted *after* the metadata was saved to S3 to be
repatriated locally which caused it to completely miss.

This addresses this issue (fixes #878) and also addresses another issue
in load_metadata when loading non existent metadata.