### PR TITLE
Reduce Metaflow overhead by optimizing content addressable store

### DIFF
--- a/metaflow/datastore/content_addressed_store.py
+++ b/metaflow/datastore/content_addressed_store.py
@@ -37,13 +37,22 @@ class ContentAddressedStore(object):
         self._blob_cache = None
 
         # Map of very common short values. Store both v2 and v4 pickled versions...
-        constants = [None, True, False, [], {}, "", "start", "end"] + list(range(100))
+        constants = [
+            None,
+            True,
+            False,
+            [],
+            {},
+            "",
+            "start",
+            "end",
+            "_parallel_ubf_iter",
+        ] + list(range(100))
         self._constants = {}
         for value in constants:
             for version in [2, 4]:
                 pickled = pickle.dumps(value, protocol=version)
                 self._constants[sha1(pickled).hexdigest()] = pickled
-
 
     def set_blob_cache(self, blob_cache):
         self._blob_cache = blob_cache

--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -147,6 +147,9 @@ class TaskDataStore(object):
                     )
                     if self.has_metadata(check_meta, add_attempt=False):
                         max_attempt = i
+                    else:
+                        # We can assume that if attempt i does not exist, i + 1 does not either
+                        break
                 if self._attempt is None:
                     self._attempt = max_attempt
                 elif max_attempt is None or self._attempt > max_attempt:


### PR DESCRIPTION
I started to profile why Metaflow runs trivial flows so slowly, at least when S3 storage is used. Turns out that metaflow stores a lot of trivial objects in S3, like None, True, and False and empty list. These arise when artifacts are stored via the "content_addressable_store" which stores the objects in paths derived from their hash. This is slow because for each object, it needs to query S3 to see if the file exits (it usually does for these trivial objects), and this takes ~250ms on my laptop.

In addition, the caching is disabled by default. I added a simple cache for small objects with bounded size. Also, we should check for the cache when putting values (they are immutable anyway). This helps when Metaflow stores small objects like step names and other metadata, which is queried twice during the task (when loading the task and when storing the task).

In addition, one small optimization to prevent loading all attempts: we shoudl stop loading attempts when attemp N does not exist anymore. N+1 won't either. This hits S3 again.

With the local parallal test:
```
python test/parallel/parallel_test_flow.py run
```

This reduced on my laptop the running time from 50s to 30s.   So still pretty slow, but an improvement.

(We should probably actually do something different for small objects and for htem just store the value instead of the hash... I might propose solution for this in a different PR.)

