### PR TITLE
Directly store small objects in the key instead of storing in S3

### DIFF
--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -147,6 +147,9 @@ class TaskDataStore(object):
                     )
                     if self.has_metadata(check_meta, add_attempt=False):
                         max_attempt = i
+                    else:
+                        # We can assume that if attempt i does not exist, i + 1 does not either
+                        break
                 if self._attempt is None:
                     self._attempt = max_attempt
                 elif max_attempt is None or self._attempt > max_attempt:


### PR DESCRIPTION
**Alternative to #938**
I started to profile why Metaflow runs trivial flows so slowly, at least when S3 storage is used. Turns out that metaflow stores a lot of trivial objects in S3, like None, True, and False and empty list. In addition, many small strings like step names are stored. These arise when artifacts are stored via the "content_addressable_store" which stores the objects in paths derived from their hash. This is slow because for each object, it needs to query S3 to see if the file exits (it usually does for these trivial objects), and this takes ~250ms on my laptop.

This PR fixes this by storing small objects directly in the content key. Keys starting with "!" have the blob itself as hex string in the rest of the key. Thus, most metadata will not hit S3.

In addition, one small optimization to prevent loading all attempts: we should stop loading attempts when attemp N does not exist anymore. N+1 won't either. This hits S3 again.

With the local parallal test:
```
python test/parallel/parallel_test_flow.py run
```
This reduced on my laptop the running time from 50s to 20s. So still pretty slow, but an improvement.

