### PR TITLE
Upgrade black to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-yaml
       - id: check-json
   - repo: https://github.com/ambv/black
-    rev: 21.9b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -1,5 +1,5 @@
 import inspect
-import os
+import pickle
 import sys
 import traceback
 from datetime import datetime
@@ -58,13 +58,6 @@ INDENT = " " * 4
 LOGGER_TIMESTAMP = "magenta"
 LOGGER_COLOR = "green"
 LOGGER_BAD_COLOR = "red"
-
-try:
-    # Python 2
-    import cPickle as pickle
-except ImportError:
-    # Python 3
-    import pickle
 
 
 def echo_dev_null(*args, **kwargs):

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -21,12 +21,6 @@ from metaflow.util import cached_property, resolve_identity, to_unicode
 
 from .filecache import FileCache
 
-try:
-    # python2
-    import cPickle as pickle
-except:  # noqa E722
-    # python3
-    import pickle
 
 # populated at the bottom of this file
 _CLASSES = {}

--- a/metaflow/client/filecache.py
+++ b/metaflow/client/filecache.py
@@ -257,7 +257,7 @@ class FileCache(object):
             self._index_objects()
         dirname = os.path.dirname(path)
         try:
-            FileCache._makedirs(dirname)
+            os.makedirs(dirname, exist_ok=True)
         except:  # noqa E722
             raise FileCacheException("Could not create directory: %s" % dirname)
         tmpfile = NamedTemporaryFile(dir=dirname, prefix="dlobj", delete=False)
@@ -329,18 +329,6 @@ class FileCache(object):
             except OSError:
                 # maybe another client had already GC'ed the file away
                 pass
-
-    @staticmethod
-    def _makedirs(path):
-        # this is for python2 compatibility.
-        # Python3 has os.makedirs(exist_ok=True).
-        try:
-            os.makedirs(path)
-        except OSError as x:
-            if x.errno == 17:
-                return
-            else:
-                raise
 
     @staticmethod
     def _get_datastore_storage_impl(ds_type):

--- a/metaflow/client/filecache.py
+++ b/metaflow/client/filecache.py
@@ -23,7 +23,6 @@ if sys.version_info[0] >= 3 and sys.version_info[1] >= 2:
     def od_move_to_end(od, key):
         od.move_to_end(key)
 
-
 else:
     # Not very efficient but works and most people are on 3.2+
     def od_move_to_end(od, key):
@@ -320,7 +319,7 @@ class FileCache(object):
 
     def _garbage_collect(self):
         now = time.time()
-        while self._objects and self._total > self._max_size * 1024 ** 2:
+        while self._objects and self._total > self._max_size * 1024**2:
             if now - self._objects[0][0] < NEW_FILE_QUARANTINE:
                 break
             ctime, size, path = self._objects.pop(0)

--- a/metaflow/datastore/local_storage.py
+++ b/metaflow/datastore/local_storage.py
@@ -14,11 +14,7 @@ class LocalStorage(DataStoreStorage):
     def get_datastore_root_from_config(cls, echo, create_on_absent=True):
         result = DATASTORE_SYSROOT_LOCAL
         if result is None:
-            try:
-                # Python2
-                current_path = os.getcwdu()
-            except:  # noqa E722
-                current_path = os.getcwd()
+            current_path = os.getcwd()
             check_dir = os.path.join(current_path, DATASTORE_LOCAL_DIR)
             check_dir = os.path.realpath(check_dir)
             orig_path = check_dir
@@ -45,16 +41,6 @@ class LocalStorage(DataStoreStorage):
         else:
             result = os.path.join(result, DATASTORE_LOCAL_DIR)
         return result
-
-    @staticmethod
-    def _makedirs(path):
-        try:
-            os.makedirs(path)
-        except OSError as x:
-            if x.errno == 17:
-                return
-            else:
-                raise
 
     def is_file(self, paths):
         results = []
@@ -113,7 +99,7 @@ class LocalStorage(DataStoreStorage):
             full_path = self.full_uri(path)
             if not overwrite and os.path.exists(full_path):
                 continue
-            LocalStorage._makedirs(os.path.dirname(full_path))
+            os.makedirs(os.path.dirname(full_path), exist_ok=True)
             with open(full_path, mode="wb") as f:
                 f.write(byte_obj.read())
             if metadata:

