### PR TITLE
Kubernetes entrypoint s3 override

### DIFF
--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -92,7 +92,7 @@ class MetaflowEnvironment(object):
             "%s -m awscli %s s3 cp %s job.tar >/dev/null && \
                         mflog 'Code package downloaded.' && break; "
             "sleep 10; i=$((i+1)); "
-            "done" % (self._python(),"--url-endpoint "+s3_endpoint_url if s3_endpoint_url is not None else "" , code_package_url),
+            "done" % (self._python(),"--endpoint-url "+s3_endpoint_url if s3_endpoint_url is not None else "" , code_package_url),
             "if [ $i -gt 5 ]; then "
             "mflog 'Failed to download code package from %s "
             "after 6 tries. Exiting...' && exit 1; "

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -89,7 +89,7 @@ class MetaflowEnvironment(object):
             "mkdir .metaflow",  # mute local datastore creation log
             "i=0; while [ $i -le 5 ]; do "
             "mflog 'Downloading code package...'; "
-            "%s -m awscli %s s3 cp %s job.tar >/dev/null && \
+            "%s -m awscli %s s3 inject cp %s job.tar >/dev/null && \
                         mflog 'Code package downloaded.' && break; "
             "sleep 10; i=$((i+1)); "
             "done" % (self._python(),"--url-endpoint "+s3_endpoint_url if s3_endpoint_url is not None else "" , code_package_url),

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -92,7 +92,14 @@ class MetaflowEnvironment(object):
             "%s -m awscli %s s3 cp %s job.tar >/dev/null && \
                         mflog 'Code package downloaded.' && break; "
             "sleep 10; i=$((i+1)); "
-            "done" % (self._python(),"--endpoint-url "+s3_endpoint_url if s3_endpoint_url is not None else "" , code_package_url),
+            "done"
+            % (
+                self._python(),
+                "--endpoint-url " + s3_endpoint_url
+                if s3_endpoint_url is not None
+                else "",
+                code_package_url,
+            ),
             "if [ $i -gt 5 ]; then "
             "mflog 'Failed to download code package from %s "
             "after 6 tries. Exiting...' && exit 1; "

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -89,7 +89,7 @@ class MetaflowEnvironment(object):
             "mkdir .metaflow",  # mute local datastore creation log
             "i=0; while [ $i -le 5 ]; do "
             "mflog 'Downloading code package...'; "
-            "%s -m awscli %s s3 inject cp %s job.tar >/dev/null && \
+            "%s -m awscli %s s3 cp %s job.tar >/dev/null && \
                         mflog 'Code package downloaded.' && break; "
             "sleep 10; i=$((i+1)); "
             "done" % (self._python(),"--url-endpoint "+s3_endpoint_url if s3_endpoint_url is not None else "" , code_package_url),

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -79,7 +79,7 @@ class MetaflowEnvironment(object):
         """
         return "Local environment"
 
-    def get_package_commands(self, code_package_url):
+    def get_package_commands(self, code_package_url, s3_endpoint_url):
         cmds = [
             BASH_MFLOG,
             "mflog 'Setting up task environment.'",
@@ -89,10 +89,10 @@ class MetaflowEnvironment(object):
             "mkdir .metaflow",  # mute local datastore creation log
             "i=0; while [ $i -le 5 ]; do "
             "mflog 'Downloading code package...'; "
-            "%s -m awscli s3 cp %s job.tar >/dev/null && \
+            "%s -m awscli %s s3 cp %s job.tar >/dev/null && \
                         mflog 'Code package downloaded.' && break; "
             "sleep 10; i=$((i+1)); "
-            "done" % (self._python(), code_package_url),
+            "done" % (self._python(),"--url-endpoint "+s3_endpoint_url if s3_endpoint_url is not None else "" , code_package_url),
             "if [ $i -gt 5 ]; then "
             "mflog 'Failed to download code package from %s "
             "after 6 tries. Exiting...' && exit 1; "

--- a/metaflow/plugins/aws/eks/kubernetes.py
+++ b/metaflow/plugins/aws/eks/kubernetes.py
@@ -268,6 +268,10 @@ class Kubernetes(object):
         for name, value in env.items():
             job.environment_variable(name, value)
 
+        # add METAFLOW_S3_ENDPOINT_URL in env variable if specified for step execution
+        if S3_ENDPOINT_URL is not None:
+            job.environment_variable("METAFLOW_S3_ENDPOINT_URL", S3_ENDPOINT_URL)
+
         # Add labels to the Kubernetes job
         #
         # Apply recommended labels https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

--- a/metaflow/plugins/aws/eks/kubernetes.py
+++ b/metaflow/plugins/aws/eks/kubernetes.py
@@ -18,7 +18,7 @@ from metaflow.metaflow_config import (
     DEFAULT_METADATA,
     BATCH_METADATA_SERVICE_HEADERS,
     DATASTORE_CARD_S3ROOT,
-    S3_ENDPOINT_URL
+    S3_ENDPOINT_URL,
 )
 from metaflow.mflog import (
     export_mflog_env_vars,
@@ -134,7 +134,9 @@ class Kubernetes(object):
             stdout_path=STDOUT_PATH,
             stderr_path=STDERR_PATH,
         )
-        init_cmds = self._environment.get_package_commands(code_package_url,S3_ENDPOINT_URL)
+        init_cmds = self._environment.get_package_commands(
+            code_package_url, S3_ENDPOINT_URL
+        )
         init_expr = " && ".join(init_cmds)
         step_expr = " && ".join(
             [

--- a/metaflow/plugins/aws/eks/kubernetes.py
+++ b/metaflow/plugins/aws/eks/kubernetes.py
@@ -268,7 +268,7 @@ class Kubernetes(object):
         for name, value in env.items():
             job.environment_variable(name, value)
 
-        # add METAFLOW_S3_ENDPOINT_URL in env variable if specified for step execution
+        # add METAFLOW_S3_ENDPOINT_URL in env variable if specified for the step execution
         if S3_ENDPOINT_URL is not None:
             job.environment_variable("METAFLOW_S3_ENDPOINT_URL", S3_ENDPOINT_URL)
 

--- a/metaflow/plugins/aws/eks/kubernetes.py
+++ b/metaflow/plugins/aws/eks/kubernetes.py
@@ -18,6 +18,7 @@ from metaflow.metaflow_config import (
     DEFAULT_METADATA,
     BATCH_METADATA_SERVICE_HEADERS,
     DATASTORE_CARD_S3ROOT,
+    S3_ENDPOINT_URL
 )
 from metaflow.mflog import (
     export_mflog_env_vars,
@@ -133,7 +134,7 @@ class Kubernetes(object):
             stdout_path=STDOUT_PATH,
             stderr_path=STDERR_PATH,
         )
-        init_cmds = self._environment.get_package_commands(code_package_url)
+        init_cmds = self._environment.get_package_commands(code_package_url,S3_ENDPOINT_URL)
         init_expr = " && ".join(init_cmds)
         step_expr = " && ".join(
             [


### PR DESCRIPTION
allow override of entrypoint kubernetes job when METAFLOW_S3_ENDPOINT_URL is set in conf.
Test on a minio.
Not test on aws and @kubernetes need s3 datastore.
Read it carefully but not a lot of code