### PR TITLE
[tag-mutation-project] Stash system info in task metadata

### DIFF
--- a/metaflow/metadata/metadata.py
+++ b/metaflow/metadata/metadata.py
@@ -6,8 +6,7 @@ from collections import namedtuple
 from datetime import datetime
 
 from metaflow.exception import MetaflowInternalError
-from metaflow.util import get_username, resolve_identity
-
+from metaflow.util import get_username, resolve_identity_as_tuple
 
 DataArtifact = namedtuple("DataArtifact", "name ds_type ds_root url type sha")
 
@@ -507,8 +506,8 @@ class MetadataProvider(object):
         sys_info["runtime"] = env["runtime"]
         sys_info["python_version"] = env["python_version_code"]
         sys_info["date"] = datetime.utcnow().strftime("%Y-%m-%d")
-        identity_parts = resolve_identity().split(":", maxsplit=1)
-        sys_info[identity_parts[0]] = identity_parts[1]
+        identity_type, identity_value = resolve_identity_as_tuple()
+        sys_info[identity_type] = identity_value
         if env["metaflow_version"]:
             sys_info["metaflow_version"] = env["metaflow_version"]
         if "metaflow_r_version" in env:
@@ -517,10 +516,10 @@ class MetadataProvider(object):
             sys_info["r_version"] = env["r_version_code"]
         return sys_info
 
-    def _get_system_info_as_tag_set(self):
-        return set(
+    def _get_system_info_as_tags(self):
+        return [
             "{}:{}".format(k, v) for k, v in self._get_system_info_as_dict().items()
-        )
+        ]
 
     def _get_system_info_as_metadatum_list(self):
         metadata = []
@@ -640,4 +639,4 @@ class MetadataProvider(object):
         self._monitor = monitor
         self._environment = environment
         self._runtime = os.environ.get("METAFLOW_RUNTIME_NAME", "dev")
-        self.add_sticky_tags(sys_tags=self._get_system_info_as_tag_set())
+        self.add_sticky_tags(sys_tags=self._get_system_info_as_tags())

--- a/metaflow/metadata/metadata.py
+++ b/metaflow/metadata/metadata.py
@@ -515,12 +515,14 @@ class MetadataProvider(object):
             sys_info["r_version"] = env["r_version_code"]
         return sys_info
 
-    def _get_system_info_as_tags(self):
+    def _get_system_tags(self):
+        """Convert system info dictionary into a list of system tags"""
         return [
             "{}:{}".format(k, v) for k, v in self._get_system_info_as_dict().items()
         ]
 
     def _register_system_metadata(self, run_id, step_name, task_id, attempt):
+        """Gather up system and code packaging info and register them as task metadata"""
         metadata = []
         # Take everything from system info and store them as metadata
         sys_info = self._get_system_info_as_dict()
@@ -626,4 +628,4 @@ class MetadataProvider(object):
         self._monitor = monitor
         self._environment = environment
         self._runtime = os.environ.get("METAFLOW_RUNTIME_NAME", "dev")
-        self.add_sticky_tags(sys_tags=self._get_system_info_as_tags())
+        self.add_sticky_tags(sys_tags=self._get_system_tags())

--- a/metaflow/metadata/metadata.py
+++ b/metaflow/metadata/metadata.py
@@ -497,28 +497,52 @@ class MetadataProvider(object):
             for datum in metadata
         ]
 
-    def _tags(self):
+    def _get_system_info(self):
+        sys_info = dict()
         env = self._environment.get_environment_info()
-        tags = [
-            resolve_identity(),
-            "runtime:" + env["runtime"],
-            "python_version:" + env["python_version_code"],
-            "date:" + datetime.utcnow().strftime("%Y-%m-%d"),
-        ]
+        sys_info["runtime"] = env["runtime"]
+        sys_info["python_version"] = env["python_version_code"]
+        sys_info["date"] = datetime.utcnow().strftime("%Y-%m-%d")
+        identity_parts = resolve_identity().split(":", maxsplit=1)
+        sys_info[identity_parts[0]] = identity_parts[1]
         if env["metaflow_version"]:
