### PR TITLE
Fix issue with @batch and num_parallel=1; improve status log.

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -181,7 +181,7 @@ class Batch(object):
         env={},
         attrs={},
         host_volumes=None,
-        num_parallel=1,
+        num_parallel=0,
     ):
         job_name = self._job_name(
             attrs.get("metaflow.user"),
@@ -283,7 +283,7 @@ class Batch(object):
         max_swap=None,
         swappiness=None,
         host_volumes=None,
-        num_parallel=1,
+        num_parallel=0,
         env={},
         attrs={},
     ):
@@ -334,8 +334,28 @@ class Batch(object):
                     if not child_jobs:
                         child_statuses = ""
                     else:
-                        child_statuses = " (child nodes: [{}])".format(
-                            ", ".join([child_job.status for child_job in child_jobs])
+                        status_keys = set(
+                            [child_job.status for child_job in child_jobs]
+                        )
+                        status_counts = [
+                            (
+                                status,
+                                len(
+                                    [
+                                        child_job.status == status
+                                        for child_job in child_jobs
+                                    ]
+                                ),
+                            )
+                            for status in status_keys
+                        ]
+                        child_statuses = " (parallel node status: [{}])".format(
+                            ", ".join(
+                                [
+                                    "{}:{}".format(status, num)
+                                    for (status, num) in sorted(status_counts)
+                                ]
+                            )
                         )
                     status = job.status
                     echo(

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -251,8 +251,8 @@ class BatchDecorator(StepDecorator):
 
             self._save_logs_sidecar = SidecarSubProcess("save_logs_periodically")
 
-        num_parallel = int(os.environ.get("AWS_BATCH_JOB_NUM_NODES", 1))
-        if num_parallel > 1 and ubf_context == UBF_CONTROL:
+        num_parallel = int(os.environ.get("AWS_BATCH_JOB_NUM_NODES", 0))
+        if num_parallel >= 1 and ubf_context == UBF_CONTROL:
             # UBF handling for multinode case
             control_task_id = current.task_id
             top_task_id = control_task_id.replace("control-", "")  # chop "-0"
@@ -266,7 +266,7 @@ class BatchDecorator(StepDecorator):
             ]
             flow._control_task_is_mapper_zero = True
 
-        if num_parallel > 1:
+        if num_parallel >= 1:
             _setup_multinode_environment()
 
     def task_post_step(
@@ -312,7 +312,7 @@ class BatchDecorator(StepDecorator):
             # Best effort kill
             pass
 
-        if is_task_ok and getattr(flow, "_control_mapper_tasks", []):
+        if is_task_ok and len(getattr(flow, "_control_mapper_tasks", [])) > 1:
             self._wait_for_mapper_tasks(flow, step_name)
 
     def _wait_for_mapper_tasks(self, flow, step_name):


### PR DESCRIPTION
Fixes major bug of running AWS Batch parallel with num_parallel=1. There was  a couple of incorrect num_parallel > 1 while they should be num_parallel >= 1. 

Tested with
`   python  test/parallel/parallel_test_flow.py --no-pylint   --with batch run --num_parallel=1
`and
`    python  test/parallel/parallel_test_flow.py --no-pylint   --with batch run --num_parallel=4
`
Also more compact logging of the statuses of child nodes while starting up:
```
Task is starting (status RUNNING)...  (parallel node status: [SUBMITTED:3])
```
