### PR TITLE
Fix minio access for remote runs

### DIFF
--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -89,7 +89,8 @@ class MetaflowEnvironment(object):
             "mkdir .metaflow",  # mute local datastore creation log
             "i=0; while [ $i -le 5 ]; do "
             "mflog 'Downloading code package...'; "
-            "%s -m awscli s3 cp %s job.tar >/dev/null && mflog 'Code package downloaded.' && break; "
+            '%s -m awscli ${METAFLOW_S3_ENDPOINT_URL:+--endpoint-url=\\"${METAFLOW_S3_ENDPOINT_URL}\\"} '
+            "s3 cp %s job.tar >/dev/null && mflog 'Code package downloaded.' && break; "
             "sleep 10; i=$((i+1)); "
             "done" % (self._python(), code_package_url),
             "if [ $i -gt 5 ]; then "


### PR DESCRIPTION
Local runs use METAFLOW_S3_ENDPOINT_URL config to set the
"--endpoint-url" parameter required to access a minio server.
Remote containers miss this part, hence can't download a package
archive to start a step execution.

This fix adds "--endpoint-url" to the awscli command if
METAFLOW_S3_ENDPOINT_URL envar is defined in the remote container.