### PR TITLE
current.pathspec to return None when used outside Flow

### DIFF
--- a/metaflow/current.py
+++ b/metaflow/current.py
@@ -90,7 +90,12 @@ class Current(object):
 
     @property
     def pathspec(self):
-        pathspec_components = (self._flow_name, self._run_id, self._step_name, self._task_id)
+        pathspec_components = (
+            self._flow_name,
+            self._run_id,
+            self._step_name,
+            self._task_id,
+        )
         if any(v is None for v in pathspec_components):
             return None
         return "/".join(pathspec_components)

--- a/metaflow/current.py
+++ b/metaflow/current.py
@@ -90,7 +90,10 @@ class Current(object):
 
     @property
     def pathspec(self):
-        return "/".join((self._flow_name, self._run_id, self._step_name, self._task_id))
+        pathspec_components = (self._flow_name, self._run_id, self._step_name, self._task_id)
+        if any(v is None for v in pathspec_components):
+            return None
+        return "/".join(pathspec_components)
 
     @property
     def namespace(self):


### PR DESCRIPTION
Address issue #1011 

While `current` usage outside of a running Flow is not part of [normal usage](https://docs.metaflow.org/metaflow/tagging#accessing-current-ids-in-a-flow), it is trivial to change to achieve more consistent behavior.