### PR TITLE
Fix incorrect import in env escape server process

### DIFF
--- a/metaflow/plugins/env_escape/server.py
+++ b/metaflow/plugins/env_escape/server.py
@@ -63,7 +63,7 @@ class Server(object):
     def __init__(self, max_pickle_version, config_dir):
 
         self._max_pickle_version = data_transferer.defaultProtocol = max_pickle_version
-        sys.path.append(config_dir)
+        sys.path.insert(0, config_dir)
         mappings = importlib.import_module("server_mappings")
         override_module = importlib.import_module("overrides")
         sys.path = sys.path[1:]


### PR DESCRIPTION
This was a nasty "typo" (the same line is present elsewhere correctly)
and caused the wrong "overrides" module to be loaded if you had, for
example, the "overrides" module installed (yes, there is such a thing)