### PR TITLE
Python Multi Version Test Suite

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -1,0 +1,8 @@
+name: Dummy-Test
+on:
+  pull_request:
+    branches:
+    - master
+jobs:
+  test: 
+    uses: '.github/workflows/test.yml'

--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -5,4 +5,4 @@ on:
     - master
 jobs:
   test: 
-    uses: '.github/workflows/test.yml'
+    uses: './.github/workflows/test.yml'

--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -1,8 +1,0 @@
-name: Dummy-Test
-on:
-  pull_request:
-    branches:
-    - master
-jobs:
-  test: 
-    uses: './.github/workflows/test.yml'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,68 +3,8 @@ on:
   release:
     types: [published]
 jobs:
-  test:
-    name: tests / ${{ matrix.lang }} tests on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        lang: [Python, R]
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Python 2.x
-      if: matrix.lang == 'Python'
-      uses: actions/setup-python@v2
-      with:
-        python-version: '2.x'
-
-    - name: Install Python 2.x dependencies
-      if: matrix.lang == 'Python'
-      run: |
-        python2 -m pip install --upgrade pip
-        python2 -m pip install tox
-
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.7'
-
-    - name: Install Python 3.x dependencies
-      run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install tox numpy
-    
-    - name: Set up R 4.1
-      if: matrix.lang == 'R'
-      uses: r-lib/actions/setup-r@v1
-      with:
-        r-version: '4.1.1' 
-    
-    - name: Install R 4.1 system dependencies
-      if: matrix.lang == 'R' && matrix.os == 'ubuntu-latest'
-      run: sudo apt-get update; sudo apt-get install -y libcurl4-openssl-dev qpdf libgit2-dev
-
-    - name: Install R 4.1 Rlang dependencies
-      if: matrix.lang == 'R'
-      run: |
-        python3 -m pip install . 
-        Rscript -e 'install.packages("devtools", repos="https://cloud.r-project.org", Ncpus=8)'
-        Rscript -e 'devtools::install_deps("R", dependencies=TRUE, repos="https://cloud.r-project.org", upgrade="default")'
-        R CMD INSTALL R
-        Rscript -e 'install.packages(c("data.table", "caret", "glmnet", "Matrix", "rjson"), repos="https://cloud.r-project.org", Ncpus=8)'   
-
-    - name: Execute R tests
-      if: matrix.lang == 'R'
-      run: |
-        cd R/tests
-        Rscript run_tests.R
-
-    - name: Execute Python tests
-      if: matrix.lang == 'python'
-      run: tox
-
+  test: 
+    uses: '.github/workflows/test.yml'
   deploy:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
     types: [published]
 jobs:
   test: 
-    uses: '.github/workflows/test.yml'
+    uses: './.github/workflows/test.yml'
   deploy:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ver: ['3.5', '3.6', '3.7', '3.8', '3.9','3.10','3.11']
+        ver: ['3.5', '3.6', '3.7', '3.8', '3.9','3.10',]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ver: ['3.5', '3.6', '3.7', '3.8', '3.9']            
+        ver: ['3.5', '3.6', '3.7', '3.8', '3.9','3.10','3.11']
 
     steps:
     - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ver: ['3.5', '3.6', '4.0', '4.1']
+        ver: ['4.0', '4.1']
    
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
     - master
+  workflow_call:
   
 jobs:
   pre-commit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
     - master
