### PR TITLE
Merging internal conda plugin to OSS version

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -214,7 +214,6 @@ AZURE_STORAGE_WORKLOAD_TYPE = from_conf(
     validate_fn=_get_validate_choice_fn(["general", "high_throughput"]),
 )
 
-
 ###
 # Metadata configuration
 ###
@@ -315,15 +314,65 @@ AIRFLOW_KUBERNETES_STARTUP_TIMEOUT = from_conf(
 ###
 # Conda configuration
 ###
+
+# Conda root in S3; under there, by default, there will be:
+# - a `conda` directory containing the packages downloaded
+# - a `conda-remote` directory containing the remote executable (optional)
+# - a `conda-local` directory containing the tar-balls for the conda distribution
+#   to use (optional)
+CONDA_S3ROOT = from_conf("METAFLOW_CONDA_S3ROOT", DATASTORE_SYSROOT_S3)
+
 # Conda package root location on S3
-CONDA_PACKAGE_S3ROOT = from_conf("METAFLOW_CONDA_PACKAGE_S3ROOT")
-# Conda package root location on Azure
-CONDA_PACKAGE_AZUREROOT = from_conf("METAFLOW_CONDA_PACKAGE_AZUREROOT")
+# This is here for legacy reasons (and therefore treated differently than the
+# `conda-remote` and `conda-local` directories)
+CONDA_PACKAGE_S3ROOT = from_conf(
+    "METAFLOW_CONDA_PACKAGE_S3ROOT",
+    os.path.join(CONDA_S3ROOT, "conda") if CONDA_S3ROOT else None,
+)
+
+# Same thing for Azure
+CONDA_AZUREROOT = from_conf("METAFLOW_CONDA_AZUREROOT", DATASTORE_SYSROOT_AZURE)
+
+CONDA_PACKAGE_AZUREROOT = from_conf(
+    "METAFLOW_CONDA_PACKAGE_AZUREROOT",
+    os.path.join(CONDA_AZUREROOT, "conda") if CONDA_AZUREROOT else None,
+)
+
+# Magic file containing information about Conda
+CONDA_MAGIC_FILE = from_conf("METAFLOW_CONDA_MAGIC_FILE", "conda.dependencies")
 
 # Use an alternate dependency resolver for conda packages instead of conda
 # Mamba promises faster package dependency resolution times, which
 # should result in an appreciable speedup in flow environment initialization.
 CONDA_DEPENDENCY_RESOLVER = from_conf("METAFLOW_CONDA_DEPENDENCY_RESOLVER", "conda")
+
+# Timeout trying to acquire the lock to create environments
+CONDA_LOCK_TIMEOUT = int(from_conf("METAFLOW_CONDA_LOCK_TIMEOUT", "3600"))
+
+# Directory in CONDA_*ROOT that contains the remote installers. If not specified,
+# Miniforge will be used
+CONDA_REMOTE_INSTALLER_DIRNAME = from_conf(
+    "METAFLOW_CONDA_REMOTE_INSTALLER_DIRNAME", "conda-remote"
+)
+
+# Binary within CONDA_REMOTE_INSTALLER_DIRNAME to use as the binary on remote instances.
+# Use {arch} to specify the architecture. This should be fully functional binary
+CONDA_REMOTE_INSTALLER = from_conf("METAFLOW_CONDA_REMOTE_INSTALLER", "conda-{arch}")
+
+# Directory in CONDA_*ROOT that contains the local distribution tarballs. If not specified,
+# a conda executable needs to be installed and will be used (if locatable in PATH)
+CONDA_LOCAL_DIST_DIRNAME = from_conf("METAFLOW_CONDA_LOCAL_DIST_DIRNAME", "conda-local")
+
+# Tar-ball containing the local distribution of conda to use.
+CONDA_LOCAL_DIST = from_conf("METAFLOW_CONDA_LOCAL_DIST", "conda-{arch}.tgz")
+
+# Path to the local conda distribution. If this is specified and a conda distribution
+# does not exist at this path, Metaflow will attempt to install it using
+# CONDA_LOCAL_DIST_DIRNAME and CONDA_LOCAL_DIST
+CONDA_LOCAL_PATH = from_conf("METAFLOW_CONDA_LOCAL_PATH")
+
+# HACK
+CONDA_FORCE_LINUX64 = ("batch", "kubernetes")
 
 ###
 # Debug configuration

--- a/metaflow/plugins/conda/conda_flow_decorator.py
+++ b/metaflow/plugins/conda/conda_flow_decorator.py
@@ -14,6 +14,10 @@ class CondaFlowDecorator(FlowDecorator):
     libraries : Dict
         Libraries to use for this flow. The key is the name of the package
         and the value is the version to use (default: `{}`).
+    channels : List
+        Additional channels to use for this flow. You can typically specify a
+        channel using <channel>:<package> as well but this does not work for
+        non aliased channels (default: `[]`).
     python : string
         Version of Python to use, e.g. '3.7.4'
         (default: None, i.e. the current Python version).
@@ -22,7 +26,7 @@ class CondaFlowDecorator(FlowDecorator):
     """
 
     name = "conda_base"
-    defaults = {"libraries": {}, "python": None, "disabled": None}
+    defaults = {"libraries": {}, "channels": [], "python": None, "disabled": None}
 
     def flow_init(
         self, flow, graph, environment, flow_datastore, metadata, logger, echo, options

--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -1,13 +1,15 @@
 import importlib
 import json
 import os
-import sys
-from hashlib import sha1
-from multiprocessing.dummy import Pool
 import platform
 import requests
 import shutil
+import sys
 import tempfile
+
+from hashlib import sha1
+from itertools import chain
+from multiprocessing.dummy import Pool
 
 try:
     from urlparse import urlparse
@@ -19,13 +21,20 @@ from metaflow.extension_support import EXT_PKG
 from metaflow.metaflow_environment import InvalidEnvironmentException
 from metaflow.metadata import MetaDatum
 from metaflow.metaflow_config import (
+    CONDA_FORCE_LINUX64,
     get_pinned_conda_libs,
 )
 from metaflow.util import get_metaflow_root
 from metaflow.datastore import DATASTORES, LocalStorage
+from metaflow.unbounded_foreach import UBF_CONTROL
 
 from ..env_escape import generate_trampolines
-from . import read_conda_manifest, write_to_conda_manifest, get_conda_package_root
+from . import (
+    arch_id,
+    read_conda_manifest,
+    write_to_conda_manifest,
+    get_conda_package_root,
+)
 from .conda import Conda
 
 try:
@@ -57,10 +66,10 @@ class CondaStepDecorator(StepDecorator):
     """
 
     name = "conda"
-    defaults = {"libraries": {}, "python": None, "disabled": None}
+    defaults = {"libraries": {}, "channels": [], "python": None, "disabled": None}
 
     conda = None
-    environments = None
+    environments = {}
 
     def _get_base_attributes(self):
         if "conda_base" in self.flow._flow_decorators:
@@ -79,6 +88,8 @@ class CondaStepDecorator(StepDecorator):
         )
 
     def is_enabled(self, ubf_context=None):