-            tags.append("metaflow_version:" + env["metaflow_version"])
-        if "metaflow_r_version" in env:
-            tags.append("metaflow_r_version:" + env["metaflow_r_version"])
+            sys_info["metaflow_version"] = env["metaflow_version"]
+        if env["metaflow_r_version"]:
+            sys_info["metaflow_r_version"] = env["metaflow_r_version"]
         if "r_version_code" in env:
-            tags.append("r_version:" + env["r_version_code"])
-        return tags
+            sys_info["r_version"] = env["r_version_code"]
+        return sys_info
 
-    def _register_code_package_metadata(self, run_id, step_name, task_id, attempt):
+    def _get_system_info_as_tags(self):
+        return set("{}:{}".format(k, v) for k, v in self._get_system_info().items())
+
+    def _register_system_info_and_code_packaging_metadata(
+        self, run_id, step_name, task_id, attempt
+    ):
         metadata = []
+        # Take everything from system info and store them as metadata
+        sys_info = self._get_system_info()
+        attempt_id_tag = "attempt_id:{0}".format(attempt)
+
+        # field, and type could get long in theory...can the metadata backend handle it?
+        # E.g. as of 5/9/2022 Metadata service's DB says VARCHAR(255).
+        # It is likely overkill to fail a flow over an over-flow. We should expect the
+        # backend to try to tolerate this (e.g. enlarge columns, truncation fallback).
+        metadata.extend(
+            MetaDatum(
+                field=str(k),
+                value=str(v),
+                type=str(k),
+                tags=[attempt_id_tag],
+            )
+            for k, v in sys_info.items()
+        )
+
+        # Also store code packaging information
         code_sha = os.environ.get("METAFLOW_CODE_SHA")
-        code_url = os.environ.get("METAFLOW_CODE_URL")
-        code_ds = os.environ.get("METAFLOW_CODE_DS")
         if code_sha:
+            code_url = os.environ.get("METAFLOW_CODE_URL")
+            code_ds = os.environ.get("METAFLOW_CODE_DS")
             metadata.append(
                 MetaDatum(
                     field="code-package",
@@ -526,11 +550,9 @@ class MetadataProvider(object):
                         {"ds_type": code_ds, "sha": code_sha, "location": code_url}
                     ),
                     type="code-package",
-                    tags=["attempt_id:{0}".format(attempt)],
+                    tags=[attempt_id_tag],
                 )
             )
-        # We don't tag with attempt_id here because not readily available; this
-        # is ok though as this doesn't change from attempt to attempt.
         if metadata:
             self.register_metadata(run_id, step_name, task_id, metadata)
 
@@ -604,4 +626,4 @@ class MetadataProvider(object):
         self._monitor = monitor
         self._environment = environment
         self._runtime = os.environ.get("METAFLOW_RUNTIME_NAME", "dev")
-        self.add_sticky_tags(sys_tags=self._tags())
+        self.add_sticky_tags(sys_tags=self._get_system_info_as_tags())

--- a/metaflow/metadata/metadata.py
+++ b/metaflow/metadata/metadata.py
@@ -505,7 +505,6 @@ class MetadataProvider(object):
         env = self._environment.get_environment_info()
         sys_info["runtime"] = env["runtime"]
         sys_info["python_version"] = env["python_version_code"]
-        sys_info["date"] = datetime.utcnow().strftime("%Y-%m-%d")
         identity_type, identity_value = resolve_identity_as_tuple()
         sys_info[identity_type] = identity_value
         if env["metaflow_version"]:

--- a/metaflow/metadata/metadata.py
+++ b/metaflow/metadata/metadata.py
@@ -520,7 +520,7 @@ class MetadataProvider(object):
             "{}:{}".format(k, v) for k, v in self._get_system_info_as_dict().items()
         ]
 
-    def _get_system_info_as_metadatum_list(self):
+    def _register_system_metadata(self, run_id, step_name, task_id, attempt):
         metadata = []
         # Take everything from system info and store them as metadata
         sys_info = self._get_system_info_as_dict()
@@ -534,18 +534,10 @@ class MetadataProvider(object):
                 field=str(k),
                 value=str(v),
                 type=str(k),
