### PR TITLE
Pass the paths used by the external interpreter to the one launching …

### DIFF
--- a/metaflow/extension_support.py
+++ b/metaflow/extension_support.py
@@ -216,7 +216,7 @@ def _get_extension_packages():
             # error if there is a transitive import error)
             if not (isinstance(e, ModuleNotFoundError) and e.name == EXT_PKG):
                 raise
-            return [], {}
+            return {}, {}
 
     # At this point, we look at all the paths and create a set. As we find distributions
     # that match it, we will remove from the set and then will be left with any

--- a/metaflow/plugins/env_escape/client.py
+++ b/metaflow/plugins/env_escape/client.py
@@ -41,7 +41,7 @@ BIND_RETRY = 0
 
 
 class Client(object):
-    def __init__(self, python_path, max_pickle_version, config_dir):
+    def __init__(self, python_executable, pythonpath, max_pickle_version, config_dir):
         # Make sure to init these variables (used in __del__) early on in case we
         # have an exception
         self._poller = None
@@ -58,10 +58,10 @@ class Client(object):
         if os.path.exists(self._socket_path):
             raise RuntimeError("Existing socket: %s" % self._socket_path)
         env = os.environ.copy()
-        # env["PYTHONPATH"] = ":".join(sys.path)
+        env["PYTHONPATH"] = pythonpath
         self._server_process = Popen(
             [
-                python_path,
+                python_executable,
                 "-u",
                 "-m",
                 server_module,

--- a/metaflow/plugins/env_escape/client_modules.py
+++ b/metaflow/plugins/env_escape/client_modules.py
@@ -107,9 +107,17 @@ class _WrappedModule(object):
 
 class ModuleImporter(object):
     # This ModuleImporter implements the Importer Protocol defined in PEP 302
-    def __init__(self, python_path, max_pickle_version, config_dir, module_prefixes):
+    def __init__(
+        self,
+        python_executable,
+        pythonpath,
+        max_pickle_version,
+        config_dir,
+        module_prefixes,
+    ):
         self._module_prefixes = module_prefixes
-        self._python_path = python_path
+        self._python_executable = python_executable
+        self._pythonpath = pythonpath
         self._config_dir = config_dir
         self._client = None
         self._max_pickle_version = max_pickle_version
@@ -142,7 +150,10 @@ class ModuleImporter(object):
             max_pickle_version = min(self._max_pickle_version, pickle.HIGHEST_PROTOCOL)
 
             self._client = Client(
-                self._python_path, max_pickle_version, self._config_dir
+                self._python_executable,
+                self._pythonpath,
+                max_pickle_version,
+                self._config_dir,
             )
             atexit.register(_clean_client, self._client)
 
@@ -241,7 +252,7 @@ class ModuleImporter(object):
         return name
 
 
-def create_modules(python_path, max_pickle_version, path, prefixes):
+def create_modules(python_executable, pythonpath, max_pickle_version, path, prefixes):
     # This is a extra verification to make sure we are not trying to use the
     # environment escape for something that is in the system
     for prefix in prefixes:
@@ -262,5 +273,7 @@ def create_modules(python_path, max_pickle_version, path, prefixes):
 
     # sys.meta_path.insert(0, ModuleImporter(python_path, path, prefixes))
     sys.meta_path.append(
-        ModuleImporter(python_path, max_pickle_version, path, prefixes)
+        ModuleImporter(
+            python_executable, pythonpath, max_pickle_version, path, prefixes
+        )
     )


### PR DESCRIPTION
…the Env Escape server

We were currently not reflecting possible values passed using PYTHONPATH or
programmatically added to the interpreter launching the environment escape server.