### PR TITLE
Fix for env_escape bug when importing local packages

### DIFF
--- a/metaflow/plugins/env_escape/__init__.py
+++ b/metaflow/plugins/env_escape/__init__.py
@@ -134,6 +134,7 @@ def load():
                 print("Not using environment escape for '%s' as module present" % prefix)
             # In both cases, we don't load our loader since
             # the package is locally present
+            sys.path = old_paths
             return
     sys.path = old_paths
     m = ModuleImporter("{python_executable}", "{pythonpath}", {max_pickle_version}, "{path}", {prefixes})


### PR DESCRIPTION
This PR aims to solve a bug related to importing multiple packages using `env_escape` when one of these packages are available locally. The steps to reproduce are given below:

```
import package A # available locally
class Flow():
       import package B # not available locally
```

`env_escape` fails for package B since we fail to update the `sys.path` when using the package A that is available locally. 