### PR TITLE
Add execution context to `current`

### DIFF
--- a/metaflow/current.py
+++ b/metaflow/current.py
@@ -15,6 +15,7 @@ class Current(object):
         self._namespace = None
         self._username = None
         self._is_running = False
+        self._tags = None
 
         def _raise(ex):
             raise ex
@@ -49,6 +50,10 @@ class Current(object):
         self._username = username
         self._is_running = is_running
         self._tags = tags
+        self._runtime_environment = os.environ.get(
+            "METAFLOW_RUNTIME_ENVIRONMENT", "local"
+        )
+        self._runtime_name = os.environ.get("METAFLOW_RUNTIME_NAME", None)
 
     def _update_env(self, env):
         for k, v in env.items():
@@ -111,6 +116,14 @@ class Current(object):
     @property
     def tags(self):
         return self._tags
+
+    @property
+    def runtime_environment(self):
+        return self._runtime_environment
+
+    @property
+    def runtime_name(self):
+        return self._runtime_name
 
 
 # instantiate the Current singleton. This will be populated

--- a/metaflow/current.py
+++ b/metaflow/current.py
@@ -18,7 +18,6 @@ class Current(object):
         self._tags = None
         self._runtime_environment = None
         self._runtime_name = None
-        self._sfn_state_machine_name = None
         self._max_workers = None
         self._max_num_splits = None
 
@@ -61,7 +60,6 @@ class Current(object):
             "METAFLOW_RUNTIME_ENVIRONMENT", "local"
         )
         self._runtime_name = os.environ.get("METAFLOW_RUNTIME_NAME", None)
-        self._sfn_state_machine_name = os.environ.get("SFN_STATE_MACHINE", None)
         self._max_workers = os.environ.get("CURRENT_MAX_WORKERS", None)
         self._max_num_splits = os.environ.get("CURRENT_MAX_NUM_SPLITS", None)
 
@@ -134,10 +132,6 @@ class Current(object):
     @property
     def runtime_name(self):
         return self._runtime_name
-
-    @property
-    def sfn_state_machine_name(self):
-        return self._sfn_state_machine_name
 
     @property
     def max_workers(self):

--- a/metaflow/current.py
+++ b/metaflow/current.py
@@ -62,8 +62,8 @@ class Current(object):
         )
         self._runtime_name = os.environ.get("METAFLOW_RUNTIME_NAME", None)
         self._sfn_state_machine_name = os.environ.get("SFN_STATE_MACHINE", None)
-        self._max_workers = os.environ.get("MAX_WORKERS", None)
-        self._max_num_splits = os.environ.get("MAX_NUM_SPLITS", None)
+        self._max_workers = os.environ.get("CURRENT_MAX_WORKERS", None)
+        self._max_num_splits = os.environ.get("CURRENT_MAX_NUM_SPLITS", None)
 
     def _update_env(self, env):
         for k, v in env.items():

--- a/metaflow/current.py
+++ b/metaflow/current.py
@@ -19,6 +19,8 @@ class Current(object):
         self._runtime_environment = None
         self._runtime_name = None
         self._sfn_state_machine_name = None
+        self._max_workers = None
+        self._max_num_splits = None
 
         def _raise(ex):
             raise ex
@@ -53,11 +55,15 @@ class Current(object):
         self._username = username
         self._is_running = is_running
         self._tags = tags
+
+        # from environment variables
         self._runtime_environment = os.environ.get(
             "METAFLOW_RUNTIME_ENVIRONMENT", "local"
         )
         self._runtime_name = os.environ.get("METAFLOW_RUNTIME_NAME", None)
         self._sfn_state_machine_name = os.environ.get("SFN_STATE_MACHINE", None)
+        self._max_workers = os.environ.get("MAX_WORKERS", None)
+        self._max_num_splits = os.environ.get("MAX_NUM_SPLITS", None)
 
     def _update_env(self, env):
         for k, v in env.items():
@@ -132,6 +138,14 @@ class Current(object):
     @property
     def sfn_state_machine_name(self):
         return self._sfn_state_machine_name
