### PR TITLE
Improve sidecar message handling

### DIFF
--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -100,8 +100,6 @@ from .metaflow_profile import profile
 # current runtime singleton
 from .current import current
 
-from .event_logger import EventLogger
-
 # Flow spec
 from .flowspec import FlowSpec
 from .includefile import IncludeFile

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -943,11 +943,11 @@ def start(
     ctx.obj.environment.validate_environment(echo)
 
     ctx.obj.event_logger = EventLogger(
-        event_logger, ctx.obj.environment, ctx.obj.flow.name
+        event_logger, ctx.obj.environment, flow_name=ctx.obj.flow.name
     )
     ctx.obj.event_logger.start()
 
-    ctx.obj.monitor = Monitor(monitor, ctx.obj.environment, ctx.obj.flow.name)
+    ctx.obj.monitor = Monitor(monitor, ctx.obj.environment, flow_name=ctx.obj.flow.name)
     ctx.obj.monitor.start()
 
     ctx.obj.metadata = [m for m in METADATA_PROVIDERS if m.TYPE == metadata][0](

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -44,8 +44,6 @@ from .metaflow_config import (
 )
 from .metaflow_environment import MetaflowEnvironment
 from .pylint_wrapper import PyLint
-from .event_logger import EventLogger
-from .monitor import Monitor
 from .R import use_r, metaflow_r_version
 from .mflog import mflog, LOG_SOURCES
 from .unbounded_foreach import UBF_CONTROL, UBF_TASK
@@ -942,12 +940,12 @@ def start(
     ][0](ctx.obj.flow)
     ctx.obj.environment.validate_environment(echo)
 
-    ctx.obj.event_logger = EventLogger(
-        event_logger, ctx.obj.environment, flow_name=ctx.obj.flow.name
+    ctx.obj.event_logger = LOGGING_SIDECARS[event_logger](
+        ctx.obj.flow, ctx.obj.environment
     )
     ctx.obj.event_logger.start()
 
-    ctx.obj.monitor = Monitor(monitor, ctx.obj.environment, flow_name=ctx.obj.flow.name)
+    ctx.obj.monitor = MONITOR_SIDECARS[monitor](ctx.obj.flow, ctx.obj.environment)
     ctx.obj.monitor.start()
 
     ctx.obj.metadata = [m for m in METADATA_PROVIDERS if m.TYPE == metadata][0](

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -941,11 +941,13 @@ def start(
     ctx.obj.environment.validate_environment(echo)
 
     ctx.obj.event_logger = LOGGING_SIDECARS[event_logger](
-        ctx.obj.flow, ctx.obj.environment
+        flow=ctx.obj.flow, env=ctx.obj.environment
     )
     ctx.obj.event_logger.start()
 
-    ctx.obj.monitor = MONITOR_SIDECARS[monitor](ctx.obj.flow, ctx.obj.environment)
+    ctx.obj.monitor = MONITOR_SIDECARS[monitor](
+        flow=ctx.obj.flow, env=ctx.obj.environment
+    )
     ctx.obj.monitor.start()
 
     ctx.obj.metadata = [m for m in METADATA_PROVIDERS if m.TYPE == metadata][0](

--- a/metaflow/event_logger.py
+++ b/metaflow/event_logger.py
@@ -9,6 +9,9 @@ class NullEventLogger(object):
     def start(self):
         pass
 
+    def add_context(self, **kwargs):
+        pass
+
     def log(self, payload):
         pass
 
@@ -17,18 +20,26 @@ class NullEventLogger(object):
 
 
 class EventLogger(NullEventLogger):
-    def __init__(self, logger_type, env, flow_name):
+    def __init__(self, logger_type, env, **kwargs):
         # type: (str, str, str) -> None
         self.sidecar_process = None
         self.logger_type = logger_type
-        self.env_info = env.get_environment_info()
-        self.env_info["flow_name"] = flow_name
+        self._context = {"env": env.get_environment_info()}
+        # The additional keywords are added to the context for the monitor.
+        # One use case is adding tags like flow_name etc.
+        if kwargs:
+            # Make sure we copy it as we don't want it to change
+            self._context["user_context"] = dict(kwargs)
 
     def start(self):
         if self.sidecar_process is None:
-            self.sidecar_process = SidecarSubProcess(
-                self.logger_type, {"env": self.env_info}
-            )
+            self.sidecar_process = SidecarSubProcess(self.logger_type, self._context)
+
+    def add_context(self, **kwargs):
+        self._context["user_context"].update(kwargs)
+        if self.sidecar_process is not None:
+            msg = Message(MessageTypes.UPDATE_CONTEXT, self._context)
+            self.sidecar_process.send(msg)
 
     def log(self, payload):
         if self.sidecar_process is not None:

--- a/metaflow/event_logger.py
+++ b/metaflow/event_logger.py
@@ -1,21 +1,31 @@
 from metaflow.sidecar import Message, MessageTypes, Sidecar
 
 
-class BaseEventLogger(Sidecar):
+class BaseEventLogger(object):
+    TYPE = "nullSidecarLogger"
+
+    def __init__(self, flow, env):
+        self._sidecar = Sidecar(self.TYPE)
+
+    def start(self):
+        return self._sidecar.start()
+
+    def terminate(self):
+        return self._sidecar.terminate()
+
+    def add_context(self, context):
+        pass
+
     def log(self, payload):
-        if self._is_active:
-            msg = Message(MessageTypes.EVENT, payload)
-            self._send(msg)
+        if self._sidecar.is_active:
+            msg = Message(MessageTypes.BEST_EFFORT, payload)
+            self._sidecar.send(msg)
+
+    @classmethod
+    def get_worker(cls):
+        return None
 
 
 # Backward compatible name
 class EventLogger(BaseEventLogger):
     pass
-
-
-class NullLogger(BaseEventLogger):
-    TYPE = "nullSidecarLogger"
-
-    @classmethod
-    def get_sidecar_worker_class(cls):
-        return None

--- a/metaflow/event_logger.py
+++ b/metaflow/event_logger.py
@@ -4,7 +4,7 @@ from metaflow.sidecar import Message, MessageTypes, Sidecar
 class BaseEventLogger(object):
     TYPE = "nullSidecarLogger"
 
-    def __init__(self, flow, env):
+    def __init__(self, flow=None, env=None):
         self._sidecar = Sidecar(self.TYPE)
 
     def start(self):
@@ -13,7 +13,7 @@ class BaseEventLogger(object):
     def terminate(self):
         return self._sidecar.terminate()
 
-    def add_context(self, context):
+    def add_to_context(self, **kwargs):
         pass
 
     def log(self, payload):

--- a/metaflow/event_logger.py
+++ b/metaflow/event_logger.py
@@ -1,10 +1,11 @@
 from metaflow.sidecar import Message, MessageTypes, Sidecar
 
 
-class BaseEventLogger(object):
+class NullEventLogger(object):
     TYPE = "nullSidecarLogger"
 
-    def __init__(self, flow=None, env=None):
+    def __init__(self, *args, **kwargs):
+        # Currently passed flow and env in kwargs
         self._sidecar = Sidecar(self.TYPE)
 
     def start(self):
@@ -13,7 +14,9 @@ class BaseEventLogger(object):
     def terminate(self):
         return self._sidecar.terminate()
 
-    def add_to_context(self, **kwargs):
+    def send(self, msg):
+        # Arbitrary message sending. Useful if you want to override some different
+        # types of messages.
         pass
 
     def log(self, payload):
@@ -24,8 +27,3 @@ class BaseEventLogger(object):
     @classmethod
     def get_worker(cls):
         return None
-
-
-# Backward compatible name
-class EventLogger(BaseEventLogger):
-    pass

--- a/metaflow/event_logger.py
+++ b/metaflow/event_logger.py
@@ -1,51 +1,21 @@
-from .sidecar import SidecarSubProcess
-from .sidecar_messages import Message, MessageTypes
+from metaflow.sidecar import Message, MessageTypes, Sidecar
 
 
-class NullEventLogger(object):
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def start(self):
-        pass
-
-    def add_context(self, **kwargs):
-        pass
-
+class BaseEventLogger(Sidecar):
     def log(self, payload):
-        pass
+        if self._is_active:
+            msg = Message(MessageTypes.EVENT, payload)
+            self._send(msg)
 
-    def terminate(self):
-        pass
+
+# Backward compatible name
+class EventLogger(BaseEventLogger):
+    pass
 
 
-class EventLogger(NullEventLogger):
-    def __init__(self, logger_type, env, **kwargs):
-        # type: (str, str, str) -> None
-        self.sidecar_process = None
-        self.logger_type = logger_type
-        self._context = {"env": env.get_environment_info()}
-        # The additional keywords are added to the context for the monitor.
-        # One use case is adding tags like flow_name etc.
-        if kwargs:
-            # Make sure we copy it as we don't want it to change
-            self._context["user_context"] = dict(kwargs)
+class NullLogger(BaseEventLogger):
+    TYPE = "null"
 
-    def start(self):
-        if self.sidecar_process is None:
-            self.sidecar_process = SidecarSubProcess(self.logger_type, self._context)
-
-    def add_context(self, **kwargs):
-        self._context["user_context"].update(kwargs)
-        if self.sidecar_process is not None:
-            msg = Message(MessageTypes.UPDATE_CONTEXT, self._context)
-            self.sidecar_process.send(msg)
-
-    def log(self, payload):
-        if self.sidecar_process is not None:
-            msg = Message(MessageTypes.LOG_EVENT, payload)
-            self.sidecar_process.send(msg)
-
-    def terminate(self):
-        if self.sidecar_process is not None:
-            self.sidecar_process.kill()
+    @classmethod
+    def get_sidecar_worker_class(cls):
+        return None

--- a/metaflow/event_logger.py
+++ b/metaflow/event_logger.py
@@ -14,7 +14,7 @@ class EventLogger(BaseEventLogger):
 
 
 class NullLogger(BaseEventLogger):
-    TYPE = "null"
+    TYPE = "nullSidecarLogger"
 
     @classmethod
     def get_sidecar_worker_class(cls):

--- a/metaflow/metadata/heartbeat.py
+++ b/metaflow/metadata/heartbeat.py
@@ -36,7 +36,7 @@ class MetadataHeartBeat(object):
             self.req_thread.start()
 
     @classmethod
-    def get_sidecar_worker_class(cls):
+    def get_worker(cls):
         return cls
 
     def _ping(self):

--- a/metaflow/metadata/heartbeat.py
+++ b/metaflow/metadata/heartbeat.py
@@ -29,7 +29,7 @@ class MetadataHeartBeat(object):
         # type: (Message) -> None
         if msg.msg_type == MessageTypes.SHUTDOWN:
             self._shutdown()
-        if (not self.req_thread.is_alive()) and msg.msg_type == MessageTypes.CONTEXT:
+        if (not self.req_thread.is_alive()) and msg.msg_type == MessageTypes.MUST_SEND:
             # set post url
             self.hb_url = msg.payload[HB_URL_KEY]
             # start thread

--- a/metaflow/metadata/heartbeat.py
+++ b/metaflow/metadata/heartbeat.py
@@ -3,7 +3,7 @@ import requests
 import json
 
 from threading import Thread
-from metaflow.sidecar_messages import MessageTypes, Message
+from metaflow.sidecar import MessageTypes, Message
 from metaflow.metaflow_config import METADATA_SERVICE_HEADERS
 from metaflow.exception import MetaflowException
 
@@ -29,11 +29,15 @@ class MetadataHeartBeat(object):
         # type: (Message) -> None
         if msg.msg_type == MessageTypes.SHUTDOWN:
             self._shutdown()
-        if (not self.req_thread.is_alive()) and msg.msg_type == MessageTypes.START:
+        if (not self.req_thread.is_alive()) and msg.msg_type == MessageTypes.CONTEXT:
             # set post url
             self.hb_url = msg.payload[HB_URL_KEY]
             # start thread
             self.req_thread.start()
+
+    @classmethod
+    def get_sidecar_worker_class(cls):
+        return cls
 
     def _ping(self):
         retry_counter = 0

--- a/metaflow/metadata/heartbeat.py
+++ b/metaflow/metadata/heartbeat.py
@@ -29,7 +29,7 @@ class MetadataHeartBeat(object):
         # type: (Message) -> None
         if msg.msg_type == MessageTypes.SHUTDOWN:
             self._shutdown()
-        if (not self.req_thread.is_alive()) and msg.msg_type == MessageTypes.MUST_SEND:
+        if not self.req_thread.is_alive():
             # set post url
             self.hb_url = msg.payload[HB_URL_KEY]
             # start thread

--- a/metaflow/mflog/save_logs_periodically.py
+++ b/metaflow/mflog/save_logs_periodically.py
@@ -19,7 +19,7 @@ class SaveLogsPeriodicallySidecar(object):
             self.is_alive = False
 
     @classmethod
-    def get_sidecar_worker_class(cls):
+    def get_worker(cls):
         return cls
 
     def _update_loop(self):

--- a/metaflow/mflog/save_logs_periodically.py
+++ b/metaflow/mflog/save_logs_periodically.py
@@ -4,8 +4,7 @@ import time
 import subprocess
 from threading import Thread
 
-from metaflow.metaflow_profile import profile
-from metaflow.sidecar import SidecarSubProcess
+from metaflow.sidecar import MessageTypes
 from . import update_delay, BASH_SAVE_LOGS_ARGS
 
 
@@ -16,10 +15,12 @@ class SaveLogsPeriodicallySidecar(object):
         self._thread.start()
 
     def process_message(self, msg):
-        pass
+        if msg.msg_type == MessageTypes.SHUTDOWN:
+            self.is_alive = False
 
-    def shutdown(self):
-        self.is_alive = False
+    @classmethod
+    def get_sidecar_worker_class(cls):
+        return cls
 
     def _update_loop(self):
         def _file_size(path):

--- a/metaflow/monitor.py
+++ b/metaflow/monitor.py
@@ -7,7 +7,6 @@ from .sidecar_messages import Message, MessageTypes
 
 COUNTER_TYPE = "COUNTER"
 GAUGE_TYPE = "GAUGE"
-MEASURE_TYPE = "MEASURE"
 TIMER_TYPE = "TIMER"
 
 
@@ -35,7 +34,7 @@ class NullMonitor(object):
 
 class Monitor(NullMonitor):
     def __init__(self, monitor_type, env, flow_name):
-        # type: (str) -> None
+        # type: (str, str, str) -> None
         self.sidecar_process = None
         self.monitor_type = monitor_type
         self.env_info = env.get_environment_info()
@@ -43,40 +42,42 @@ class Monitor(NullMonitor):
 
     def start(self):
         if self.sidecar_process is None:
-            self.sidecar_process = SidecarSubProcess(self.monitor_type)
+            self.sidecar_process = SidecarSubProcess(
+                self.monitor_type, {"env": self.env_info}
+            )
 
     @contextmanager
     def count(self, name):
         if self.sidecar_process is not None:
-            counter = Counter(name, self.env_info)
+            counter = Counter(name)
             counter.increment()
-            payload = {"counter": counter.to_dict()}
+            payload = {"counter": counter.serialize()}
             msg = Message(MessageTypes.LOG_EVENT, payload)
             yield
-            self.sidecar_process.msg_handler(msg)
+            self.sidecar_process.send(msg)
         else:
             yield
 
     @contextmanager
     def measure(self, name):
         if self.sidecar_process is not None:
-            timer = Timer(name + "_timer", self.env_info)
-            counter = Counter(name + "_counter", self.env_info)
+            timer = Timer(name + "_timer")
+            counter = Counter(name + "_counter")
             timer.start()
             counter.increment()
             yield
             timer.end()
-            payload = {"counter": counter.to_dict(), "timer": timer.to_dict()}
+            payload = {"counter": counter.serialize(), "timer": timer.serialize()}
             msg = Message(MessageTypes.LOG_EVENT, payload)
-            self.sidecar_process.msg_handler(msg)
+            self.sidecar_process.send(msg)
         else:
             yield
 
     def gauge(self, gauge):
         if self.sidecar_process is not None:
-            payload = {"gauge": gauge.to_dict()}
+            payload = {"gauge": gauge.serialize()}
             msg = Message(MessageTypes.LOG_EVENT, payload)
-            self.sidecar_process.msg_handler(msg)
+            self.sidecar_process.send(msg)
 
     def terminate(self):
         if self.sidecar_process is not None:
@@ -88,83 +89,98 @@ class Metric(object):
     Abstract base class
     """
 
-    def __init__(self, type, env):
+    def __init__(self, metric_type, name, env=None):
+        self._type = metric_type
+        self._name = name
         self._env = env
-        self._type = type
+
+    @property
+    def metric_type(self):
+        return self._type
 
     @property
     def name(self):
-        raise NotImplementedError()
+        return self._name
 
     @property
     def flow_name(self):
-        return self._env["flow_name"]
+        if self._env is not None:
+            return self._env.get("flow_name", None)
+        return None
 
     @property
     def env(self):
         return self._env
 
+    @env.setter
+    def env(self, new_env):
+        self._env = new_env
+
     @property
     def value(self):
         raise NotImplementedError()
 
-    def set_env(self, env):
-        self._env = env
+    def serialize(self):
+        # We purposefully do not serialize the environment as it can be large;
+        # it will be transferred using a different mechanism and reset on the other
+        # end.
+        return {"_name": self._name, "_type": self._type}
 
-    def to_dict(self):
-        return {
-            "_env": self._env,
-            "_type": self._type,
-        }
+    @classmethod
+    def deserialize(cls, value):
+        if value is None:
+            return None
+        metric_type = value.get("_type", "INVALID")
+        metric_name = value.get("_name", None)
+        metric_cls = _str_type_to_type.get(metric_type, None)
+        if metric_cls:
+            return metric_cls.deserialize(metric_name, value)
+        else:
+            raise NotImplementedError("Metric class %s is not supported" % metric_type)
 
 
 class Timer(Metric):
-    def __init__(self, name, env):
-        super(Timer, self).__init__(TIMER_TYPE, env)
-        self._name = name
+    def __init__(self, name, env=None):
+        super(Timer, self).__init__(TIMER_TYPE, name, env)
         self._start = 0
         self._end = 0
 
+    def start(self, now=None):
+        if now is None:
+            now = time.time()
+        self._start = now
+
+    def end(self, now=None):
+        if now is None:
+            now = time.time()
+        self._end = now
+
     @property
-    def name(self):
-        return self._name
-
-    def start(self):
-        self._start = time.time()
-
-    def end(self):
-        self._end = time.time()
-
-    def set_start(self, start):
-        self._start = start
-
-    def set_end(self, end):
-        self._end = end
-
-    def get_duration(self):
+    def duration(self):
         return self._end - self._start
 
     @property
     def value(self):
-        return (self._end - self._start) * 1000
+        return self.duration * 1000
 
-    def to_dict(self):
-        parent_dict = super(Timer, self).to_dict()
-        parent_dict["_name"] = self.name
-        parent_dict["_start"] = self._start
-        parent_dict["_end"] = self._end
-        return parent_dict
+    def serialize(self):
+        parent_ser = super(Timer, self).serialize()
+        parent_ser["_start"] = self._start
+        parent_ser["_end"] = self._end
+        return parent_ser
+
+    @classmethod
+    def deserialize(cls, metric_name, value):
+        t = Timer(metric_name)
+        t.start(value.get("_start", 0))
+        t.end(value.get("_end", 0))
+        return t
 
 
 class Counter(Metric):
-    def __init__(self, name, env):
-        super(Counter, self).__init__(COUNTER_TYPE, env)
-        self._name = name
+    def __init__(self, name, env=None):
+        super(Counter, self).__init__(COUNTER_TYPE, name, env)
         self._count = 0
-
-    @property
-    def name(self):
-        return self._name
 
     def increment(self):
         self._count += 1
@@ -176,22 +192,22 @@ class Counter(Metric):
     def value(self):
         return self._count
 
-    def to_dict(self):
-        parent_dict = super(Counter, self).to_dict()
-        parent_dict["_name"] = self.name
-        parent_dict["_count"] = self._count
-        return parent_dict
+    def serialize(self):
+        parent_ser = super(Counter, self).serialize()
+        parent_ser["_count"] = self._count
+        return parent_ser
+
+    @classmethod
+    def deserialize(cls, metric_name, value):
+        c = Counter(metric_name)
+        c.set_count(value.get("_count", 0))
+        return c
 
 
 class Gauge(Metric):
-    def __init__(self, name, env):
-        super(Gauge, self).__init__(GAUGE_TYPE, env)
-        self._name = name
+    def __init__(self, name, env=None):
+        super(Gauge, self).__init__(GAUGE_TYPE, name, env)
         self._value = 0
-
-    @property
-    def name(self):
-        return self._name
 
     def set_value(self, val):
         self._value = val
@@ -203,47 +219,15 @@ class Gauge(Metric):
     def value(self):
         return self._value
 
-    def to_dict(self):
-        parent_dict = super(Gauge, self).to_dict()
-        parent_dict["_name"] = self.name
-        parent_dict["_value"] = self.value
-        return parent_dict
+    def serialize(self):
+        parent_ser = super(Gauge, self).serialize()
+        parent_ser["_value"] = self._value
+
+    @classmethod
+    def deserialize(cls, metric_name, value):
+        g = Gauge(metric_name)
+        g.set_value(value.get("_value", 0))
+        return g
 
 
-def deserialize_metric(metrics_dict):
-    if metrics_dict is None:
-        return
-
-    type = metrics_dict.get("_type")
-    name = metrics_dict.get("_name")
-    if type == COUNTER_TYPE:
-        try:
-            counter = Counter(name, None)
-            counter.set_env(metrics_dict.get("_env"))
-        except Exception as ex:
-            return
-
-        counter.set_count(metrics_dict.get("_count"))
-        return counter
-    elif type == TIMER_TYPE:
-        timer = Timer(name, None)
-        timer.set_start(metrics_dict.get("_start"))
-        timer.set_end(metrics_dict.get("_end"))
-        timer.set_env(metrics_dict.get("_env"))
-        return timer
-    elif type == GAUGE_TYPE:
-        gauge = Gauge(name, None)
-        gauge.set_env(metrics_dict.get("_env"))
-        gauge.set_value(metrics_dict.get("_value"))
-        return gauge
-    else:
-        raise NotImplementedError("UNSUPPORTED MESSAGE TYPE IN MONITOR")
-
-
-def get_monitor_msg_type(msg):
-    if msg.payload.get("gauge") is not None:
-        return GAUGE_TYPE
-    if msg.payload.get("counter") is not None:
-        if msg.payload.get("timer") is not None:
-            return MEASURE_TYPE
-        return COUNTER_TYPE
+_str_type_to_type = {COUNTER_TYPE: Counter, GAUGE_TYPE: Gauge, TIMER_TYPE: Timer}

--- a/metaflow/monitor.py
+++ b/metaflow/monitor.py
@@ -12,7 +12,7 @@ TIMER_TYPE = "TIMER"
 class BaseMonitor(object):
     TYPE = "nullSidecarMonitor"
 
-    def __init__(self, flow, env):
+    def __init__(self, flow=None, env=None):
         self._sidecar = Sidecar(self.TYPE)
 
     def start(self):
@@ -21,7 +21,7 @@ class BaseMonitor(object):
     def terminate(self):
         return self._sidecar.terminate()
 
-    def add_context(self, context):
+    def add_to_context(self, **kwargs):
         pass
 
     @contextmanager

--- a/metaflow/monitor.py
+++ b/metaflow/monitor.py
@@ -9,10 +9,11 @@ GAUGE_TYPE = "GAUGE"
 TIMER_TYPE = "TIMER"
 
 
-class BaseMonitor(object):
+class NullMonitor(object):
     TYPE = "nullSidecarMonitor"
 
-    def __init__(self, flow=None, env=None):
+    def __init__(self, *args, **kwargs):
+        # Currently passed flow and env as kwargs
         self._sidecar = Sidecar(self.TYPE)
 
     def start(self):
@@ -21,8 +22,10 @@ class BaseMonitor(object):
     def terminate(self):
         return self._sidecar.terminate()
 
-    def add_to_context(self, **kwargs):
-        pass
+    def send(self, msg):
+        # Arbitrary message sending. Useful if you want to override some different
+        # types of messages.
+        self._sidecar.send(msg)
 
     @contextmanager
     def count(self, name):

--- a/metaflow/monitor.py
+++ b/metaflow/monitor.py
@@ -45,7 +45,7 @@ class BaseMonitor(Sidecar):
 
 
 class NullMonitor(BaseMonitor):
-    TYPE = "null"
+    TYPE = "nullSidecarMonitor"
 
     @classmethod
     def get_sidecar_worker_class(cls):

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -1,4 +1,5 @@
 import sys
+import traceback
 import types
 
 
@@ -66,6 +67,11 @@ try:
                 v[1](_ext_plugins[k], module_override)
 except Exception as e:
     _ext_debug("\tWARNING: ignoring all plugins due to error during import: %s" % e)
+    print(
+        "WARNING: Plugins did not load -- ignoring all of them which may not "
+        "be what you want: %s" % e
+    )
+    traceback.print_exc()
     _ext_plugins = {k: v[0] for k, v in _expected_extensions.items()}
 
 _ext_debug("\tWill import the following plugins: %s" % str(_ext_plugins))
@@ -202,15 +208,15 @@ SIDECARS = {
 SIDECARS.update(_ext_plugins["SIDECARS"])
 
 # Add logger
-from .debug_logger import DebugEventLogger
+from .debug_logger import DebugEventLoggerSidecar
 
-LOGGING_SIDECARS = {"debugLogger": DebugEventLogger, "nullSidecarLogger": None}
+LOGGING_SIDECARS = {"debugLogger": DebugEventLoggerSidecar, "nullSidecarLogger": None}
 LOGGING_SIDECARS.update(_ext_plugins["LOGGING_SIDECARS"])
 
 # Add monitor
-from .debug_monitor import DebugMonitor
+from .debug_monitor import DebugMonitorSidecar
 
-MONITOR_SIDECARS = {"debugMonitor": DebugMonitor, "nullSidecarMonitor": None}
+MONITOR_SIDECARS = {"debugMonitor": DebugMonitorSidecar, "nullSidecarMonitor": None}
 MONITOR_SIDECARS.update(_ext_plugins["MONITOR_SIDECARS"])
 
 SIDECARS.update(LOGGING_SIDECARS)

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -209,21 +209,21 @@ SIDECARS.update(_ext_plugins["SIDECARS"])
 
 # Add logger
 from .debug_logger import DebugEventLogger
-from metaflow.event_logger import NullLogger
+from metaflow.event_logger import BaseEventLogger
 
 LOGGING_SIDECARS = {
     DebugEventLogger.TYPE: DebugEventLogger,
-    NullLogger.TYPE: NullLogger,
+    BaseEventLogger.TYPE: BaseEventLogger,
 }
 LOGGING_SIDECARS.update(_ext_plugins["LOGGING_SIDECARS"])
 
 # Add monitor
 from .debug_monitor import DebugMonitor
-from metaflow.monitor import NullMonitor
+from metaflow.monitor import BaseMonitor
 
 MONITOR_SIDECARS = {
     DebugMonitor.TYPE: DebugMonitor,
-    NullMonitor.TYPE: NullMonitor,
+    BaseMonitor.TYPE: BaseMonitor,
 }
 MONITOR_SIDECARS.update(_ext_plugins["MONITOR_SIDECARS"])
 

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -209,21 +209,21 @@ SIDECARS.update(_ext_plugins["SIDECARS"])
 
 # Add logger
 from .debug_logger import DebugEventLogger
-from metaflow.event_logger import BaseEventLogger
+from metaflow.event_logger import NullEventLogger
 
 LOGGING_SIDECARS = {
     DebugEventLogger.TYPE: DebugEventLogger,
-    BaseEventLogger.TYPE: BaseEventLogger,
+    NullEventLogger.TYPE: NullEventLogger,
 }
 LOGGING_SIDECARS.update(_ext_plugins["LOGGING_SIDECARS"])
 
 # Add monitor
 from .debug_monitor import DebugMonitor
-from metaflow.monitor import BaseMonitor
+from metaflow.monitor import NullMonitor
 
 MONITOR_SIDECARS = {
     DebugMonitor.TYPE: DebugMonitor,
-    BaseMonitor.TYPE: BaseMonitor,
+    NullMonitor.TYPE: NullMonitor,
 }
 MONITOR_SIDECARS.update(_ext_plugins["MONITOR_SIDECARS"])
 

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -208,15 +208,23 @@ SIDECARS = {
 SIDECARS.update(_ext_plugins["SIDECARS"])
 
 # Add logger
-from .debug_logger import DebugEventLoggerSidecar
+from .debug_logger import DebugEventLogger
+from metaflow.event_logger import NullLogger
 
-LOGGING_SIDECARS = {"debugLogger": DebugEventLoggerSidecar, "nullSidecarLogger": None}
+LOGGING_SIDECARS = {
+    DebugEventLogger.TYPE: DebugEventLogger,
+    NullLogger.TYPE: NullLogger,
+}
 LOGGING_SIDECARS.update(_ext_plugins["LOGGING_SIDECARS"])
 
 # Add monitor
-from .debug_monitor import DebugMonitorSidecar
+from .debug_monitor import DebugMonitor
+from metaflow.monitor import NullMonitor
 
-MONITOR_SIDECARS = {"debugMonitor": DebugMonitorSidecar, "nullSidecarMonitor": None}
+MONITOR_SIDECARS = {
+    DebugMonitor.TYPE: DebugMonitor,
+    NullMonitor.TYPE: NullMonitor,
+}
 MONITOR_SIDECARS.update(_ext_plugins["MONITOR_SIDECARS"])
 
 SIDECARS.update(LOGGING_SIDECARS)

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -626,8 +626,8 @@ class ArgoWorkflows(object):
                 "--environment=%s" % self.environment.TYPE,
                 "--datastore=%s" % self.flow_datastore.TYPE,
                 "--datastore-root=%s" % self.flow_datastore.datastore_root,
-                "--event-logger=%s" % self.event_logger.logger_type,
-                "--monitor=%s" % self.monitor.monitor_type,
+                "--event-logger=%s" % self.event_logger.TYPE,
+                "--monitor=%s" % self.monitor.TYPE,
                 "--no-pylint",
                 "--with=argo_workflows_internal",
             ]

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -20,7 +20,7 @@ from metaflow.metaflow_config import (
     ECS_FARGATE_EXECUTION_ROLE,
     DATASTORE_LOCAL_DIR,
 )
-from metaflow.sidecar import Message, MessageTypes, Sidecar
+from metaflow.sidecar import Sidecar
 from metaflow.unbounded_foreach import UBF_CONTROL
 
 from .batch import BatchException
@@ -251,6 +251,7 @@ class BatchDecorator(StepDecorator):
             metadata.register_metadata(run_id, step_name, task_id, entries)
 
             self._save_logs_sidecar = Sidecar("save_logs_periodically")
+            self._save_logs_sidecar.start()
 
         num_parallel = int(os.environ.get("AWS_BATCH_JOB_NUM_NODES", 0))
         if num_parallel >= 1 and ubf_context == UBF_CONTROL:
@@ -289,7 +290,6 @@ class BatchDecorator(StepDecorator):
                 )
 
         try:
-            self._save_logs_sidecar.send(Message(MessageTypes.SHUTDOWN, None))
             self._save_logs_sidecar.terminate()
         except:
             # Best effort kill

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -20,7 +20,7 @@ from metaflow.metaflow_config import (
     ECS_FARGATE_EXECUTION_ROLE,
     DATASTORE_LOCAL_DIR,
 )
-from metaflow.sidecar import SidecarSubProcess
+from metaflow.sidecar import Message, MessageTypes, Sidecar
 from metaflow.unbounded_foreach import UBF_CONTROL
 
 from .batch import BatchException
@@ -250,7 +250,7 @@ class BatchDecorator(StepDecorator):
             # Register book-keeping metadata for debugging.
             metadata.register_metadata(run_id, step_name, task_id, entries)
 
-            self._save_logs_sidecar = SidecarSubProcess("save_logs_periodically")
+            self._save_logs_sidecar = Sidecar("save_logs_periodically")
 
         num_parallel = int(os.environ.get("AWS_BATCH_JOB_NUM_NODES", 0))
         if num_parallel >= 1 and ubf_context == UBF_CONTROL:
@@ -289,7 +289,8 @@ class BatchDecorator(StepDecorator):
                 )
 
         try:
-            self._save_logs_sidecar.kill()
+            self._save_logs_sidecar.send(Message(MessageTypes.SHUTDOWN, None))
+            self._save_logs_sidecar.terminate()
         except:
             # Best effort kill
             pass

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -728,8 +728,8 @@ class StepFunctions(object):
             "--environment=%s" % self.environment.TYPE,
             "--datastore=%s" % self.flow_datastore.TYPE,
             "--datastore-root=%s" % self.flow_datastore.datastore_root,
-            "--event-logger=%s" % self.event_logger.logger_type,
-            "--monitor=%s" % self.monitor.monitor_type,
+            "--event-logger=%s" % self.event_logger.TYPE,
+            "--monitor=%s" % self.monitor.TYPE,
             "--no-pylint",
             "--with=step_functions_internal",
         ]

--- a/metaflow/plugins/debug_logger.py
+++ b/metaflow/plugins/debug_logger.py
@@ -1,17 +1,19 @@
 import sys
 
-from metaflow.sidecar_messages import Message
+from metaflow.sidecar_messages import Message, MessageTypes
 
 
-class DebugEventLogger(object):
-    TYPE = "debugLogger"
-
-    def log(self, msg):
-        sys.stderr.write("event_logger: " + str(msg) + "\n")
+class DebugEventLoggerSidecar(object):
+    def __init__(self):
+        pass
 
     def process_message(self, msg):
         # type: (Message) -> None
-        self.log(msg.payload)
+        if msg.msg_type == MessageTypes.SHUTDOWN:
+            print("Debug event: got shutdown!")
+            self._shutdown()
+        elif msg.msg_type == MessageTypes.LOG_EVENT:
+            print("Debug event logging %s" % str(msg.payload), file=sys.stderr)
 
-    def shutdown(self):
-        pass
+    def _shutdown(self):
+        sys.stderr.flush()

--- a/metaflow/plugins/debug_logger.py
+++ b/metaflow/plugins/debug_logger.py
@@ -8,7 +8,7 @@ class DebugEventLogger(BaseEventLogger):
     TYPE = "debugLogger"
 
     @classmethod
-    def get_sidecar_worker_class(cls):
+    def get_worker(cls):
         return DebugEventLoggerSidecar
 
 
@@ -21,7 +21,7 @@ class DebugEventLoggerSidecar(object):
         if msg.msg_type == MessageTypes.SHUTDOWN:
             print("Debug[shutdown]: got shutdown!", file=sys.stderr)
             self._shutdown()
-        elif msg.msg_type == MessageTypes.EVENT:
+        elif msg.msg_type == MessageTypes.BEST_EFFORT:
             print("Debug[event]: %s" % str(msg.payload), file=sys.stderr)
 
     def _shutdown(self):

--- a/metaflow/plugins/debug_logger.py
+++ b/metaflow/plugins/debug_logger.py
@@ -1,6 +1,15 @@
 import sys
 
-from metaflow.sidecar_messages import Message, MessageTypes
+from metaflow.event_logger import BaseEventLogger
+from metaflow.sidecar import Message, MessageTypes
+
+
+class DebugEventLogger(BaseEventLogger):
+    TYPE = "debugLogger"
+
+    @classmethod
+    def get_sidecar_worker_class(cls):
+        return DebugEventLoggerSidecar
 
 
 class DebugEventLoggerSidecar(object):
@@ -10,10 +19,10 @@ class DebugEventLoggerSidecar(object):
     def process_message(self, msg):
         # type: (Message) -> None
         if msg.msg_type == MessageTypes.SHUTDOWN:
-            print("Debug event: got shutdown!")
+            print("Debug[shutdown]: got shutdown!", file=sys.stderr)
             self._shutdown()
-        elif msg.msg_type == MessageTypes.LOG_EVENT:
-            print("Debug event logging %s" % str(msg.payload), file=sys.stderr)
+        elif msg.msg_type == MessageTypes.EVENT:
+            print("Debug[event]: %s" % str(msg.payload), file=sys.stderr)
 
     def _shutdown(self):
         sys.stderr.flush()

--- a/metaflow/plugins/debug_logger.py
+++ b/metaflow/plugins/debug_logger.py
@@ -1,10 +1,10 @@
 import sys
 
-from metaflow.event_logger import BaseEventLogger
+from metaflow.event_logger import NullEventLogger
 from metaflow.sidecar import Message, MessageTypes
 
 
-class DebugEventLogger(BaseEventLogger):
+class DebugEventLogger(NullEventLogger):
     TYPE = "debugLogger"
 
     @classmethod
@@ -22,7 +22,9 @@ class DebugEventLoggerSidecar(object):
             print("Debug[shutdown]: got shutdown!", file=sys.stderr)
             self._shutdown()
         elif msg.msg_type == MessageTypes.BEST_EFFORT:
-            print("Debug[event]: %s" % str(msg.payload), file=sys.stderr)
+            print("Debug[best_effort]: %s" % str(msg.payload), file=sys.stderr)
+        elif msg.msg_type == MessageTypes.MUST_SEND:
+            print("Debug[must_send]: %s" % str(msg.payload), file=sys.stderr)
 
     def _shutdown(self):
         sys.stderr.flush()

--- a/metaflow/plugins/debug_monitor.py
+++ b/metaflow/plugins/debug_monitor.py
@@ -3,41 +3,29 @@ from __future__ import print_function
 import sys
 
 from metaflow.sidecar_messages import MessageTypes, Message
-from metaflow.monitor import Timer, deserialize_metric
-from metaflow.monitor import MEASURE_TYPE, get_monitor_msg_type
+from metaflow.monitor import Metric
 
 
-class DebugMonitor(object):
-    TYPE = "debugMonitor"
-
+class DebugMonitorSidecar(object):
     def __init__(self):
-        self.logger("init")
-
-    def count(self, count):
-        pass
-
-    def measure(self, timer):
-        # type: (Timer) -> None
-        self.logger(
-            "elapsed time for {}: {}".format(timer.name, str(timer.get_duration()))
-        )
-
-    def gauge(self, gauge):
-        pass
+        self._env = None
 
     def process_message(self, msg):
         # type: (Message) -> None
-        self.logger("processing message %s" % str(msg.msg_type))
-        msg_type = get_monitor_msg_type(msg)
-        if msg_type == MEASURE_TYPE:
-            timer = deserialize_metric(msg.payload.get("timer"))
-            self.measure(timer)
-        else:
-            pass
+        if msg.msg_type == MessageTypes.START:
+            self._env = msg.payload.get("env", None)
+        elif msg.msg_type == MessageTypes.SHUTDOWN:
+            print("Debug monitor got shutdown!", file=sys.stderr)
+            self._shutdown()
+        elif msg.msg_type == MessageTypes.LOG_EVENT:
+            for v in msg.payload.values():
+                metric = Metric.deserialize(v)
+                metric.env = self._env
+                print(
+                    "%s for %s: %s"
+                    % (metric.metric_type, metric.name, str(metric.value)),
+                    file=sys.stderr,
+                )
 
-    def shutdown(self):
-        sys.stderr.flush()
-
-    def logger(self, msg):
-        print("local_monitor: %s" % msg, file=sys.stderr)
+    def _shutdown(self):
         sys.stderr.flush()

--- a/metaflow/plugins/debug_monitor.py
+++ b/metaflow/plugins/debug_monitor.py
@@ -8,19 +8,20 @@ from metaflow.monitor import Metric
 
 class DebugMonitorSidecar(object):
     def __init__(self):
-        self._env = None
+        self._context = None
 
     def process_message(self, msg):
         # type: (Message) -> None
         if msg.msg_type == MessageTypes.START:
-            self._env = msg.payload.get("env", None)
+            self._context = msg.payload
+        elif msg.msg_type == MessageTypes.UPDATE_CONTEXT:
+            self._context = msg.payload
         elif msg.msg_type == MessageTypes.SHUTDOWN:
-            print("Debug monitor got shutdown!", file=sys.stderr)
             self._shutdown()
         elif msg.msg_type == MessageTypes.LOG_EVENT:
             for v in msg.payload.values():
                 metric = Metric.deserialize(v)
-                metric.env = self._env
+                metric.context = self._context
                 print(
                     "%s for %s: %s"
                     % (metric.metric_type, metric.name, str(metric.value)),

--- a/metaflow/plugins/debug_monitor.py
+++ b/metaflow/plugins/debug_monitor.py
@@ -1,27 +1,30 @@
-from __future__ import print_function
-
 import sys
 
-from metaflow.sidecar_messages import MessageTypes, Message
-from metaflow.monitor import Metric
+from metaflow.sidecar import MessageTypes, Message
+from metaflow.monitor import BaseMonitor, Metric
+
+
+class DebugMonitor(BaseMonitor):
+    TYPE = "debugMonitor"
+
+    @classmethod
+    def get_sidecar_worker_class(cls):
+        return DebugMonitorSidecar
 
 
 class DebugMonitorSidecar(object):
     def __init__(self):
-        self._context = None
+        pass
 
     def process_message(self, msg):
         # type: (Message) -> None
-        if msg.msg_type == MessageTypes.START:
-            self._context = msg.payload
-        elif msg.msg_type == MessageTypes.UPDATE_CONTEXT:
+        if msg.msg_type == MessageTypes.CONTEXT:
             self._context = msg.payload
         elif msg.msg_type == MessageTypes.SHUTDOWN:
             self._shutdown()
-        elif msg.msg_type == MessageTypes.LOG_EVENT:
+        elif msg.msg_type == MessageTypes.EVENT:
             for v in msg.payload.values():
                 metric = Metric.deserialize(v)
-                metric.context = self._context
                 print(
                     "%s for %s: %s"
                     % (metric.metric_type, metric.name, str(metric.value)),

--- a/metaflow/plugins/debug_monitor.py
+++ b/metaflow/plugins/debug_monitor.py
@@ -8,7 +8,7 @@ class DebugMonitor(BaseMonitor):
     TYPE = "debugMonitor"
 
     @classmethod
-    def get_sidecar_worker_class(cls):
+    def get_worker(cls):
         return DebugMonitorSidecar
 
 
@@ -22,7 +22,7 @@ class DebugMonitorSidecar(object):
             self._context = msg.payload
         elif msg.msg_type == MessageTypes.SHUTDOWN:
             self._shutdown()
-        elif msg.msg_type == MessageTypes.EVENT:
+        elif msg.msg_type == MessageTypes.BEST_EFFORT:
             for v in msg.payload.values():
                 metric = Metric.deserialize(v)
                 print(

--- a/metaflow/plugins/debug_monitor.py
+++ b/metaflow/plugins/debug_monitor.py
@@ -1,10 +1,10 @@
 import sys
 
 from metaflow.sidecar import MessageTypes, Message
-from metaflow.monitor import BaseMonitor, Metric
+from metaflow.monitor import NullMonitor, Metric
 
 
-class DebugMonitor(BaseMonitor):
+class DebugMonitor(NullMonitor):
     TYPE = "debugMonitor"
 
     @classmethod
@@ -19,14 +19,15 @@ class DebugMonitorSidecar(object):
     def process_message(self, msg):
         # type: (Message) -> None
         if msg.msg_type == MessageTypes.MUST_SEND:
-            self._context = msg.payload
+            print("DebugMonitor[must_send]: %s" % str(msg.payload), file=sys.stderr)
         elif msg.msg_type == MessageTypes.SHUTDOWN:
+            print("DebugMonitor[shutdown]: got shutdown!", file=sys.stderr)
             self._shutdown()
         elif msg.msg_type == MessageTypes.BEST_EFFORT:
             for v in msg.payload.values():
                 metric = Metric.deserialize(v)
                 print(
-                    "%s for %s: %s"
+                    "DebugMonitor[metric]: %s for %s: %s"
                     % (metric.metric_type, metric.name, str(metric.value)),
                     file=sys.stderr,
                 )

--- a/metaflow/plugins/debug_monitor.py
+++ b/metaflow/plugins/debug_monitor.py
@@ -18,7 +18,7 @@ class DebugMonitorSidecar(object):
 
     def process_message(self, msg):
         # type: (Message) -> None
-        if msg.msg_type == MessageTypes.CONTEXT:
+        if msg.msg_type == MessageTypes.MUST_SEND:
             self._context = msg.payload
         elif msg.msg_type == MessageTypes.SHUTDOWN:
             self._shutdown()

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -21,7 +21,7 @@ from metaflow.metaflow_config import (
 )
 from metaflow.plugins import ResourcesDecorator
 from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task
-from metaflow.sidecar import SidecarSubProcess
+from metaflow.sidecar import Message, MessageTypes, Sidecar
 
 from ..aws.aws_utils import get_docker_registry
 from .kubernetes import KubernetesException
@@ -302,7 +302,7 @@ class KubernetesDecorator(StepDecorator):
             metadata.register_metadata(run_id, step_name, task_id, entries)
 
             # Start MFLog sidecar to collect task logs.
-            self._save_logs_sidecar = SidecarSubProcess("save_logs_periodically")
+            self._save_logs_sidecar = Sidecar("save_logs_periodically")
 
     def task_finished(
         self, step_name, flow, graph, is_task_ok, retry_count, max_retries
@@ -326,7 +326,8 @@ class KubernetesDecorator(StepDecorator):
                 )
 
         try:
-            self._save_logs_sidecar.kill()
+            self._save_logs_sidecar.send(Message(MessageTypes.SHUTDOWN, None))
+            self._save_logs_sidecar.terminate()
         except:
             # Best effort kill
             pass

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -21,7 +21,7 @@ from metaflow.metaflow_config import (
 )
 from metaflow.plugins import ResourcesDecorator
 from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task
-from metaflow.sidecar import Message, MessageTypes, Sidecar
+from metaflow.sidecar import Sidecar
 
 from ..aws.aws_utils import get_docker_registry
 from .kubernetes import KubernetesException
@@ -303,6 +303,7 @@ class KubernetesDecorator(StepDecorator):
 
             # Start MFLog sidecar to collect task logs.
             self._save_logs_sidecar = Sidecar("save_logs_periodically")
+            self._save_logs_sidecar.start()
 
     def task_finished(
         self, step_name, flow, graph, is_task_ok, retry_count, max_retries
@@ -326,7 +327,6 @@ class KubernetesDecorator(StepDecorator):
                 )
 
         try:
-            self._save_logs_sidecar.send(Message(MessageTypes.SHUTDOWN, None))
             self._save_logs_sidecar.terminate()
         except:
             # Best effort kill

--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -136,7 +136,8 @@ class ServiceMetadataProvider(MetadataProvider):
             self.sidecar = Sidecar("none")
         else:
             self.sidecar = Sidecar("heartbeat")
-        self.sidecar.send(Message(MessageTypes.CONTEXT, payload))
+        self.sidecar.start()
+        self.sidecar.send(Message(MessageTypes.MUST_SEND, payload))
 
     def start_run_heartbeat(self, flow_id, run_id):
         self._start_heartbeat(HeartbeatTypes.RUN, flow_id, run_id)
@@ -148,8 +149,6 @@ class ServiceMetadataProvider(MetadataProvider):
         return self.sidecar is not None
 
     def stop_heartbeat(self):
-        msg = Message(MessageTypes.SHUTDOWN, None)
-        self.sidecar.send(msg)
         self.sidecar.terminate()
 
     def register_data_artifacts(

--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -12,7 +12,7 @@ from metaflow.metaflow_config import (
 )
 from metaflow.metadata import MetadataProvider
 from metaflow.metadata.heartbeat import HB_URL_KEY
-from metaflow.sidecar import Message, MessageTypes, SidecarSubProcess
+from metaflow.sidecar import Message, MessageTypes, Sidecar
 
 # Define message enums
 class HeartbeatTypes(object):
@@ -45,7 +45,7 @@ class ServiceMetadataProvider(MetadataProvider):
         self.url_run_template = os.path.join(
             METADATA_SERVICE_URL, "flows/{flow_id}/runs/{run_number}/heartbeat"
         )
-        self.sidecar_process = None
+        self.sidecar = None
 
     @classmethod
     def compute_info(cls, val):
@@ -133,10 +133,10 @@ class ServiceMetadataProvider(MetadataProvider):
         ):
             # if old version of the service is running
             # then avoid running real heartbeat sidecar process
-            self.sidecar_process = SidecarSubProcess("nullSidecarHeartbeat")
+            self.sidecar = Sidecar("none")
         else:
-            self.sidecar_process = SidecarSubProcess("heartbeat")
-        self.sidecar_process.send(Message(MessageTypes.CONTEXT, payload))
+            self.sidecar = Sidecar("heartbeat")
+        self.sidecar.send(Message(MessageTypes.CONTEXT, payload))
 
     def start_run_heartbeat(self, flow_id, run_id):
         self._start_heartbeat(HeartbeatTypes.RUN, flow_id, run_id)
@@ -145,11 +145,12 @@ class ServiceMetadataProvider(MetadataProvider):
         self._start_heartbeat(HeartbeatTypes.TASK, flow_id, run_id, step_name, task_id)
 
     def _already_started(self):
-        return self.sidecar_process is not None
+        return self.sidecar is not None
 
     def stop_heartbeat(self):
         msg = Message(MessageTypes.SHUTDOWN, None)
-        self.sidecar_process.send(msg)
+        self.sidecar.send(msg)
+        self.sidecar.terminate()
 
     def register_data_artifacts(
         self, run_id, step_name, task_id, attempt_id, artifacts

--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -12,8 +12,7 @@ from metaflow.metaflow_config import (
 )
 from metaflow.metadata import MetadataProvider
 from metaflow.metadata.heartbeat import HB_URL_KEY
-from metaflow.sidecar import SidecarSubProcess
-from metaflow.sidecar_messages import MessageTypes, Message
+from metaflow.sidecar import Message, MessageTypes, SidecarSubProcess
 
 # Define message enums
 class HeartbeatTypes(object):
@@ -134,9 +133,10 @@ class ServiceMetadataProvider(MetadataProvider):
         ):
             # if old version of the service is running
             # then avoid running real heartbeat sidecar process
-            self.sidecar_process = SidecarSubProcess("nullSidecarHeartbeat", payload)
+            self.sidecar_process = SidecarSubProcess("nullSidecarHeartbeat")
         else:
-            self.sidecar_process = SidecarSubProcess("heartbeat", payload)
+            self.sidecar_process = SidecarSubProcess("heartbeat")
+        self.sidecar_process.send(Message(MessageTypes.CONTEXT, payload))
 
     def start_run_heartbeat(self, flow_id, run_id):
         self._start_heartbeat(HeartbeatTypes.RUN, flow_id, run_id)

--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -137,7 +137,7 @@ class ServiceMetadataProvider(MetadataProvider):
         else:
             self.sidecar = Sidecar("heartbeat")
         self.sidecar.start()
-        self.sidecar.send(Message(MessageTypes.MUST_SEND, payload))
+        self.sidecar.send(Message(MessageTypes.BEST_EFFORT, payload))
 
     def start_run_heartbeat(self, flow_id, run_id):
         self._start_heartbeat(HeartbeatTypes.RUN, flow_id, run_id)

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -689,8 +689,8 @@ class Task(object):
         self.error_retries = 0
 
         self.tags = metadata.sticky_tags
-        self.event_logger_type = self.event_logger.logger_type
-        self.monitor_type = monitor.monitor_type
+        self.event_logger_type = self.event_logger.TYPE
+        self.monitor_type = monitor.TYPE
 
         self.metadata_type = metadata.TYPE
         self.datastore_type = flow_datastore.TYPE

--- a/metaflow/sidecar.py
+++ b/metaflow/sidecar.py
@@ -159,10 +159,13 @@ class SidecarSubProcess(object):
                     self._send_context()
                 if self._send_context_remaining_tries == 0:
                     self._emit_msg(msg)
+                    self._prev_message_error = False
+                    return True
             else:
                 self._emit_msg(msg)
-            self._prev_message_error = False
-            return True
+                self._prev_message_error = False
+                return True
+            return False
         except MsgTimeoutError:
             # drop message, do not retry on timeout
             self._logger("Unable to send message due to timeout")

--- a/metaflow/sidecar.py
+++ b/metaflow/sidecar.py
@@ -98,6 +98,11 @@ class SidecarSubProcess(object):
                 )
                 self._poller = NullPoller()
 
+    def update_context(self, new_context):
+        self._context = new_context
+        if self._process is not None:
+            self._emit_msg(Message(MessageTypes.UPDATE_CONTEXT, self._context))
+
     def kill(self):
         try:
             msg = Message(MessageTypes.SHUTDOWN, None)

--- a/metaflow/sidecar.py
+++ b/metaflow/sidecar.py
@@ -173,6 +173,9 @@ class SidecarSubProcess(object):
         except Exception as ex:
             if isinstance(ex, (PipeUnavailableError, BrokenPipeError)):
                 self._logger("Restarting sidecar due to broken/unavailable pipe")
+                self._send_context_remaining_tries = (
+                    CONTEXT_RETRY_TIMES if self._context is not None else 0
+                )
                 self.start()
                 # For context sending, we don't retry since we already did it in
                 # start

--- a/metaflow/sidecar.py
+++ b/metaflow/sidecar.py
@@ -171,7 +171,8 @@ class SidecarSubProcess(object):
             self._logger("Unable to send message due to timeout")
             self._prev_message_error = True
         except Exception as ex:
-            if isinstance(ex, PipeUnavailableError):
+            if isinstance(ex, (PipeUnavailableError, BrokenPipeError)):
+                self._logger("Restarting sidecar due to broken/unavailable pipe")
                 self.start()
                 # For context sending, we don't retry since we already did it in
                 # start

--- a/metaflow/sidecar/__init__.py
+++ b/metaflow/sidecar/__init__.py
@@ -1,0 +1,3 @@
+from .sidecar import Sidecar
+from .sidecar_messages import MessageTypes, Message
+from .sidecar_subprocess import SidecarSubProcess

--- a/metaflow/sidecar/sidecar.py
+++ b/metaflow/sidecar/sidecar.py
@@ -1,9 +1,12 @@
-from metaflow.plugins import SIDECARS
 from .sidecar_subprocess import SidecarSubProcess
 
 
 class Sidecar(object):
     def __init__(self, sidecar_type):
+        # Needs to be here because this file gets loaded early in the TL when we
+        # don't yet have all the sidecars
+        from metaflow.plugins import SIDECARS
+
         self._sidecar_type = sidecar_type
         self._has_valid_worker = False
         t = SIDECARS.get(self._sidecar_type)

--- a/metaflow/sidecar/sidecar.py
+++ b/metaflow/sidecar/sidecar.py
@@ -3,8 +3,8 @@ from .sidecar_subprocess import SidecarSubProcess
 
 class Sidecar(object):
     def __init__(self, sidecar_type):
-        # Needs to be here because this file gets loaded early in the TL when we
-        # don't yet have all the sidecars
+        # Needs to be here because this file gets loaded by lots of things and SIDECARS
+        # may not be fully populated by then
         from metaflow.plugins import SIDECARS
 
         self._sidecar_type = sidecar_type

--- a/metaflow/sidecar/sidecar.py
+++ b/metaflow/sidecar/sidecar.py
@@ -1,0 +1,42 @@
+from tracemalloc import is_tracing
+from .sidecar_subprocess import SidecarSubProcess
+from .sidecar_messages import Message, MessageTypes
+
+
+class Sidecar(object):
+    TYPE = ""
+
+    def __init__(self, flow, env):
+        self.sidecar_process = None
+
+    def start(self):
+        if not self._is_active and self.get_sidecar_worker_class() is not None:
+            self.sidecar_process = SidecarSubProcess(self._get_sidecar_worker_type())
+
+    def add_to_context(self, **kwargs):
+        if self._is_active:
+            msg = Message(MessageTypes.CONTEXT, self._get_context())
+            self.sidecar_process.send(msg)
+
+    def terminate(self):
+        if self._is_active:
+            self.sidecar_process.kill()
+
+    @classmethod
+    def get_sidecar_worker_class(cls):
+        raise NotImplementedError()
+
+    def _send(self, msg):
+        if self._is_active:
+            self.sidecar_process.send(msg)
+
+    @property
+    def _is_active(self):
+        return self.sidecar_process is not None
+
+    def _get_context(self):
+        return None
+
+    @classmethod
+    def _get_sidecar_worker_type(cls):
+        return cls.TYPE

--- a/metaflow/sidecar/sidecar_messages.py
+++ b/metaflow/sidecar/sidecar_messages.py
@@ -3,8 +3,14 @@ import json
 # Define message enums
 # Unfortunately we can't use enums because they are not supported
 # officially in Python2
+# INVALID: Not a valid message
+# MUST_SEND: Will attempt to send until successful and not send any BEST_EFFORT
+#            messages until then. A newer MUST_SEND message will take precedence on
+#            any currently unsent one
+# BEST_EFFORT: Will try to send once and drop if not possible
+# SHUTDOWN: Signal termination; also best effort
 class MessageTypes(object):
-    INVALID, CONTEXT, BEST_EFFORT, SHUTDOWN = range(1, 5)
+    INVALID, MUST_SEND, BEST_EFFORT, SHUTDOWN = range(1, 5)
 
 
 class Message(object):

--- a/metaflow/sidecar/sidecar_messages.py
+++ b/metaflow/sidecar/sidecar_messages.py
@@ -4,7 +4,7 @@ import json
 # Unfortunately we can't use enums because they are not supported
 # officially in Python2
 class MessageTypes(object):
-    INVALID, START, UPDATE_CONTEXT, SHUTDOWN, LOG_EVENT = range(1, 6)
+    INVALID, CONTEXT, EVENT, SHUTDOWN = range(1, 5)
 
 
 class Message(object):
@@ -12,13 +12,11 @@ class Message(object):
         self.msg_type = msg_type
         self.payload = payload
 
-    def serialize(self, clear_previous=False):
+    def serialize(self):
         msg = {
             "msg_type": self.msg_type,
             "payload": self.payload,
         }
-        if clear_previous:
-            return "\n" + json.dumps(msg) + "\n"
         return json.dumps(msg) + "\n"
 
     @staticmethod

--- a/metaflow/sidecar/sidecar_messages.py
+++ b/metaflow/sidecar/sidecar_messages.py
@@ -4,7 +4,7 @@ import json
 # Unfortunately we can't use enums because they are not supported
 # officially in Python2
 class MessageTypes(object):
-    INVALID, CONTEXT, EVENT, SHUTDOWN = range(1, 5)
+    INVALID, CONTEXT, BEST_EFFORT, SHUTDOWN = range(1, 5)
 
 
 class Message(object):

--- a/metaflow/sidecar/sidecar_subprocess.py
+++ b/metaflow/sidecar/sidecar_subprocess.py
@@ -146,7 +146,7 @@ class SidecarSubProcess(object):
         if self._process is None:
             return False
         try:
-            if msg.msg_type == MessageTypes.EVENT:
+            if msg.msg_type == MessageTypes.BEST_EFFORT:
                 # If we have a context to send, we need to send it first prior to
                 # sending an EVENT message
                 if self._send_context_remaining_tries == -1:

--- a/metaflow/sidecar/sidecar_worker.py
+++ b/metaflow/sidecar/sidecar_worker.py
@@ -6,12 +6,12 @@ import sys
 import traceback
 
 
-# add module to python path if not already present
+# add metaflow module to python path if not already present
 myDir = os.path.dirname(os.path.abspath(__file__))
-parentDir = os.path.split(myDir)[0]
+parentDir = os.path.split(os.path.split(myDir)[0])[0]
 sys.path.insert(0, parentDir)
 
-from metaflow.sidecar_messages import Message, MessageTypes
+from metaflow.sidecar import Message, MessageTypes
 from metaflow.plugins import SIDECARS
 from metaflow._vendor import click
 
@@ -24,7 +24,7 @@ def process_messages(worker_type, worker):
                 parsed_msg = Message.deserialize(msg)
                 if parsed_msg.msg_type == MessageTypes.INVALID:
                     print(
-                        "[sidecarProcess:%s] Invalid message -- skipping: %s"
+                        "[sidecar:%s] Invalid message -- skipping: %s"
                         % (worker_type, str(msg))
                     )
                     continue
@@ -36,7 +36,10 @@ def process_messages(worker_type, worker):
                 break
 
         except:  # todo handle other possible exceptions gracefully
-            print(traceback.format_exc(), file=sys.stderr)
+            print(
+                "[sidecar:%s]: %s" % (worker_type, traceback.format_exc()),
+                file=sys.stderr,
+            )
             break
     try:
         worker.shutdown()
@@ -47,12 +50,18 @@ def process_messages(worker_type, worker):
 @click.command(help="Initialize workers")
 @click.argument("worker-type")
 def main(worker_type):
-    worker_process = SIDECARS.get(worker_type)
-
-    if worker_process is not None:
-        process_messages(worker_type, worker_process())
+    sidecar_type = SIDECARS.get(worker_type)
+    if sidecar_type is not None:
+        worker_class = sidecar_type.get_sidecar_worker_class()
+        if worker_class is not None:
+            process_messages(worker_type, worker_class())
+        else:
+            print(
+                "[sidecar:%s] Sidecar does not have associated worker" % worker_type,
+                file=sys.stderr,
+            )
     else:
-        print("Unrecognized worker: %s" % worker_type, file=sys.stderr)
+        print("Unrecognized sidecar_process: %s" % worker_type, file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/metaflow/sidecar/sidecar_worker.py
+++ b/metaflow/sidecar/sidecar_worker.py
@@ -52,7 +52,7 @@ def process_messages(worker_type, worker):
 def main(worker_type):
     sidecar_type = SIDECARS.get(worker_type)
     if sidecar_type is not None:
-        worker_class = sidecar_type.get_sidecar_worker_class()
+        worker_class = sidecar_type.get_worker()
         if worker_class is not None:
             process_messages(worker_type, worker_class())
         else:

--- a/metaflow/sidecar_messages.py
+++ b/metaflow/sidecar_messages.py
@@ -4,7 +4,7 @@ import json
 # Unfortunately we can't use enums because they are not supported
 # officially in Python2
 class MessageTypes(object):
-    INVALID, START, SHUTDOWN, LOG_EVENT = range(1, 5)
+    INVALID, START, UPDATE_CONTEXT, SHUTDOWN, LOG_EVENT = range(1, 6)
 
 
 class Message(object):

--- a/metaflow/sidecar_messages.py
+++ b/metaflow/sidecar_messages.py
@@ -12,11 +12,13 @@ class Message(object):
         self.msg_type = msg_type
         self.payload = payload
 
-    def serialize(self):
+    def serialize(self, clear_previous=False):
         msg = {
             "msg_type": self.msg_type,
             "payload": self.payload,
         }
+        if clear_previous:
+            return "\n" + json.dumps(msg) + "\n"
         return json.dumps(msg) + "\n"
 
     @staticmethod

--- a/metaflow/sidecar_messages.py
+++ b/metaflow/sidecar_messages.py
@@ -4,7 +4,7 @@ import json
 # Unfortunately we can't use enums because they are not supported
 # officially in Python2
 class MessageTypes(object):
-    SHUTDOWN, LOG_EVENT = range(1, 3)
+    INVALID, START, SHUTDOWN, LOG_EVENT = range(1, 5)
 
 
 class Message(object):
@@ -19,6 +19,9 @@ class Message(object):
         }
         return json.dumps(msg) + "\n"
 
-
-def deserialize(json_msg):
-    return Message(**json.loads(json_msg))
+    @staticmethod
+    def deserialize(json_msg):
+        try:
+            return Message(**json.loads(json_msg))
+        except json.decoder.JSONDecodeError:
+            return Message(MessageTypes.INVALID, None)

--- a/metaflow/sidecar_worker.py
+++ b/metaflow/sidecar_worker.py
@@ -16,14 +16,17 @@ from metaflow.plugins import SIDECARS
 from metaflow._vendor import click
 
 
-def process_messages(worker):
+def process_messages(worker_type, worker):
     while True:
         try:
             msg = sys.stdin.readline().strip()
             if msg:
                 parsed_msg = Message.deserialize(msg)
                 if parsed_msg.msg_type == MessageTypes.INVALID:
-                    print("Invalid message -- skipping")
+                    print(
+                        "[sidecarProcess:%s] Invalid message -- skipping: %s"
+                        % (worker_type, str(msg))
+                    )
                     continue
                 else:
                     worker.process_message(parsed_msg)
@@ -47,7 +50,7 @@ def main(worker_type):
     worker_process = SIDECARS.get(worker_type)
 
     if worker_process is not None:
-        process_messages(worker_process())
+        process_messages(worker_type, worker_process())
     else:
         print("Unrecognized worker: %s" % worker_type, file=sys.stderr)
 

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -449,9 +449,6 @@ class MetaflowTask(object):
         start = time.time()
         self.metadata.start_task_heartbeat(self.flow.name, run_id, step_name, task_id)
         try:
-            # init side cars
-            logger.start()
-
             msg = {
                 "task_id": task_id,
                 "msg": "task starting",
@@ -648,5 +645,4 @@ class MetaflowTask(object):
                 )
 
             # terminate side cars
-            logger.terminate()
             self.metadata.stop_heartbeat()


### PR DESCRIPTION
Several changes:
  - allow side-passing of a static "context" to the sidecar process to keep
    messages as small as possible
  - clean up the interfaces and make it clearer what is what (ie: there is
    an emitter inside the process and then a sidecar that runs outside)
  - better error checking
  - better handling of shutdown (sidecars will now properly get a shutdown
    message giving them the opportunity to clean up -- this may add a bit
    of latency at the end of the program execution.

Also improved message when plugins don't load in case of an issue with
Metaflow extensions