### PR TITLE
Changed error to warning in AWS retry

### DIFF
--- a/metaflow/datatools/s3util.py
+++ b/metaflow/datatools/s3util.py
@@ -10,6 +10,7 @@ from metaflow.metaflow_config import (
     DATATOOLS_DEFAULT_CLIENT_PARAMS,
     DATATOOLS_DEFAULT_SESSION_VARS,
     S3_RETRY_COUNT,
+    RETRY_WARNING_THRESHOLD,
 )
 
 
@@ -55,11 +56,14 @@ def aws_retry(f):
                     function_name = f.func_name
                 except AttributeError:
                     function_name = f.__name__
-                sys.stderr.write(
-                    "S3 datastore operation %s failed (%s). "
-                    "Retrying %d more times..\n"
-                    % (function_name, ex, S3_RETRY_COUNT - i)
-                )
+                if i + 1 > RETRY_WARNING_THRESHOLD:
+                    # Print this warning message only after a certain
+                    # amount of retries
+                    sys.stderr.write(
+                        "[WARNING] S3 datastore operation %s failed (%s). "
+                        "Retrying %d more times..\n"
+                        % (function_name, ex, S3_RETRY_COUNT - i)
+                    )
                 self.reset_client(hard_reset=True)
                 last_exc = ex
                 # exponential backoff for real failures

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -94,6 +94,9 @@ S3_VERIFY_CERTIFICATE = from_conf("METAFLOW_S3_VERIFY_CERTIFICATE", None)
 # so setting it to 0 means each operation will be tried once.
 S3_RETRY_COUNT = int(from_conf("METAFLOW_S3_RETRY_COUNT", 7))
 
+# Threshold to start printing warnings for an AWS retry
+RETRY_WARNING_THRESHOLD = 3
+
 # S3 datatools root location
 DATATOOLS_SUFFIX = from_conf("METAFLOW_DATATOOLS_SUFFIX", "data")
 DATATOOLS_S3ROOT = from_conf(


### PR DESCRIPTION
We have seen issues this utility. We print to stderr when we are retrying on an exception that gets fixed on one or more retries. However, the user perceives this to be an `ERROR` when actually it is merely a `WARNING`. This PR fixes this issue by adding a `[WARNING]` prefix and only printing this warning when a certain amount of retries have been made.