### PR TITLE
Allow specifying parameters when calling `step-functions create`

### DIFF
--- a/metaflow/plugins/aws/step_functions/event_bridge_client.py
+++ b/metaflow/plugins/aws/step_functions/event_bridge_client.py
@@ -24,12 +24,12 @@ class EventBridgeClient(object):
         self.state_machine_arn = state_machine_arn
         return self
 
-    def schedule(self):
+    def schedule(self, params={}):
         if not self.cron:
             # reset the schedule
             self._disable()
         else:
-            self._set()
+            self._set(params)
         return self.name
 
     def _disable(self):
@@ -38,7 +38,7 @@ class EventBridgeClient(object):
         except self._client.exceptions.ResourceNotFoundException:
             pass
 
-    def _set(self):
+    def _set(self, params={}):
         # Generate a new rule or update existing rule.
         self._client.put_rule(
             Name=self.name,
@@ -54,7 +54,7 @@ class EventBridgeClient(object):
                     "Id": self.name,
                     "Arn": self.state_machine_arn,
                     # Set input parameters to empty.
-                    "Input": json.dumps({"Parameters": json.dumps({})}),
+                    "Input": json.dumps({"Parameters": json.dumps(params)}),
                     "RoleArn": self.role_arn,
                 }
             ],

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -131,7 +131,7 @@ class StepFunctions(object):
         except Exception as e:
             raise StepFunctionsException(repr(e))
 
-    def schedule(self):
+    def schedule(self, params={}):
         # Scheduling is currently enabled via AWS Event Bridge.
         if EVENTS_SFN_ACCESS_IAM_ROLE is None:
             raise StepFunctionsSchedulingException(
@@ -153,7 +153,7 @@ class StepFunctions(object):
                 .cron(self._cron)
                 .role_arn(EVENTS_SFN_ACCESS_IAM_ROLE)
                 .state_machine_arn(self._state_machine_arn)
-                .schedule()
+                .schedule(params)
             )
         except Exception as e:
             raise StepFunctionsSchedulingException(repr(e))

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -178,7 +178,7 @@ def create(
 
     params = {
         param.name: _convert_value(param)
-        for _, param in flow._get_parameters()
+        for _, param in obj.flow._get_parameters()
         if kwargs.get(param.name.replace("-", "_").lower()) is not None
     }
 


### PR DESCRIPTION
Currently `step-functions trigger` allows specifying parameters to invoke the step function, but not `step-functions create` (the default set of parameters is `{}`). This PR allows specifying parameters when calling `step-functions create`, similar to how `step-functions trigger` does it.

PS: I actually just copied the code from the `trigger` function.