### PR TITLE
Fail early step function create with @parallel.

### DIFF
--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -230,7 +230,7 @@ class StepFunctions(object):
         def _visit(node, workflow, exit_node=None):
             if node.parallel_foreach:
                 raise StepFunctionsException(
-                    "Parallel steps are not supported for Step functions yet."
+                    "@parallel is not yet supported for AWS Step Functions."
                 )
 
             # Assign an AWS Batch job to the AWS Step Functions state

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -228,6 +228,11 @@ class StepFunctions(object):
 
         # Visit every node of the flow and recursively build the state machine.
         def _visit(node, workflow, exit_node=None):
+            if node.parallel_foreach:
+                raise StepFunctionsException(
+                    "Parallel steps are not supported for Step functions yet."
+                )
+
             # Assign an AWS Batch job to the AWS Step Functions state
             # and pass the intermediate state by exposing `JobId` and
             # `Parameters` to the child job(s) as outputs. `Index` and

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -230,7 +230,8 @@ class StepFunctions(object):
         def _visit(node, workflow, exit_node=None):
             if node.parallel_foreach:
                 raise StepFunctionsException(
-                    "@parallel is not yet supported for AWS Step Functions."
+                    "Deploying flows with @parallel decorator(s) "
+                    "to AWS Step Functions is not supported currently."
                 )
 
             # Assign an AWS Batch job to the AWS Step Functions state


### PR DESCRIPTION
As title. Now `step-functions create` fails.