### PR TITLE
Fix DeprecationWarning on invalid escape sequence

### DIFF
--- a/metaflow/mflog/mflog.py
+++ b/metaflow/mflog/mflog.py
@@ -9,7 +9,7 @@ from metaflow.util import to_bytes, to_fileobj, to_unicode
 
 VERSION = b"0"
 
-RE = b"(\[!)?" b"\[MFLOG\|" b"(0)\|" b"(.+?)Z\|" b"(.+?)\|" b"(.+?)\]" b"(.*)"
+RE = br"(\[!)?" br"\[MFLOG\|" br"(0)\|" br"(.+?)Z\|" br"(.+?)\|" br"(.+?)\]" br"(.*)"
 
 # the RE groups defined above must match the MFLogline fields below
 # except utc_timestamp, which is filled in by the parser based on utc_tstamp_str


### PR DESCRIPTION
Fixes issue https://github.com/Netflix/metaflow/issues/680
