### PR TITLE
Move a sys.path modification in s3op to __main__

### DIFF
--- a/metaflow/datatools/s3op.py
+++ b/metaflow/datatools/s3op.py
@@ -25,10 +25,6 @@ except:
     from urllib.parse import urlparse
     from queue import Full as QueueFull
 
-# s3op can be launched as a stand-alone script. We must set
-# PYTHONPATH for the parent Metaflow explicitly.
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
-
 from metaflow._vendor import click
 
 # we use Metaflow's parallel_imap_unordered instead of
@@ -1056,4 +1052,9 @@ def info(
 
 
 if __name__ == "__main__":
+    # When launched standalone, point to our parent metaflow
+    sys.path.insert(
+        0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+    )
+
     cli(auto_envvar_prefix="S3OP")


### PR DESCRIPTION
In its current location, this could modify the sys.path of the current
running metaflow which could have nefarious consequences with the escape
hatch which uses sys.path to determine the outside environment's python path.

The following scenario would cause issues:
  - metaflow is installed in the usual path on the system
  - a conda environment was manually bootstrapped from a directory A.
    + at this point, sys.path starts with `A` and then contains the other
      system includes
    + s3op.py is imported at some point by the Conda installer when it calls `get_many`
    + this modifies sys.path to insert, at the beginning, the parent of Metaflow; so
      in this case, sys.path looks something like
      ['/apps/python3/lib/python3.7/site-packages', 'A', '/apps/python3/lib/python3.7/site-packages'...]
    + when the escape hatch trampolines are created, this sys.path is used to determine what the
      sys.path for the outside interpreter is.
    + in A, we create:
      * INFO
      * metaflow
      * metaflow_extensions
      which properly describe the installation of metaflow
  - when the escape hatch client runs, it runs in the conda environment and uses metaflow
    created in A.
  - when the client wants to start the server, this is where we run into issues because, at this
    point, the server will use the PYTHONPATH which starts with '/apps/python3/lib/python3.7/site-packages'
    in which it will find metaflow. It will therefore use that metaflow (which is the same
    as the one linked in A) to start the server. This runs into issues though because A
    is also in PYTHONPATH and so the extension support loader will also try to load `A/metaflow_extensions`.
    This will cause issues if multiple extensions are installed there (it will complain about duplicate
    configurations for example. The `INFO` file typically used to solve this problem is not read as it was
    not present for the TL metaflow.

This patch simply moves the modification of sys.path to where it is actually needed and avoids polluting
sys.path when the module is simply included (and not called as a script).