### PR TITLE
Add optional setting for max cpu and max memory to config

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -245,6 +245,8 @@ if AWS_SANDBOX_ENABLED:
     METADATA_SERVICE_HEADERS["x-api-key"] = AWS_SANDBOX_API_KEY
     SFN_STATE_MACHINE_PREFIX = from_conf("METAFLOW_AWS_SANDBOX_STACK_NAME")
 
+MAX_MEMORY_PER_TASK = from_conf("METAFLOW_MAX_MEMORY_PER_TASK")
+MAX_CPU_PER_TASK = from_conf("METAFLOW_MAX_CPU_PER_TASK")
 
 # MAX_ATTEMPTS is the maximum number of attempts, including the first
 # task, retries, and the final fallback task and its retries.

--- a/metaflow/plugins/aws/aws_utils.py
+++ b/metaflow/plugins/aws/aws_utils.py
@@ -1,6 +1,7 @@
 import re
 
 from metaflow.exception import MetaflowException
+from metaflow.metaflow_config import MAX_MEMORY_PER_TASK, MAX_CPU_PER_TASK
 
 
 def get_docker_registry(image_uri):
@@ -54,7 +55,7 @@ def get_docker_registry(image_uri):
     return registry
 
 
-def compute_resource_attributes(decos, compute_deco, resource_defaults):
+def compute_resource_attributes(decos, compute_deco, step_name, resource_defaults):
     """
     Compute resource values taking into account defaults, the values specified
     in the compute decorator (like @batch or @kubernetes) directly, and
@@ -100,5 +101,18 @@ def compute_resource_attributes(decos, compute_deco, resource_defaults):
     for k in resource_defaults:
         if compute_deco.attributes.get(k) is not None:
             result[k] = str(compute_deco.attributes[k] or "0")
+
+    if "cpu" in result and MAX_CPU_PER_TASK:
+        if float(result["cpu"]) > float(MAX_CPU_PER_TASK):
+            raise MetaflowException(
+                "Step %s requires %s CPU units, but you cannot use more than %s per step in this environment"
+                % (step_name, result["cpu"], MAX_CPU_PER_TASK)
+            )
+    if "memory" in result and MAX_MEMORY_PER_TASK:
+        if float(result["memory"]) > float(MAX_MEMORY_PER_TASK):
+            raise MetaflowException(
+                "Step %s requires %s CPU units, but you cannot use more than %s per step in this environment"
+                % (step_name, result["memory"], MAX_MEMORY_PER_TASK)
+            )
 
     return result

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -151,7 +151,7 @@ class BatchDecorator(StepDecorator):
         self.flow_datastore = flow_datastore
 
         self.attributes.update(
-            compute_resource_attributes(decos, self, self.resource_defaults)
+            compute_resource_attributes(decos, self, step, self.resource_defaults)
         )
 
         # Set run time limit for the AWS Batch job.

--- a/metaflow/plugins/aws/eks/kubernetes_decorator.py
+++ b/metaflow/plugins/aws/eks/kubernetes_decorator.py
@@ -129,7 +129,7 @@ class KubernetesDecorator(StepDecorator):
         self.step = step
         self.flow_datastore = flow_datastore
         self.attributes.update(
-            compute_resource_attributes(decos, self, self.resource_defaults)
+            compute_resource_attributes(decos, self, step, self.resource_defaults)
         )
 
         for deco in decos:

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -632,7 +632,7 @@ class StepFunctions(object):
         resources.update(batch_deco.attributes)
         resources.update(
             compute_resource_attributes(
-                node.decorators, batch_deco, batch_deco.resource_defaults
+                node.decorators, batch_deco, node.name, batch_deco.resource_defaults
             )
         )
         # Resolve retry strategy.

--- a/test/unit/test_compute_resource_attributes.py
+++ b/test/unit/test_compute_resource_attributes.py
@@ -8,28 +8,28 @@ MockDeco = namedtuple("MockDeco", ["name", "attributes"])
 def test_compute_resource_attributes():
 
     # use default if nothing is set
-    assert compute_resource_attributes([], MockDeco("batch", {}), {"cpu": "1"}) == {
-        "cpu": "1"
-    }
+    assert compute_resource_attributes(
+        [], MockDeco("batch", {}), "test", {"cpu": "1"}
+    ) == {"cpu": "1"}
 
     # @batch overrides default and you can use ints as attributes
     assert compute_resource_attributes(
-        [], MockDeco("batch", {"cpu": 1}), {"cpu": "2"}
+        [], MockDeco("batch", {"cpu": 1}), "test", {"cpu": "2"}
     ) == {"cpu": "1"}
 
     # Same but value set as str not int
     assert compute_resource_attributes(
-        [], MockDeco("batch", {"cpu": "1"}), {"cpu": "2"}
+        [], MockDeco("batch", {"cpu": "1"}), "test", {"cpu": "2"}
     ) == {"cpu": "1"}
 
     # same but use default memory
     assert compute_resource_attributes(
-        [], MockDeco("batch", {"cpu": "1"}), {"cpu": "2", "memory": "100"}
+        [], MockDeco("batch", {"cpu": "1"}), "test", {"cpu": "2", "memory": "100"}
     ) == {"cpu": "1", "memory": "100"}
 
     # same but cpu set via @resources
     assert compute_resource_attributes(
-        [], MockDeco("resources", {"cpu": "1"}), {"cpu": "2", "memory": "100"}
+        [], MockDeco("resources", {"cpu": "1"}), "test", {"cpu": "2", "memory": "100"}
     ) == {"cpu": "1", "memory": "100"}
 
     # take largest of @resources and @batch if both are present
@@ -37,6 +37,7 @@ def test_compute_resource_attributes():
         compute_resource_attributes(
             [MockDeco("resources", {"cpu": "2"})],
             MockDeco("batch", {"cpu": 1}),
+            "test",
             {"cpu": "3"},
         )
         == {"cpu": "2"}
@@ -48,7 +49,7 @@ def test_compute_resource_attributes_string():
 
     # if default is None, and the value is not set in @batch, the value is not included in computed attributes in the end
     assert compute_resource_attributes(
-        [], MockDeco("batch", {}), {"cpu": "1", "instance_type": None}
+        [], MockDeco("batch", {}), "test", {"cpu": "1", "instance_type": None}
     ) == {"cpu": "1"}
 
     # use string value from deco if set (default is None)
@@ -56,6 +57,7 @@ def test_compute_resource_attributes_string():
         compute_resource_attributes(
             [],
             MockDeco("batch", {"instance_type": "p3.xlarge"}),
+            "test",
             {"cpu": "1", "instance_type": None},
         )
         == {"cpu": "1", "instance_type": "p3.xlarge"}
@@ -66,6 +68,7 @@ def test_compute_resource_attributes_string():
         compute_resource_attributes(
             [],
             MockDeco("batch", {"instance_type": "p3.xlarge"}),
+            "test",
             {"cpu": "1", "instance_type": "p4.xlarge"},
         )
         == {"cpu": "1", "instance_type": "p3.xlarge"}
@@ -76,6 +79,7 @@ def test_compute_resource_attributes_string():
         compute_resource_attributes(
             [],
             MockDeco("batch", {"instance_type": None}),
+            "test",
             {"cpu": "1", "instance_type": "p4.xlarge"},
         )
         == {"cpu": "1", "instance_type": "p4.xlarge"}


### PR DESCRIPTION
There is a recurring problem with remote execution environments, where Metaflow task may request more resources that can be provisioned, and that causes task be stuck. These issues tend to be hard to debug -- for example, AWS Batch will not return an error in this case. 

Generally speaking, it is hard for Metaflow to determine _exactly_ what is maximum amount of memory or cpu that can be used at any moment, since it depends on autoscaling configuration of AWS Batch or K8S, that can be pretty complex. However, usually the person who configured the cluster can come up a decent upper bound. For example, there is no chance a task requesting 100GB of RAM will be scheduled in a cluster that only has instances with 32GB RAM.

This PR allows Metaflow config to specify that upper bound for CPU and Memory limits so that Metaflow will immediately reject tasks that request more with a nice error message. It is intended to be set by Metaflow admins, and distributed to end users as part of the config profile.