### PR TITLE
Configurable temp root when pulling artifacts from s3

### DIFF
--- a/metaflow/datastore/s3_storage.py
+++ b/metaflow/datastore/s3_storage.py
@@ -3,7 +3,7 @@ import os
 from itertools import starmap
 
 from ..datatools.s3 import S3, S3Client, S3PutObject
-from ..metaflow_config import DATASTORE_SYSROOT_S3
+from ..metaflow_config import DATASTORE_SYSROOT_S3, ARTIFACT_LOCALROOT
 from .datastore_storage import CloseAfterUse, DataStoreStorage
 
 
@@ -29,7 +29,7 @@ class S3Storage(DataStoreStorage):
     def is_file(self, paths):
         with S3(
             s3root=self.datastore_root,
-            tmproot=os.getcwd(),
+            tmproot=ARTIFACT_LOCALROOT,
             external_client=self.s3_client,
         ) as s3:
             if len(paths) > 10:
@@ -44,7 +44,7 @@ class S3Storage(DataStoreStorage):
     def info_file(self, path):
         with S3(
             s3root=self.datastore_root,
-            tmproot=os.getcwd(),
+            tmproot=ARTIFACT_LOCALROOT,
             external_client=self.s3_client,
         ) as s3:
             s3obj = s3.info(path, return_missing=True)
@@ -53,7 +53,7 @@ class S3Storage(DataStoreStorage):
     def size_file(self, path):
         with S3(
             s3root=self.datastore_root,
-            tmproot=os.getcwd(),
+            tmproot=ARTIFACT_LOCALROOT,
             external_client=self.s3_client,
         ) as s3:
             s3obj = s3.info(path, return_missing=True)
@@ -63,7 +63,7 @@ class S3Storage(DataStoreStorage):
         strip_prefix_len = len(self.datastore_root.rstrip("/")) + 1
         with S3(
             s3root=self.datastore_root,
-            tmproot=os.getcwd(),
+            tmproot=ARTIFACT_LOCALROOT,
             external_client=self.s3_client,
         ) as s3:
             results = s3.list_paths(paths)
@@ -86,7 +86,7 @@ class S3Storage(DataStoreStorage):
 
         with S3(
             s3root=self.datastore_root,
-            tmproot=os.getcwd(),
+            tmproot=ARTIFACT_LOCALROOT,
             external_client=self.s3_client,
         ) as s3:
             # HACK: The S3 datatools we rely on does not currently do a good job
@@ -120,7 +120,7 @@ class S3Storage(DataStoreStorage):
 
         s3 = S3(
             s3root=self.datastore_root,
-            tmproot=os.getcwd(),
+            tmproot=ARTIFACT_LOCALROOT,
             external_client=self.s3_client,
         )
 

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -76,6 +76,9 @@ DATATOOLS_LOCALROOT = from_conf(
     else None,
 )
 
+# The root directory to save artifact pulls in, when using S3
+ARTIFACT_LOCALROOT = from_conf("METAFLOW_ARTIFACT_LOCALROOT", os.getcwd())
+
 # Cards related config variables
 DATASTORE_CARD_SUFFIX = "mf.cards"
 DATASTORE_CARD_LOCALROOT = from_conf("METAFLOW_CARD_LOCALROOT")


### PR DESCRIPTION
This addresses https://github.com/Netflix/metaflow/issues/990 by

1. Adds `METAFLOW_ARTIFACT_LOCALROOT` to the configuration. It defaults to `os.getcwd()`
2. When instantiating the `S3` object in `metaflow/datastore/s3_storage.py`, use that configurable value instead of `os.getcwd()`

I tested this locally by adding `"METAFLOW_ARTIFACT_LOCALROOT": "/tmp/"` to my `~/.metaflowconfig/config.json` file, and then pulling some artifacts via `task.data`. It did indeed create a `/tmp/metaflow.s3.br9v3iit` instead of going in the current directory.