### PR TITLE
Fixing some hacky plumbing in card test suite

### DIFF
--- a/test/core/tests/card_default_editable.py
+++ b/test/core/tests/card_default_editable.py
@@ -91,7 +91,7 @@ class MyNativeType:
                         step.name,
                         task_id,
                         card_type,
-                        "%d\n" % number,
+                        "%d" % number,
                         card_hash=card["hash"],
                         exact_match=True,
                     )

--- a/test/core/tests/card_default_editable_customize.py
+++ b/test/core/tests/card_default_editable_customize.py
@@ -58,7 +58,7 @@ class DefaultEditableCardWithCustomizeTest(MetaflowTest):
                         step.name,
                         task_id,
                         card_type,
-                        "%d\n" % number,
+                        "%d" % number,
                         card_hash=card["hash"],
                         exact_match=True,
                     )

--- a/test/core/tests/card_default_editable_with_id.py
+++ b/test/core/tests/card_default_editable_with_id.py
@@ -66,7 +66,7 @@ class DefaultEditableCardWithIdTest(MetaflowTest):
                         step.name,
                         task_id,
                         "test_editable_card",
-                        "%d\n" % number,
+                        "%d" % number,
                         card_hash=card["hash"],
                         exact_match=True,
                     )

--- a/test/core/tests/card_id_append.py
+++ b/test/core/tests/card_id_append.py
@@ -59,7 +59,7 @@ class CardsWithIdTest(MetaflowTest):
                         "test_editable_card"
                         if step.name == "start"
                         else "test_non_editable_card",
-                        "%d\n" % number,
+                        "%d" % number,
                         card_id="abc",
                         exact_match=True,
                     )

--- a/test/core/tests/card_import.py
+++ b/test/core/tests/card_import.py
@@ -64,7 +64,7 @@ class CardImportTest(MetaflowTest):
                         step.name,
                         task_id,
                         impc_ne["type"],
-                        "%s\n" % cards_info["pathspec"],
+                        "%s" % cards_info["pathspec"],
                         card_hash=impc_ne["hash"],
                         exact_match=True,
                     )
@@ -72,7 +72,7 @@ class CardImportTest(MetaflowTest):
                         step.name,
                         task_id,
                         impc_e["type"],
-                        "%d\n" % random_number,
+                        "%d" % random_number,
                         card_hash=impc_e["hash"],
                         exact_match=True,
                     )

--- a/test/core/tests/card_resume.py
+++ b/test/core/tests/card_resume.py
@@ -45,5 +45,5 @@ class CardResumeTest(MetaflowTest):
                         step.name,
                         task_id,
                         "taskspec_card",
-                        "%s\n" % cli_check_dict[task_pathspec]["origin_pathspec"],
+                        "%s" % cli_check_dict[task_pathspec]["origin_pathspec"],
                     )

--- a/test/core/tests/card_simple.py
+++ b/test/core/tests/card_simple.py
@@ -51,7 +51,7 @@ class CardDecoratorBasicTest(MetaflowTest):
                         step.name,
                         task_id,
                         "taskspec_card",
-                        "%s\n" % taskpathspec_artifact,
+                        "%s" % taskpathspec_artifact,
                     )
         else:
             # This means MetadataCheck is in context.


### PR DESCRIPTION
## Purpose
This PR helps resolve some hacky code added to the card test suite where we checked stdout to validate if a command threw a specific error. This was a brittle solution. Patching for something that is more conventional. By explicitly piping errors from stderr. 

## Changes 
- Added `--file` arg to `card list` cli
- Using files to get the information written by cli
- changes to test to use files instead of stdout
- Piping std errors to stderr to capture card not found errors.