-                tags=[],
+                tags=["attempt_id:{0}".format(attempt)],
             )
             for k, v in sys_info.items()
         )
-        return metadata
-
-    def _register_system_info_and_code_packaging_metadata(
-        self, run_id, step_name, task_id, attempt
-    ):
-        # Take everything from system info and store them as metadata
-        metadata = self._get_system_info_as_metadatum_list()
-
         # Also store code packaging information
         code_sha = os.environ.get("METAFLOW_CODE_SHA")
         if code_sha:
@@ -558,14 +550,10 @@ class MetadataProvider(object):
                         {"ds_type": code_ds, "sha": code_sha, "location": code_url}
                     ),
                     type="code-package",
-                    tags=[],
+                    tags=["attempt_id:{0}".format(attempt)],
                 )
             )
         if metadata:
-            # Tag all metadatums with attempt_id
-            attempt_id_tag = "attempt_id:{0}".format(attempt)
-            for metadatum in metadata:
-                metadatum.tags.append(attempt_id_tag)
             self.register_metadata(run_id, step_name, task_id, metadata)
 
     @staticmethod

--- a/metaflow/plugins/metadata/local.py
+++ b/metaflow/plugins/metadata/local.py
@@ -80,7 +80,9 @@ class LocalMetadataProvider(MetadataProvider):
         except ValueError:
             self._new_task(run_id, step_name, task_id, attempt, tags, sys_tags)
         else:
-            self._register_code_package_metadata(run_id, step_name, task_id, attempt)
+            self._register_system_info_and_code_packaging_metadata(
+                run_id, step_name, task_id, attempt
+            )
 
     def register_data_artifacts(
         self, run_id, step_name, task_id, attempt_id, artifacts
@@ -236,7 +238,9 @@ class LocalMetadataProvider(MetadataProvider):
     ):
         self._ensure_meta("step", run_id, step_name, None)
         self._ensure_meta("task", run_id, step_name, task_id, tags, sys_tags)
