### PR TITLE
Inject secrets from AWS Secrets Manager into AWS Batch job

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -182,6 +182,7 @@ class Batch(object):
         attrs={},
         host_volumes=None,
         num_parallel=0,
+        secrets=None,
     ):
         job_name = self._job_name(
             attrs.get("metaflow.user"),
@@ -285,6 +286,7 @@ class Batch(object):
         swappiness=None,
         host_volumes=None,
         num_parallel=0,
+        secrets=None,
         env={},
         attrs={},
     ):
@@ -317,6 +319,7 @@ class Batch(object):
             attrs=attrs,
             host_volumes=host_volumes,
             num_parallel=num_parallel,
+            secrets=secrets,
         )
         self.num_parallel = num_parallel
         self.job = job.execute()

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -214,6 +214,7 @@ class Batch(object):
                 swappiness,
                 host_volumes=host_volumes,
                 num_parallel=num_parallel,
+                secrets=secrets,
             )
             .cpu(cpu)
             .gpu(gpu)

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -149,6 +149,12 @@ def kill(ctx, run_id, user, my_runs):
     type=int,
     help="Number of parallel nodes to run as a multi-node job.",
 )
+@click.option(
+    "--secrets",
+    multiple=True,
+    default=None,
+    help="Secrets for AWS Batch job"
+)
 @click.pass_context
 def step(
     ctx,
@@ -169,6 +175,7 @@ def step(
     swappiness=None,
     host_volumes=None,
     num_parallel=None,
+    secrets=None,
     **kwargs
 ):
     def echo(msg, stream="stderr", batch_id=None):
@@ -294,6 +301,7 @@ def step(
                 attrs=attrs,
                 host_volumes=host_volumes,
                 num_parallel=num_parallel,
+                secrets=secrets,
             )
     except Exception as e:
         traceback.print_exc()

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -6,7 +6,7 @@ import traceback
 
 from distutils.dir_util import copy_tree
 
-from metaflow import util
+from metaflow import JSONType, util
 from metaflow import R
 from metaflow.exception import CommandException, METAFLOW_EXIT_DISALLOW_RETRY
 from metaflow.metadata.util import sync_local_metadata_from_datastore
@@ -151,9 +151,9 @@ def kill(ctx, run_id, user, my_runs):
 )
 @click.option(
     "--secrets",
-    multiple=True,
+    type=JSONType,
     default=None,
-    help="Secrets for AWS Batch job"
+    help="Secrets to inject into AWS Batch job",
 )
 @click.pass_context
 def step(

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -263,20 +263,11 @@ class BatchJob(object):
                 )
 
         if secrets:
-            job_definition["containerProperties"]["secrets"] = []
-            if isinstance(secrets, str):
-                secrets = [secrets]
-            for secret in secrets:
-                delimiter = ","
-                if delimiter not in secret:
-                    raise ValueError(
-                        "Secrets should be of the format `environment_key_name,value_from`\n"
-                        "got %s" % secret
-                    )
-                name, value_from = secret.split(delimiter)
-                job_definition["containerProperties"]["secrets"].append(
-                    {"name": name, "valueFrom": value_from}
-                )
+            if not isinstance(secrets, dict):
+                raise TypeError(secrets)
+            job_definition["containerProperties"]["secrets"] = [
+                {"name": k, "valueFrom": v} for k, v in secrets.items()
+            ]
 
         # This block must be last evaluated to account for all updates to `containerProperties`
         self.num_parallel = num_parallel or 0

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -150,6 +150,7 @@ class BatchJob(object):
         swappiness,
         host_volumes,
         num_parallel,
+        secrets,
     ):
         # identify platform from any compute environment associated with the
         # queue
@@ -261,6 +262,17 @@ class BatchJob(object):
                     {"sourceVolume": name, "containerPath": host_path}
                 )
 
+        if secrets:
+            job_definition["containerProperties"]["secrets"] = []
+            if isinstance(secrets, str):
+                secrets = [secrets]
+            for secret in secrets:
+                name, value_from = secret.split("=")
+                job_definition["containerProperties"]["secrets"].append(
+                    {"name": name, "valueFrom": value_from}
+                )
+
+        # This block must be last evaluated to account for all updates to `containerProperties`
         self.num_parallel = num_parallel or 0
         if self.num_parallel >= 1:
             job_definition["type"] = "multinode"
@@ -323,6 +335,7 @@ class BatchJob(object):
         swappiness,
         host_volumes,
         num_parallel,
+        secrets,
     ):
         self.payload["jobDefinition"] = self._register_job_definition(
             image,
@@ -334,6 +347,7 @@ class BatchJob(object):
             swappiness,
             host_volumes,
             num_parallel,
+            secrets,
         )
         return self
 

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -267,7 +267,13 @@ class BatchJob(object):
             if isinstance(secrets, str):
                 secrets = [secrets]
             for secret in secrets:
