### PR TITLE
Fix an issue with get_cards not respecting a Task's ds-root

### DIFF
--- a/metaflow/plugins/cards/card_client.py
+++ b/metaflow/plugins/cards/card_client.py
@@ -261,23 +261,17 @@ def _get_flow_datastore(task):
     # We need to set the correct datastore root here so that
     # we can ensure the the card client picks up the correct path to the cards
 
-    for meta in task.metadata:
-        if meta.name == "ds-type":
-            ds_type = meta.value
-            break
-
-    ds_root = CardDatastore.get_storage_root(ds_type)
-
-    if ds_root is None:
-        for meta in task.metadata:
-            # Incase METAFLOW_CARD_S3ROOT and METAFLOW_DATASTORE_SYSROOT_S3 are absent
-            # then construct the default path for METAFLOW_CARD_S3ROOT from ds-root metadata
-            if meta.name == "ds-root":
-                ds_root = os.path.join(meta.value, DATASTORE_CARD_SUFFIX)
-                break
+    meta_dict = task.metadata_dict
+    ds_type = meta_dict.get("ds-type", None)
 
     if ds_type is None:
         raise UnresolvableDatastoreException(task)
+
+    ds_root = meta_dict.get("ds-root", None)
+    if ds_root:
+        ds_root = os.path.join(ds_root, DATASTORE_CARD_SUFFIX)
+    else:
+        ds_root = CardDatastore.get_storage_root(ds_type)
 
     storage_impl = DATASTORES[ds_type]
     return FlowDataStore(


### PR DESCRIPTION
get_cards would not always respect a Task's ds-root leading to cases
where a Task has cards but they cannot be accessed because of an invalid
path.