-        self._register_code_package_metadata(run_id, step_name, task_id, attempt)
+        self._register_system_info_and_code_packaging_metadata(
+            run_id, step_name, task_id, attempt
+        )
 
     @staticmethod
     def _make_path(

--- a/metaflow/plugins/metadata/local.py
+++ b/metaflow/plugins/metadata/local.py
@@ -80,9 +80,7 @@ class LocalMetadataProvider(MetadataProvider):
         except ValueError:
             self._new_task(run_id, step_name, task_id, attempt, tags, sys_tags)
         else:
-            self._register_system_info_and_code_packaging_metadata(
-                run_id, step_name, task_id, attempt
-            )
+            self._register_system_metadata(run_id, step_name, task_id, attempt)
 
     def register_data_artifacts(
         self, run_id, step_name, task_id, attempt_id, artifacts
@@ -238,9 +236,7 @@ class LocalMetadataProvider(MetadataProvider):
     ):
         self._ensure_meta("step", run_id, step_name, None)
         self._ensure_meta("task", run_id, step_name, task_id, tags, sys_tags)
-        self._register_system_info_and_code_packaging_metadata(
-            run_id, step_name, task_id, attempt
-        )
+        self._register_system_metadata(run_id, step_name, task_id, attempt)
 
     @staticmethod
     def _make_path(

--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -94,7 +94,9 @@ class ServiceMetadataProvider(MetadataProvider):
                 run_id, step_name, task_id, attempt, tags=tags, sys_tags=sys_tags
             )
         else:
-            self._register_code_package_metadata(run_id, step_name, task_id, attempt)
+            self._register_system_info_and_code_packaging_metadata(
+                run_id, step_name, task_id, attempt
+            )
 
     def _start_heartbeat(
         self, heartbeat_type, flow_id, run_id, step_name=None, task_id=None
@@ -234,7 +236,7 @@ class ServiceMetadataProvider(MetadataProvider):
         task = self._get_or_create(
             "task", run_id, step_name, task_id, tags=tags, sys_tags=sys_tags
         )
-        self._register_code_package_metadata(
+        self._register_system_info_and_code_packaging_metadata(
             run_id, step_name, task["task_id"], attempt
         )
         return task["task_id"]

--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -94,9 +94,7 @@ class ServiceMetadataProvider(MetadataProvider):
                 run_id, step_name, task_id, attempt, tags=tags, sys_tags=sys_tags
             )
         else:
-            self._register_system_info_and_code_packaging_metadata(
-                run_id, step_name, task_id, attempt
-            )
+            self._register_system_metadata(run_id, step_name, task_id, attempt)
 
     def _start_heartbeat(
         self, heartbeat_type, flow_id, run_id, step_name=None, task_id=None
@@ -236,9 +234,7 @@ class ServiceMetadataProvider(MetadataProvider):
         task = self._get_or_create(
             "task", run_id, step_name, task_id, tags=tags, sys_tags=sys_tags
         )
-        self._register_system_info_and_code_packaging_metadata(
-            run_id, step_name, task["task_id"], attempt
-        )
+        self._register_system_metadata(run_id, step_name, task["task_id"], attempt)
         return task["task_id"]
 
     @staticmethod

--- a/metaflow/util.py
+++ b/metaflow/util.py
@@ -174,15 +174,20 @@ def get_username():
     return None
 
 
-def resolve_identity():
+def resolve_identity_as_tuple():
     prod_token = os.environ.get("METAFLOW_PRODUCTION_TOKEN")
     if prod_token:
-        return "production:%s" % prod_token
+        return "production", prod_token
     user = get_username()
     if user and user != "root":
-        return "user:%s" % user
+        return "user", user
     else:
         raise MetaflowUnknownUser()
+
+
+def resolve_identity():
+    identity_type, identity_value = resolve_identity_as_tuple()
+    return "%s:%s" % (identity_type, identity_value)
 
 
 def get_latest_run_id(echo, flow_name):

--- a/test/core/tests/resume_end_step.py
+++ b/test/core/tests/resume_end_step.py
@@ -36,7 +36,7 @@ class ResumeEndStepTest(MetaflowTest):
         if run is not None:
             # We can also check the metadata for all steps
             common_run_id = None
-            exclude_keys = ["origin-task-id", "origin-run-id"]
+            exclude_keys = ["origin-task-id", "origin-run-id", "python_version"]
             for step in run:
                 for task in step:
                     resumed_metadata = task.metadata_dict


### PR DESCRIPTION
This is part of project to add tag mutation support. RFC [here](https://www.notion.so/outerbounds/RFC-Implementing-tag-mutation-98ef6ba39aee4aeeb9c6150b4cffea2a) (see "Consolidate tagging to Runs")

A side effect of consolidating tagging to Runs on the read paths is that Task-level tags and system_tags are no longer accessible over the Metaflow client API - we will get only Run-level tags and system tags.  In most cases this is fine because usually tags are the same between a Run and its descendant Tasks.  The exception is Task-level system tags which may diverge from the Run's system tags in some rare situations.

In this PR:
* We explicitly name the information being stored as system tags (including at Task-level) "system information"
* For tasks, we _continue_ to store this "system information" as system tags.  This is for backwards compatibility.  Eventually we we can look to stop doing so (e.g. Deprecation policy TBD....).
* For tasks, we also stash the same "system information" in a Task's metadata.  This allows Task-divergent system information previously accessed in a task's tags to become accessible within a Task's metadata instead.

We added the concept of "system information" to maintain a single info source driving both "system tags" today as well as what to save as Task metadata.  I.e. we don't want to be go from dictionary-like information to a list of `"%s:%s"` strings and then back again to construct Task metadata.

For simplicity, we also just stash away all existing system information items as Task metadata, rather than picking / excluding certain items. This removes the dependence for detailed knowledge about exactly which items are important to stash or which can possibly diverge between Run and Task, both today and in future.

Drive-by: we also remove `date` as a piece of system information.  I.e. it will no longer show up as a system tag for ALL objects,  It is too-generically named and similar information is available in client API as `created_at`.

This PR took some cues from this [older PR](https://github.com/Netflix/metaflow/pull/917).