+        if ubf_context == UBF_CONTROL:
+            return False
         return not next(
             x
             for x in [
@@ -105,27 +116,45 @@ class CondaStepDecorator(StepDecorator):
         deps.update(step_deps)
         return deps
 
-    def _step_deps(self):
+    def _channel_deps(self):
+        channels = []
+
+        step_channels = self.attributes["channels"]
+        base_channels = self.base_attributes["channels"]
+
+        if isinstance(step_channels, list):
+            channels.extend(step_channels)
+        channels.extend(base_channels)
+
+        return channels
+
+    def _step_deps(self, include_channels=True):
         deps = [b"python==%s" % self._python_version().encode()]
         deps.extend(
             b"%s==%s" % (name.encode("ascii"), ver.encode("ascii"))
             for name, ver in self._lib_deps().items()
         )
+        if include_channels:
+            deps.extend(
+                b"-c %s" % channel.encode("ascii") for channel in self._channel_deps()
+            )
         return deps
 
     def _env_id(self):
-        deps = self._step_deps()
+        # We will hash the channels too but separately to respect the order
+        # specified for them
+        deps = self._step_deps(include_channels=False)
         return "metaflow_%s_%s_%s" % (
             self.flow.name,
             self.architecture,
-            sha1(b" ".join(sorted(deps))).hexdigest(),
+            sha1(b" ".join(chain(sorted(deps), self._channel_deps()))).hexdigest(),
         )
 
     def _resolve_step_environment(self, ds_root, force=False):
         env_id = self._env_id()
         cached_deps = read_conda_manifest(ds_root, self.flow.name)
         if CondaStepDecorator.conda is None:
-            CondaStepDecorator.conda = Conda()
+            CondaStepDecorator.conda = Conda(self.flow_datastore.TYPE)
             CondaStepDecorator.environments = CondaStepDecorator.conda.environments(
                 self.flow.name
             )
@@ -231,31 +260,16 @@ class CondaStepDecorator(StepDecorator):
         # a macOS. This is needed because of gotchas around inconsistently
         # case-(in)sensitive filesystems for macOS and linux.
         for deco in decos:
-            if deco.name in ("batch", "kubernetes") and platform.system() == "Darwin":
+            if deco.name in CONDA_FORCE_LINUX64 and platform.system() == "Darwin":
                 return True
         return False
 
     def _architecture(self, decos):
         for deco in decos:
-            if deco.name in ("batch", "kubernetes"):
+            if deco.name in CONDA_FORCE_LINUX64:
                 # force conda resolution for linux-64 architectures
                 return "linux-64"
-        bit = "32"
-        if platform.machine().endswith("64"):
-            bit = "64"
-        if platform.system() == "Linux":
-            return "linux-%s" % bit
-        elif platform.system() == "Darwin":
-            # Support M1 Mac
-            if platform.machine() == "arm64":
-                return "osx-arm64"
-            else:
-                return "osx-%s" % bit
-        else:
-            raise InvalidEnvironmentException(
-                "The *@conda* decorator is not supported "
-                "outside of Linux and Darwin platforms"
-            )
+        return arch_id()
 
     def runtime_init(self, flow, graph, package, run_id):
         # Create a symlink to installed version of metaflow to execute user code against
@@ -359,6 +373,8 @@ class CondaStepDecorator(StepDecorator):
         ubf_context,
         inputs,
     ):
+        if ubf_context == UBF_CONTROL:
+            os.environ["_METAFLOW_CONDA_ENV"] = self._env_id()
         if self.is_enabled(ubf_context):
             # Add the Python interpreter's parent to the path. This is to
             # ensure that any non-pythonic dependencies introduced by the conda
@@ -385,14 +401,18 @@ class CondaStepDecorator(StepDecorator):
     def runtime_step_cli(
         self, cli_args, retry_count, max_user_code_retries, ubf_context
     ):
-        no_batch = "batch" not in cli_args.commands
-        no_kubernetes = "kubernetes" not in cli_args.commands
-        if self.is_enabled(ubf_context) and no_batch and no_kubernetes:
+        no_force = all([x not in cli_args.commands for x in CONDA_FORCE_LINUX64])
+        if self.is_enabled(ubf_context) and no_force:
             python_path = self.metaflow_home
             if self.addl_paths is not None:
                 addl_paths = os.pathsep.join(self.addl_paths)
                 python_path = os.pathsep.join([addl_paths, python_path])
 
+            env_path = os.path.dirname(self.conda.python(self.env_id))
+            if os.environ.get("PATH") is not None:
+                env_path = os.pathsep.join([env_path, os.environ["PATH"]])
+
+            cli_args.env["PATH"] = env_path
             cli_args.env["PYTHONPATH"] = python_path
             cli_args.env["_METAFLOW_CONDA_ENV"] = self.env_id
             cli_args.entrypoint[0] = self.conda.python(self.env_id)


### PR DESCRIPTION
This cleans up a few things and also introduces the
possibility of installing a pre-configured Conda distribution
to use on both machines that launch Metaflow flows and machines
that execute them (like batch).