### PR TITLE
Airflow Support

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -100,8 +100,6 @@ class Decorator(object):
 
     name = "NONAME"
     defaults = {}
-    # `allow_multiple` allows setting many decorators of the same type to a step/flow.
-    allow_multiple = False
 
     def __init__(self, attributes=None, statically_defined=False):
         self.attributes = self.defaults.copy()
@@ -227,6 +225,9 @@ class StepDecorator(Decorator):
                   step.__name__ etc., so that we don't have to
                   pass them around with every lifecycle call.
     """
+
+    # `allow_multiple` allows setting many decorators of the same type to a step.
+    allow_multiple = False
 
     def step_init(
         self, flow, graph, step_name, decorators, environment, flow_datastore, logger
@@ -373,17 +374,12 @@ def _base_flow_decorator(decofunc, *args, **kwargs):
         if isinstance(cls, type) and issubclass(cls, FlowSpec):
             # flow decorators add attributes in the class dictionary,
             # _flow_decorators.
-            if decofunc.name in cls._flow_decorators and not decofunc.allow_multiple:
+            if decofunc.name in cls._flow_decorators:
                 raise DuplicateFlowDecoratorException(decofunc.name)
             else:
-                deco_instance = decofunc(attributes=kwargs, statically_defined=True)
-                if decofunc.allow_multiple:
-                    if decofunc.name not in cls._flow_decorators:
-                        cls._flow_decorators[decofunc.name] = [deco_instance]
-                    else:
-                        cls._flow_decorators[decofunc.name].append(deco_instance)
-                else:
-                    cls._flow_decorators[decofunc.name] = deco_instance
+                cls._flow_decorators[decofunc.name] = decofunc(
+                    attributes=kwargs, statically_defined=True
+                )
         else:
             raise BadFlowDecoratorException(decofunc.name)
         return cls
@@ -473,26 +469,11 @@ def _attach_decorators_to_step(step, decospecs):
 def _init_flow_decorators(
     flow, graph, environment, flow_datastore, metadata, logger, echo, deco_options
 ):
-    # Certain decorators can be specified multiple times and exist as lists in the _flow_decorators dictionary
     for deco in flow._flow_decorators.values():
-        if type(deco) == list:
-            for rd in deco:
-                opts = {option: deco_options[option] for option in rd.options}
-                rd.flow_init(
-                    flow,
-                    graph,
-                    environment,
-                    flow_datastore,
-                    metadata,
-                    logger,
-                    echo,
-                    opts,
-                )
-        else:
-            opts = {option: deco_options[option] for option in deco.options}
-            deco.flow_init(
-                flow, graph, environment, flow_datastore, metadata, logger, echo, opts
-            )
+        opts = {option: deco_options[option] for option in deco.options}
+        deco.flow_init(
+            flow, graph, environment, flow_datastore, metadata, logger, echo, opts
+        )
 
 
 def _init_step_decorators(flow, graph, environment, flow_datastore, logger):

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -242,6 +242,15 @@ KUBERNETES_CONTAINER_REGISTRY = (
 )
 #
 
+##
+# Airflow Configuration
+##
+# This configuration sets `startup_timeout_seconds` in airflow's KubernetesPodOperator.
+AIRFLOW_KUBERNETES_STARTUP_TIMEOUT = from_conf(
+    "METAFLOW_AIRFLOW_KUBERNETES_STARTUP_TIMEOUT_SECONDS", 60 * 60
+)
+
+
 ###
 # Conda configuration
 ###

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -88,6 +88,7 @@ def get_plugin_cli():
     from .aws.batch import batch_cli
     from .kubernetes import kubernetes_cli
     from .aws.step_functions import step_functions_cli
+    from .airflow import airflow_cli
     from .argo import argo_workflows_cli
     from .cards import card_cli
     from . import tag_cli
@@ -98,6 +99,7 @@ def get_plugin_cli():
         card_cli.cli,
         kubernetes_cli.cli,
         step_functions_cli.cli,
+        airflow_cli.cli,
         argo_workflows_cli.cli,
         tag_cli.cli,
     ]
@@ -121,6 +123,7 @@ from .test_unbounded_foreach_decorator import (
 from .conda.conda_step_decorator import CondaStepDecorator
 from .cards.card_decorator import CardDecorator
 from .frameworks.pytorch import PytorchParallelDecorator
+from .airflow.airflow_decorator import AirflowInternalDecorator
 
 
 STEP_DECORATORS = [
@@ -137,6 +140,7 @@ STEP_DECORATORS = [
     ParallelDecorator,
     PytorchParallelDecorator,
     InternalTestUnboundedForeachDecorator,
+    AirflowInternalDecorator,
     ArgoWorkflowsInternalDecorator,
 ]
 _merge_lists(STEP_DECORATORS, _ext_plugins["STEP_DECORATORS"], "name")
@@ -161,7 +165,12 @@ from .conda.conda_flow_decorator import CondaFlowDecorator
 from .aws.step_functions.schedule_decorator import ScheduleDecorator
 from .project_decorator import ProjectDecorator
 
-FLOW_DECORATORS = [CondaFlowDecorator, ScheduleDecorator, ProjectDecorator]
+
+FLOW_DECORATORS = [
+    CondaFlowDecorator,
+    ScheduleDecorator,
+    ProjectDecorator,
+]
 _merge_lists(FLOW_DECORATORS, _ext_plugins["FLOW_DECORATORS"], "name")
 
 # Cards

--- a/metaflow/plugins/airflow/airflow.py
+++ b/metaflow/plugins/airflow/airflow.py
@@ -514,13 +514,10 @@ class Airflow(object):
 
         if node.name == "start":
             # We need a separate unique ID for the special _parameters task
-            task_id_params = (
-                "%s-params"
-                % (
-                    AIRFLOW_MACROS.TASK_ID
-                    if not self.contains_foreach
-                    else AIRFLOW_MACROS.FOREACH_TASK_ID
-                )
+            task_id_params = "%s-params" % (
+                AIRFLOW_MACROS.TASK_ID
+                if not self.contains_foreach
+                else AIRFLOW_MACROS.FOREACH_TASK_ID
             )
             # Export user-defined parameters into runtime environment
             param_file = "".join(

--- a/metaflow/plugins/airflow/airflow.py
+++ b/metaflow/plugins/airflow/airflow.py
@@ -1,0 +1,687 @@
+from io import BytesIO
+import json
+import os
+import random
+import string
+import sys
+from datetime import datetime, timedelta
+
+import metaflow.util as util
+from metaflow.decorators import flow_decorators
+from metaflow.exception import MetaflowException
+from metaflow.metaflow_config import (
+    BATCH_METADATA_SERVICE_HEADERS,
+    BATCH_METADATA_SERVICE_URL,
+    DATASTORE_CARD_S3ROOT,
+    DATASTORE_SYSROOT_S3,
+    DATATOOLS_S3ROOT,
+    KUBERNETES_SERVICE_ACCOUNT,
+    KUBERNETES_SECRETS,
+    AIRFLOW_KUBERNETES_STARTUP_TIMEOUT,
+)
+from metaflow.parameters import deploy_time_eval
+from metaflow.plugins.kubernetes.kubernetes import Kubernetes
+
+# TODO: Move chevron to _vendor
+from metaflow.plugins.cards.card_modules import chevron
+from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task
+from metaflow.util import dict_to_cli_options, get_username, compress_list
+from metaflow.parameters import JSONTypeClass
+
+from . import airflow_utils
+from .exception import AirflowException
+from .airflow_utils import (
+    TASK_ID_XCOM_KEY,
+    AirflowTask,
+    Workflow,
+    AIRFLOW_MACROS,
+)
+from metaflow import current
+
+AIRFLOW_DEPLOY_TEMPLATE_FILE = os.path.join(os.path.dirname(__file__), "dag.py")
+
+
+class Airflow(object):
+
+    TOKEN_STORAGE_ROOT = "mf.airflow"
+
+    def __init__(
+        self,
+        name,
+        graph,
+        flow,
+        code_package_sha,
+        code_package_url,
+        metadata,
+        flow_datastore,
+        environment,
+        event_logger,
+        monitor,
+        production_token,
+        tags=None,
+        namespace=None,
+        username=None,
+        max_workers=None,
+        worker_pool=None,
+        description=None,
+        file_path=None,
+        workflow_timeout=None,
+        is_paused_upon_creation=True,
+    ):
+        self.name = name
+        self.graph = graph
+        self.flow = flow
+        self.code_package_sha = code_package_sha
+        self.code_package_url = code_package_url
+        self.metadata = metadata
+        self.flow_datastore = flow_datastore
+        self.environment = environment
+        self.event_logger = event_logger
+        self.monitor = monitor
+        self.tags = tags
+        self.namespace = namespace  # this is the username space
+        self.username = username
+        self.max_workers = max_workers
+        self.description = description
+        self._file_path = file_path
+        _, self.graph_structure = self.graph.output_steps()
+        self.worker_pool = worker_pool
+        self.is_paused_upon_creation = is_paused_upon_creation
+        self.workflow_timeout = workflow_timeout
+        self.schedule = self._get_schedule()
+        self.parameters = self._process_parameters()
+        self.production_token = production_token
+
+    @classmethod
+    def get_existing_deployment(cls, name, flow_datastore):
+        _backend = flow_datastore._storage_impl
+        token_paths = _backend.list_content([cls.get_token_path(name)])
+        if len(token_paths) == 0:
+            return None
+
+        with _backend.load_bytes([token_paths[0]]) as get_results:
+            for _, path, _ in get_results:
+                if path is not None:
+                    with open(path, "r") as f:
+                        data = json.loads(f.read())
+                    return (data["owner"], data["production_token"])
+
+    @classmethod
+    def get_token_path(cls, name):
+        return os.path.join(cls.TOKEN_STORAGE_ROOT, name)
+
+    @classmethod
+    def save_deployment_token(cls, owner, token, flow_datastore):
+        _backend = flow_datastore._storage_impl
+        _backend.save_bytes(
+            [
+                (
+                    cls.get_token_path(token),
+                    BytesIO(
+                        bytes(
+                            json.dumps({"production_token": token, "owner": owner}),
+                            "utf-8",
+                        )
+                    ),
+                )
+            ],
+            overwrite=False,
+        )
+
+    def _get_schedule(self):
+        # Using the cron presets provided here :
+        # https://airflow.apache.org/docs/apache-airflow/stable/dag-run.html?highlight=schedule%20interval#cron-presets
+        schedule = self.flow._flow_decorators.get("schedule")
+        if not schedule:
+            return None
+        if schedule.attributes["cron"]:
+            return schedule.attributes["cron"]
+        elif schedule.attributes["weekly"]:
+            return "@weekly"
+        elif schedule.attributes["hourly"]:
+            return "@hourly"
+        elif schedule.attributes["daily"]:
+            return "@daily"
+        return None
+
+    def _get_retries(self, node):
+        max_user_code_retries = 0
+        max_error_retries = 0
+        foreach_default_retry = 1
+        # Different decorators may have different retrying strategies, so take
+        # the max of them.
+        for deco in node.decorators:
+            user_code_retries, error_retries = deco.step_task_retry_count()
+            max_user_code_retries = max(max_user_code_retries, user_code_retries)
+            max_error_retries = max(max_error_retries, error_retries)
+        parent_is_foreach = any(  # The immediate parent is a foreach node.
+            self.graph[n].type == "foreach" for n in node.in_funcs
+        )
+
+        if parent_is_foreach:
+            max_user_code_retries + foreach_default_retry
+        return max_user_code_retries, max_user_code_retries + max_error_retries
+
+    def _get_retry_delay(self, node):
+        retry_decos = [deco for deco in node.decorators if deco.name == "retry"]
+        if len(retry_decos) > 0:
+            retry_mins = retry_decos[0].attributes["minutes_between_retries"]
+            return timedelta(minutes=int(retry_mins))
+        return None
+
+    def _process_parameters(self):
+        seen = set()
+        airflow_params = []
+        type_transform_dict = {
+            int.__name__: "integer",
+            str.__name__: "string",
+            bool.__name__: "string",
+            float.__name__: "number",
+            JSONTypeClass.name: "string",
+        }
+        type_parser = {bool.__name__: lambda v: str(v)}
+
+        for var, param in self.flow._get_parameters():
+            # Throw an exception if the parameter is specified twice.
+            norm = param.name.lower()
+            if norm in seen:
+                raise MetaflowException(
+                    "Parameter *%s* is specified twice. "
+                    "Note that parameter names are "
+                    "case-insensitive." % param.name
+                )
+            seen.add(norm)
+
+            # Airflow requires defaults set for parameters.
+            if "default" not in param.kwargs:
+                raise MetaflowException(
+                    "Parameter *%s* does not have a "
+                    "default value. "
+                    "A default value is required for parameters when deploying flows on Airflow."
+                )
+            value = deploy_time_eval(param.kwargs.get("default"))
+            # Setting airflow related param args.
+            param_type = param.kwargs.get("type")
+            airflow_param = dict(
+                name=param.name,
+            )
+            if value is not None:
+                airflow_param["default"] = value
+            if param.kwargs.get("help"):
+                airflow_param["description"] = param.kwargs.get("help")
+            if param_type is not None:
+                # Todo (fast-follow): Check if we can support more `click.Param` types
+                param_type_name = getattr(param_type, "__name__", None)
+                if not param_type_name and isinstance(param_type, JSONTypeClass):
+                    # `JSONTypeClass` has no __name__ attribute so we need to explicitly check if
+                    # `param_type` is an instance of `JSONTypeClass``
+                    param_type_name = param_type.name
+
+                if param_type_name in type_transform_dict:
+                    airflow_param["type"] = type_transform_dict[param_type_name]
+                    if param_type_name in type_parser and value is not None:
+                        airflow_param["default"] = type_parser[param_type_name](value)
+
+            airflow_params.append(airflow_param)
+
+        return airflow_params
+
+    def _compress_input_path(
+        self,
+        steps,
+    ):
+        """
+        This function is meant to compress the input paths and it specifically doesn't use
+        `metaflow.util.compress_list` under the hood. The reason is because the `AIRFLOW_MACROS.RUN_ID` is a complicated macro string
+        that doesn't behave nicely with `metaflow.util.decompress_list` since the `decompress_util`
+        function expects a string which doesn't contain any delimiter characters and the run-id string does.
+        Hence we have a custom compression string created via `_compress_input_path` function instead of `compress_list`.
+        """
+        return "%s:" % (AIRFLOW_MACROS.RUN_ID) + ",".join(
+            self._make_input_path(step, only_task_id=True) for step in steps
+        )
+
+    def _make_foreach_input_path(self, step_name):
+        return (
+            "%s/%s/:{{ task_instance.xcom_pull(task_ids='%s',key='%s') | join_list }}"
+            % (
+                AIRFLOW_MACROS.RUN_ID,
+                step_name,
+                step_name,
+                TASK_ID_XCOM_KEY,
+            )
+        )
+
+    def _make_input_path(self, step_name, only_task_id=False):
+        """
+        This is set using the `airflow_internal` decorator to help pass state.
+        This will pull the `TASK_ID_XCOM_KEY` xcom which holds task-ids. The key is set via the `MetaflowKubernetesOperator`.
+        """
+        task_id_string = "/%s/{{ task_instance.xcom_pull(task_ids='%s',key='%s') }}" % (
+            step_name,
+            step_name,
+            TASK_ID_XCOM_KEY,
+        )
+
+        if only_task_id:
+            return task_id_string
+
+        return "%s%s" % (AIRFLOW_MACROS.RUN_ID, task_id_string)
+
+    def _to_job(self, node):
+        """
+        This function will transform the node's specification into Airflow compatible operator arguments.
+        Since this function is long, below is the summary of the two major duties it performs:
+            1. Based on the type of the graph node (start/linear/foreach/join etc.) it will decide how to set the input paths
+            2. Based on node's decorator specification convert the information into a job spec for the KubernetesPodOperator.
+        """
+        # Add env vars from the optional @environment decorator.
+        env_deco = [deco for deco in node.decorators if deco.name == "environment"]
+        env = {}
+        if env_deco:
+            env = env_deco[0].attributes["vars"]
+
+        # The below if/else block handles "input paths".
+        # Input Paths help manage dataflow across the graph.
+        if node.name == "start":
+            # POSSIBLE_FUTURE_IMPROVEMENT:
+            # We can extract metadata about the possible upstream sensor triggers.
+            # There is a previous commit (7bdf6) in the `airflow` branch that has `SensorMetaExtractor` class and
+            # associated MACRO we have built to handle this case if a metadata regarding the sensor is needed.
+            # Initialize parameters for the flow in the `start` step.
+            # `start` step has no upstream input dependencies aside from
+            # parameters.
+
+            if len(self.parameters):
+                env["METAFLOW_PARAMETERS"] = AIRFLOW_MACROS.PARAMETERS
+            input_paths = None
+        else:
+            # If it is not the start node then we check if there are many paths
+            # converging into it or a single path. Based on that we set the INPUT_PATHS
+            if node.parallel_foreach:
+                raise AirflowException(
+                    "Parallel steps are not supported yet with Airflow."
+                )
+            is_foreach_join = (
+                node.type == "join"
+                and self.graph[node.split_parents[-1]].type == "foreach"
+            )
+            if is_foreach_join:
+                input_paths = self._make_foreach_input_path(node.in_funcs[0])
+
+            elif len(node.in_funcs) == 1:
+                # set input paths where this is only one parent node
+                # The parent-task-id is passed via the xcom; There is no other way to get that.
+                # One key thing about xcoms is that they are immutable and only accepted if the task
+                # doesn't fail.
+                # From airflow docs :
+                # "Note: If the first task run is not succeeded then on every retry task XComs will be cleared to make the task run idempotent."
+                input_paths = self._make_input_path(node.in_funcs[0])
+            else:
+                # this is a split scenario where there can be more than one input paths.
+                input_paths = self._compress_input_path(node.in_funcs)
+
+            # env["METAFLOW_INPUT_PATHS"] = input_paths
+
+        env["METAFLOW_CODE_URL"] = self.code_package_url
+        env["METAFLOW_FLOW_NAME"] = self.flow.name
+        env["METAFLOW_STEP_NAME"] = node.name
+        env["METAFLOW_OWNER"] = self.username
+
+        metadata_env = self.metadata.get_runtime_environment("airflow")
+        env.update(metadata_env)
+
+        metaflow_version = self.environment.get_environment_info()
+        metaflow_version["flow_name"] = self.graph.name
+        metaflow_version["production_token"] = self.production_token
+        env["METAFLOW_VERSION"] = json.dumps(metaflow_version)
+
+        # Extract the k8s decorators for constructing the arguments of the K8s Pod Operator on Airflow.
+        k8s_deco = [deco for deco in node.decorators if deco.name == "kubernetes"][0]
+        user_code_retries, _ = self._get_retries(node)
+        retry_delay = self._get_retry_delay(node)
+        # This sets timeouts for @timeout decorators.
+        # The timeout is set as "execution_timeout" for an airflow task.
+        runtime_limit = get_run_time_limit_for_task(node.decorators)
+
+        k8s = Kubernetes(self.flow_datastore, self.metadata, self.environment)
+        user = util.get_username()
+
+        labels = {
+            "app": "metaflow",
+            "app.kubernetes.io/name": "metaflow-task",
+            "app.kubernetes.io/part-of": "metaflow",
+            "app.kubernetes.io/created-by": user,
+            # Question to (savin) : Should we have username set over here for created by since it is the airflow installation that is creating the jobs.
+            # Technically the "user" is the stakeholder but should these labels be present.
+        }
+        additional_mf_variables = {
+            "METAFLOW_CODE_SHA": self.code_package_sha,
+            "METAFLOW_CODE_URL": self.code_package_url,
+            "METAFLOW_CODE_DS": self.flow_datastore.TYPE,
+            "METAFLOW_USER": user,
+            "METAFLOW_SERVICE_URL": BATCH_METADATA_SERVICE_URL,
+            "METAFLOW_SERVICE_HEADERS": json.dumps(BATCH_METADATA_SERVICE_HEADERS),
+            "METAFLOW_DATASTORE_SYSROOT_S3": DATASTORE_SYSROOT_S3,
+            "METAFLOW_DATATOOLS_S3ROOT": DATATOOLS_S3ROOT,
+            "METAFLOW_DEFAULT_DATASTORE": "s3",
+            "METAFLOW_DEFAULT_METADATA": "service",
+            "METAFLOW_KUBERNETES_WORKLOAD": str(
+                1
+            ),  # This is used by kubernetes decorator.
+            "METAFLOW_RUNTIME_ENVIRONMENT": "kubernetes",
+            "METAFLOW_CARD_S3ROOT": DATASTORE_CARD_S3ROOT,
+            "METAFLOW_RUN_ID": AIRFLOW_MACROS.RUN_ID,
+            "METAFLOW_AIRFLOW_TASK_ID": AIRFLOW_MACROS.TASK_ID,
+            "METAFLOW_AIRFLOW_DAG_RUN_ID": AIRFLOW_MACROS.AIRFLOW_RUN_ID,
+            "METAFLOW_AIRFLOW_JOB_ID": AIRFLOW_MACROS.AIRFLOW_JOB_ID,
+            "METAFLOW_PRODUCTION_TOKEN": self.production_token,
+            "METAFLOW_ATTEMPT_NUMBER": AIRFLOW_MACROS.ATTEMPT,
+        }
+        env.update(additional_mf_variables)
+        service_account = (
+            KUBERNETES_SERVICE_ACCOUNT
+            if k8s_deco.attributes["service_account"] is None
+            else k8s_deco.attributes["service_account"]
+        )
+        k8s_namespace = (
+            k8s_deco.attributes["namespace"]
+            if k8s_deco.attributes["namespace"] is not None
+            else "default"
+        )
+
+        resources = dict(
+            requests={
+                "cpu": k8s_deco.attributes["cpu"],
+                "memory": "%sM" % str(k8s_deco.attributes["memory"]),
+                "ephemeral-storage": str(k8s_deco.attributes["disk"]),
+            }
+        )
+        if k8s_deco.attributes["gpu"] is not None:
+            resources.update(
+                dict(
+                    limits={
+                        "%s.com/gpu".lower()
+                        % k8s_deco.attributes["gpu_vendor"]: str(
+                            k8s_deco.attributes["gpu"]
+                        )
+                    }
+                )
+            )
+
+        annotations = {
+            "metaflow/production_token": self.production_token,
+            "metaflow/owner": self.username,
+            "metaflow/user": self.username,
+            "metaflow/flow_name": self.flow.name,
+        }
+        if current.get("project_name"):
+            annotations.update(
+                {
+                    "metaflow/project_name": current.project_name,
+                    "metaflow/branch_name": current.branch_name,
+                    "metaflow/project_flow_name": current.project_flow_name,
+                }
+            )
+
+        k8s_operator_args = dict(
+            # like argo workflows we use step_name as name of container
+            name=node.name,
+            namespace=k8s_namespace,
+            service_account_name=service_account,
+            node_selector=k8s_deco.attributes["node_selector"],
+            cmds=k8s._command(
+                self.flow.name,
+                AIRFLOW_MACROS.RUN_ID,
+                node.name,
+                AIRFLOW_MACROS.TASK_ID,
+                AIRFLOW_MACROS.ATTEMPT,
+                code_package_url=self.code_package_url,
+                step_cmds=self._step_cli(
+                    node, input_paths, self.code_package_url, user_code_retries
+                ),
+            ),
+            annotations=annotations,
+            image=k8s_deco.attributes["image"],
+            resources=resources,
+            execution_timeout=dict(seconds=runtime_limit),
+            retries=user_code_retries,
+            env_vars=[dict(name=k, value=v) for k, v in env.items()],
+            labels=labels,
+            task_id=node.name,
+            startup_timeout_seconds=AIRFLOW_KUBERNETES_STARTUP_TIMEOUT,
+            in_cluster=True,
+            get_logs=True,
+            do_xcom_push=True,
+            log_events_on_failure=True,
+            is_delete_operator_pod=True,
+            retry_exponential_backoff=False,  # todo : should this be a arg we allow on CLI. not right now - there is an open ticket for this - maybe at some point we will.
+            reattach_on_restart=False,
+            secrets=[],
+        )
+        if k8s_deco.attributes["secrets"]:
+            if isinstance(k8s_deco.attributes["secrets"], str):
+                k8s_operator_args["secrets"] = k8s_deco.attributes["secrets"].split(",")
+            elif isinstance(k8s_deco.attributes["secrets"], list):
+                k8s_operator_args["secrets"] = k8s_deco.attributes["secrets"]
+        if len(KUBERNETES_SECRETS) > 0:
+            k8s_operator_args["secrets"] += KUBERNETES_SECRETS.split(",")
+
+        if retry_delay:
+            k8s_operator_args["retry_delay"] = dict(seconds=retry_delay.total_seconds())
+
+        return k8s_operator_args
+
+    def _step_cli(self, node, paths, code_package_url, user_code_retries):
+        cmds = []
+
+        script_name = os.path.basename(sys.argv[0])
+        executable = self.environment.executable(node.name)
+
+        entrypoint = [executable, script_name]
+
+        top_opts_dict = {
+            "with": [
+                decorator.make_decorator_spec()
+                for decorator in node.decorators
+                if not decorator.statically_defined
+            ]
+        }
+        # FlowDecorators can define their own top-level options. They are
+        # responsible for adding their own top-level options and values through
+        # the get_top_level_options() hook. See similar logic in runtime.py.
+        for deco in flow_decorators():
+            top_opts_dict.update(deco.get_top_level_options())
+
+        top_opts = list(dict_to_cli_options(top_opts_dict))
+
+        top_level = top_opts + [
+            "--quiet",
+            "--metadata=%s" % self.metadata.TYPE,
+            "--environment=%s" % self.environment.TYPE,
+            "--datastore=%s" % self.flow_datastore.TYPE,
+            "--datastore-root=%s" % self.flow_datastore.datastore_root,
+            "--event-logger=%s" % self.event_logger.TYPE,
+            "--monitor=%s" % self.monitor.TYPE,
+            "--no-pylint",
+            "--with=airflow_internal",
+        ]
+
+        if node.name == "start":
+            # We need a separate unique ID for the special _parameters task
+            task_id_params = "%s-params" % AIRFLOW_MACROS.TASK_ID
+            # Export user-defined parameters into runtime environment
+            param_file = "".join(
+                random.choice(string.ascii_lowercase) for _ in range(10)
+            )
+            # Setup Parameters as environment variables which are stored in a dictionary.
+            export_params = (
+                "python -m "
+                "metaflow.plugins.airflow.plumbing.set_parameters %s "
+                "&& . `pwd`/%s" % (param_file, param_file)
+            )
+            # Setting parameters over here.
+            params = (
+                entrypoint
+                + top_level
+                + [
+                    "init",
+                    "--run-id %s" % AIRFLOW_MACROS.RUN_ID,
+                    "--task-id %s" % task_id_params,
+                ]
+            )
+
+            # Assign tags to run objects.
+            if self.tags:
+                params.extend("--tag %s" % tag for tag in self.tags)
+
+            # If the start step gets retried, we must be careful not to
+            # regenerate multiple parameters tasks. Hence we check first if
+            # _parameters exists already.
+            exists = entrypoint + [
+                # Dump the parameters task
+                "dump",
+                "--max-value-size=0",
+                "%s/_parameters/%s" % (AIRFLOW_MACROS.RUN_ID, task_id_params),
+            ]
+            cmd = "if ! %s >/dev/null 2>/dev/null; then %s && %s; fi" % (
+                " ".join(exists),
+                export_params,
+                " ".join(params),
+            )
+            cmds.append(cmd)
+            # set input paths for parameters
+            paths = "%s/_parameters/%s" % (AIRFLOW_MACROS.RUN_ID, task_id_params)
+
+        step = [
+            "step",
+            node.name,
+            "--run-id %s" % AIRFLOW_MACROS.RUN_ID,
+            "--task-id %s" % AIRFLOW_MACROS.TASK_ID,
+            "--retry-count %s" % AIRFLOW_MACROS.ATTEMPT,
+            "--max-user-code-retries %d" % user_code_retries,
+            "--input-paths %s" % paths,
+        ]
+        if self.tags:
+            step.extend("--tag %s" % tag for tag in self.tags)
+        if self.namespace is not None:
+            step.append("--namespace=%s" % self.namespace)
+
+        parent_is_foreach = any(  # The immediate parent is a foreach node.
+            self.graph[n].type == "foreach" for n in node.in_funcs
+        )
+        if parent_is_foreach:
+            step.append("--split-index %s" % AIRFLOW_MACROS.FOREACH_SPLIT_INDEX)
+
+        cmds.append(" ".join(entrypoint + top_level + step))
+        return cmds
+
+    def _contains_foreach(self):
+        for node in self.graph:
+            if node.type == "foreach":
+                return True
+        return False
+
+    def compile(self):
+        # Visit every node of the flow and recursively build the state machine.
+        def _visit(node, workflow, exit_node=None):
+            if node.parallel_foreach:
+                raise AirflowException(
+                    "Deploying flows with @parallel decorator(s) "
+                    "to Airflow is not supported currently."
+                )
+            parent_is_foreach = any(  # Any immediate parent is a foreach node.
+                self.graph[n].type == "foreach" for n in node.in_funcs
+            )
+            state = AirflowTask(
+                node.name, is_mapper_node=parent_is_foreach
+            ).set_operator_args(**self._to_job(node))
+            if node.type == "end":
+                workflow.add_state(state)
+
+            # Continue linear assignment within the (sub)workflow if the node
+            # doesn't branch or fork.
+            elif node.type in ("start", "linear", "join", "foreach"):
+                workflow.add_state(state)
+                _visit(
+                    self.graph[node.out_funcs[0]],
+                    workflow,
+                )
+
+            elif node.type == "split":
+                workflow.add_state(state)
+                for func in node.out_funcs:
+                    _visit(
+                        self.graph[func],
+                        workflow,
+                    )
+            else:
+                raise AirflowException(
+                    "Node type *%s* for  step *%s* "
+                    "is not currently supported by "
+                    "Airflow." % (node.type, node.name)
+                )
+
+            return workflow
+
+        # set max active tasks here , For more info check here :
+        # https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/dag/index.html#airflow.models.dag.DAG
+        airflow_dag_args = (
+            {} if self.max_workers is None else dict(max_active_tasks=self.max_workers)
+        )
+        airflow_dag_args["is_paused_upon_creation"] = self.is_paused_upon_creation
+
+        # workflow timeout should only be enforced if a dag is scheduled.
+        if self.workflow_timeout is not None and self.schedule is not None:
+            airflow_dag_args["dagrun_timeout"] = dict(seconds=self.workflow_timeout)
+
+        workflow = Workflow(
+            dag_id=self.name,
+            default_args=self._create_defaults(),
+            description=self.description,
+            schedule_interval=self.schedule,
+            # `start_date` is a mandatory argument even though the documentation lists it as optional value
+            # Based on the code, Airflow will throw a `AirflowException` when `start_date` is not provided
+            # to a DAG : https://github.com/apache/airflow/blob/0527a0b6ce506434a23bc2a6f5ddb11f492fc614/airflow/models/dag.py#L2170
+            start_date=datetime.now(),
+            tags=self.tags,
+            file_path=self._file_path,
+            graph_structure=self.graph_structure,
+            metadata=dict(contains_foreach=self._contains_foreach()),
+            **airflow_dag_args
+        )
+        workflow = _visit(self.graph["start"], workflow)
+
+        workflow.set_parameters(self.parameters)
+        return self._to_airflow_dag_file(workflow.to_dict())
+
+    def _to_airflow_dag_file(self, json_dag):
+        util_file = None
+        with open(airflow_utils.__file__) as f:
+            util_file = f.read()
+        with open(AIRFLOW_DEPLOY_TEMPLATE_FILE) as f:
+            return chevron.render(
+                f.read(),
+                dict(
+                    # Converting the configuration to base64 so that there can be no indentation related issues that can be caused because of
+                    # malformed strings / json.
+                    config=json_dag,
+                    utils=util_file,
+                    deployed_on=str(datetime.now()),
+                ),
+            )
+
+    def _create_defaults(self):
+        defu_ = {
+            "owner": get_username(),
+            # If set on a task, doesn’t run the task in the current DAG run if the previous run of the task has failed.
+            "depends_on_past": False,
+            # TODO: Enable emails
+            "execution_timeout": timedelta(days=5),
+            "retry_delay": timedelta(seconds=200),
+            # check https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/baseoperator/index.html?highlight=retry_delay#airflow.models.baseoperator.BaseOperatorMeta
+        }
+        if self.worker_pool is not None:
+            defu_["pool"] = self.worker_pool
+
+        return defu_

--- a/metaflow/plugins/airflow/airflow.py
+++ b/metaflow/plugins/airflow/airflow.py
@@ -520,7 +520,7 @@ class Airflow(object):
                     AIRFLOW_MACROS.TASK_ID
                     if not self.contains_foreach
                     else AIRFLOW_MACROS.FOREACH_TASK_ID
-                ),
+                )
             )
             # Export user-defined parameters into runtime environment
             param_file = "".join(

--- a/metaflow/plugins/airflow/airflow_cli.py
+++ b/metaflow/plugins/airflow/airflow_cli.py
@@ -1,0 +1,409 @@
+import os
+import re
+import sys
+import base64
+from metaflow import current, decorators
+from metaflow._vendor import click
+from metaflow.exception import MetaflowException, MetaflowInternalError
+from metaflow.package import MetaflowPackage
+from hashlib import sha1
+from metaflow.plugins import KubernetesDecorator
+from metaflow.util import get_username, to_bytes, to_unicode
+
+from .airflow import Airflow
+from .exception import AirflowException, NotSupportedException
+
+from metaflow.plugins.aws.step_functions.production_token import (
+    load_token,
+    new_token,
+    store_token,
+)
+
+
+class IncorrectProductionToken(MetaflowException):
+    headline = "Incorrect production token"
+
+
+VALID_NAME = re.compile("[^a-zA-Z0-9_\-\.]")
+
+
+def resolve_token(
+    name, token_prefix, obj, authorize, given_token, generate_new_token, is_project
+):
+    # 1) retrieve the previous deployment, if one exists
+
+    workflow = Airflow.get_existing_deployment(name, obj.flow_datastore)
+    if workflow is None:
+        obj.echo(
+            "It seems this is the first time you are deploying *%s* to "
+            "Airflow." % name
+        )
+        prev_token = None
+    else:
+        prev_user, prev_token = workflow
+
+    # 2) authorize this deployment
+    if prev_token is not None:
+        if authorize is None:
+            authorize = load_token(token_prefix)
+        elif authorize.startswith("production:"):
+            authorize = authorize[11:]
+
+        # we allow the user who deployed the previous version to re-deploy,
+        # even if they don't have the token
+        if prev_user != get_username() and authorize != prev_token:
+            obj.echo(
+                "There is an existing version of *%s* on Airflow which was "
+                "deployed by the user *%s*." % (name, prev_user)
+            )
+            obj.echo(
+                "To deploy a new version of this flow, you need to use the same "
+                "production token that they used. "
+            )
+            obj.echo(
+                "Please reach out to them to get the token. Once you have it, call "
+                "this command:"
+            )
+            obj.echo("    airflow create --authorize MY_TOKEN", fg="green")
+            obj.echo(
+                'See "Organizing Results" at docs.metaflow.org for more information '
+                "about production tokens."
+            )
+            raise IncorrectProductionToken(
+                "Try again with the correct production token."
+            )
+
+    # 3) do we need a new token or should we use the existing token?
+    if given_token:
+        if is_project:
+            # we rely on a known prefix for @project tokens, so we can't
+            # allow the user to specify a custom token with an arbitrary prefix
+            raise MetaflowException(
+                "--new-token is not supported for @projects. Use --generate-new-token "
+                "to create a new token."
+            )
+        if given_token.startswith("production:"):
+            given_token = given_token[11:]
+        token = given_token
+        obj.echo("")
+        obj.echo("Using the given token, *%s*." % token)
+    elif prev_token is None or generate_new_token:
+        token = new_token(token_prefix, prev_token)
+        if token is None:
+            if prev_token is None:
+                raise MetaflowInternalError(
+                    "We could not generate a new token. This is unexpected. "
+                )
+            else:
+                raise MetaflowException(
+                    "--generate-new-token option is not supported after using "
+                    "--new-token. Use --new-token to make a new namespace."
+                )
+        obj.echo("")
+        obj.echo("A new production token generated.")
+        Airflow.save_deployment_token(get_username(), token, obj.flow_datastore)
+    else:
+        token = prev_token
+
+    obj.echo("")
+    obj.echo("The namespace of this production flow is")
+    obj.echo("    production:%s" % token, fg="green")
+    obj.echo(
+        "To analyze results of this production flow add this line in your notebooks:"
+    )
+    obj.echo('    namespace("production:%s")' % token, fg="green")
+    obj.echo(
+        "If you want to authorize other people to deploy new versions of this flow to "
+        "Airflow, they need to call"
+    )
+    obj.echo("    airflow create --authorize %s" % token, fg="green")
+    obj.echo("when deploying this flow to Airflow for the first time.")
+    obj.echo(
+        'See "Organizing Results" at https://docs.metaflow.org/ for more '
+        "information about production tokens."
+    )
+    obj.echo("")
+    store_token(token_prefix, token)
+
+    return token
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.group(help="Commands related to Airflow.")
+@click.option(
+    "--name",
+    default=None,
+    type=str,
+    help="Airflow DAG name. The flow name is used instead if this option is not "
+    "specified",
+)
+@click.pass_obj
+def airflow(obj, name=None):
+    obj.check(obj.graph, obj.flow, obj.environment, pylint=obj.pylint)
+    obj.dag_name, obj.token_prefix, obj.is_project = resolve_dag_name(name)
+
+
+@airflow.command(help="Compile a new version of this flow to Airflow DAG.")
+@click.argument("file", required=True)
+@click.option(
+    "--authorize",
+    default=None,
+    help="Authorize using this production token. You need this "
+    "when you are re-deploying an existing flow for the first "
+    "time. The token is cached in METAFLOW_HOME, so you only "
+    "need to specify this once.",
+)
+@click.option(
+    "--generate-new-token",
+    is_flag=True,
+    help="Generate a new production token for this flow. "
+    "This will move the production flow to a new namespace.",
+)
+@click.option(
+    "--new-token",
+    "given_token",
+    default=None,
+    help="Use the given production token for this flow. "
+    "This will move the production flow to the given namespace.",
+)
+@click.option(
+    "--tag",
+    "tags",
+    multiple=True,
+    default=None,
+    help="Annotate all objects produced by Airflow DAG executions "
+    "with the given tag. You can specify this option multiple "
+    "times to attach multiple tags.",
+)
+@click.option(
+    "--is-paused-upon-creation",
+    default=False,
+    is_flag=True,
+    help="Generated Airflow DAG is paused/unpaused upon creation.",
+)
+@click.option(
+    "--namespace",
+    "user_namespace",
+    default=None,
+    # TODO (savin): Identify the default namespace?
+    help="Change the namespace from the default to the given tag. "
+    "See run --help for more information.",
+)
+@click.option(
+    "--max-workers",
+    default=100,
+    show_default=True,
+    help="Maximum number of parallel processes.",
+)
+@click.option(
+    "--workflow-timeout",
+    default=None,
+    type=int,
+    help="Workflow timeout in seconds. Enforced only for scheduled DAGs.",
+)
+@click.option(
+    "--worker-pool",
+    default=None,
+    show_default=True,
+    help="Worker pool for Airflow DAG execution.",
+)
+@click.pass_obj
+def create(
+    obj,
+    file,
+    authorize=None,
+    generate_new_token=False,
+    given_token=None,
+    tags=None,
+    is_paused_upon_creation=False,
+    user_namespace=None,
+    max_workers=None,
+    workflow_timeout=None,
+    worker_pool=None,
+):
+    if os.path.abspath(sys.argv[0]) == os.path.abspath(file):
+        raise MetaflowException(
+            "Airflow DAG file name cannot be the same as flow file name"
+        )
+
+    obj.echo("Compiling *%s* to Airflow DAG..." % obj.dag_name, bold=True)
+
+    token = resolve_token(
+        obj.dag_name,
+        obj.token_prefix,
+        obj,
+        authorize,
+        given_token,
+        generate_new_token,
+        obj.is_project,
+    )
+
+    flow = make_flow(
+        obj,
+        obj.dag_name,
+        token,
+        tags,
+        is_paused_upon_creation,
+        user_namespace,
+        max_workers,
+        workflow_timeout,
+        worker_pool,
+        file,
+    )
+    with open(file, "w") as f:
+        f.write(flow.compile())
+
+    obj.echo(
+        "DAG *{dag_name}* "
+        "for flow *{name}* compiled to "
+        "Airflow successfully.\n".format(dag_name=obj.dag_name, name=current.flow_name),
+        bold=True,
+    )
+
+
+def make_flow(
+    obj,
+    dag_name,
+    production_token,
+    tags,
+    is_paused_upon_creation,
+    namespace,
+    max_workers,
+    workflow_timeout,
+    worker_pool,
+    file,
+):
+    # Validate if the workflow is correctly parsed.
+    _validate_workflow(
+        obj.flow, obj.graph, obj.flow_datastore, obj.metadata, workflow_timeout
+    )
+
+    # Attach @kubernetes.
+    decorators._attach_decorators(obj.flow, [KubernetesDecorator.name])
+
+    decorators._init_step_decorators(
+        obj.flow, obj.graph, obj.environment, obj.flow_datastore, obj.logger
+    )
+
+    # Save the code package in the flow datastore so that both user code and
+    # metaflow package can be retrieved during workflow execution.
+    obj.package = MetaflowPackage(
+        obj.flow, obj.environment, obj.echo, obj.package_suffixes
+    )
+    package_url, package_sha = obj.flow_datastore.save_data(
+        [obj.package.blob], len_hint=1
+    )[0]
+
+    return Airflow(
+        dag_name,
+        obj.graph,
+        obj.flow,
+        package_sha,
+        package_url,
+        obj.metadata,
+        obj.flow_datastore,
+        obj.environment,
+        obj.event_logger,
+        obj.monitor,
+        production_token,
+        tags=tags,
+        namespace=namespace,
+        username=get_username(),
+        max_workers=max_workers,
+        worker_pool=worker_pool,
+        workflow_timeout=workflow_timeout,
+        description=obj.flow.__doc__,
+        file_path=file,
+        is_paused_upon_creation=is_paused_upon_creation,
+    )
+
+
+def _validate_foreach_constraints(graph):
+    # Todo :Invoke this function when we integrate foreach's
+    def traverse_graph(node, state):
+        if node.type == "foreach" and node.is_inside_foreach:
+            raise NotSupportedException(
+                "Step *%s* is a foreach step called within a foreach step. This type of graph is currently not supported with Airflow."
+                % node.name
+            )
+
+        if node.type == "foreach":
+            state["foreach_stack"] = [node.name]
+
+        if node.type in ("start", "linear", "join", "foreach"):
+            if node.type == "linear" and node.is_inside_foreach:
+                state["foreach_stack"].append(node.name)
+
+            if len(state["foreach_stack"]) > 2:
+                raise NotSupportedException(
+                    "The foreach step *%s* created by step *%s* needs to have an immidiate join step. "
+                    "Step *%s* is invalid since it is a linear step with a foreach. "
+                    "This type of graph is currently not supported with Airflow."
+                    % (
+                        state["foreach_stack"][1],
+                        state["foreach_stack"][0],
+                        state["foreach_stack"][-1],
+                    )
+                )
+
+            traverse_graph(graph[node.out_funcs[0]], state)
+
+        elif node.type == "split":
+            for func in node.out_funcs:
+                traverse_graph(graph[func], state)
+
+    traverse_graph(graph["start"], {})
+
+
+def _validate_workflow(flow, graph, flow_datastore, metadata, workflow_timeout):
+    # check for other compute related decorators.
+    for node in graph:
+        if node.type == "foreach":
+            raise NotSupportedException(
+                "Step *%s* is a foreach step and Foreach steps are not currently supported with Airflow."
+                % node.name
+            )
+        if any([d.name == "batch" for d in node.decorators]):
+            raise NotSupportedException(
+                "Step *%s* is marked for execution on AWS Batch with Airflow which isn't currently supported."
+                % node.name
+            )
+
+    if flow_datastore.TYPE != "s3":
+        raise AirflowException('Datastore of type "s3" required with `airflow create`')
+
+
+def resolve_dag_name(name):
+    project = current.get("project_name")
+    is_project = False
+
+    if project:
+        is_project = True
+        if name:
+            raise MetaflowException(
+                "--name is not supported for @projects. " "Use --branch instead."
+            )
+        dag_name = current.project_flow_name
+        if dag_name and VALID_NAME.search(dag_name):
+            raise MetaflowException(
+                "Name '%s' contains invalid characters. Please construct a name using regex %s"
+                % (dag_name, VALID_NAME.pattern)
+            )
+        project_branch = to_bytes(".".join((project, current.branch_name)))
+        token_prefix = (
+            "mfprj-%s"
+            % to_unicode(base64.b32encode(sha1(project_branch).digest()))[:16]
+        )
+    else:
+        if name and VALID_NAME.search(name):
+            raise MetaflowException(
+                "Name '%s' contains invalid characters. Please construct a name using regex %s"
+                % (name, VALID_NAME.pattern)
+            )
+        dag_name = name if name else current.flow_name
+        token_prefix = dag_name
+    return dag_name, token_prefix.lower(), is_project

--- a/metaflow/plugins/airflow/airflow_decorator.py
+++ b/metaflow/plugins/airflow/airflow_decorator.py
@@ -1,0 +1,66 @@
+import json
+import os
+from metaflow.decorators import StepDecorator
+from metaflow.metadata import MetaDatum
+
+from .airflow_utils import (
+    TASK_ID_XCOM_KEY,
+    FOREACH_CARDINALITY_XCOM_KEY,
+)
+
+K8S_XCOM_DIR_PATH = "/airflow/xcom"
+
+
+def safe_mkdir(dir):
+    try:
+        os.makedirs(dir)
+    except FileExistsError:
+        pass
+
+
+def push_xcom_values(xcom_dict):
+    safe_mkdir(K8S_XCOM_DIR_PATH)
+    with open(os.path.join(K8S_XCOM_DIR_PATH, "return.json"), "w") as f:
+        json.dump(xcom_dict, f)
+
+
+class AirflowInternalDecorator(StepDecorator):
+    name = "airflow_internal"
+
+    def task_pre_step(
+        self,
+        step_name,
+        task_datastore,
+        metadata,
+        run_id,
+        task_id,
+        flow,
+        graph,
+        retry_count,
+        max_user_code_retries,
+        ubf_context,
+        inputs,
+    ):
+        meta = {}
+        meta["airflow-dag-run-id"] = os.environ["METAFLOW_AIRFLOW_DAG_RUN_ID"]
+        meta["airflow-job-id"] = os.environ["METAFLOW_AIRFLOW_JOB_ID"]
+        entries = [
+            MetaDatum(
+                field=k, value=v, type=k, tags=["attempt_id:{0}".format(retry_count)]
+            )
+            for k, v in meta.items()
+        ]
+
+        # Register book-keeping metadata for debugging.
+        metadata.register_metadata(run_id, step_name, task_id, entries)
+
+    def task_finished(
+        self, step_name, flow, graph, is_task_ok, retry_count, max_user_code_retries
+    ):
+        # This will pass the xcom when the task finishes.
+        xcom_values = {
+            TASK_ID_XCOM_KEY: os.environ["METAFLOW_AIRFLOW_TASK_ID"],
+        }
+        if graph[step_name].type == "foreach":
+            xcom_values[FOREACH_CARDINALITY_XCOM_KEY] = flow._foreach_num_splits
+        push_xcom_values(xcom_values)

--- a/metaflow/plugins/airflow/airflow_utils.py
+++ b/metaflow/plugins/airflow/airflow_utils.py
@@ -144,6 +144,11 @@ class AIRFLOW_MACROS:
     # Hence : Foreachs will require some special form of plumbing.
     # https://stackoverflow.com/questions/62962386/can-an-airflow-task-dynamically-generate-a-dag-at-runtime
     TASK_ID = (
+        "%s-{{ [run_id, ti.task_id, dag_run.dag_id] | task_id_creator  }}"
+        % RUN_ID_PREFIX
+    )
+
+    FOREACH_TASK_ID = (
         "%s-{{ [run_id, ti.task_id, dag_run.dag_id, ti.map_index] | task_id_creator  }}"
         % RUN_ID_PREFIX
     )

--- a/metaflow/plugins/airflow/airflow_utils.py
+++ b/metaflow/plugins/airflow/airflow_utils.py
@@ -1,0 +1,583 @@
+import hashlib
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+
+TASK_ID_XCOM_KEY = "metaflow_task_id"
+FOREACH_CARDINALITY_XCOM_KEY = "metaflow_foreach_cardinality"
+FOREACH_XCOM_KEY = "metaflow_foreach_indexes"
+RUN_HASH_ID_LEN = 12
+TASK_ID_HASH_LEN = 8
+RUN_ID_PREFIX = "airflow"
+AIRFLOW_FOREACH_SUPPORT_VERSION = "2.3.0"
+AIRFLOW_MIN_SUPPORT_VERSION = "2.0.0"
+KUBERNETES_PROVIDER_FOREACH_VERSION = "4.2.0"
+
+
+class KubernetesProviderNotFound(Exception):
+    headline = "Kubernetes provider not found"
+
+
+class ForeachIncompatibleException(Exception):
+    headline = "Airflow version is incompatible to support Metaflow foreach's."
+
+
+class IncompatibleVersionException(Exception):
+    headline = "Metaflow is incompatible with current version of Airflow."
+
+    def __init__(self, version_number) -> None:
+        msg = (
+            "Airflow version %s is incompatible with Metaflow. Metaflow requires Airflow a minimum version %s"
+            % (version_number, AIRFLOW_MIN_SUPPORT_VERSION)
+        )
+        super().__init__(msg)
+
+
+class IncompatibleKubernetesProviderVersionException(Exception):
+    headline = (
+        "Kubernetes Provider version is incompatible with Metaflow foreach's. "
+        "Install the provider via "
+        "`%s -m pip install apache-airflow-providers-cncf-kubernetes==%s`"
+    ) % (sys.executable, KUBERNETES_PROVIDER_FOREACH_VERSION)
+
+
+def create_absolute_version_number(version):
+    abs_version = None
+    # For all digits
+    if all(v.isdigit() for v in version.split(".")):
+        abs_version = sum(
+            [
+                (10 ** (3 - idx)) * i
+                for idx, i in enumerate([int(v) for v in version.split(".")])
+            ]
+        )
+    # For first two digits
+    elif all(v.isdigit() for v in version.split(".")[:2]):
+        abs_version = sum(
+            [
+                (10 ** (3 - idx)) * i
+                for idx, i in enumerate([int(v) for v in version.split(".")[:2]])
+            ]
+        )
+    return abs_version
+
+
+def _validate_dyanmic_mapping_compatibility():
+    from airflow.version import version
+
+    af_ver = create_absolute_version_number(version)
+    if af_ver is None or af_ver < create_absolute_version_number(
+        AIRFLOW_FOREACH_SUPPORT_VERSION
+    ):
+        ForeachIncompatibleException(
+            "Please install airflow version %s to use Airflow's Dynamic task mapping functionality."
+            % AIRFLOW_FOREACH_SUPPORT_VERSION
+        )
+
+
+def get_kubernetes_provider_version():
+    try:
+        from airflow.providers.cncf.kubernetes.get_provider_info import (
+            get_provider_info,
+        )
+    except ImportError as e:
+        raise KubernetesProviderNotFound(
+            "This DAG utilizes `KubernetesPodOperator`. "
+            "Install the Airflow Kubernetes provider using "
+            "`%s -m pip install apache-airflow-providers-cncf-kubernetes`"
+            % sys.executable
+        )
+    return get_provider_info()["versions"][0]
+
+
+def _validate_minimum_airflow_version():
+    from airflow.version import version
+
+    af_ver = create_absolute_version_number(version)
+    if af_ver is None or af_ver < create_absolute_version_number(
+        AIRFLOW_MIN_SUPPORT_VERSION
+    ):
+        raise IncompatibleVersionException(version)
+
+
+def _check_foreach_compatible_kubernetes_provider():
+    provider_version = get_kubernetes_provider_version()
+    ver = create_absolute_version_number(provider_version)
+    if ver is None or ver < create_absolute_version_number(
+        KUBERNETES_PROVIDER_FOREACH_VERSION
+    ):
+        raise IncompatibleKubernetesProviderVersionException()
+
+
+class AIRFLOW_MACROS:
+    # run_id_creator is added via the `user_defined_filters`
+    RUN_ID = "%s-{{ [run_id, dag_run.dag_id] | run_id_creator }}" % RUN_ID_PREFIX
+    PARAMETERS = "{{ params | json_dump }}"
+
+    # AIRFLOW_MACROS.TASK_ID will work for linear/branched workflows.
+    # ti.task_id is the stepname in metaflow code.
+    # AIRFLOW_MACROS.TASK_ID uses a jinja filter called `task_id_creator` which helps
+    # concatenate the string using a `/`. Since run-id will keep changing and stepname will be
+    # the same task id will change. Since airflow doesn't encourage dynamic rewriting of dags
+    # we can rename steps in a foreach with indexes (eg. `stepname-$index`) to create those steps.
+    # Hence : Foreachs will require some special form of plumbing.
+    # https://stackoverflow.com/questions/62962386/can-an-airflow-task-dynamically-generate-a-dag-at-runtime
+    TASK_ID = (
+        "%s-{{ [run_id, ti.task_id, dag_run.dag_id, ti.map_index] | task_id_creator  }}"
+        % RUN_ID_PREFIX
+    )
+
+    # Airflow run_ids are of the form : "manual__2022-03-15T01:26:41.186781+00:00"
+    # Such run-ids break the `metaflow.util.decompress_list`; this is why we hash the runid
+    # We do echo -n because emits line breaks and we dont want to consider that since it we want same hash value when retrieved in python.
+    RUN_ID_SHELL = (
+        "%s-$(echo -n {{ run_id }}-{{ dag_run.dag_id }} | md5sum | awk '{print $1}' | awk '{print substr ($0, 0, %s)}')"
+        % (RUN_ID_PREFIX, str(RUN_HASH_ID_LEN))
+    )
+
+    ATTEMPT = "{{ task_instance.try_number - 1 }}"
+
+    AIRFLOW_RUN_ID = "{{ run_id }}"
+
+    AIRFLOW_JOB_ID = "{{ ti.job_id }}"
+
+    FOREACH_SPLIT_INDEX = "{{ ti.map_index }}"
+
+
+def run_id_creator(val):
+    # join `[dag-id,run-id]` of airflow dag.
+    return hashlib.md5("-".join([str(x) for x in val]).encode("utf-8")).hexdigest()[
+        :RUN_HASH_ID_LEN
+    ]
+
+
+def task_id_creator(val):
+    # join `[dag-id,run-id]` of airflow dag.
+    return hashlib.md5("-".join([str(x) for x in val]).encode("utf-8")).hexdigest()[
+        :TASK_ID_HASH_LEN
+    ]
+
+
+def id_creator(val, hash_len):
+    # join `[dag-id,run-id]` of airflow dag.
+    return hashlib.md5("-".join([str(x) for x in val]).encode("utf-8")).hexdigest()[
+        :hash_len
+    ]
+
+
+def json_dump(val):
+    return json.dumps(val)
+
+
+class AirflowDAGArgs(object):
+
+    # `_arg_types` is a dictionary which represents the types of the arguments of an Airflow `DAG`.
+    # `_arg_types` is used when parsing types back from the configuration json.
+    # It doesn't cover all the arguments but covers many of the important one which can come from the cli.
+    _arg_types = {
+        "dag_id": str,
+        "description": str,
+        "schedule_interval": str,
+        "start_date": datetime,
+        "catchup": bool,
+        "tags": list,
+        "dagrun_timeout": timedelta,
+        "default_args": {
+            "owner": str,
+            "depends_on_past": bool,
+            "email": list,
+            "email_on_failure": bool,
+            "email_on_retry": bool,
+            "retries": int,
+            "retry_delay": timedelta,
+            "queue": str,  #  which queue to target when running this job. Not all executors implement queue management, the CeleryExecutor does support targeting specific queues.
+            "pool": str,  # the slot pool this task should run in, slot pools are a way to limit concurrency for certain tasks
+            "priority_weight": int,
+            "wait_for_downstream": bool,
+            "sla": timedelta,
+            "execution_timeout": timedelta,
+            "trigger_rule": str,
+        },
+    }
+
+    # Reference for user_defined_filters : https://stackoverflow.com/a/70175317
+    filters = dict(
+        task_id_creator=lambda v: task_id_creator(v),
+        json_dump=lambda val: json_dump(val),
+        run_id_creator=lambda val: run_id_creator(val),
+        join_list=lambda x: ",".join(list(x)),
+    )
+
+    def __init__(self, **kwargs):
+        self._args = kwargs
+
+    @property
+    def arguments(self):
+        return dict(**self._args, user_defined_filters=self.filters)
+
+    def serialize(self):
+        def parse_args(dd):
+            data_dict = {}
+            for k, v in dd.items():
+                if isinstance(v, dict):
+                    data_dict[k] = parse_args(v)
+                elif isinstance(v, datetime):
+                    data_dict[k] = v.isoformat()
+                elif isinstance(v, timedelta):
+                    data_dict[k] = dict(seconds=v.total_seconds())
+                else:
+                    data_dict[k] = v
+            return data_dict
+
+        return parse_args(self._args)
+
+    @classmethod
+    def deserialize(cls, data_dict):
+        def parse_args(dd, type_check_dict):
+            kwrgs = {}
+            for k, v in dd.items():
+                if k not in type_check_dict:
+                    kwrgs[k] = v
+                elif isinstance(v, dict) and isinstance(type_check_dict[k], dict):
+                    kwrgs[k] = parse_args(v, type_check_dict[k])
+                elif type_check_dict[k] == datetime:
+                    kwrgs[k] = datetime.fromisoformat(v)
+                elif type_check_dict[k] == timedelta:
+                    kwrgs[k] = timedelta(**v)
+                else:
+                    kwrgs[k] = v
+            return kwrgs
+
+        return cls(**parse_args(data_dict, cls._arg_types))
+
+
+def _kubernetes_pod_operator_args(operator_args):
+    from kubernetes import client
+
+    from airflow.kubernetes.secret import Secret
+
+    # Set dynamic env variables like run-id, task-id etc from here.
+    secrets = [
+        Secret("env", secret, secret) for secret in operator_args.get("secrets", [])
+    ]
+    args = operator_args
+    args.update(
+        {
+            "secrets": secrets,
+            # Question for (savin):
+            # Default timeout in airflow is 120. I can remove `startup_timeout_seconds` for now. how should we expose it to the user?
+        }
+    )
+    # We need to explicity add the `client.V1EnvVar` over here because
+    # `pod_runtime_info_envs` doesn't accept arguments in dictionary form and strictly
+    # Requires objects of type `client.V1EnvVar`
+    additional_env_vars = [
+        client.V1EnvVar(
+            name=k,
+            value_from=client.V1EnvVarSource(
+                field_ref=client.V1ObjectFieldSelector(field_path=str(v))
+            ),
+        )
+        for k, v in {
+            "METAFLOW_KUBERNETES_POD_NAMESPACE": "metadata.namespace",
+            "METAFLOW_KUBERNETES_POD_NAME": "metadata.name",
+            "METAFLOW_KUBERNETES_POD_ID": "metadata.uid",
+            "METAFLOW_KUBERNETES_SERVICE_ACCOUNT_NAME": "spec.serviceAccountName",
+        }.items()
+    ]
+    args["pod_runtime_info_envs"] = additional_env_vars
+
+    resources = args.get("resources")
+    # KubernetesPodOperator version 4.2.0 renamed `resources` to
+    # `container_resources` (https://github.com/apache/airflow/pull/24673) / (https://github.com/apache/airflow/commit/45f4290712f5f779e57034f81dbaab5d77d5de85)
+    # This was done because `KubernetesPodOperator` didn't play nice with dynamic task mapping
+    # and they had to deprecate the `resources` argument. Hence the below codepath checks for the version of `KubernetesPodOperator`
+    # and then sets the argument. If the version < 4.2.0 then we set the argument as `resources`.
+    # If it is > 4.2.0 then we set the argument as `container_resources`
+    # The `resources` argument of KuberentesPodOperator is going to be deprecated soon in the future.
+    # So we will only use it for `KuberentesPodOperator` version < 4.2.0
+    # The `resources` argument will also not work for foreach's.
+    provider_version = get_kubernetes_provider_version()
+    k8s_op_ver = create_absolute_version_number(provider_version)
+    if k8s_op_ver is None or k8s_op_ver < create_absolute_version_number(
+        KUBERNETES_PROVIDER_FOREACH_VERSION
+    ):
+        # Since the provider version is less than `4.2.0` so we need to use the `resources` argument
+        # We need to explicitly parse `resources`/`container_resources` to k8s.V1ResourceRequirements otherwise airflow tries
+        # to parse dictionaries to `airflow.providers.cncf.kubernetes.backcompat.pod.Resources` object via
+        # `airflow.providers.cncf.kubernetes.backcompat.backward_compat_converts.convert_resources` function.
+        # This fails many times since the dictionary structure it expects is not the same as `client.V1ResourceRequirements`.
+        args["resources"] = client.V1ResourceRequirements(
+            requests=resources["requests"],
+            limits=None if "limits" not in resources else resources["limits"],
+        )
+    else:  # since the provider version is greater than `4.2.0` so should use the `container_resources` argument
+        args["container_resources"] = client.V1ResourceRequirements(
+            requests=resources["requests"],
+            limits=None if "limits" not in resources else resources["limits"],
+        )
+        del args["resources"]
+
+    if operator_args.get("execution_timeout"):
+        args["execution_timeout"] = timedelta(
+            **operator_args.get(
+                "execution_timeout",
+            )
+        )
+    if operator_args.get("retry_delay"):
+        args["retry_delay"] = timedelta(**operator_args.get("retry_delay"))
+    return args
+
+
+def get_metaflow_kuberentes_operator():
+    try:
+        from airflow.contrib.operators.kubernetes_pod_operator import (
+            KubernetesPodOperator,
+        )
+    except ImportError:
+        try:
+            from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
+                KubernetesPodOperator,
+            )
+        except ImportError as e:
+            raise KubernetesProviderNotFound(
+                "This DAG utilizes `KubernetesPodOperator`. "
+                "Install the Airflow Kubernetes provider using "
+                "`%s -m pip install apache-airflow-providers-cncf-kubernetes`"
+                % sys.executable
+            )
+
+    class MetaflowKubernetesOperator(KubernetesPodOperator):
+        """
+        ## Why Inherit the `KubernetesPodOperator` class ?
+
+        Two key reasons :
+
+        1. So that we can override the `execute` method.
+        The only change we introduce to the method is to explicitly modify xcom relating to `return_values`.
+        We do this so that the `XComArg` object can work with `expand` function.
+
+        2. So that we can introduce an keyword argument named `mapper_arr`.
+        This keyword argument can help as a dummy argument for the `KubernetesPodOperator.partial().expand` method. Any Airflow Operator can be dynamically mapped to runtime artifacts using `Operator.partial(**kwargs).extend(**mapper_kwargs)` post the introduction of [Dynamic Task Mapping](https://airflow.apache.org/docs/apache-airflow/stable/concepts/dynamic-task-mapping.html).
+        The `expand` function takes keyword arguments taken by the operator.
+
+        ## Why override the `execute` method  ?
+
+        When we dynamically map vanilla Airflow operators with artifacts generated at runtime, we need to pass that information via `XComArg` to a operator's keyword argument in the `expand` [function](https://airflow.apache.org/docs/apache-airflow/stable/concepts/dynamic-task-mapping.html#mapping-over-result-of-classic-operators).
+        The `XComArg` object retrieves XCom values for a particular task based on a `key`, the default key being `return_values`.
+        Oddly dynamic task mapping [doesn't support XCom values from any other key except](https://github.com/apache/airflow/blob/8a34d25049a060a035d4db4a49cd4a0d0b07fb0b/airflow/models/mappedoperator.py#L150) `return_values`
+        The values of XCom passed by the `KubernetesPodOperator` are mapped to the `return_values` XCom key.
+
+        The biggest problem this creates is that the values of the Foreach cadinality are stored inside the dictionary of `return_values` and cannot   be accessed trivially like : `XComArg(task)['foreach_key']` since they are resolved during runtime.
+        This puts us in a bind since the only xcom we can retrieve is the full dictionary and we cannot pass that as the iteratable for the mapper tasks.
+        Hence we inherit the `execute` method and push custom xcom keys (needed by downstream tasks such as metaflow taskids) and modify `return_values` captured from the container whenever a foreach related xcom is passed.
+        When we encounter a foreach xcom we resolve the cardinality which is passed to an actual list and return that as `return_values`.
+        This is later useful in the `Workflow.compile` where the operator's `expand` method is called and we are able to retrieve the xcom value.
+        """
+
+        def __init__(self, *args, mapper_arr=None, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.mapper_arr = mapper_arr
+
+        def execute(self, context):
+            result = super().execute(context)
+            if result is None:
+                return
+            ti = context["ti"]
+            if TASK_ID_XCOM_KEY in result:
+                ti.xcom_push(
+                    key=TASK_ID_XCOM_KEY,
+                    value=result[TASK_ID_XCOM_KEY],
+                )
+            if FOREACH_CARDINALITY_XCOM_KEY in result:
+                return list(range(result[FOREACH_CARDINALITY_XCOM_KEY]))
+
+    return MetaflowKubernetesOperator
+
+
+class AirflowTask(object):
+    def __init__(
+        self, name, operator_type="kubernetes", flow_name=None, is_mapper_node=False
+    ):
+        self.name = name
+        self._is_mapper_node = is_mapper_node
+        self._operator_args = None
+        self._operator_type = operator_type
+        self._flow_name = flow_name
+
+    @property
+    def is_mapper_node(self):
+        return self._is_mapper_node
+
+    def set_operator_args(self, **kwargs):
+        self._operator_args = kwargs
+        return self
+
+    def to_dict(self):
+        return {
+            "name": self.name,
+            "is_mapper_node": self._is_mapper_node,
+            "operator_type": self._operator_type,
+            "operator_args": self._operator_args,
+        }
+
+    @classmethod
+    def from_dict(cls, task_dict, flow_name=None):
+        op_args = {} if not "operator_args" in task_dict else task_dict["operator_args"]
+        is_mapper_node = (
+            False if "is_mapper_node" not in task_dict else task_dict["is_mapper_node"]
+        )
+        return cls(
+            task_dict["name"],
+            is_mapper_node=is_mapper_node,
+            operator_type=task_dict["operator_type"]
+            if "operator_type" in task_dict
+            else "kubernetes",
+            flow_name=flow_name,
+        ).set_operator_args(**op_args)
+
+    def _kubenetes_task(self):
+        MetaflowKubernetesOperator = get_metaflow_kuberentes_operator()
+        k8s_args = _kubernetes_pod_operator_args(self._operator_args)
+        return MetaflowKubernetesOperator(**k8s_args)
+
+    def _kubernetes_mapper_task(self):
+        MetaflowKubernetesOperator = get_metaflow_kuberentes_operator()
+        k8s_args = _kubernetes_pod_operator_args(self._operator_args)
+        return MetaflowKubernetesOperator.partial(**k8s_args)
+
+    def to_task(self):
+        if self._operator_type == "kubernetes":
+            if not self.is_mapper_node:
+                return self._kubenetes_task()
+            else:
+                return self._kubernetes_mapper_task()
+
+
+class Workflow(object):
+    def __init__(self, file_path=None, graph_structure=None, metadata=None, **kwargs):
+        self._dag_instantiation_params = AirflowDAGArgs(**kwargs)
+        self._file_path = file_path
+        self._metadata = metadata
+        tree = lambda: defaultdict(tree)
+        self.states = tree()
+        self.metaflow_params = None
+        self.graph_structure = graph_structure
+
+    def set_parameters(self, params):
+        self.metaflow_params = params
+
+    def add_state(self, state):
+        self.states[state.name] = state
+
+    def to_dict(self):
+        return dict(
+            metadata=self._metadata,
+            graph_structure=self.graph_structure,
+            states={s: v.to_dict() for s, v in self.states.items()},
+            dag_instantiation_params=self._dag_instantiation_params.serialize(),
+            file_path=self._file_path,
+            metaflow_params=self.metaflow_params,
+        )
+
+    def to_json(self):
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data_dict):
+        re_cls = cls(
+            file_path=data_dict["file_path"],
+            graph_structure=data_dict["graph_structure"],
+            metadata={} if "metadata" not in data_dict else data_dict["metadata"],
+        )
+        re_cls._dag_instantiation_params = AirflowDAGArgs.deserialize(
+            data_dict["dag_instantiation_params"]
+        )
+
+        for sd in data_dict["states"].values():
+            re_cls.add_state(
+                AirflowTask.from_dict(
+                    sd, flow_name=re_cls._dag_instantiation_params.arguments["dag_id"]
+                )
+            )
+        re_cls.set_parameters(data_dict["metaflow_params"])
+        return re_cls
+
+    @classmethod
+    def from_json(cls, json_string):
+        data = json.loads(json_string)
+        return cls.from_dict(data)
+
+    def _construct_params(self):
+        from airflow.models.param import Param
+
+        if self.metaflow_params is None:
+            return {}
+        param_dict = {}
+        for p in self.metaflow_params:
+            name = p["name"]
+            del p["name"]
+            param_dict[name] = Param(**p)
+        return param_dict
+
+    def compile(self):
+        from airflow import DAG
+        from airflow import XComArg
+
+        _validate_minimum_airflow_version()
+
+        if self._metadata["contains_foreach"]:
+            _validate_dyanmic_mapping_compatibility()
+            # We need to verify if KubernetesPodOperator is of version > 4.2.0 to support foreachs / dynamic task mapping.
+            # If the dag uses dynamic Task mapping then we throw an error since the `resources` argument in the `KuberentesPodOperator`
+            # doesn't work for dynamic task mapping for `KuberentesPodOperator` version < 4.2.0.
+            # For more context check this issue :  https://github.com/apache/airflow/issues/24669
+            _check_foreach_compatible_kubernetes_provider()
+
+        params_dict = self._construct_params()
+        # DAG Params can be seen here :
+        # https://airflow.apache.org/docs/apache-airflow/2.0.0/_api/airflow/models/dag/index.html#airflow.models.dag.DAG
+        # Airflow 2.0.0 Allows setting Params.
+        dag = DAG(params=params_dict, **self._dag_instantiation_params.arguments)
+        dag.fileloc = self._file_path if self._file_path is not None else dag.fileloc
+
+        def add_node(node, parents, dag):
+            """
+            A recursive function to traverse the specialized
+            graph_structure datastructure.
+            """
+            if type(node) == str:
+                task = self.states[node].to_task()
+                if parents:
+                    for parent in parents:
+                        # Handle foreach nodes.
+                        if self.states[node].is_mapper_node:
+                            task = task.expand(mapper_arr=XComArg(parent))
+                        parent >> task
+                return [task]  # Return Parent
+
+            # this means a split from parent
+            if type(node) == list:
+                # this means branching since everything within the list is a list
+                if all(isinstance(n, list) for n in node):
+                    curr_parents = parents
+                    parent_list = []
+                    for node_list in node:
+                        last_parent = add_node(node_list, curr_parents, dag)
+                        parent_list.extend(last_parent)
+                    return parent_list
+                else:
+                    # this means no branching and everything within the list is not a list and can be actual nodes.
+                    curr_parents = parents
+                    for node_x in node:
+                        curr_parents = add_node(node_x, curr_parents, dag)
+                    return curr_parents
+
+        with dag:
+            parent = None
+            for node in self.graph_structure:
+                parent = add_node(node, parent, dag)
+
+        return dag

--- a/metaflow/plugins/airflow/dag.py
+++ b/metaflow/plugins/airflow/dag.py
@@ -1,0 +1,9 @@
+# Deployed on {{deployed_on}}
+
+CONFIG = {{{config}}}
+
+{{{utils}}}
+
+dag = Workflow.from_dict(CONFIG).compile()
+with dag:
+    pass

--- a/metaflow/plugins/airflow/exception.py
+++ b/metaflow/plugins/airflow/exception.py
@@ -1,0 +1,12 @@
+from metaflow.exception import MetaflowException
+
+
+class AirflowException(MetaflowException):
+    headline = "Airflow Exception"
+
+    def __init__(self, msg):
+        super().__init__(msg)
+
+
+class NotSupportedException(MetaflowException):
+    headline = "Not yet supported with Airflow"

--- a/metaflow/plugins/airflow/plumbing/set_parameters.py
+++ b/metaflow/plugins/airflow/plumbing/set_parameters.py
@@ -1,0 +1,21 @@
+import os
+import json
+import sys
+
+
+def export_parameters(output_file):
+    input = json.loads(os.environ.get("METAFLOW_PARAMETERS", "{}"))
+    with open(output_file, "w") as f:
+        for k in input:
+            # Replace `-` with `_` is parameter names since `-` isn't an
+            # allowed character for environment variables. cli.py will
+            # correctly translate the replaced `-`s.
+            f.write(
+                "export METAFLOW_INIT_%s=%s\n"
+                % (k.upper().replace("-", "_"), json.dumps(input[k]))
+            )
+    os.chmod(output_file, 509)
+
+
+if __name__ == "__main__":
+    export_parameters(sys.argv[1])


### PR DESCRIPTION
# Key changes
The following are the key user-related constructs exposed by metaflow to support the Airflow universe:

- A CLI command to create airflow workflow DAG file from metaflow `FlowSpec`. 

## How it works

Metaflow users can now easily compile Metaflow workflows into Airflow compatible workflows. Every Metaflow `FlowSpec` file exposes a `airflow create` command to compile the workflow into an Airflow DAG file. Under the hood metaflow packages the code packages, stores them in S3 and then compiles the code into a airflow compatible python file. The generated file can be moved to the Airflow scheduler's DAGs folder. From there the scheduler will run the workflow as a native airflow workflow. 

Metaflow requires Kubernetes as Airflow's compute-execution medium. Metaflow leverages the Airflow `KuberneterPodOperator` to run different `@step`s on Kubernetes via Airflow. 

## Decorator Support 
`@conda`,`@catch`, `@retry`,`@card`,`@project`,`@environment`,`@timeout`,`@environment`,`@kubernetes`,`@resources`
## Version Support 
A minimum Airflow version of `2.2.0` is required to support basic Metaflow decorators and flows with nested branches. _*Foreach's are not supported with Airflow version 2.2.0*_. Decorators like `@batch` are also not supported with Airflow. 

Airflow introduced [dynamic task mapping](https://airflow.apache.org/docs/apache-airflow/stable/concepts/dynamic-task-mapping.html) in version 2.3.0. Metaflow will very soon support foreach's which can work with Airflow version `2.3.0`. _*Foreach support will also require that the airflow installation has [apache-airflow-providers-cncf-kubernetes](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/index.html) provider installed at minimum of version 4.2.0*_.  


## CLI Usage
Metaflow exposes an `airflow create` command from the FlowSpec file's cli. This command can help convert a FlowSpec file into a Airflow DAG.  
```
Usage: python myflow.py airflow create [OPTIONS] FILE

  Compile a new version of this flow to Airflow DAG.

Options:
  --authorize TEXT            Authorize using this production token. You need
                              this when you are re-deploying an existing flow
                              for the first time. The token is cached in
                              METAFLOW_HOME, so you only need to specify this
                              once.

  --generate-new-token        Generate a new production token for this flow.
                              This will move the production flow to a new
                              namespace.

  --new-token TEXT            Use the given production token for this flow.
                              This will move the production flow to the given
                              namespace.

  --tag TEXT                  Annotate all objects produced by Airflow DAG
                              executions with the given tag. You can specify
                              this option multiple times to attach multiple
                              tags.

  --is-paused-upon-creation   Generated Airflow DAG is paused/unpaused upon
                              creation.

  --namespace TEXT            Change the namespace from the default to the
                              given tag. See run --help for more information.

  --max-workers INTEGER       Maximum number of parallel processes.  [default:
                              100]

  --workflow-timeout INTEGER  Workflow timeout in seconds. Enforced only for
                              scheduled DAGs.

  --worker-pool TEXT          Worker pool for Airflow DAG execution.
  --help                      Show this message and exit
```

## Scheduling Airflow Dags
Metaflow compile airflow DAGs can be scheduled via [@schedule](http://docs.metaflow.org/going-to-production-with-metaflow/scheduling-metaflow-flows/scheduling-with-argo-workflows#scheduling-a-flow) decorator. 


# Resources 
1. [Airflow Task Instance](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/taskinstance/index.html#airflow.models.taskinstance.TaskInstance)
2. [Airflow Task Object](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/taskmixin/index.html)
3. [Airflow Dag Run](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/dagrun/index.html#airflow.models.dagrun.DagRun)
4. [Running Airflow with Metaflow on Minikube](https://github.com/outerbounds/airflow-on-minikube)