### PR TITLE
Card Import Refactors

### DIFF
--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -182,7 +182,8 @@ CARDS = [
     TestNonEditableCard,
     BlankCard,
     DefaultCardJSON,
-] + MF_EXTERNAL_CARDS
+]
+_merge_lists(CARDS, MF_EXTERNAL_CARDS, "type")
 # Sidecars
 from ..mflog.save_logs_periodically import SaveLogsPeriodicallySidecar
 from metaflow.metadata.heartbeat import MetadataHeartBeat

--- a/metaflow/plugins/cards/card_decorator.py
+++ b/metaflow/plugins/cards/card_decorator.py
@@ -7,7 +7,6 @@ from metaflow.decorators import StepDecorator, flow_decorators
 from metaflow.current import current
 from metaflow.util import to_unicode
 from .component_serializer import CardComponentCollector, get_card_class
-from .card_modules import _get_external_card_package_paths
 
 
 # from metaflow import get_metadata
@@ -65,16 +64,6 @@ class CardDecorator(StepDecorator):
         ):
             file_path, arcname = path_tuple
             yield (file_path, os.path.join("metaflow", "plugins", "cards", arcname))
-
-        external_card_pth_generator = _get_external_card_package_paths()
-        if external_card_pth_generator is None:
-            return
-        for module_pth, parent_arcname in external_card_pth_generator:
-            # `_get_card_package_paths` is a generator which yields
-            # path to the module and its relative arcname in the metaflow-extensions package.
-            for file_pth, rel_path in self._walk(module_pth, prefix_root=True):
-                arcname = os.path.join(parent_arcname, rel_path)
-                yield (file_pth, arcname)
 
     def _walk(self, root, filter_extensions=[], prefix_root=False):
         root = to_unicode(root)  # handle files/folder with non ascii chars

--- a/metaflow/plugins/cards/card_modules/__init__.py
+++ b/metaflow/plugins/cards/card_modules/__init__.py
@@ -3,6 +3,8 @@ import traceback
 from .card import MetaflowCard, MetaflowCardComponent
 from metaflow.extension_support import get_modules, EXT_PKG, _ext_debug
 
+_CARD_MODULES = []
+
 
 def iter_namespace(ns_pkg):
     # Specifying the second argument (prefix) to iter_modules makes the
@@ -14,53 +16,39 @@ def iter_namespace(ns_pkg):
     return pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + ".")
 
 
-def _get_external_card_packages(with_paths=False):
+def _get_external_card_packages():
     """
-    Safely extract all exteranl card modules
-    Args:
-        with_paths (bool, optional): setting `with_paths=True` will result in a list of tuples: `[( mf_extensions_parent_path , relative_path_to_module, module)]`. setting false will return a list of modules Defaults to False.
-
+    Safely extract all external card modules
     Returns:
-        `list` of `ModuleType` or `list` of `tuples` where each tuple if of the form (mf_extensions_parent_path , relative_path_to_module, ModuleType)
+        `list` of `ModuleType`
     """
     import importlib
 
-    available_card_modules = []
+    # Caching card related modules.
+    global _CARD_MODULES
+    if len(_CARD_MODULES) > 0:
+        return _CARD_MODULES
     for m in get_modules("plugins.cards"):
         # Iterate submodules of metaflow_extensions.X.plugins.cards
         # For example metaflow_extensions.X.plugins.cards.monitoring
         card_packages = []
-        for fndx, card_mod, ispkg_c in iter_namespace(m.module):
+        if getattr(m, "__path__", None):
+            card_packages.append(m)
+        for _, card_mod, ispkg_c in iter_namespace(m.module):
             try:
                 if not ispkg_c:
                     continue
                 cm = importlib.import_module(card_mod)
                 _ext_debug("Importing card package %s" % card_mod)
-                if with_paths:
-                    card_packages.append((fndx.path, cm))
-                else:
-                    card_packages.append(cm)
+                card_packages.append(cm)
             except Exception as e:
                 _ext_debug(
                     "External Card Module Import Exception \n\n %s \n\n %s"
                     % (str(e), traceback.format_exc())
                 )
-        if with_paths:
-            card_packages = [
-                (
-                    os.path.abspath(
-                        os.path.join(pth, "../../../../")
-                    ),  # parent path to metaflow_extensions
-                    os.path.join(
-                        EXT_PKG,
-                        os.path.relpath(m.__path__[0], os.path.join(pth, "../../../")),
-                    ),  # construct relative path to parent.
-                    m,
-                )
-                for pth, m in card_packages
-            ]
-        available_card_modules.extend(card_packages)
-    return available_card_modules
+
+        _CARD_MODULES.extend(card_packages)
+    return _CARD_MODULES
 
 
 def _load_external_cards():
@@ -93,20 +81,6 @@ def _load_external_cards():
                 # external_cards[c.type] = c
                 card_arr.append(c)
     return card_arr
-
-
-def _get_external_card_package_paths():
-    pkg_iter = _get_external_card_packages(with_paths=True)
-    if pkg_iter is None:
-        return None
-    for (
-        mf_extension_parent_path,
-        relative_path_to_module,
-        _,
-    ) in pkg_iter:
-        module_pth = os.path.join(mf_extension_parent_path, relative_path_to_module)
-        arcname = relative_path_to_module
-        yield module_pth, arcname
 
 
 MF_EXTERNAL_CARDS = _load_external_cards()


### PR DESCRIPTION
## Purpose of PR
We were double importing packages unnecessarily and also double packaging card-related extensions files. This PR tries to clean up those changes. 

## Changes. 
- Removes functions that resolved paths. 
- Leaving packaging of extensions up to code managing extensions. 

## todos
1. There are slight issues with packaging cards with HTML and other assets. Need to document and test that approach. 