### PR TITLE
Add two options to resume: the ability to specify a run-id and the ab…

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -700,6 +700,7 @@ def common_run_options(func):
     default=False,
     show_default=True,
     help="Only clone tasks without continuing execution",
+    hidden=True,
 )
 @click.option(
     "--reentrant/--no-reentrant",

--- a/metaflow/metadata/metadata.py
+++ b/metaflow/metadata/metadata.py
@@ -154,6 +154,10 @@ class MetadataProvider(object):
             Tags to apply to this particular run, by default None
         sys_tags : list, optional
             System tags to apply to this particular run, by default None
+        Returns
+        -------
+        bool
+            True if a new run was registered; False if it already existed
         """
         raise NotImplementedError()
 
@@ -199,6 +203,10 @@ class MetadataProvider(object):
             Tags to apply to this particular run, by default []
         sys_tags : list, optional
             System tags to apply to this particular run, by default []
+        Returns
+        -------
+        bool
+            True if a new run was registered; False if it already existed
         """
         raise NotImplementedError()
 

--- a/metaflow/plugins/metadata/local.py
+++ b/metaflow/plugins/metadata/local.py
@@ -64,7 +64,7 @@ class LocalMetadataProvider(MetadataProvider):
             # on creation). However, some IDs are created outside the metadata
             # provider and need to be properly registered
             int(run_id)
-            return
+            return False
         except ValueError:
             return self._new_run(run_id, tags, sys_tags)
 
@@ -81,7 +81,7 @@ class LocalMetadataProvider(MetadataProvider):
             # Same logic as register_run_id
             int(task_id)
         except ValueError:
-            self._new_task(
+            return self._new_task(
                 run_id,
                 step_name,
                 task_id,
@@ -91,6 +91,7 @@ class LocalMetadataProvider(MetadataProvider):
             )
         else:
             self._register_system_metadata(run_id, step_name, task_id, attempt)
+            return False
 
     def register_data_artifacts(
         self, run_id, step_name, task_id, attempt_id, artifacts
@@ -341,7 +342,11 @@ class LocalMetadataProvider(MetadataProvider):
         selfname = os.path.join(subpath, "_self.json")
         self._makedirs(subpath)
         if os.path.isfile(selfname):
-            return
+            # There is a race here but we are not aiming to make this as solid as
+            # the metadata service. This is used primarily for concurrent resumes
+            # so it is highly unlikely that this combination (multiple resumes of
+            # the same flow on the same machine) happens.
+            return False
         # In this case, the metadata information does not exist so we create it
         self._save_meta(
             subpath,
@@ -356,17 +361,21 @@ class LocalMetadataProvider(MetadataProvider):
                 )
             },
         )
+        return True
 
     def _new_run(self, run_id, tags=None, sys_tags=None):
         self._ensure_meta("flow", None, None, None)
-        self._ensure_meta("run", run_id, None, None, tags, sys_tags)
+        return self._ensure_meta("run", run_id, None, None, tags, sys_tags)
 
     def _new_task(
         self, run_id, step_name, task_id, attempt=0, tags=None, sys_tags=None
     ):
         self._ensure_meta("step", run_id, step_name, None)
-        self._ensure_meta("task", run_id, step_name, task_id, tags, sys_tags)
+        to_return = self._ensure_meta(
+            "task", run_id, step_name, task_id, tags, sys_tags
+        )
         self._register_system_metadata(run_id, step_name, task_id, attempt)
+        return to_return
 
     @staticmethod
     def _make_path(

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -863,7 +863,7 @@ class Task(object):
             if self.ubf_context == UBF_CONTROL:
                 tags = [CONTROL_TASK_TAG]
                 attempt_id = 0
-                already_existed = self.metadata.register_task_id(
+                already_existed = not self.metadata.register_task_id(
                     self.run_id,
                     self.step,
                     task_id,

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -253,7 +253,7 @@ class NativeRuntime(object):
             )
         else:
             raise MetaflowInternalError(
-                "The *end* step was not successful " "by the end of flow."
+                "The *end* step was not successful by the end of flow."
             )
 
     def _killall(self):

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -1,12 +1,17 @@
 from __future__ import print_function
+from io import BytesIO
+import math
 import sys
 import os
 import time
 
 from types import MethodType, FunctionType
 
+from metaflow.datastore.exceptions import DataException
+
 from .metaflow_config import MAX_ATTEMPTS
 from .metadata import MetaDatum
+from .mflog import TASK_LOG_SOURCE
 from .datastore import Inputs, TaskDataStoreSet
 from .exception import (
     MetaflowInternalError,
@@ -157,7 +162,7 @@ class MetaflowTask(object):
         if not ds_list:
             # this guards against errors in input paths
             raise MetaflowDataMissing(
-                "Input paths *%s* resolved to zero " "inputs" % ",".join(input_paths)
+                "Input paths *%s* resolved to zero inputs" % ",".join(input_paths)
             )
         return ds_list
 
@@ -256,11 +261,37 @@ class MetaflowTask(object):
         x._set_datastore(datastore)
         return x
 
-    def clone_only(self, step_name, run_id, task_id, clone_origin_task, retry_count):
+    def clone_only(
+        self,
+        step_name,
+        run_id,
+        task_id,
+        clone_origin_task,
+        retry_count,
+        wait_only=False,
+    ):
         if not clone_origin_task:
             raise MetaflowInternalError(
-                "task.clone_only needs a valid " "clone_origin_task value."
+                "task.clone_only needs a valid clone_origin_task value."
             )
+        if wait_only:
+            # In this case, we are actually going to wait for the clone to be done
+            # by someone else. To do this, we just get the task_datastore in "r" mode
+            while True:
+                try:
+                    ds = self.flow_datastore.get_task_datastore(
+                        run_id, step_name, task_id
+                    )
+                    if not ds["_task_ok"]:
+                        raise MetaflowInternalError(
+                            "Externally cloned task did not succeed"
+                        )
+                    break
+                except DataException:
+                    # No need to get fancy with the sleep here.
+                    time.sleep(5)
+            return
+        # If we actually have to do the clone ourselves, proceed...
         # 1. initialize output datastore
         output = self.flow_datastore.get_task_datastore(
             run_id, step_name, task_id, attempt=0, mode="w"
@@ -299,6 +330,20 @@ class MetaflowTask(object):
                     tags=metadata_tags,
                 ),
             ],
+        )
+        # We write a single line to the log to give a better experience to the user
+        # (particularly in the UI)
+        output.save_logs(
+            TASK_LOG_SOURCE,
+            {
+                "stdout": BytesIO(
+                    bytes(
+                        "Task was cloned from %s/%s"
+                        % (self.flow_datastore.flow_name, clone_origin_task),
+                        encoding="utf-8",
+                    )
+                )
+            },
         )
         output.done()
 
@@ -354,7 +399,7 @@ class MetaflowTask(object):
             self.metadata.register_task_id(run_id, step_name, task_id, retry_count)
         else:
             raise MetaflowInternalError(
-                "task.run_step needs a valid run_id " "and task_id"
+                "task.run_step needs a valid run_id and task_id"
             )
 
         if retry_count >= MAX_ATTEMPTS:
@@ -362,7 +407,7 @@ class MetaflowTask(object):
             # by datastore, so running a task with such a retry_could would
             # be pointless and dangerous
             raise MetaflowInternalError(
-                "Too many task attempts (%d)! " "MAX_ATTEMPTS exceeded." % retry_count
+                "Too many task attempts (%d)! MAX_ATTEMPTS exceeded." % retry_count
             )
 
         metadata_tags = ["attempt_id:{0}".format(retry_count)]

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -331,20 +331,6 @@ class MetaflowTask(object):
                 ),
             ],
         )
-        # We write a single line to the log to give a better experience to the user
-        # (particularly in the UI)
-        output.save_logs(
-            TASK_LOG_SOURCE,
-            {
-                "stdout": BytesIO(
-                    bytes(
-                        "Task was cloned from %s/%s"
-                        % (self.flow_datastore.flow_name, clone_origin_task),
-                        encoding="utf-8",
-                    )
-                )
-            },
-        )
         output.done()
 
     def _finalize_control_task(self):


### PR DESCRIPTION
…ility to only clone tasks

The scenario for this use is mainly for external schedulers that are
capable of "resuming" failed runs by only re-executing the ones that failed
or didn't execute the first time. We need a way for Metaflow to "clone" the
tasks that are not re-executed.

Also took the opportunity to fix a few TODOs related to status updates for local runs
as well as some tiny cleanups.