### PR TITLE
METAFLOW_ARTIFACT_LOCALROOT S3() tmproot default

### DIFF
--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -11,7 +11,7 @@ from tempfile import mkdtemp, NamedTemporaryFile
 
 from .. import FlowSpec
 from ..current import current
-from ..metaflow_config import DATATOOLS_S3ROOT, S3_RETRY_COUNT
+from ..metaflow_config import DATATOOLS_S3ROOT, S3_RETRY_COUNT, from_conf
 from ..util import (
     namedtuple_with_defaults,
     is_stringish,
@@ -287,7 +287,7 @@ class S3(object):
         return DATATOOLS_S3ROOT
 
     def __init__(
-        self, tmproot=".", bucket=None, prefix=None, run=None, s3root=None, **kwargs
+        self, tmproot=None, bucket=None, prefix=None, run=None, s3root=None, **kwargs
     ):
         """
         Initialize a new context for S3 operations. This object is used as
@@ -304,11 +304,16 @@ class S3(object):
             s3root: (optional) An S3 root URL for all operations. If this is
                     not specified, all operations require a full S3 URL.
         These options are supported in both the modes:
-            tmproot: (optional) Root path for temporary files (default: '.')
+            tmproot: (optional) Root path for temporary files
+                     (default: METAFLOW_ARTIFACT_LOCALROOT else ".")
         """
 
         if not boto_found:
             raise MetaflowException("You need to install 'boto3' in order to use S3.")
+
+        if tmproot is None:
+            artifact_localroot = from_conf("METAFLOW_ARTIFACT_LOCALROOT")
+            tmproot = artifact_localroot if artifact_localroot else "."
 
         if run:
             # 1. use a (current) run ID with optional customizations


### PR DESCRIPTION
`S3(tmproot)` default to be `METAFLOW_ARTIFACT_LOCALROOT` if defined else `"."`

see comment: https://github.com/Netflix/metaflow/pull/991#issuecomment-1097237329