+
+    @property
+    def max_workers(self):
+        return int(self._max_workers)
+
+    @property
+    def max_num_splits(self):
+        return int(self._max_num_splits)
 
 
 # instantiate the Current singleton. This will be populated

--- a/metaflow/current.py
+++ b/metaflow/current.py
@@ -16,6 +16,9 @@ class Current(object):
         self._username = None
         self._is_running = False
         self._tags = None
+        self._runtime_environment = None
+        self._runtime_name = None
+        self._sfn_state_machine_name = None
 
         def _raise(ex):
             raise ex
@@ -54,6 +57,7 @@ class Current(object):
             "METAFLOW_RUNTIME_ENVIRONMENT", "local"
         )
         self._runtime_name = os.environ.get("METAFLOW_RUNTIME_NAME", None)
+        self._sfn_state_machine_name = os.environ.get("SFN_STATE_MACHINE", None)
 
     def _update_env(self, env):
         for k, v in env.items():
@@ -124,6 +128,10 @@ class Current(object):
     @property
     def runtime_name(self):
         return self._runtime_name
+
+    @property
+    def sfn_state_machine_name(self):
+        return self._sfn_state_machine_name
 
 
 # instantiate the Current singleton. This will be populated

--- a/metaflow/plugins/aws/step_functions/step_functions_decorator.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_decorator.py
@@ -4,6 +4,7 @@ import time
 
 from metaflow.decorators import StepDecorator
 from metaflow.metadata import MetaDatum
+from metaflow import current
 
 from .dynamo_db_client import DynamoDbClient
 
@@ -36,6 +37,9 @@ class StepFunctionsInternalDecorator(StepDecorator):
         ]
         # Register book-keeping metadata for debugging.
         metadata.register_metadata(run_id, step_name, task_id, entries)