--- a/metaflow/datastore/s3_storage.py
+++ b/metaflow/datastore/s3_storage.py
@@ -7,14 +7,6 @@ from ..metaflow_config import DATASTORE_SYSROOT_S3, ARTIFACT_LOCALROOT
 from .datastore_storage import CloseAfterUse, DataStoreStorage
 
 
-try:
-    # python2
-    from urlparse import urlparse
-except:
-    # python3
-    from urllib.parse import urlparse
-
-
 class S3Storage(DataStoreStorage):
     TYPE = "s3"
 

--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -5,9 +5,10 @@ import time
 import shutil
 import random
 import subprocess
-from io import RawIOBase, BytesIO, BufferedIOBase
+from io import RawIOBase, BufferedIOBase
 from itertools import chain, starmap
 from tempfile import mkdtemp, NamedTemporaryFile
+from urllib.parse import urlparse
 
 from .. import FlowSpec
 from ..current import current
@@ -24,12 +25,6 @@ from ..util import (
 from ..exception import MetaflowException
 from ..debug import debug
 
-try:
-    # python2
-    from urlparse import urlparse
-except:
-    # python3
-    from urllib.parse import urlparse
 
 from .s3util import get_s3_client, read_in_chunks, get_timestamp
 

--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -932,7 +932,7 @@ class S3(object):
                 os.unlink(tmp.name)
             self._s3_client.reset_client()
             # add some jitter to make sure retries are not synchronized
-            time.sleep(2 ** i + random.randint(0, 10))
+            time.sleep(2**i + random.randint(0, 10))
         raise MetaflowS3Exception(
             "S3 operation failed.\n" "Key requested: %s\n" "Error: %s" % (url, error)
         )
@@ -1048,6 +1048,6 @@ class S3(object):
                     elif ex.returncode == s3op.ERROR_URL_ACCESS_DENIED:
                         raise MetaflowS3AccessDenied(err_out)
                     print("Error with S3 operation:", err_out)
-                    time.sleep(2 ** i + random.randint(0, 10))
+                    time.sleep(2**i + random.randint(0, 10))
 
         return None, err_out

--- a/metaflow/datatools/s3op.py
+++ b/metaflow/datatools/s3op.py
@@ -307,10 +307,10 @@ def process_urls(mode, urls, verbose, num_workers, s3role):
 
 
 def with_unit(x):
-    if x > 1024 ** 3:
-        return "%.1fGB" % (x / 1024.0 ** 3)
-    elif x > 1024 ** 2:
-        return "%.1fMB" % (x / 1024.0 ** 2)
+    if x > 1024**3:
+        return "%.1fGB" % (x / 1024.0**3)
+    elif x > 1024**2:
+        return "%.1fMB" % (x / 1024.0**2)
     elif x > 1024:
         return "%.1fKB" % (x / 1024.0)
     else:

--- a/metaflow/datatools/s3op.py
+++ b/metaflow/datatools/s3op.py
@@ -9,19 +9,12 @@ import traceback
 from functools import partial
 from hashlib import sha1
 from tempfile import NamedTemporaryFile
+from urllib.parse import urlparse
 from multiprocessing import Process, Queue
 from itertools import starmap, chain, islice
 
 from boto3.s3.transfer import TransferConfig
 
-try:
-    # python2
-    from urlparse import urlparse
-    from Queue import Full as QueueFull
-except:
-    # python3
-    from urllib.parse import urlparse
-    from queue import Full as QueueFull
 
 # s3op can be launched as a stand-alone script. We must set
 # PYTHONPATH for the parent Metaflow explicitly.

--- a/metaflow/datatools/s3tail.py
+++ b/metaflow/datatools/s3tail.py
@@ -1,12 +1,6 @@
 from io import BytesIO
+from urllib.parse import urlparse
 from .s3util import aws_retry, get_s3_client
-
-try:
-    # python2
-    from urlparse import urlparse
-except:
-    # python3
-    from urllib.parse import urlparse
 
 
 class S3Tail(object):

--- a/metaflow/datatools/s3util.py
+++ b/metaflow/datatools/s3util.py
@@ -85,5 +85,7 @@ def read_in_chunks(dst, src, src_sz, max_chunk_size):
 def get_timestamp(dt):
     """
     Python2 compatible way to compute the timestamp (seconds since 1/1/1970)
+
+    TODO: Update for python 3
     """
     return (dt.replace(tzinfo=None) - datetime(1970, 1, 1)).total_seconds()

--- a/metaflow/datatools/s3util.py
+++ b/metaflow/datatools/s3util.py
@@ -59,7 +59,7 @@ def aws_retry(f):
                 last_exc = ex
                 # exponential backoff for real failures
                 if not (TEST_S3_RETRY and i == 0):
-                    time.sleep(2 ** i + random.randint(0, 5))
+                    time.sleep(2**i + random.randint(0, 5))
         raise last_exc
 
     return retry_wrapper

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -496,12 +496,7 @@ def step(f):
     """
     f.is_step = True
     f.decorators = []
-    try:
-        # python 3
-        f.name = f.__name__
-    except:
-        # python 2
-        f.name = f.__func__.func_name
+    f.name = f.__name__
     return f
 
 

--- a/metaflow/includefile.py
+++ b/metaflow/includefile.py
@@ -126,9 +126,9 @@ class Local(object):
 
     def _path(self, key):
         key = to_unicode(key)
-        if key.startswith(u"local://"):
+        if key.startswith("local://"):
             return key[8:]
-        elif key[0] != u"/":
+        elif key[0] != "/":
             if current.is_running_flow:
                 raise MetaflowLocalURLException(
                     "Specify Local(run=self) when you use Local inside a running "
@@ -145,7 +145,7 @@ class Local(object):
 
     def get(self, key=None, return_missing=False):
         p = self._path(key)
-        url = u"local://%s" % p
+        url = "local://%s" % p
         if not os.path.isfile(p):
             if return_missing:
                 p = None
@@ -159,7 +159,7 @@ class Local(object):
             Local._makedirs(os.path.dirname(p))
             with open(p, "wb") as f:
                 f.write(obj)
-        return u"local://%s" % p
+        return "local://%s" % p
 
 
 # From here on out, this is the IncludeFile implementation.
@@ -190,7 +190,7 @@ class LocalFile:
                 )
             path = decoded_value["url"]
         for prefix, handler in DATACLIENTS.items():
-            if path.startswith(u"%s://" % prefix):
+            if path.startswith("%s://" % prefix):
                 return True, Uploader(handler), None
         try:
             with open(path, mode="r") as _:

--- a/metaflow/main_cli.py
+++ b/metaflow/main_cli.py
@@ -10,18 +10,6 @@ from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
 from metaflow.util import to_unicode
 
 
-def makedirs(path):
-    # This is for python2 compatibility.
-    # Python3 has os.makedirs(exist_ok=True).
-    try:
-        os.makedirs(path)
-    except OSError as x:
-        if x.errno == 17:
-            return
-        else:
-            raise
-
-
 def echo_dev_null(*args, **kwargs):
     pass
 
@@ -218,7 +206,7 @@ def pull(episode):
             validate_episode(episode)
     # Create destination `metaflow-tutorials` dir.
     dst_parent = os.path.join(os.getcwd(), "metaflow-tutorials")
-    makedirs(dst_parent)
+    os.makedirs(dst_parent, exist_ok=True)
 
     # Pull specified episodes.
     for episode in episodes:
@@ -274,7 +262,7 @@ METAFLOW_CONFIGURATION_DIR = expanduser(
 
 @main.group(help="Configure Metaflow to access the cloud.")
 def configure():
-    makedirs(METAFLOW_CONFIGURATION_DIR)
+    os.makedirs(METAFLOW_CONFIGURATION_DIR, exist_ok=True)
 
 
 def get_config_path(profile):

--- a/metaflow/metadata/heartbeat.py
+++ b/metaflow/metadata/heartbeat.py
@@ -49,7 +49,7 @@ class MetadataHeartBeat(object):
                 retry_counter = 0
             except HeartBeatException as e:
                 retry_counter = retry_counter + 1
-                time.sleep(4 ** retry_counter)
+                time.sleep(4**retry_counter)
 
     def heartbeat(self):
         if self.hb_url is not None:

--- a/metaflow/mflog/mflog.py
+++ b/metaflow/mflog/mflog.py
@@ -42,21 +42,10 @@ if time.timezone == 0:
     # on conversions
     utc_to_local = lambda x: x
 else:
-    try:
-        # python3
-        from datetime import timezone
+    from datetime import timezone
 
-        def utc_to_local(utc_dt):
-            return utc_dt.replace(tzinfo=timezone.utc).astimezone(tz=None)
-
-    except ImportError:
-        # python2
-        import calendar
-
-        def utc_to_local(utc_dt):
-            timestamp = calendar.timegm(utc_dt.timetuple())
-            local_dt = datetime.fromtimestamp(timestamp)
-            return local_dt.replace(microsecond=utc_dt.microsecond)
+    def utc_to_local(utc_dt):
+        return utc_dt.replace(tzinfo=timezone.utc).astimezone(tz=None)
 
 
 def decorate(source, line, version=VERSION, now=None, lineid=None):

--- a/metaflow/mflog/tee.py
+++ b/metaflow/mflog/tee.py
@@ -10,16 +10,7 @@ if __name__ == "__main__":
     SOURCE = sys.argv[1].encode("ascii")
 
     with open(sys.argv[2], mode="ab", buffering=0) as f:
-        if sys.version_info < (3, 0):
-            # Python 2
-            for line in iter(sys.stdin.readline, ""):
-                # https://bugs.python.org/issue3907
-                decorated = decorate(SOURCE, line)
-                f.write(decorated)
-                sys.stdout.write(line)
-        else:
-            # Python 3
-            for line in sys.stdin.buffer:
-                decorated = decorate(SOURCE, line)
-                f.write(decorated)
-                sys.stdout.buffer.write(line)
+        for line in sys.stdin.buffer:
+            decorated = decorate(SOURCE, line)
+            f.write(decorated)
+            sys.stdout.buffer.write(line)

--- a/metaflow/multicore_utils.py
+++ b/metaflow/multicore_utils.py
@@ -1,16 +1,11 @@
-import sys
 import os
+import pickle
+import sys
 import traceback
 from itertools import islice
 from multiprocessing import cpu_count
 from tempfile import NamedTemporaryFile
 
-try:
-    # Python 2
-    import cPickle as pickle
-except:
-    # Python 3
-    import pickle
 
 # This module reimplements select functions from the standard
 # Python multiprocessing module.

--- a/metaflow/parameters.py
+++ b/metaflow/parameters.py
@@ -10,12 +10,6 @@ from .exception import (
     MetaflowException,
 )
 
-try:
-    # Python2
-    strtype = basestring
-except NameError:
-    # Python3
-    strtype = str
 
 # ParameterContext allows deploy-time functions modify their
 # behavior based on the context. We can add fields here without
@@ -37,7 +31,7 @@ class JSONTypeClass(click.ParamType):
     name = "JSON"
 
     def convert(self, value, param, ctx):
-        if not isinstance(value, strtype):
+        if not isinstance(value, str):
             # Already a correct type
             return value
         try:
@@ -238,7 +232,7 @@ class Parameter(object):
     @property
     def is_string_type(self):
         return self.kwargs.get("type", str) == str and isinstance(
-            self.kwargs.get("default", ""), strtype
+            self.kwargs.get("default", ""), str
         )
 
     # this is needed to appease Pylint for JSONType'd parameters,

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -201,7 +201,7 @@ def step(
     if num_parallel and num_parallel > 1:
         # For multinode, we need to add a placeholder that can be mutated by the caller
         step_args += " [multinode-args]"
-    step_cli = u"{entrypoint} {top_args} step {step} {step_args}".format(
+    step_cli = "{entrypoint} {top_args} step {step} {step_args}".format(
         entrypoint=entrypoint,
         top_args=top_args,
         step=step_name,

--- a/metaflow/plugins/aws/eks/kubernetes_cli.py
+++ b/metaflow/plugins/aws/eks/kubernetes_cli.py
@@ -153,7 +153,7 @@ def step(
         )
         time.sleep(minutes_between_retries * 60)
 
-    step_cli = u"{entrypoint} {top_args} step {step} {step_args}".format(
+    step_cli = "{entrypoint} {top_args} step {step} {step_args}".format(
         entrypoint="%s -u %s" % (executable, os.path.basename(sys.argv[0])),
         top_args=" ".join(util.dict_to_cli_options(ctx.parent.parent.params)),
         step=step_name,

--- a/metaflow/plugins/aws/step_functions/production_token.py
+++ b/metaflow/plugins/aws/step_functions/production_token.py
@@ -17,18 +17,6 @@ def _token_generator(token_prefix):
         yield prefix + "".join(random.sample(string.ascii_lowercase, 4))
 
 
-def _makedirs(path):
-    # this is for python2 compatibility.
-    # Python3 has os.makedirs(exist_ok=True).
-    try:
-        os.makedirs(path)
-    except OSError as x:
-        if x.errno == 17:
-            return
-        else:
-            raise
-
-
 def _load_config(path):
     if os.path.exists(path):
         with open(path) as f:
@@ -63,6 +51,6 @@ def store_token(token_prefix, token):
     path = _path(token_prefix)
     config = _load_config(path)
     config["production_token"] = token
-    _makedirs(os.path.dirname(path))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w") as f:
         json.dump(config, f)

--- a/metaflow/plugins/cards/card_datastore.py
+++ b/metaflow/plugins/cards/card_datastore.py
@@ -201,11 +201,11 @@ class CardDatastore(object):
         # todo : replace this function with the FileCache
         if save_path is None:
             if not is_file_present(self._temp_card_save_path):
-                LocalStorage._makedirs(self._temp_card_save_path)
+                os.makedirs(self._temp_card_save_path, exist_ok=True)
         else:
             save_dir = os.path.dirname(save_path)
             if save_dir != "" and not is_file_present(save_dir):
-                LocalStorage._makedirs(os.path.dirname(save_path))
+                os.makedirs(os.path.dirname(save_path), exist_ok=True)
 
         with self._backend.load_bytes([path]) as get_results:
             for key, path, meta in get_results:

--- a/metaflow/plugins/cards/card_modules/chevron/main.py
+++ b/metaflow/plugins/cards/card_modules/chevron/main.py
@@ -3,12 +3,8 @@
 import io
 import sys
 
-try:
-    from .renderer import render
-    from .metadata import version
-except (ValueError, SystemError):  # python 2
-    from renderer import render
-    from metadata import version
+from .renderer import render
+from .metadata import version
 
 
 def main(template, data=None, **kwargs):

--- a/metaflow/plugins/cards/card_modules/chevron/renderer.py
+++ b/metaflow/plugins/cards/card_modules/chevron/renderer.py
@@ -23,7 +23,6 @@ if sys.version_info[0] == 3:
     def unicode(x, y):
         return x
 
-
 else:  # python 2
     python3 = False
     unicode_type = unicode

--- a/metaflow/plugins/env_escape/data_transferer.py
+++ b/metaflow/plugins/env_escape/data_transferer.py
@@ -165,7 +165,6 @@ if sys.version_info[0] >= 3:
     def _load_invalidunicode(obj_type, transferer, json_annotation, json_obj):
         return _load_simple(str, transferer, json_annotation, json_obj)
 
-
 else:
 
     @_register_dumper((str,))

--- a/metaflow/plugins/metadata/local.py
+++ b/metaflow/plugins/metadata/local.py
@@ -185,19 +185,6 @@ class LocalMetadataProvider(MetadataProvider):
                 result.append(LocalMetadataProvider._read_json_file(self_file))
         return MetadataProvider._apply_filter(result, filters)
 
-    @staticmethod
-    def _makedirs(path):
-        # this is for python2 compatibility.
-        # Python3 has os.makedirs(exist_ok=True).
-        try:
-            os.makedirs(path)
-        except OSError as x:
-            if x.errno == 17:
-                # Error raised when directory exists
-                return
-            else:
-                raise
-
     def _ensure_meta(
         self, obj_type, run_id, step_name, task_id, tags=None, sys_tags=None
     ):
@@ -209,7 +196,7 @@ class LocalMetadataProvider(MetadataProvider):
             self._flow_name, run_id, step_name, task_id
         )
         selfname = os.path.join(subpath, "_self.json")
-        self._makedirs(subpath)
+        os.makedirs(subpath, exist_ok=True)
         if os.path.isfile(selfname):
             return
         # In this case, the metadata information does not exist so we create it
@@ -279,7 +266,7 @@ class LocalMetadataProvider(MetadataProvider):
             flow_name, run_id, step_name, task_id
         )
         subpath = os.path.join(root_path, LocalStorage.METADATA_DIR)
-        LocalMetadataProvider._makedirs(subpath)
+        os.makedirs(subpath, exist_ok=True)
         return subpath
 
     @staticmethod

--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -376,7 +376,7 @@ class ServiceMetadataProvider(MetadataProvider):
                         resp.status_code,
                         resp.text,
                     )
-            time.sleep(2 ** i)
+            time.sleep(2**i)
 
         if resp:
             raise ServiceException(
@@ -423,7 +423,7 @@ class ServiceMetadataProvider(MetadataProvider):
                         resp.status_code,
                         resp.text,
                     )
-            time.sleep(2 ** i)
+            time.sleep(2**i)
         if resp:
             raise ServiceException(
                 "Metadata request (%s) failed (code %s): %s"

--- a/metaflow/plugins/test_unbounded_foreach_decorator.py
+++ b/metaflow/plugins/test_unbounded_foreach_decorator.py
@@ -111,11 +111,11 @@ class InternalTestUnboundedForeachDecorator(StepDecorator):
             cmd = cli_args.step_command(
                 executable, script, step_name, step_kwargs=kwargs
             )
-            step_cli = u" ".join(cmd)
+            step_cli = " ".join(cmd)
             # Print cmdline for execution. Doesn't work without the temporary
             # unicode object while using `print`.
             print(
-                u"[${cwd}] Starting split#{split} with cmd:{cmd}".format(
+                "[${cwd}] Starting split#{split} with cmd:{cmd}".format(
                     cwd=os.getcwd(), split=i, cmd=step_cli
                 )
             )

--- a/metaflow/sidecar.py
+++ b/metaflow/sidecar.py
@@ -17,12 +17,6 @@ MESSAGE_WRITE_TIMEOUT_IN_MS = 1000
 
 NULL_SIDECAR_PREFIX = "nullSidecar"
 
-# for python 2 compatibility
-try:
-    blockingError = BlockingIOError
-except:
-    blockingError = OSError
-
 
 class PipeUnavailableError(Exception):
     """raised when unable to write to pipe given allotted time"""
@@ -105,7 +99,7 @@ class SidecarSubProcess(object):
                     stdout=open(os.devnull, "w"),
                     bufsize=0,
                 )
-            except blockingError as be:
+            except BlockingIOError as be:
                 self.logger("warning: sidecar popen failed: %s" % repr(be))
             except Exception as e:
                 self.logger(repr(e))

--- a/metaflow/sidecar_messages.py
+++ b/metaflow/sidecar_messages.py
@@ -3,6 +3,7 @@ import json
 # Define message enums
 # Unfortunately we can't use enums because they are not supported
 # officially in Python2
+# TODO: Update for python 3
 class MessageTypes(object):
     SHUTDOWN, LOG_EVENT = range(1, 3)
 

--- a/test/core/tests/basic_include.py
+++ b/test/core/tests/basic_include.py
@@ -26,9 +26,9 @@ with open('override.txt', mode='w') as f:
     @steps(0, ["all"])
     def step_all(self):
         assert_equals("Regular Text File", self.myfile_txt)
-        assert_equals(u"UTF Text File \u5e74", self.myfile_utf8)
+        assert_equals("UTF Text File \u5e74", self.myfile_utf8)
         assert_equals(
-            u"UTF Text File \u5e74".encode(encoding="utf8"), self.myfile_binary
+            "UTF Text File \u5e74".encode(encoding="utf8"), self.myfile_binary
         )
         assert_equals("Override Text File", self.myfile_overriden)
 

--- a/test/core/tests/basic_log.py
+++ b/test/core/tests/basic_log.py
@@ -14,7 +14,7 @@ class BasicLogTest(MetaflowTest):
         import sys
 
         msg1 = "stdout: A regular message.\n"
-        msg2 = u"stdout: A message with unicode: \u5e74\n"
+        msg2 = "stdout: A message with unicode: \u5e74\n"
         sys.stdout.write(msg1)
         if not sys.stdout.encoding:
             sys.stdout.write(msg2.encode("utf8"))
@@ -22,7 +22,7 @@ class BasicLogTest(MetaflowTest):
             sys.stdout.write(msg2)
 
         msg3 = "stderr: A regular message.\n"
-        msg4 = u"stderr: A message with unicode: \u5e74\n"
+        msg4 = "stderr: A message with unicode: \u5e74\n"
         sys.stderr.write(msg3)
         if not sys.stderr.encoding:
             sys.stderr.write(msg4.encode("utf8"))
@@ -35,11 +35,11 @@ class BasicLogTest(MetaflowTest):
 
     def check_results(self, flow, checker):
         msg1 = "stdout: A regular message.\n"
-        msg2 = u"stdout: A message with unicode: \u5e74\n"
+        msg2 = "stdout: A message with unicode: \u5e74\n"
         stdout_combined_msg = "".join([msg1, msg2, ""])
 
         msg3 = "stderr: A regular message.\n"
-        msg4 = u"stderr: A message with unicode: \u5e74\n"
+        msg4 = "stderr: A message with unicode: \u5e74\n"
         stderr_combined_msg = "".join([msg3, msg4, ""])
 
         for step in flow:

--- a/test/core/tests/basic_tags.py
+++ b/test/core/tests/basic_tags.py
@@ -31,11 +31,11 @@ class BasicTagTest(MetaflowTest):
         # test crazy unicode and spaces in tags
         # these tags must be set with --tag option in contexts.json
         tags = (
-            u"project:basic_tag",
-            u"project_branch:user.tester",
-            u"user:%s" % os.environ.get("METAFLOW_USER"),
-            u"刺身 means sashimi",
-            u"multiple tags should be ok",
+            "project:basic_tag",
+            "project_branch:user.tester",
+            "user:%s" % os.environ.get("METAFLOW_USER"),
+            "刺身 means sashimi",
+            "multiple tags should be ok",
         )
         for tag in tags:
             # test different namespaces: one is a system-tag,

--- a/test/core/tests/large_artifact.py
+++ b/test/core/tests/large_artifact.py
@@ -16,7 +16,7 @@ class LargeArtifactTest(MetaflowTest):
         import sys
 
         if sys.version_info[0] > 2:
-            self.large = b"x" * int(4.1 * 1024 ** 3)
+            self.large = b"x" * int(4.1 * 1024**3)
             self.noop = False
         else:
             self.noop = True
@@ -26,7 +26,7 @@ class LargeArtifactTest(MetaflowTest):
         import sys
 
         if sys.version_info[0] > 2:
-            assert_equals(self.large, b"x" * int(4.1 * 1024 ** 3))
+            assert_equals(self.large, b"x" * int(4.1 * 1024**3))
 
     @steps(1, ["all"])
     def step_all(self):
@@ -37,4 +37,4 @@ class LargeArtifactTest(MetaflowTest):
 
         noop = next(iter(checker.artifact_dict("end", "noop").values()))["noop"]
         if not noop and sys.version_info[0] > 2:
-            checker.assert_artifact("end", "large", b"x" * int(4.1 * 1024 ** 3))
+            checker.assert_artifact("end", "large", b"x" * int(4.1 * 1024**3))

--- a/test/data/s3/s3_data.py
+++ b/test/data/s3/s3_data.py
@@ -36,7 +36,7 @@ BASIC_METADATA = {
     "complex": (
         "text/plain",
         {
-            "utf8-data": u"\u523a\u8eab/means sashimi",
+            "utf8-data": "\u523a\u8eab/means sashimi",
             "with-weird-chars": "Space and !@#<>:/-+=&%",
         },
     ),
@@ -44,7 +44,7 @@ BASIC_METADATA = {
 
 BASIC_RANGE_INFO = {
     "from_beg": (0, 16),  # From beginning
-    "exceed_end": (0, 10 * 1024 ** 3),  # From beginning, should fetch full file
+    "exceed_end": (0, 10 * 1024**3),  # From beginning, should fetch full file
     "middle": (5, 10),  # From middle
     "end": (None, -5),  # Fetch from end
     "till_end": (5, None),  # Fetch till end
@@ -61,7 +61,7 @@ BASIC_DATA = [
     # a basic sanity check
     (
         "3_small_files",
-        {"empty_file": 0, "kb_file": 1024, "mb_file": 1024 ** 2, "missing_file": None},
+        {"empty_file": 0, "kb_file": 1024, "mb_file": 1024**2, "missing_file": None},
     ),
     # S3 paths can be longer than the max allowed filename on Linux
     (
@@ -90,27 +90,27 @@ BASIC_DATA = [
     (
         "crazypath",
         {
-            u"crazy spaces": 34,
-            u"\x01\xff": 64,
-            u"\u523a\u8eab/means sashimi": 33,
-            u"crazy-!.$%@2_()\"'": 100,
-            u" /cra._:zy/\x01\x02/p a t h/$this/!!is()": 1000,
-            u"crazy missing :(": None,
+            "crazy spaces": 34,
+            "\x01\xff": 64,
+            "\u523a\u8eab/means sashimi": 33,
+            "crazy-!.$%@2_()\"'": 100,
+            " /cra._:zy/\x01\x02/p a t h/$this/!!is()": 1000,
+            "crazy missing :(": None,
         },
     ),
 ]
 
 BIG_DATA = [
     # test a file > 4GB
-    ("5gb_file", {"5gb_file": 5 * 1024 ** 3}),
+    ("5gb_file", {"5gb_file": 5 * 1024**3}),
     # ensure that e.g. paged listings work correctly with many keys
     ("3000_files", {str(i): i for i in range(3000)}),
 ]
 
 # Large file to use for benchmark, must be in BASIC_DATA or BIG_DATA
 BENCHMARK_SMALL_FILE = ("3000_files", {"1": 1})
-BENCHMARK_MEDIUM_FILE = ("3_small_files", {"mb_file": 1024 ** 2})
-BENCHMARK_LARGE_FILE = ("5gb_file", {"5gb_file": 5 * 1024 ** 3})
+BENCHMARK_MEDIUM_FILE = ("3_small_files", {"mb_file": 1024**2})
+BENCHMARK_LARGE_FILE = ("5gb_file", {"5gb_file": 5 * 1024**3})
 
 BENCHMARK_SMALL_ITER_MAX = 10001
 BENCHMARK_MEDIUM_ITER_MAX = 501
@@ -382,7 +382,7 @@ def pytest_many_prefixes_case():
 def pytest_put_strings_case(meta=None):
     put_prefix = os.path.join(S3ROOT, PUT_PREFIX)
     data = [
-        u"unicode: \u523a\u8eab means sashimi",
+        "unicode: \u523a\u8eab means sashimi",
         b"bytes: \x00\x01\x02",
         "just a string",
     ]

--- a/test/unit/test_compute_resource_attributes.py
+++ b/test/unit/test_compute_resource_attributes.py
@@ -33,14 +33,11 @@ def test_compute_resource_attributes():
     ) == {"cpu": "1", "memory": "100"}
 
     # take largest of @resources and @batch if both are present
-    assert (
-        compute_resource_attributes(
-            [MockDeco("resources", {"cpu": "2"})],
-            MockDeco("batch", {"cpu": 1}),
-            {"cpu": "3"},
-        )
-        == {"cpu": "2"}
-    )
+    assert compute_resource_attributes(
+        [MockDeco("resources", {"cpu": "2"})],
+        MockDeco("batch", {"cpu": 1}),
+        {"cpu": "3"},
+    ) == {"cpu": "2"}
 
 
 def test_compute_resource_attributes_string():
@@ -52,31 +49,22 @@ def test_compute_resource_attributes_string():
     ) == {"cpu": "1"}
 
     # use string value from deco if set (default is None)
-    assert (
-        compute_resource_attributes(
-            [],
-            MockDeco("batch", {"instance_type": "p3.xlarge"}),
-            {"cpu": "1", "instance_type": None},
-        )
-        == {"cpu": "1", "instance_type": "p3.xlarge"}
-    )
+    assert compute_resource_attributes(
+        [],
+        MockDeco("batch", {"instance_type": "p3.xlarge"}),
+        {"cpu": "1", "instance_type": None},
+    ) == {"cpu": "1", "instance_type": "p3.xlarge"}
 
     # use string value from deco if set (default is not None)
-    assert (
-        compute_resource_attributes(
-            [],
-            MockDeco("batch", {"instance_type": "p3.xlarge"}),
-            {"cpu": "1", "instance_type": "p4.xlarge"},
-        )
-        == {"cpu": "1", "instance_type": "p3.xlarge"}
-    )
+    assert compute_resource_attributes(
+        [],
+        MockDeco("batch", {"instance_type": "p3.xlarge"}),
+        {"cpu": "1", "instance_type": "p4.xlarge"},
+    ) == {"cpu": "1", "instance_type": "p3.xlarge"}
 
     # use string value from defaults if @batch has it set to None
-    assert (
-        compute_resource_attributes(
-            [],
-            MockDeco("batch", {"instance_type": None}),
-            {"cpu": "1", "instance_type": "p4.xlarge"},
-        )
-        == {"cpu": "1", "instance_type": "p4.xlarge"}
-    )
+    assert compute_resource_attributes(
+        [],
+        MockDeco("batch", {"instance_type": None}),
+        {"cpu": "1", "instance_type": "p4.xlarge"},
+    ) == {"cpu": "1", "instance_type": "p4.xlarge"}


### PR DESCRIPTION
### Why
The black version `21.9b0` doesn’t work with new [click](https://pypi.org/project/click/#history) version 8.1.0 released on Mar 28, and it’s fixed by [black](https://pypi.org/project/black/#history) version 22.3.0  released on the same day. Upgrading black in this PR.

The new black version no longer support python 2 formats however. Specifically string is assumed to be unicode. Therefore this PR assumes that **python 2 compatibility is dropped**.

### What
- Upgrade black to 22.3.0 and run `pre-commit run --all-files`
- Remove python 2 compatibility code as they no longer make sense.