+  
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -13,51 +14,60 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.3
-  test:
-    name: tests / ${{ matrix.lang }} tests on ${{ matrix.os }}
+
+  Python:
+    name: core / Python ${{ matrix.ver }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        lang: [Python, R]
+        ver: ['2.x', '3.5', '3.6', '3.7', '3.8', '3.9']            
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 2.x
-      if: matrix.lang == 'Python'
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '2.x'
+        python-version: ${{ matrix.ver }}
 
     - name: Install Python 2.x dependencies
-      if: matrix.lang == 'Python'
+      if: matrix.ver == '2.x'
       run: |
         python2 -m pip install --upgrade pip
         python2 -m pip install tox
 
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.7'
-
-    - name: Install Python 3.x dependencies
+    - name: Install Python ${{ matrix.ver }} dependencies
+      if: matrix.ver != '2.x'
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install tox numpy
-    
-    - name: Set up R 4.1
-      if: matrix.lang == 'R'
-      uses: r-lib/actions/setup-r@v1
+
+    - name: Execute Python tests
+      run: tox
+
+  R:
+    name: core / R ${{ matrix.ver }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        ver: ['3.5', '3.6', '4.0', '4.1']
+   
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up ${{ matrix.ver }}
+      uses: r-lib/actions/setup-r@v2
       with:
-        r-version: '4.1.1'
+        r-version: ${{ matrix.ver }}
     
-    - name: Install R 4.1 system dependencies
-      if: matrix.lang == 'R' && matrix.os == 'ubuntu-latest'
+    - name: Install R ${{ matrix.ver }} system dependencies
+      if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get update; sudo apt-get install -y libcurl4-openssl-dev qpdf libgit2-dev
 
-    - name: Install R 4.1 Rlang dependencies
-      if: matrix.lang == 'R'
+    - name: Install R ${{ matrix.ver }} Rlang dependencies
       run: |
         python3 -m pip install . 
         Rscript -e 'install.packages("devtools", repos="https://cloud.r-project.org", Ncpus=8)'
@@ -66,11 +76,8 @@ jobs:
         Rscript -e 'install.packages(c("data.table", "caret", "glmnet", "Matrix", "rjson"), repos="https://cloud.r-project.org", Ncpus=8)'   
 
     - name: Execute R tests
-      if: matrix.lang == 'R'
       run: |
         cd R/tests
         Rscript run_tests.R
 
-    - name: Execute Python tests
-      if: matrix.lang == 'python'
-      run: tox
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ver: ['2.x', '3.5', '3.6', '3.7', '3.8', '3.9']            
+        ver: ['3.5', '3.6', '3.7', '3.8', '3.9']            
 
     steps:
     - uses: actions/checkout@v2
@@ -32,14 +32,7 @@ jobs:
       with:
         python-version: ${{ matrix.ver }}
 
-    - name: Install Python 2.x dependencies
-      if: matrix.ver == '2.x'
-      run: |
-        python2 -m pip install --upgrade pip
-        python2 -m pip install tox
-
     - name: Install Python ${{ matrix.ver }} dependencies
-      if: matrix.ver != '2.x'
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install tox numpy

--- a/metaflow/datastore/flow_datastore.py
+++ b/metaflow/datastore/flow_datastore.py
@@ -1,6 +1,5 @@
 import itertools
 import json
-import sys
 
 from .. import metaflow_config
 

--- a/metaflow/datastore/flow_datastore.py
+++ b/metaflow/datastore/flow_datastore.py
@@ -159,9 +159,7 @@ class FlowDataStore(object):
                     elif fname == TaskDataStore.METADATA_DATA_SUFFIX:
                         # This somewhat breaks the abstraction since we are using
                         # load_bytes directly instead of load_metadata
-                        with open(path, "rb") as f:
-                            if sys.version_info < (3, 6):
-                                f = f.decode("utf-8")
+                        with open(path, encoding="utf-8") as f:
                             data_objs[(run, step, task, attempt)] = json.load(f)
         # We now figure out the latest attempt that started *and* finished.
         # Note that if an attempt started but didn't finish, we do *NOT* return

--- a/metaflow/datastore/flow_datastore.py
+++ b/metaflow/datastore/flow_datastore.py
@@ -1,5 +1,6 @@
 import itertools
 import json
+import sys
 
 from .. import metaflow_config
 
@@ -159,6 +160,8 @@ class FlowDataStore(object):
                         # This somewhat breaks the abstraction since we are using
                         # load_bytes directly instead of load_metadata
                         with open(path, "rb") as f:
+                            if sys.version_info < (3, 6):
+                                f = f.decode("utf-8")
                             data_objs[(run, step, task, attempt)] = json.load(f)
         # We now figure out the latest attempt that started *and* finished.
         # Note that if an attempt started but didn't finish, we do *NOT* return

--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -489,14 +489,13 @@ class TaskDataStore(object):
         Dict: string -> JSON decoded object
             Results indexed by the name of the metadata loaded
         """
-        ret_dict = {}
-        for k, v in self._load_file(names, add_attempt).items():
-            if sys.version_info < (3, 6):
-                value = v.decode("utf-8")
-            else:
-                value = v
-            ret_dict[k] = json.loads(value) if v is not None else None
-        return ret_dict
+        transformer = lambda x: x
+        if sys.version_info < (3, 6):
+            transformer = lambda x: x.decode("utf-8")
+        return {
+            k: json.loads(transformer(v)) if v is not None else None
+            for k, v in self._load_file(names, add_attempt).items()
+        }
 
     @require_mode(None)
     def has_metadata(self, name, add_attempt=True):

--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -489,10 +489,14 @@ class TaskDataStore(object):
         Dict: string -> JSON decoded object
             Results indexed by the name of the metadata loaded
         """
-        return {
-            k: json.loads(v) if v is not None else None
-            for k, v in self._load_file(names, add_attempt).items()
-        }
+        ret_dict = {}
+        for k, v in self._load_file(names, add_attempt).items():
+            if sys.version_info < (3, 6):
+                value = v.decode("utf-8")
+            else:
+                value = v
+            ret_dict[k] = json.loads(value) if v is not None else None
+        return ret_dict
 
     @require_mode(None)
     def has_metadata(self, name, add_attempt=True):

--- a/test/core/run_tests.py
+++ b/test/core/run_tests.py
@@ -102,8 +102,8 @@ def run_test(formatter, context, debug, checks, env_base):
         pythonpath = os.environ.get("PYTHONPATH", ".")
         env.update(
             {
-                "LANG": "C.UTF-8",
-                "LC_ALL": "C.UTF-8",
+                "LANG": "en_US.UTF-8",
+                "LC_ALL": "en_US.UTF-8",
                 "PATH": os.environ.get("PATH", "."),
                 "PYTHONIOENCODING": "utf_8",
                 "PYTHONPATH": "%s:%s" % (package, pythonpath),

--- a/test/core/run_tests.py
+++ b/test/core/run_tests.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 from multiprocessing import Pool
 
-from metaflow._vendor import click
+import click
 
 from metaflow_test import MetaflowTest
 from metaflow_test.formatter import FlowFormatter
@@ -61,7 +61,12 @@ def log(msg, formatter=None, context=None, real_bad=False, real_good=False):
     click.echo("[pid %s] %s" % (pid, line))
 
 
-def run_test(formatter, context, debug, checks, env_base):
+def copy_coverage_files(dstdir):
+    for fname in glob.glob(".coverage.*"):
+        shutil.copy(fname, dstdir)
+
+
+def run_test(formatter, context, coverage_dir, debug, checks, env_base):
     def run_cmd(mode):
         cmd = [context["python"], "-B", "test_flow.py"]
         cmd.extend(context["top_options"])
@@ -79,6 +84,8 @@ def run_test(formatter, context, debug, checks, env_base):
             f.write(formatter.flow_code)
         with open("check_flow.py", "w") as f:
             f.write(formatter.check_code)
+        with open(".coveragerc", "w") as f:
+            f.write("[run]\ndisable_warnings = module-not-measured\n")
 
         shutil.copytree(
             os.path.join(cwd, "metaflow_test"), os.path.join(tempdir, "metaflow_test")
@@ -102,8 +109,8 @@ def run_test(formatter, context, debug, checks, env_base):
         pythonpath = os.environ.get("PYTHONPATH", ".")
         env.update(
             {
-                "LANG": "C.UTF-8",
-                "LC_ALL": "C.UTF-8",
+                "LANG": "en_US.UTF-8",
+                "LC_ALL": "en_US.UTF-8",
                 "PATH": os.environ.get("PATH", "."),
                 "PYTHONIOENCODING": "utf_8",
                 "PYTHONPATH": "%s:%s" % (package, pythonpath),
@@ -160,6 +167,9 @@ def run_test(formatter, context, debug, checks, env_base):
                     context,
                 )
 
+        # copy coverage files
+        if coverage_dir:
+            copy_coverage_files(coverage_dir)
         return ret, path
     finally:
         os.chdir(cwd)
@@ -167,7 +177,9 @@ def run_test(formatter, context, debug, checks, env_base):
             shutil.rmtree(tempdir)
 
 
-def run_all(ok_tests, ok_contexts, ok_graphs, debug, num_parallel, inherit_env):
+def run_all(
+    ok_tests, ok_contexts, ok_graphs, coverage_dir, debug, num_parallel, inherit_env
+):
 
     tests = [
         test
@@ -184,17 +196,22 @@ def run_all(ok_tests, ok_contexts, ok_graphs, debug, num_parallel, inherit_env):
     if debug or num_parallel is None:
         for test in tests:
             failed.extend(
-                run_test_cases((test, ok_contexts, ok_graphs, debug, base_env))
+                run_test_cases(
+                    (test, ok_contexts, ok_graphs, coverage_dir, debug, base_env)
+                )
             )
     else:
-        args = [(test, ok_contexts, ok_graphs, debug, base_env) for test in tests]
+        args = [
+            (test, ok_contexts, ok_graphs, coverage_dir, debug, base_env)
+            for test in tests
+        ]
         for fail in Pool(num_parallel).imap_unordered(run_test_cases, args):
             failed.extend(fail)
     return failed
 
 
 def run_test_cases(args):
-    test, ok_contexts, ok_graphs, debug, base_env = args
+    test, ok_contexts, ok_graphs, coverage_dir, debug, base_env = args
     contexts = json.load(open("contexts.json"))
     graphs = list(iter_graphs())
     test_name = test.__class__.__name__
@@ -229,6 +246,7 @@ def run_test_cases(args):
                 ret, path = run_test(
                     formatter,
                     context,
+                    coverage_dir,
                     debug,
                     contexts["checks"],
                     base_env,
@@ -245,6 +263,24 @@ def run_test_cases(args):
         else:
             log("not a valid combination. Skipped.", formatter)
     return failed
+
+
+def produce_coverage_report(coverage_dir, coverage_output):
+    COVERAGE = sys.executable + " -m coverage "
+    cwd = os.getcwd()
+    try:
+        os.chdir(coverage_dir)
+        if os.listdir("."):
+            subprocess.check_call(COVERAGE + "combine .coverage*", shell=True)
+            subprocess.check_call(
+                COVERAGE + "xml -o %s.xml" % coverage_output, shell=True
+            )
+            subprocess.check_call(COVERAGE + "html -d %s" % coverage_output, shell=True)
+            log("Coverage report written to %s" % coverage_output, real_good=True)
+        else:
+            log("No coverage data was produced", real_bad=True)
+    finally:
+        os.chdir(cwd)
 
 
 @click.command(help="Run tests")
@@ -267,6 +303,13 @@ def run_test_cases(args):
     help="A comma-separate list of graphs to include (default: all).",
 )
 @click.option(
+    "--coverage-output",
+    default=None,
+    type=str,
+    show_default=True,
+    help="Output prefix for the coverage reports (default: None)",
+)
+@click.option(
     "--debug",
     is_flag=True,
     default=False,
@@ -286,33 +329,44 @@ def cli(
     tests=None,
     contexts=None,
     graphs=None,
+    coverage_output=None,
     num_parallel=None,
     debug=False,
     inherit_env=False,
 ):
 
     parse = lambda x: {t.lower() for t in x.split(",") if t}
-
-    failed = run_all(
-        parse(tests),
-        parse(contexts),
-        parse(graphs),
-        debug,
-        num_parallel,
-        inherit_env,
+    coverage_dir = (
+        tempfile.mkdtemp("_metaflow_test_coverage") if coverage_output else None
     )
+    try:
+        failed = run_all(
+            parse(tests),
+            parse(contexts),
+            parse(graphs),
+            coverage_dir,
+            debug,
+            num_parallel,
+            inherit_env,
+        )
 
-    if failed:
-        log("The following tests failed:")
-        for fail, path in failed:
-            if debug:
-                log("%s (path %s)" % (fail, path), real_bad=True)
-            else:
-                log(fail, real_bad=True)
-        sys.exit(1)
-    else:
-        log("All tests were successful!", real_good=True)
-        sys.exit(0)
+        if coverage_output and not debug:
+            produce_coverage_report(coverage_dir, os.path.abspath(coverage_output))
+
+        if failed:
+            log("The following tests failed:")
+            for fail, path in failed:
+                if debug:
+                    log("%s (path %s)" % (fail, path), real_bad=True)
+                else:
+                    log(fail, real_bad=True)
+            sys.exit(1)
+        else:
+            log("All tests were successful!", real_good=True)
+            sys.exit(0)
+    finally:
+        if coverage_dir:
+            shutil.rmtree(coverage_dir)
 
 
 if __name__ == "__main__":

--- a/test/core/run_tests.py
+++ b/test/core/run_tests.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 from multiprocessing import Pool
 
-import click
+from metaflow._vendor import click
 
 from metaflow_test import MetaflowTest
 from metaflow_test.formatter import FlowFormatter
@@ -61,12 +61,7 @@ def log(msg, formatter=None, context=None, real_bad=False, real_good=False):
     click.echo("[pid %s] %s" % (pid, line))
 
 
-def copy_coverage_files(dstdir):
-    for fname in glob.glob(".coverage.*"):
-        shutil.copy(fname, dstdir)
-
-
-def run_test(formatter, context, coverage_dir, debug, checks, env_base):
+def run_test(formatter, context, debug, checks, env_base):
     def run_cmd(mode):
         cmd = [context["python"], "-B", "test_flow.py"]
         cmd.extend(context["top_options"])
@@ -84,8 +79,6 @@ def run_test(formatter, context, coverage_dir, debug, checks, env_base):
             f.write(formatter.flow_code)
         with open("check_flow.py", "w") as f:
             f.write(formatter.check_code)
-        with open(".coveragerc", "w") as f:
-            f.write("[run]\ndisable_warnings = module-not-measured\n")
 
         shutil.copytree(
             os.path.join(cwd, "metaflow_test"), os.path.join(tempdir, "metaflow_test")
@@ -109,8 +102,8 @@ def run_test(formatter, context, coverage_dir, debug, checks, env_base):
         pythonpath = os.environ.get("PYTHONPATH", ".")
         env.update(
             {
-                "LANG": "en_US.UTF-8",
-                "LC_ALL": "en_US.UTF-8",
+                "LANG": "C.UTF-8",
+                "LC_ALL": "C.UTF-8",
                 "PATH": os.environ.get("PATH", "."),
                 "PYTHONIOENCODING": "utf_8",
                 "PYTHONPATH": "%s:%s" % (package, pythonpath),
@@ -167,9 +160,6 @@ def run_test(formatter, context, coverage_dir, debug, checks, env_base):
                     context,
                 )
 
-        # copy coverage files
-        if coverage_dir:
-            copy_coverage_files(coverage_dir)
         return ret, path
     finally:
         os.chdir(cwd)
@@ -177,9 +167,7 @@ def run_test(formatter, context, coverage_dir, debug, checks, env_base):
             shutil.rmtree(tempdir)
 
 
-def run_all(
-    ok_tests, ok_contexts, ok_graphs, coverage_dir, debug, num_parallel, inherit_env
-):
+def run_all(ok_tests, ok_contexts, ok_graphs, debug, num_parallel, inherit_env):
 
     tests = [
         test
@@ -196,22 +184,17 @@ def run_all(
     if debug or num_parallel is None:
         for test in tests:
             failed.extend(
-                run_test_cases(
-                    (test, ok_contexts, ok_graphs, coverage_dir, debug, base_env)
-                )
+                run_test_cases((test, ok_contexts, ok_graphs, debug, base_env))
             )
     else:
-        args = [
-            (test, ok_contexts, ok_graphs, coverage_dir, debug, base_env)
-            for test in tests
-        ]
+        args = [(test, ok_contexts, ok_graphs, debug, base_env) for test in tests]
         for fail in Pool(num_parallel).imap_unordered(run_test_cases, args):
             failed.extend(fail)
     return failed
 
 
 def run_test_cases(args):
-    test, ok_contexts, ok_graphs, coverage_dir, debug, base_env = args
+    test, ok_contexts, ok_graphs, debug, base_env = args
     contexts = json.load(open("contexts.json"))
     graphs = list(iter_graphs())
     test_name = test.__class__.__name__
@@ -246,7 +229,6 @@ def run_test_cases(args):
                 ret, path = run_test(
                     formatter,
                     context,
-                    coverage_dir,
                     debug,
                     contexts["checks"],
                     base_env,
@@ -263,24 +245,6 @@ def run_test_cases(args):
         else:
             log("not a valid combination. Skipped.", formatter)
     return failed
-
-
-def produce_coverage_report(coverage_dir, coverage_output):
-    COVERAGE = sys.executable + " -m coverage "
-    cwd = os.getcwd()
-    try:
-        os.chdir(coverage_dir)
-        if os.listdir("."):
-            subprocess.check_call(COVERAGE + "combine .coverage*", shell=True)
-            subprocess.check_call(
-                COVERAGE + "xml -o %s.xml" % coverage_output, shell=True
-            )
-            subprocess.check_call(COVERAGE + "html -d %s" % coverage_output, shell=True)
-            log("Coverage report written to %s" % coverage_output, real_good=True)
-        else:
-            log("No coverage data was produced", real_bad=True)
-    finally:
-        os.chdir(cwd)
 
 
 @click.command(help="Run tests")
@@ -303,13 +267,6 @@ def produce_coverage_report(coverage_dir, coverage_output):
     help="A comma-separate list of graphs to include (default: all).",
 )
 @click.option(
-    "--coverage-output",
-    default=None,
-    type=str,
-    show_default=True,
-    help="Output prefix for the coverage reports (default: None)",
-)
-@click.option(
     "--debug",
     is_flag=True,
     default=False,
@@ -329,44 +286,33 @@ def cli(
     tests=None,
     contexts=None,
     graphs=None,
-    coverage_output=None,
     num_parallel=None,
     debug=False,
     inherit_env=False,
 ):
 
     parse = lambda x: {t.lower() for t in x.split(",") if t}
-    coverage_dir = (
-        tempfile.mkdtemp("_metaflow_test_coverage") if coverage_output else None
+
+    failed = run_all(
+        parse(tests),
+        parse(contexts),
+        parse(graphs),
+        debug,
+        num_parallel,
+        inherit_env,
     )
-    try:
-        failed = run_all(
-            parse(tests),
-            parse(contexts),
-            parse(graphs),
-            coverage_dir,
-            debug,
-            num_parallel,
-            inherit_env,
-        )
 
-        if coverage_output and not debug:
-            produce_coverage_report(coverage_dir, os.path.abspath(coverage_output))
-
-        if failed:
-            log("The following tests failed:")
-            for fail, path in failed:
-                if debug:
-                    log("%s (path %s)" % (fail, path), real_bad=True)
-                else:
-                    log(fail, real_bad=True)
-            sys.exit(1)
-        else:
-            log("All tests were successful!", real_good=True)
-            sys.exit(0)
-    finally:
-        if coverage_dir:
-            shutil.rmtree(coverage_dir)
+    if failed:
+        log("The following tests failed:")
+        for fail, path in failed:
+            if debug:
+                log("%s (path %s)" % (fail, path), real_bad=True)
+            else:
+                log(fail, real_bad=True)
+        sys.exit(1)
+    else:
+        log("All tests were successful!", real_good=True)
+        sys.exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Changes 
- Ported changes to GH action tests from #940 
- Python3.5 is not playing nice with bytes-based JSON loading. Throws an error like [TypeError: the JSON object must be str, not 'bytes'](https://stackoverflow.com/questions/42683478/typeerror-the-json-object-must-be-str-not-bytes). This error doesn't persist in py3.6+. This resulted in minor changes to the way we read task metadata in task_datastore.py and flow_datastore.py
- The tests in the `publish.yml` are refactored to come from `test.yml`. We reuse the jobs in the Test gh action. Workflows being reused need to have [on.workflow_call](https://docs.github.com/en/actions/using-workflows/reusing-workflows#example-reusable-workflow). This helps reuse [it locally](https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/). 