+        current._update_env(
+            dict(sfn_state_machine_name=os.environ["SFN_STATE_MACHINE"])
+        )
 
     def task_finished(
         self, step_name, flow, graph, is_task_ok, retry_count, max_user_code_retries

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -134,6 +134,10 @@ class NativeRuntime(object):
         # finished.
         self._control_num_splits = {}  # control_task -> num_splits mapping
 
+        # to allow the current singleton access within Tasks (which are in subprocesses)
+        os.environ["MAX_WORKERS"] = str(max_workers)
+        os.environ["MAX_NUM_SPLITS"] = str(max_num_splits)
+
         for step in flow:
             for deco in step.decorators:
                 deco.runtime_init(flow, graph, package, self._run_id)

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -135,8 +135,8 @@ class NativeRuntime(object):
         self._control_num_splits = {}  # control_task -> num_splits mapping
 
         # to allow the current singleton access within Tasks (which are in subprocesses)
-        os.environ["MAX_WORKERS"] = str(max_workers)
-        os.environ["MAX_NUM_SPLITS"] = str(max_num_splits)
+        os.environ["CURRENT_MAX_WORKERS"] = str(max_workers)
+        os.environ["CURRENT_MAX_NUM_SPLITS"] = str(max_num_splits)
 
         for step in flow:
             for deco in step.decorators:

--- a/test/core/run_tests.py
+++ b/test/core/run_tests.py
@@ -258,7 +258,7 @@ def run_test_cases(args):
     "--tests",
     default="",
     type=str,
-    help="A comma-separate list of graphs to include (default: all).",
+    help="A comma-separate list of tests to include (default: all).",
 )
 @click.option(
     "--graphs",

--- a/test/core/tests/current_singleton.py
+++ b/test/core/tests/current_singleton.py
@@ -153,4 +153,4 @@ class CurrentSingletonTest(MetaflowTest):
             assert_equals({None}, run.data.runtime_name)
             assert_equals({None}, run.data.sfn_state_machine_name)
             assert_equals({50}, run.data.max_workers)
-            assert_equals({10_000}, run.data.max_num_splits)
+            assert_equals({10000}, run.data.max_num_splits)

--- a/test/core/tests/current_singleton.py
+++ b/test/core/tests/current_singleton.py
@@ -31,7 +31,6 @@ class CurrentSingletonTest(MetaflowTest):
         self.tags = current.tags
         self.runtime_environment = {current.runtime_environment}
         self.runtime_name = {current.runtime_name}
-        self.sfn_state_machine_name = {current.sfn_state_machine_name}
         self.max_workers = {current.max_workers}
         self.max_num_splits = {current.max_num_splits}
 
@@ -61,9 +60,6 @@ class CurrentSingletonTest(MetaflowTest):
         self.tags = set(chain(*(i.tags for i in inputs)))
         self.runtime_environment = set(chain(*(i.runtime_environment for i in inputs)))
         self.runtime_name = set(chain(*(i.runtime_name for i in inputs)))
-        self.sfn_state_machine_name = set(
-            chain(*(i.sfn_state_machine_name for i in inputs))
-        )
         self.max_workers = set(chain(*(i.max_workers for i in inputs)))
         self.max_num_splits = set(chain(*(i.max_num_splits for i in inputs)))
 
@@ -84,7 +80,6 @@ class CurrentSingletonTest(MetaflowTest):
         self.tags.update(current.tags)
         self.runtime_environment.add(current.runtime_environment)
         self.runtime_name.add(current.runtime_name)
-        self.sfn_state_machine_name.add(current.sfn_state_machine_name)
         self.max_workers.add(current.max_workers)
         self.max_num_splits.add(current.max_num_splits)
 
@@ -109,7 +104,6 @@ class CurrentSingletonTest(MetaflowTest):
         self.tags.update(current.tags)
         self.runtime_environment.add(current.runtime_environment)
         self.runtime_name.add(current.runtime_name)
-        self.sfn_state_machine_name.add(current.sfn_state_machine_name)
         self.max_workers.add(current.max_workers)
         self.max_num_splits.add(current.max_num_splits)
 
@@ -151,6 +145,5 @@ class CurrentSingletonTest(MetaflowTest):
             )
             assert_equals({"local"}, run.data.runtime_environment)
             assert_equals({None}, run.data.runtime_name)
-            assert_equals({None}, run.data.sfn_state_machine_name)
             assert_equals({50}, run.data.max_workers)
             assert_equals({10000}, run.data.max_num_splits)

--- a/test/core/tests/current_singleton.py
+++ b/test/core/tests/current_singleton.py
@@ -31,6 +31,7 @@ class CurrentSingletonTest(MetaflowTest):
         self.tags = current.tags
         self.runtime_environment = {current.runtime_environment}
         self.runtime_name = {current.runtime_name}
+        self.sfn_state_machine_name = {current.sfn_state_machine_name}
 
     @steps(1, ["join"])
     def step_join(self):
@@ -58,6 +59,9 @@ class CurrentSingletonTest(MetaflowTest):
         self.tags = set(chain(*(i.tags for i in inputs)))
         self.runtime_environment = set(chain(*(i.runtime_environment for i in inputs)))
         self.runtime_name = set(chain(*(i.runtime_name for i in inputs)))
+        self.sfn_state_machine_name = set(
+            chain(*(i.sfn_state_machine_name for i in inputs))
+        )
 
         # add data for the join step
         self.project_names.add(current.project_name)
@@ -76,6 +80,7 @@ class CurrentSingletonTest(MetaflowTest):
         self.tags.update(current.tags)
         self.runtime_environment.add(current.runtime_environment)
         self.runtime_name.add(current.runtime_name)
+        self.sfn_state_machine_name.add(current.sfn_state_machine_name)
 
     @steps(2, ["all"])
     def step_all(self):
@@ -98,6 +103,7 @@ class CurrentSingletonTest(MetaflowTest):
         self.tags.update(current.tags)
         self.runtime_environment.add(current.runtime_environment)
         self.runtime_name.add(current.runtime_name)