-                name, value_from = secret.split("=")
+                delimiter = ","
+                if delimiter not in secret:
+                    raise ValueError(
+                        "Secrets should be of the format `environment_key_name,value_from`\n"
+                        "got %s" % secret
+                    )
+                name, value_from = secret.split(delimiter)
                 job_definition["containerProperties"]["secrets"].append(
                     {"name": name, "valueFrom": value_from}
                 )

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -83,6 +83,9 @@ class BatchDecorator(StepDecorator):
         A swappiness value of 0 causes swapping not to happen unless absolutely
         necessary. A swappiness value of 100 causes pages to be swapped very
         aggressively. Accepted values are whole numbers between 0 and 100.
+    secrets : string
+        Inject secrets from AWS Secrets Manager into an AWS Batch job
+        "environment_variable_name=arn:aws::secret"
     """
 
     name = "batch"
@@ -98,6 +101,7 @@ class BatchDecorator(StepDecorator):
         "max_swap": None,
         "swappiness": None,
         "host_volumes": None,
+        "secrets": None,
     }
     resource_defaults = {
         "cpu": "1",

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -83,10 +83,10 @@ class BatchDecorator(StepDecorator):
         A swappiness value of 0 causes swapping not to happen unless absolutely
         necessary. A swappiness value of 100 causes pages to be swapped very
         aggressively. Accepted values are whole numbers between 0 and 100.
-    secrets : string
-        Inject secrets from AWS Secrets Manager into an AWS Batch job.
-        Secret should be formatted as "environment_variable_name,arn:aws:secretsmanager:region:aws_account_id:secret:secret_name"
-        See https://docs.aws.amazon.com/batch/latest/userguide/specifying-sensitive-data-secrets.html
+    secrets : dict
+        Inject secrets from AWS Secrets Manager into an AWS Batch job as environment variables.
+        Secrets should be a dictionary where the key is the environment variable name and the value is an AWS Secrets Manager Resource ARN
+        See the AWS documentation for more information: https://docs.aws.amazon.com/batch/latest/userguide/specifying-sensitive-data-secrets.html
     """
 
     name = "batch"

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -84,8 +84,9 @@ class BatchDecorator(StepDecorator):
         necessary. A swappiness value of 100 causes pages to be swapped very
         aggressively. Accepted values are whole numbers between 0 and 100.
     secrets : string
-        Inject secrets from AWS Secrets Manager into an AWS Batch job
-        "environment_variable_name=arn:aws::secret"
+        Inject secrets from AWS Secrets Manager into an AWS Batch job.
+        Secret should be formatted as "environment_variable_name,arn:aws:secretsmanager:region:aws_account_id:secret:secret_name"
+        See https://docs.aws.amazon.com/batch/latest/userguide/specifying-sensitive-data-secrets.html
     """
 
     name = "batch"

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -675,6 +675,7 @@ class StepFunctions(object):
                 env=env,
                 attrs=attrs,
                 host_volumes=resources["host_volumes"],
+                secrets=resources["secrets"],
             )
             .attempts(total_retries + 1)
         )


### PR DESCRIPTION
Resolves https://github.com/Netflix/metaflow/issues/814

## Feature Overview

[AWS Batch allows for the injection of secrets into jobs](https://docs.aws.amazon.com/batch/latest/userguide/specifying-sensitive-data-secrets.html) by pulling them from AWS Secrets Manager and exposing them as environment variables.

Users would need to provide an environment variable name where the secret should be exposed and an Amazon Resource Name (ARN) of the Secrets Manager secret. They should be able to provide multiple `environment_variable:secret_arn` key pairs.

This feature should help users eliminate any code calling out to Secrets Manager directly, and instead pull a secret from an environment variable directly.
 
## Manual Integration Tests

### AWS Batch

```
python main.py --no-pylint run --with batch:secrets='{"SNOWFLAKE_USER": "arn:aws:secretsmanager:region:123:secret:MyFlow-abc:SNOWFLAKE_USER::", "SNOWFLAKE_PASSWORD": "arn:aws:secretsmanager:region:123:secret:MyFlow-abc:SNOWFLAKE_PASSWORD::"}'
```

✅ 

### AWS Step Functions

```
python src/main.py --no-pylint --with batch:secrets='{"SNOWFLAKE_USER": "arn:aws:secretsmanager:region:123:secret:MyFlow-abc:SNOWFLAKE_USER::", "SNOWFLAKE_PASSWORD": "arn:aws:secretsmanager:region:123:secret:MyFlow-abc:SNOWFLAKE_PASSWORD::"}' step-functions create
```

❌ 

