### PR TITLE
Pin older click compatible to old black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,9 @@ repos:
       - id: check-yaml
       - id: check-json
   - repo: https://github.com/ambv/black
-    rev: 21.9b0
+    rev: 21.12b0
     hooks:
       - id: black
         language_version: python3
         exclude: "^metaflow/_vendor/"
+        additional_dependencies: ["click<8.1.0"]

--- a/metaflow/client/filecache.py
+++ b/metaflow/client/filecache.py
@@ -23,7 +23,6 @@ if sys.version_info[0] >= 3 and sys.version_info[1] >= 2:
     def od_move_to_end(od, key):
         od.move_to_end(key)
 
-
 else:
     # Not very efficient but works and most people are on 3.2+
     def od_move_to_end(od, key):

--- a/metaflow/plugins/cards/card_modules/chevron/renderer.py
+++ b/metaflow/plugins/cards/card_modules/chevron/renderer.py
@@ -23,7 +23,6 @@ if sys.version_info[0] == 3:
     def unicode(x, y):
         return x
 
-
 else:  # python 2
     python3 = False
     unicode_type = unicode

--- a/metaflow/plugins/env_escape/data_transferer.py
+++ b/metaflow/plugins/env_escape/data_transferer.py
@@ -165,7 +165,6 @@ if sys.version_info[0] >= 3:
     def _load_invalidunicode(obj_type, transferer, json_annotation, json_obj):
         return _load_simple(str, transferer, json_annotation, json_obj)
 
-
 else:
 
     @_register_dumper((str,))


### PR DESCRIPTION
Alternative solution to https://github.com/Netflix/metaflow/pull/998

### Why
The black version 21.9b0 doesn’t work with new [click](https://pypi.org/project/click/#history) version 8.1.0 released on Mar 28, and it’s fixed by [black](https://pypi.org/project/black/#history) version 22.3.0 released on the same day. 

However black version 22.3.0 doesn't support python 2. Instead pinning an older version of click in pre-commit hook allow us to keep python 2 compatibility.

### What
Pin latest version of click that stays compatible with black 21.9b0