+        self.sfn_state_machine_name.add(current.sfn_state_machine_name)
 
     def check_results(self, flow, checker):
         run = checker.get_run()
@@ -137,3 +143,4 @@ class CurrentSingletonTest(MetaflowTest):
             )
             assert_equals(run.data.runtime_environment, {"local"})
             assert_equals(run.data.runtime_name, {None})
+            assert_equals(run.data.sfn_state_machine_name, {None})

--- a/test/core/tests/current_singleton.py
+++ b/test/core/tests/current_singleton.py
@@ -29,6 +29,8 @@ class CurrentSingletonTest(MetaflowTest):
         self.uuid = str(uuid4())
         self.task_data = {current.pathspec: self.uuid}
         self.tags = current.tags
+        self.runtime_environment = {current.runtime_environment}
+        self.runtime_name = {current.runtime_name}
 
     @steps(1, ["join"])
     def step_join(self):
@@ -54,6 +56,8 @@ class CurrentSingletonTest(MetaflowTest):
         for i in inputs:
             self.task_data.update(i.task_data)
         self.tags = set(chain(*(i.tags for i in inputs)))
+        self.runtime_environment = set(chain(*(i.runtime_environment for i in inputs)))
+        self.runtime_name = set(chain(*(i.runtime_name for i in inputs)))
 
         # add data for the join step
         self.project_names.add(current.project_name)
@@ -70,6 +74,8 @@ class CurrentSingletonTest(MetaflowTest):
         self.uuid = str(uuid4())
         self.task_data[current.pathspec] = self.uuid
         self.tags.update(current.tags)
+        self.runtime_environment.add(current.runtime_environment)
+        self.runtime_name.add(current.runtime_name)
 
     @steps(2, ["all"])
     def step_all(self):
@@ -90,6 +96,8 @@ class CurrentSingletonTest(MetaflowTest):
         self.uuid = str(uuid4())
         self.task_data[current.pathspec] = self.uuid
         self.tags.update(current.tags)
+        self.runtime_environment.add(current.runtime_environment)
+        self.runtime_name.add(current.runtime_name)
 
     def check_results(self, flow, checker):
         run = checker.get_run()
@@ -127,3 +135,5 @@ class CurrentSingletonTest(MetaflowTest):
                 run.data.tags,
                 {"\u523a\u8eab means sashimi", "multiple tags should be ok"},
             )
+            assert_equals(run.data.runtime_environment, {"local"})
+            assert_equals(run.data.runtime_name, {None})

--- a/test/core/tests/current_singleton.py
+++ b/test/core/tests/current_singleton.py
@@ -127,30 +127,30 @@ class CurrentSingletonTest(MetaflowTest):
 
             task_data = run.data.task_data
             for pathspec, uuid in task_data.items():
-                assert_equals(Task(pathspec).data.uuid, uuid)
+                assert_equals(uuid, Task(pathspec).data.uuid)
             for step in run:
                 for task in step:
-                    assert_equals(task.data.step_name, step.id)
+                    assert_equals(step.id, task.data.step_name)
                     pathspec = "/".join(task.pathspec.split("/")[-4:])
-                    assert_equals(task.data.uuid, task_data[pathspec])
-            assert_equals(run.data.project_names, {"current_singleton"})
-            assert_equals(run.data.branch_names, {"user.tester"})
+                    assert_equals(task_data[pathspec], task.data.uuid)
+            assert_equals({"current_singleton"}, run.data.project_names)
+            assert_equals({"user.tester"}, run.data.branch_names)
             assert_equals(
-                run.data.project_flow_names,
                 {"current_singleton.user.tester.CurrentSingletonTestFlow"},
+                run.data.project_flow_names,
             )
-            assert_equals(run.data.is_production, {False})
-            assert_equals(run.data.flow_names, {run.parent.id})
-            assert_equals(run.data.run_ids, {run.id})
-            assert_equals(run.data.origin_run_ids, {None})
-            assert_equals(run.data.namespaces, {"user:tester"})
-            assert_equals(run.data.usernames, {"tester"})
+            assert_equals({False}, run.data.is_production)
+            assert_equals({run.parent.id}, run.data.flow_names)
+            assert_equals({run.id}, run.data.run_ids)
+            assert_equals({None}, run.data.origin_run_ids)
+            assert_equals({"user:tester"}, run.data.namespaces)
+            assert_equals({"tester"}, run.data.usernames)
             assert_equals(
-                run.data.tags,
                 {"\u523a\u8eab means sashimi", "multiple tags should be ok"},
+                run.data.tags,
             )
-            assert_equals(run.data.runtime_environment, {"local"})
-            assert_equals(run.data.runtime_name, {None})
-            assert_equals(run.data.sfn_state_machine_name, {None})
-            assert_equals(run.data.max_workers, {16})
-            assert_equals(run.data.max_num_splits, {100})
+            assert_equals({"local"}, run.data.runtime_environment)
+            assert_equals({None}, run.data.runtime_name)
+            assert_equals({None}, run.data.sfn_state_machine_name)
+            assert_equals({50}, run.data.max_workers)
+            assert_equals({10_000}, run.data.max_num_splits)

--- a/test/core/tests/current_singleton.py
+++ b/test/core/tests/current_singleton.py
@@ -32,6 +32,8 @@ class CurrentSingletonTest(MetaflowTest):
         self.runtime_environment = {current.runtime_environment}
         self.runtime_name = {current.runtime_name}
         self.sfn_state_machine_name = {current.sfn_state_machine_name}
+        self.max_workers = {current.max_workers}
+        self.max_num_splits = {current.max_num_splits}
 
     @steps(1, ["join"])
     def step_join(self):
@@ -62,6 +64,8 @@ class CurrentSingletonTest(MetaflowTest):
         self.sfn_state_machine_name = set(
             chain(*(i.sfn_state_machine_name for i in inputs))
         )
+        self.max_workers = set(chain(*(i.max_workers for i in inputs)))
+        self.max_num_splits = set(chain(*(i.max_num_splits for i in inputs)))
 
         # add data for the join step
         self.project_names.add(current.project_name)
@@ -81,6 +85,8 @@ class CurrentSingletonTest(MetaflowTest):
         self.runtime_environment.add(current.runtime_environment)
         self.runtime_name.add(current.runtime_name)
         self.sfn_state_machine_name.add(current.sfn_state_machine_name)
+        self.max_workers.add(current.max_workers)
+        self.max_num_splits.add(current.max_num_splits)
 
     @steps(2, ["all"])
     def step_all(self):
@@ -104,6 +110,8 @@ class CurrentSingletonTest(MetaflowTest):
         self.runtime_environment.add(current.runtime_environment)
         self.runtime_name.add(current.runtime_name)
         self.sfn_state_machine_name.add(current.sfn_state_machine_name)
+        self.max_workers.add(current.max_workers)
+        self.max_num_splits.add(current.max_num_splits)
 
     def check_results(self, flow, checker):
         run = checker.get_run()
@@ -144,3 +152,5 @@ class CurrentSingletonTest(MetaflowTest):
             assert_equals(run.data.runtime_environment, {"local"})
             assert_equals(run.data.runtime_name, {None})
             assert_equals(run.data.sfn_state_machine_name, {None})
+            assert_equals(run.data.max_workers, {16})
+            assert_equals(run.data.max_num_splits, {100})


### PR DESCRIPTION
This PR will fix #1017, fix #571 

Currently implemented:
- [x] runtime_environment - this can be one of [local, aws-batch, kubernetes]
- [x] runtime_name - this can be one of [None, step-functions]
- [x] sfn state machine name - the name of the state machine if the flow is running on sfn 

To add:
- [ ] max_num_splits
- [ ] max_workers

These are trickier, as they cannot be accessed inside `task.Task.run_step`. I've looked at importing `current` inside `runtime.py`, however as tasks are spun up in subprocesses, the instance of `current` will be a new one, so the values will not actually be reference-able from inside the step
