### PR TITLE
GCP datastore implementation

### DIFF
--- a/metaflow/datastore/__init__.py
+++ b/metaflow/datastore/__init__.py
@@ -6,5 +6,11 @@ from .task_datastore import TaskDataStore
 from .local_storage import LocalStorage
 from .s3_storage import S3Storage
 from .azure_storage import AzureStorage
+from .gs_storage import GSStorage
 
-DATASTORES = {"local": LocalStorage, "s3": S3Storage, "azure": AzureStorage}
+DATASTORES = {
+    "local": LocalStorage,
+    "s3": S3Storage,
+    "azure": AzureStorage,
+    "gs": GSStorage,
+}

--- a/metaflow/datastore/azure_storage.py
+++ b/metaflow/datastore/azure_storage.py
@@ -1,18 +1,13 @@
-import math
-import platform
-
-import multiprocessing
 import json
 import os
 import shutil
 import uuid
-import sys
 import time
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from tempfile import mkdtemp
 
 from metaflow.datastore.datastore_storage import DataStoreStorage, CloseAfterUse
-from metaflow.exception import MetaflowInternalError, MetaflowException
+from metaflow.exception import MetaflowInternalError
 from metaflow.metaflow_config import (
     DATASTORE_SYSROOT_AZURE,
     ARTIFACT_LOCALROOT,
@@ -30,140 +25,13 @@ from metaflow.plugins.azure.blob_service_client_factory import (
     get_azure_blob_service_client,
 )
 
-if sys.version_info[:2] < (3, 7):
-    # in 3.6, Only BrokenProcessPool exists (there is no BrokenThreadPool)
-    from concurrent.futures.process import BrokenProcessPool as BrokenExecutor
-else:
-    # in 3.7 and newer, BrokenExecutor is a base class that parents BrokenProcessPool AND BrokenThreadPool
-    from concurrent.futures import BrokenExecutor
-
-# TODO keyboard interrupt crazy tracebacks in process pool
-
-
-def _determine_effective_cpu_limit():
-    """Calculate CPU limit (in number of cores) based on:
-
-    - /sys/fs/cgroup/cpu/cpu.max (if available, cgroup 2)
-    OR
-    - /sys/fs/cgroup/cpu/cpu.cfs_quota_us
-    - /sys/fs/cgroup/cpu/cpu.cfs_period_us
-
-    Returns:
-        > 0 if limit was successfully calculated
-        = 0 if we determined that there is no limit
-        -1 if we failed to determine the limit
-    """
-    try:
-        if platform.system() == "Darwin":
-            # On MacOS, and not in a container
-            # We are assuming it is extremely out-of-the-way to run a Darwin container
-            return 0
-        elif platform.system() == "Linux":
-            # Bare metal Linux, or a Linux container running on either Linux or MacOS system
-            # Linux containers on MacOS have this cpu.max file
-            with open("/sys/fs/cgroup/cpu.max", "rb") as f:
-                parts = f.read().decode("utf-8").split(" ")
-                if len(parts) == 2:
-                    if parts[0] == "max":
-                        return 0
-                    return int(parts[0]) / int(parts[1])
-
-            with open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us", "rb") as f:
-                quota = int(f.read())
-                # this file shows -1 for no limit
-                if quota == -1:
-                    return 0
-                # some other negative number - this is weird...return "undetermined"
-                if quota < 0:
-                    return -1
-            with open("/sys/fs/cgroup/cpu/cpu.cfs_period_us", "rb") as f:
-                period = int(f.read())
-                # should be positive. we don't want div by zero errors.
-                if period <= 0:
-                    return -1
-                return quota / period
-        else:
-            # Not Linux or MacOS...give up and return "undetermined"
-            return -1
-    except Exception:
-        return -1
-
-
-def _noop_for_executor_warm_up():
-    pass
-
-
-def _compute_executor_max_workers():
-    # For processes, let's start conservative. Let's restrict to 4-18 always. Can be configurable one day.
-    min_processes = 4
-    max_processes = 18
-    # make an effort to get cgroup cpu limits
-    effective_cpu_limit = _determine_effective_cpu_limit()
-
-    def _bracket(min_v, v, max_v):
-        assert min_v <= max_v
-        if v < min_v:
-            return min_v
-        if v > max_v:
-            return max_v
-        return v
-
-    if effective_cpu_limit < 0:
-        # We don't know the limit, stick to min
-        processpool_max_workers = min_processes
-    elif effective_cpu_limit == 0:
-        # There is (probably) no limit, use physical core count
-        processpool_max_workers = _bracket(
-            min_processes, os.cpu_count() or 1, max_processes
-        )
-    else:
-        # There is a limit, so let's bracket it within min / max
-        processpool_max_workers = _bracket(
-            min_processes, math.ceil(effective_cpu_limit), max_processes
-        )
-    # Threads a lighter than processes... so just tack on a little more
-    threadpool_max_workers = processpool_max_workers + 4
-    return processpool_max_workers, threadpool_max_workers
-
-
-class AzureStorageExecutor(object):
-    """Thin wrapper around a ProcessPoolExecutor, or a ThreadPoolExecutor where
-    the former may be unsafe.
-    """
-
-    def __init__(self, use_processes=False):
-        (
-            processpool_max_workers,
-            threadpool_max_workers,
-        ) = _compute_executor_max_workers()
-        if use_processes:
-            mp_start_method = multiprocessing.get_start_method(allow_none=True)
-            if mp_start_method == "spawn":
-                self._executor = ProcessPoolExecutor(
-                    max_workers=processpool_max_workers
-                )
-            elif sys.version_info[:2] >= (3, 7):
-                self._executor = ProcessPoolExecutor(
-                    mp_context=multiprocessing.get_context("spawn"),
-                    max_workers=processpool_max_workers,
-                )
-            else:
-                raise MetaflowException(
-                    msg="Cannot use ProcessPoolExecutor because Python version is older than 3.7 and multiprocess start method has been set to something other than 'spawn'"
-                )
-        else:
-            self._executor = ThreadPoolExecutor(max_workers=threadpool_max_workers)
-
-    def warm_up(self):
-        # warm up at least one process or thread in the pool.
-        # we don't await future... just let it complete in background
-        self._executor.submit(_noop_for_executor_warm_up)
-
-    def submit(self, *args, **kwargs):
-        return self._executor.submit(*args, **kwargs)
-
 
 # How many threads / connections to use per upload or download operation
+from metaflow.plugins.storage_executor import (
+    StorageExecutor,
+    handle_executor_exceptions,
+)
+
 AZURE_STORAGE_DOWNLOAD_MAX_CONCURRENCY = 4
 AZURE_STORAGE_UPLOAD_MAX_CONCURRENCY = 16
 
@@ -377,27 +245,6 @@ class _AzureRootClient(object):
             process_exception(e)
 
 
-def handle_executor_exceptions(func):
-    """
-    Decorator for handling errors that come from an Executor. This decorator should
-    only be used on functions where executor errors are possible. I.e. the function
-    uses AzureStorageExecutor.
-    """
-
-    def inner_function(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except BrokenExecutor:
-            # This is fatal. So we bail ASAP.
-            # We also don't want to log, because KeyboardInterrupt on worker processes
-            # also take us here, so it's going to be "normal" user operation most of the
-            # time.
-            # BrokenExecutor parents both BrokenThreadPool and BrokenProcessPool.
-            sys.exit(1)
-
-    return inner_function
-
-
 class AzureStorage(DataStoreStorage):
     TYPE = "azure"
 
@@ -410,7 +257,7 @@ class AzureStorage(DataStoreStorage):
         self._root_client = None
 
         self._use_processes = AZURE_STORAGE_WORKLOAD_TYPE == "high_throughput"
-        self._executor = AzureStorageExecutor(use_processes=self._use_processes)
+        self._executor = StorageExecutor(use_processes=self._use_processes)
         self._executor.warm_up()
 
     @handle_exceptions

--- a/metaflow/datastore/gs_storage.py
+++ b/metaflow/datastore/gs_storage.py
@@ -1,0 +1,275 @@
+import json
+import os
+import shutil
+import uuid
+from concurrent.futures import as_completed
+from tempfile import mkdtemp
+
+
+from metaflow.datastore.datastore_storage import DataStoreStorage, CloseAfterUse
+from metaflow.exception import MetaflowInternalError
+from metaflow.metaflow_config import (
+    DATASTORE_SYSROOT_GS,
+    ARTIFACT_LOCALROOT,
+    GS_STORAGE_WORKLOAD_TYPE,
+)
+
+from metaflow.plugins.gcp.gs_storage_client_factory import get_gs_storage_client
+from metaflow.plugins.gcp.gs_utils import (
+    check_gs_deps,
+    parse_gs_full_path,
+    process_gs_exception,
+)
+from metaflow.plugins.storage_executor import (
+    StorageExecutor,
+    handle_executor_exceptions,
+)
+
+
+class _GSRootClient(object):
+    """
+    datastore_root aware Google Cloud Storage client. I.e. blob operations are
+    all done relative to datastore_root.
+
+    This must be picklable, so methods may be passed across process boundaries.
+    """
+
+    def __init__(self, datastore_root):
+        if datastore_root is None:
+            raise MetaflowInternalError("datastore_root must be set")
+        self._datastore_root = datastore_root
+
+    def get_datastore_root(self):
+        return self._datastore_root
+
+    def get_blob_full_path(self, path):
+        """
+        Full path means <blob_prefix>/<path> where:
+        datastore_root is gs://<bucket_name>/<blob_prefix>
+        """
+        _, blob_prefix = parse_gs_full_path(self._datastore_root)
+        if blob_prefix is None:
+            return path
+        path = path.lstrip("/")
+        return "/".join([blob_prefix, path])
+
+    def get_bucket_client(self):
+        bucket_name, _ = parse_gs_full_path(self._datastore_root)
+        client = get_gs_storage_client()
+        return client.bucket(bucket_name)
+
+    def get_blob_client(self, path):
+        bucket = self.get_bucket_client()
+        blob_full_path = self.get_blob_full_path(path)
+        blob = bucket.blob(blob_full_path)
+        return blob
+
+    # GS blob operations. These are meant to be single units of work
+    # to be performed by thread or process pool workers.
+    def is_file_single(self, path):
+        """Drives GSStorage.is_file()"""
+        try:
+            blob = self.get_blob_client(path)
+            result = blob.exists()
+
+            return result
+        except Exception as e:
+            process_gs_exception(e)
+
+    def list_content_single(self, path):
+        """Drives GSStorage.list_content()"""
+
+        def _trim_result(name, prefix):
+            # Remove a prefix from the name, if present
+            if prefix is not None and name[: len(prefix)] == prefix:
+                name = name[len(prefix) + 1 :]
+            return name
+
+        try:
+            path = path.rstrip("/") + "/"
+            bucket_name, blob_prefix = parse_gs_full_path(self._datastore_root)
+            full_path = self.get_blob_full_path(path)
+            blobs = get_gs_storage_client().list_blobs(
+                bucket_name,
+                prefix=full_path,
+                delimiter="/",
+                include_trailing_delimiter=False,
+            )
+            result = []
+            for b in blobs:
+                result.append((_trim_result(b.name, blob_prefix), True))
+            for p in blobs.prefixes:
+                result.append((_trim_result(p, blob_prefix).rstrip("/"), False))
+            return result
+        except Exception as e:
+            process_gs_exception(e)
+
+    def save_bytes_single(
+        self,
+        path_tmpfile_metadata_triple,
+        overwrite=False,
+    ):
+        try:
+            path, tmpfile, metadata = path_tmpfile_metadata_triple
+            blob = self.get_blob_client(path)
+            if not overwrite:
+                if blob.exists():
+                    return
+            if metadata is not None:
+                blob.metadata = {"metaflow-user-attributes": json.dumps(metadata)}
+            from google.cloud.storage.retry import DEFAULT_RETRY
+
+            blob.upload_from_filename(tmpfile, retry=DEFAULT_RETRY)
+        except Exception as e:
+            process_gs_exception(e)
+
+    def load_bytes_single(self, tmpdir, key):
+        """Drives GSStorage.load_bytes()"""
+        tmp_filename = os.path.join(tmpdir, str(uuid.uuid4()))
+        blob = self.get_blob_client(key)
+        metaflow_user_attributes = None
+        import google.api_core.exceptions
+
+        try:
+            blob.reload()
+            if blob.metadata and "metaflow-user-attributes" in blob.metadata:
+                metaflow_user_attributes = json.loads(
+                    blob.metadata["metaflow-user-attributes"]
+                )
+            blob.download_to_filename(tmp_filename)
+        except google.api_core.exceptions.NotFound:
+            tmp_filename = None
+        return key, tmp_filename, metaflow_user_attributes
+
+
+class GSStorage(DataStoreStorage):
+    TYPE = "gs"
+
+    def __init__(self, root=None):
+        # cannot decorate __init__... invoke it with dummy decoratee
+        check_gs_deps(lambda: 0)
+        super(GSStorage, self).__init__(root)
+        self._tmproot = ARTIFACT_LOCALROOT
+        self._root_client = None
+
+        self._use_processes = GS_STORAGE_WORKLOAD_TYPE == "high_throughput"
+        self._executor = StorageExecutor(use_processes=self._use_processes)
+        self._executor.warm_up()
+
+    @property
+    def root_client(self):
+        """Root client is datastore_root aware. All blob operations go through root_client's
+        methods.
+
+        Method calls may run on the main thread, or be submitted to a process or thread pool.
+        """
+        if self._root_client is None:
+            self._root_client = _GSRootClient(
+                datastore_root=self.datastore_root,
+            )
+        return self._root_client
+
+    @classmethod
+    def get_datastore_root_from_config(cls, echo, create_on_absent=True):
+        # create_on_absent doesn't do anything.  This matches S3Storage
+        return DATASTORE_SYSROOT_GS
+
+    @handle_executor_exceptions
+    def is_file(self, paths):
+        # preserving order is important...
+        futures = [
+            self._executor.submit(
+                self.root_client.is_file_single,
+                path,
+            )
+            for path in paths
+        ]
+        # preserving order is important...
+        return [future.result() for future in futures]
+
+    def info_file(self, path):
+        # not used anywhere... we should consider killing this on all data storage implementations
+        raise NotImplementedError()
+
+    def size_file(self, path):
+        import google.api_core.exceptions
+
+        try:
+            blob = self.root_client.get_blob_client(path)
+            blob.reload()
+            return blob.size
+        except google.api_core.exceptions.NotFound:
+            return None
+
+    @handle_executor_exceptions
+    def list_content(self, paths):
+        futures = [
+            self._executor.submit(self.root_client.list_content_single, path)
+            for path in paths
+        ]
+        result = []
+        for future in as_completed(futures):
+            result.extend(self.list_content_result(*x) for x in future.result())
+        return result
+
+    @handle_executor_exceptions
+    def save_bytes(self, path_and_bytes_iter, overwrite=False, len_hint=0):
+        tmpdir = None
+        try:
+            tmpdir = mkdtemp(dir=ARTIFACT_LOCALROOT, prefix="metaflow.gs.save_bytes.")
+            futures = []
+            for path, byte_stream in path_and_bytes_iter:
+                metadata = None
+                # bytes_stream could actually be (bytes_stream, metadata) instead.
+                # Read the small print on DatastoreStorage.save_bytes()
+                if isinstance(byte_stream, tuple):
+                    byte_stream, metadata = byte_stream
+                tmp_filename = os.path.join(tmpdir, str(uuid.uuid4()))
+                with open(tmp_filename, "wb") as f:
+                    f.write(byte_stream.read())
+                # Fully finish writing the file, before submitting work. Careful with indentation.
+
+                futures.append(
+                    self._executor.submit(
+                        self.root_client.save_bytes_single,
+                        (path, tmp_filename, metadata),
+                        overwrite=overwrite,
+                    )
+                )
+            for future in as_completed(futures):
+                future.result()
+        finally:
+            # *Future* improvement: We could clean up individual tmp files as each future completes
+            if tmpdir and os.path.exists(tmpdir):
+                shutil.rmtree(tmpdir)
+
+    @handle_executor_exceptions
+    def load_bytes(self, keys):
+        tmpdir = mkdtemp(dir=self._tmproot, prefix="metaflow.gs.load_bytes.")
+        try:
+            futures = [
+                self._executor.submit(
+                    self.root_client.load_bytes_single,
+                    tmpdir,
+                    key,
+                )
+                for key in keys
+            ]
+
+            # Let's detect any failures fast. Stop and cleanup ASAP.
+            # Note that messing up return order is beneficial re: Hyrum's law too.
+            items = [future.result() for future in as_completed(futures)]
+        except Exception:
+            # Other BaseExceptions will skip clean up here.
+            # We let this go - smooth exit in those circumstances is more important than cleaning up a few tmp files
+            if os.path.exists(tmpdir):
+                shutil.rmtree(tmpdir)
+            raise
+
+        class _Closer(object):
+            @staticmethod
+            def close():
+                if os.path.isdir(tmpdir):
+                    shutil.rmtree(tmpdir)
+
+        return CloseAfterUse(iter(items), closer=_Closer)

--- a/metaflow/includefile.py
+++ b/metaflow/includefile.py
@@ -14,6 +14,7 @@ from .exception import MetaflowException
 from .metaflow_config import DATATOOLS_LOCALROOT, DATATOOLS_SUFFIX
 from .parameters import DeployTimeField, Parameter
 from .plugins.azure.includefile_support import Azure
+from .plugins.gcp.includefile_support import GS
 from .util import to_unicode
 
 try:
@@ -166,7 +167,12 @@ class Local(object):
 # From here on out, this is the IncludeFile implementation.
 from .datatools import S3
 
-DATACLIENTS = {"local": Local, "s3": S3, "azure": Azure}
+DATACLIENTS = {
+    "local": Local,
+    "s3": S3,
+    "azure": Azure,
+    "gs": GS,
+}
 
 
 class LocalFile:

--- a/metaflow/main_cli.py
+++ b/metaflow/main_cli.py
@@ -533,6 +533,21 @@ def configure_azure_datastore(existing_env):
     return env
 
 
+def configure_gs_datastore(existing_env):
+    env = {}
+    # Set Google Cloud Storage as default datastore.
+    env["METAFLOW_DEFAULT_DATASTORE"] = "gs"
+    # Set Google Cloud Storage folder for datastore.
+    env["METAFLOW_DATASTORE_SYSROOT_GS"] = click.prompt(
+        cyan("[METAFLOW_DATASTORE_SYSROOT_GS]")
+        + " Google Cloud Storage folder for Metaflow artifact storage "
+        + "(Format: gs://<bucket>/<prefix>)",
+        default=existing_env.get("METAFLOW_DATASTORE_SYSROOT_GS"),
+        show_default=True,
+    )
+    return env
+
+
 def configure_metadata_service(existing_env):
     empty_profile = False
     if not existing_env:
@@ -598,6 +613,44 @@ def configure_azure_datastore_and_metadata(existing_env):
         + " and persist flow execution metadata.\nConfiguring the "
         "service is a requirement if you intend to schedule your "
         "flows with Kubernetes on Azure (AKS or self-managed).\nWould you like to "
+        "configure the Metadata Service?",
+        default=empty_profile
+        or existing_env.get("METAFLOW_DEFAULT_METADATA", "") == "service",
+        abort=False,
+    ):
+        env.update(configure_metadata_service(existing_env))
+    return env
+
+
+def configure_gs_datastore_and_metadata(existing_env):
+    empty_profile = False
+    if not existing_env:
+        empty_profile = True
+    env = {}
+
+    # Configure Google Cloud Storage as the datastore.
+    use_gs_as_datastore = click.confirm(
+        "\nMetaflow can use "
+        + yellow("Google Cloud Storage as the storage backend")
+        + " for all code and data artifacts on "
+        + "Google Cloud Storage.\nGoogle Cloud Storage is a strict requirement if you "
+        + "intend to execute your flows on a Kubernetes cluster on GCP (GKE or self-managed)"
+        + ".\nWould you like to configure Google Cloud Storage "
+        + "as the default storage backend?",
+        default=empty_profile
+        or existing_env.get("METAFLOW_DEFAULT_DATASTORE", "") == "gs",
+        abort=False,
+    )
+    if use_gs_as_datastore:
+        env.update(configure_gs_datastore(existing_env))
+
+    # Configure Metadata service for tracking.
+    if click.confirm(
+        "\nMetaflow can use a "
+        + yellow("remote Metadata Service to track")
+        + " and persist flow execution metadata.\nConfiguring the "
+        "service is a requirement if you intend to schedule your "
+        "flows with Kubernetes on GCP (GKE or self-managed).\nWould you like to "
         "configure the Metadata Service?",
         default=empty_profile
         or existing_env.get("METAFLOW_DEFAULT_METADATA", "") == "service",
@@ -882,7 +935,32 @@ def verify_azure_credentials(ctx):
         ctx.abort()
 
 
-@configure.command(help="Configure metaflow to access Azure Blob Storage.")
+def verify_gcp_credentials(ctx):
+    # Verify that the user has configured AWS credentials on their computer.
+    if not click.confirm(
+        "\nMetaflow relies on "
+        + yellow("GCP access credentials")
+        + " present on your computer to access resources on GCP."
+        "\nBefore proceeding further, please confirm that you "
+        "have already configured these access credentials on "
+        "this computer.",
+        default=True,
+    ):
+        echo(
+            "There are many ways to setup your GCP access credentials. You "
+            "can get started by getting familiar with the following: ",
+            nl=False,
+            fg="yellow",
+        )
+        echo("")
+        echo(
+            "- https://cloud.google.com/docs/authentication/provide-credentials-adc",
+            fg="cyan",
+        )
+        ctx.abort()
+
+
+@configure.command(help="Configure metaflow to access Microsoft Azure.")
 @click.option(
     "--profile",
     "-p",
@@ -919,6 +997,48 @@ def azure(ctx, profile):
             + yellow("executing your steps on Kubernetes.")
             + "\nYou may use Azure Kubernetes Service (AKS)"
             " or a self-managed Kubernetes cluster on Azure VMs."
+            + " If/when your Kubernetes cluster is ready for use,"
+            " please run 'metaflow configure kubernetes'.",
+        )
+
+
+@configure.command(help="Configure metaflow to access Google Cloud Platform.")
+@click.option(
+    "--profile",
+    "-p",
+    default="",
+    help="Configure a named profile. Activate the profile by setting "
+    "`METAFLOW_PROFILE` environment variable.",
+)
+@click.pass_context
+def gcp(ctx, profile):
+
+    # Greet the user!
+    echo(
+        "Welcome to Metaflow! Follow the prompts to configure your installation.\n",
+        bold=True,
+    )
+
+    # Check for existing configuration.
+    if not confirm_overwrite_config(profile):
+        ctx.abort()
+
+    verify_gcp_credentials(ctx)
+
+    existing_env = get_env(profile)
+
+    env = {}
+    env.update(configure_gs_datastore_and_metadata(existing_env))
+
+    persist_env({k: v for k, v in env.items() if v}, profile)
+
+    # Prompt user to also configure Kubernetes for compute if using Google Cloud Storage
+    if env.get("METAFLOW_DEFAULT_DATASTORE") == "gs":
+        click.echo(
+            "\nFinal note! Metaflow can scale your flows by "
+            + yellow("executing your steps on Kubernetes.")
+            + "\nYou may use Google Kubernetes Engine (GKE)"
+            " or a self-managed Kubernetes cluster on Google Compute Engine VMs."
             + " If/when your Kubernetes cluster is ready for use,"
             " please run 'metaflow configure kubernetes'.",
         )

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -104,6 +104,14 @@ class MetaflowEnvironment(object):
                 blob=blob,
                 container=container_name,
             )
+        elif datastore_type == "gs":
+            from .plugins.gcp.gs_utils import parse_gs_full_path
+
+            bucket_name, gs_object = parse_gs_full_path(code_package_url)
+            return (
+                "download-gcp-object --bucket=%s --object=%s --output-file=job.tar"
+                % (bucket_name, gs_object)
+            )
         else:
             raise NotImplementedError(
                 "We don't know how to generate a download code package cmd for datastore %s"
@@ -117,6 +125,11 @@ class MetaflowEnvironment(object):
         elif datastore_type == "azure":
             cmds.append(
                 "%s -m pip install azure-identity azure-storage-blob simple-azure-blob-downloader -qqq"
+                % self._python()
+            )
+        elif datastore_type == "gs":
+            cmds.append(
+                "%s -m pip install google-cloud-storage google-auth simple-gcp-object-downloader -qqq"
                 % self._python()
             )
         else:

--- a/metaflow/mflog/__init__.py
+++ b/metaflow/mflog/__init__.py
@@ -154,6 +154,10 @@ def get_log_tailer(log_url, datastore_type):
         from metaflow.plugins.azure.azure_tail import AzureTail
 
         return AzureTail(log_url)
+    elif datastore_type == "gs":
+        from metaflow.plugins.gcp.gs_tail import GSTail
+
+        return GSTail(log_url)
     else:
         raise MetaflowInternalError(
             "Log tailing implementation missing for datastore type %s"

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -22,6 +22,8 @@ from metaflow.metaflow_config import (
     AZURE_STORAGE_BLOB_SERVICE_ENDPOINT,
     DATASTORE_SYSROOT_AZURE,
     DATASTORE_CARD_AZUREROOT,
+    DATASTORE_SYSROOT_GS,
+    DATASTORE_CARD_GSROOT,
 )
 from metaflow.mflog import BASH_SAVE_LOGS, bash_capture_logs, export_mflog_env_vars
 from metaflow.parameters import deploy_time_eval
@@ -795,6 +797,10 @@ class ArgoWorkflows(object):
             ] = AZURE_STORAGE_BLOB_SERVICE_ENDPOINT
             env["METAFLOW_DATASTORE_SYSROOT_AZURE"] = DATASTORE_SYSROOT_AZURE
             env["METAFLOW_DATASTORE_CARD_AZUREROOT"] = DATASTORE_CARD_AZUREROOT
+
+            # GCP stuff
+            env["METAFLOW_DATASTORE_SYSROOT_GS"] = DATASTORE_SYSROOT_GS
+            env["METAFLOW_DATASTORE_CARD_GSROOT"] = DATASTORE_CARD_GSROOT
 
             metaflow_version = self.environment.get_environment_info()
             metaflow_version["flow_name"] = self.graph.name

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -328,9 +328,9 @@ def make_flow(
 ):
     # TODO: Make this check less specific to Amazon S3 as we introduce
     #       support for more cloud object stores.
-    if obj.flow_datastore.TYPE not in ("azure", "s3"):
+    if obj.flow_datastore.TYPE not in ("azure", "gs", "s3"):
         raise MetaflowException(
-            "Argo Workflows requires --datastore=s3 or --datastore=azure"
+            "Argo Workflows requires --datastore=s3 or --datastore=azure or --datastore=gs"
         )
 
     # Attach @kubernetes and @environment decorator to the flow to

--- a/metaflow/plugins/cards/card_datastore.py
+++ b/metaflow/plugins/cards/card_datastore.py
@@ -15,6 +15,7 @@ from metaflow.metaflow_config import (
     DATASTORE_LOCAL_DIR,
     DATASTORE_CARD_SUFFIX,
     DATASTORE_CARD_AZUREROOT,
+    DATASTORE_CARD_GSROOT,
 )
 
 from .exception import CardNotPresentException
@@ -48,6 +49,8 @@ class CardDatastore(object):
             return DATASTORE_CARD_S3ROOT
         elif storage_type == "azure":
             return DATASTORE_CARD_AZUREROOT
+        elif storage_type == "gs":
+            return DATASTORE_CARD_GSROOT
         elif storage_type == "local":
             # Borrowing some of the logic from LocalStorage.get_storage_root
             result = DATASTORE_CARD_LOCALROOT

--- a/metaflow/plugins/conda/__init__.py
+++ b/metaflow/plugins/conda/__init__.py
@@ -8,7 +8,9 @@ from metaflow.metaflow_config import (
     CONDA_PACKAGE_S3ROOT,
     DATASTORE_SYSROOT_S3,
     CONDA_PACKAGE_AZUREROOT,
+    CONDA_PACKAGE_GSROOT,
     DATASTORE_SYSROOT_AZURE,
+    DATASTORE_SYSROOT_GS,
 )
 
 CONDA_MAGIC_FILE = "conda.dependencies"
@@ -72,6 +74,15 @@ def get_conda_package_root(datastore_type):
             return "%s/conda" % DATASTORE_SYSROOT_AZURE
         else:
             return CONDA_PACKAGE_AZUREROOT
+    elif datastore_type == "gs":
+        if CONDA_PACKAGE_GSROOT is None:
+            if DATASTORE_SYSROOT_GS is None:
+                raise MetaflowException(
+                    msg="METAFLOW_DATASTORE_SYSROOT_GS must be set!"
+                )
+            return "%s/conda" % DATASTORE_SYSROOT_GS
+        else:
+            return CONDA_PACKAGE_GSROOT
     else:
         raise MetaflowInternalError(
             msg="Unsupported storage backend '%s' for working with Conda"

--- a/metaflow/plugins/conda/batch_bootstrap.py
+++ b/metaflow/plugins/conda/batch_bootstrap.py
@@ -67,7 +67,6 @@ def download_conda_packages(flow_name, env_id, datastore_type):
                     msg="Downloading conda code packages from datastore backend %s is unimplemented!"
                     % datastore_type
                 )
-
             conda_package_root = get_conda_package_root(datastore_type)
             storage = DATASTORES[datastore_type](conda_package_root)
             with storage.load_bytes(env["cache_urls"]) as load_result:

--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -153,7 +153,7 @@ class CondaStepDecorator(StepDecorator):
                 payload = cached_deps[env_id]
 
             if (
-                self.flow_datastore.TYPE in ("s3", "azure")
+                self.flow_datastore.TYPE in ("s3", "azure", "gs")
                 and "cache_urls" not in payload
             ):
                 payload["cache_urls"] = self._cache_env()

--- a/metaflow/plugins/gcp/gs_exceptions.py
+++ b/metaflow/plugins/gcp/gs_exceptions.py
@@ -1,0 +1,5 @@
+from metaflow.exception import MetaflowException
+
+
+class MetaflowGSPackageError(MetaflowException):
+    headline = "Missing required packages google-cloud-storage google-auth"

--- a/metaflow/plugins/gcp/gs_storage_client_factory.py
+++ b/metaflow/plugins/gcp/gs_storage_client_factory.py
@@ -1,0 +1,21 @@
+import os
+import threading
+
+_client_cache = dict()
+
+
+def _get_cache_key():
+    return os.getpid(), threading.get_ident()
+
+
+def get_gs_storage_client():
+    cache_key = _get_cache_key()
+    if cache_key not in _client_cache:
+        from google.cloud import storage
+        import google.auth
+
+        credentials, project_id = google.auth.default(scopes=storage.Client.SCOPE)
+        _client_cache[cache_key] = storage.Client(
+            credentials=credentials, project=project_id
+        )
+    return _client_cache[cache_key]

--- a/metaflow/plugins/gcp/gs_tail.py
+++ b/metaflow/plugins/gcp/gs_tail.py
@@ -1,0 +1,85 @@
+from io import BytesIO
+
+from google.cloud.exceptions import NotFound, ClientError
+
+from metaflow.exception import MetaflowException
+
+from metaflow.plugins.gcp.gs_storage_client_factory import get_gs_storage_client
+from metaflow.plugins.gcp.gs_utils import parse_gs_full_path
+
+
+class GSTail(object):
+    def __init__(self, blob_full_uri):
+        """Location should be something like gs://<bucket_name>/blob"""
+        bucket_name, blob_name = parse_gs_full_path(blob_full_uri)
+        if not blob_name:
+            raise MetaflowException(
+                msg="Failed to parse blob_full_uri into gs://<bucket_name>/<blob_name> (got %s)"
+                % blob_full_uri
+            )
+        client = get_gs_storage_client()
+        bucket = client.bucket(bucket_name)
+        self._blob_client = bucket.blob(blob_name)
+        self._pos = 0
+        self._tail = b""
+
+    def __iter__(self):
+        buf = self._fill_buf()
+        if buf is not None:
+            # If there are no line breaks in the entries
+            # file, then we will yield nothing, ever.
+            #
+            # This apes S3 tail. We can fix it here and in S3
+            # if/when this becomes an issue. It boils down to
+            # knowing when to give up waiting on partial lines
+            # to become full lines (tricky, need more info).
+            #
+            # Likely this has been OK because we control the
+            # line-break presence in the objects we tail.
+            for line in buf:
+                if line.endswith(b"\n"):
+                    yield line
+                else:
+                    self._tail = line
+                    break
+
+    def _make_range_request(self):
+        try:
+            # Yes we read to the end... memory blow up is possible. We can improve by specifying length param
+            return self._blob_client.download_as_bytes(start=self._pos)
+        except NotFound:
+            return None
+        except ClientError as e:
+            # be silent on range errors - it means log did not advance
+            if e.code != 416:
+                print("Failed to tail log from step (status code = %d)" % (e.code,))
+            return None
+        except Exception as e:
+            print("Failed to tail log from step (%s)" % type(e))
+            return None
+
+    def _fill_buf(self):
+        data = self._make_range_request()
+        if data is None:
+            return None
+        if data:
+            buf = BytesIO(data)
+            self._pos += len(data)
+            self._tail = b""
+            return buf
+        else:
+            return None
+
+
+if __name__ == "__main__":
+    # This main program is for debugging and testing purposes
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Tail an Google Cloud Storage blob.")
+    parser.add_argument(
+        "blob_full_uri", help="The blob to tail. Format is gs://<bucket_name>/<blob>"
+    )
+    args = parser.parse_args()
+    gs_tail = GSTail(args.blob_full_uri)
+    for line in gs_tail:
+        print(line.strip().decode("utf-8"))

--- a/metaflow/plugins/gcp/gs_utils.py
+++ b/metaflow/plugins/gcp/gs_utils.py
@@ -1,0 +1,65 @@
+import sys
+
+from metaflow.exception import MetaflowException, MetaflowInternalError
+from metaflow.plugins.gcp.gs_exceptions import MetaflowGSPackageError
+
+
+def parse_gs_full_path(gs_uri):
+    from urllib.parse import urlparse
+
+    #  <scheme>://<netloc>/<path>;<params>?<query>#<fragment>
+    scheme, netloc, path, _, _, _ = urlparse(gs_uri)
+    assert scheme == "gs"
+    assert netloc is not None
+
+    bucket = netloc
+    path = path.lstrip("/").rstrip("/")
+    if path == "":
+        path = None
+
+    return bucket, path
+
+
+def _check_and_init_gs_deps():
+    try:
+        from google.cloud import storage
+        import google.auth
+    except ImportError:
+        raise MetaflowGSPackageError()
+
+    if sys.version_info[:2] < (3, 7):
+        raise MetaflowException(
+            msg="Metaflow may only use Google Cloud Storage with Python 3.7 or newer"
+        )
+
+
+def check_gs_deps(func):
+    """The decorated function checks GS dependencies (as needed for Azure storage backend). This includes
+    various GCP SDK packages, as well as a Python version of >=3.7
+    """
+
+    def _inner_func(*args, **kwargs):
+        _check_and_init_gs_deps()
+        return func(*args, **kwargs)
+
+    return _inner_func
+
+
+@check_gs_deps
+def process_gs_exception(e):
+    """
+    Translate errors to Metaflow errors for standardized messaging. The intent is that all
+    Google Cloud Storage integration logic should send errors to this function for
+    translation.
+
+    We explicitly EXCLUDE executor related errors here.  See handle_executor_exceptions
+    """
+    if isinstance(e, MetaflowException):
+        # If it's already a MetaflowException... no translation needed
+        raise
+    if isinstance(e, ImportError):
+        # Surprise ImportError here... (expected to see this handled and wrapped as MetaflowGSPackagingError)
+        # Reraise it raw for visibility, it's a bug and is catastrophic anyway.
+        raise
+    # TODO we may catch and wrap more GCP errors here, as needed.
+    raise MetaflowInternalError(msg=str(e))

--- a/metaflow/plugins/gcp/includefile_support.py
+++ b/metaflow/plugins/gcp/includefile_support.py
@@ -1,0 +1,90 @@
+import io
+import os
+import shutil
+import uuid
+from tempfile import mkdtemp
+
+from metaflow.exception import MetaflowException, MetaflowInternalError
+
+
+class GS(object):
+    @classmethod
+    def get_root_from_config(cls, echo, create_on_absent=True):
+        from metaflow.metaflow_config import DATATOOLS_GSROOT
+
+        return DATATOOLS_GSROOT
+
+    def __init__(self):
+        # This local directory is used to house any downloaded blobs, for lifetime of
+        # this object as a context manager.
+        self._tmpdir = None
+
+    def _get_storage_backend_and_subpath(self, key):
+        """
+        Return an GSDatastore, rooted at the container level, no prefix.
+        Key MUST be a fully qualified path. e.g. gs://<bucket_name>/b/l/o/b/n/a/m/e
+        """
+        from metaflow.plugins.gcp.gs_utils import parse_gs_full_path
+
+        # we parse out the bucket name only, and use that to root our storage implementation
+        bucket_name, subpath = parse_gs_full_path(key)
+        # Import DATASTORES dynamically... otherwise, circular import
+        from metaflow.datastore import DATASTORES
+
+        storage_impl = DATASTORES["gs"]
+        return storage_impl("gs://" + bucket_name), subpath
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        if self._tmpdir and os.path.exists(self._tmpdir):
+            shutil.rmtree(self._tmpdir)
+
+    def get(self, key=None, return_missing=False):
+        """Key MUST be a fully qualified path.  gs://<bucket_name>/b/l/o/b/n/a/m/e"""
+        if not return_missing:
+            raise MetaflowException("GS object supports only return_missing=True")
+        if not key.startswith("gs://"):
+            raise MetaflowInternalError(
+                msg="Expected GS object key to start with 'gs://'"
+            )
+        storage, subpath = self._get_storage_backend_and_subpath(key)
+        gs_object = None
+        with storage.load_bytes([subpath]) as load_result:
+            for _, tmpfile, _ in load_result:
+                if tmpfile is None:
+                    gs_object = GSObject(key, None, False)
+                else:
+                    if not self._tmpdir:
+                        self._tmpdir = mkdtemp(prefix="metaflow.includefile.gs.")
+                    output_file_path = os.path.join(self._tmpdir, str(uuid.uuid4()))
+                    shutil.move(tmpfile, output_file_path)
+                    gs_object = GSObject(key, output_file_path, True)
+                break
+        return gs_object
+
+    def put(self, key, obj, overwrite=True):
+        """Key MUST be a fully qualified path.  gs://<bucket_name>/b/l/o/b/n/a/m/e"""
+        storage, subpath = self._get_storage_backend_and_subpath(key)
+        storage.save_bytes([(subpath, io.BytesIO(obj))], overwrite=overwrite)
+        return key
+
+
+class GSObject(object):
+    def __init__(self, url, path, exists):
+        self._path = path
+        self._url = url
+        self._exists = exists
+
+    @property
+    def path(self):
+        return self._path
+
+    @property
+    def url(self):
+        return self._url
+
+    @property
+    def exists(self):
+        return self._exists

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -19,6 +19,8 @@ from metaflow.metaflow_config import (
     AZURE_STORAGE_BLOB_SERVICE_ENDPOINT,
     DATASTORE_SYSROOT_AZURE,
     DATASTORE_CARD_AZUREROOT,
+    DATASTORE_SYSROOT_GS,
+    DATASTORE_CARD_GSROOT,
 )
 from metaflow.mflog import (
     BASH_SAVE_LOGS,
@@ -204,6 +206,8 @@ class Kubernetes(object):
                 "METAFLOW_DATASTORE_SYSROOT_AZURE", DATASTORE_SYSROOT_AZURE
             )
             .environment_variable("METAFLOW_CARD_AZUREROOT", DATASTORE_CARD_AZUREROOT)
+            .environment_variable("METAFLOW_DATASTORE_SYSROOT_GS", DATASTORE_SYSROOT_GS)
+            .environment_variable("METAFLOW_CARD_GSROOT", DATASTORE_CARD_GSROOT)
             # support Metaflow sandboxes
             .environment_variable(
                 "METAFLOW_INIT_SCRIPT", KUBERNETES_SANDBOX_INIT_SCRIPT

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -122,9 +122,9 @@ class KubernetesDecorator(StepDecorator):
     # Refer https://github.com/Netflix/metaflow/blob/master/docs/lifecycle.png
     def step_init(self, flow, graph, step, decos, environment, flow_datastore, logger):
         # Executing Kubernetes jobs requires a non-local datastore.
-        if flow_datastore.TYPE not in ("s3", "azure"):
+        if flow_datastore.TYPE not in ("s3", "azure", "gs"):
             raise KubernetesException(
-                "The *@kubernetes* decorator requires --datastore=s3 or --datastore=azure at the moment."
+                "The *@kubernetes* decorator requires --datastore=s3 or --datastore=azure or --datastore=gs at the moment."
             )
 
         # Set internal state.

--- a/metaflow/plugins/storage_executor.py
+++ b/metaflow/plugins/storage_executor.py
@@ -1,0 +1,164 @@
+import math
+import multiprocessing
+import os
+import platform
+import sys
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+
+from metaflow.exception import MetaflowException
+
+if sys.version_info[:2] < (3, 7):
+    # in 3.6, Only BrokenProcessPool exists (there is no BrokenThreadPool)
+    from concurrent.futures.process import BrokenProcessPool
+
+    BrokenStorageExecutorError = BrokenProcessPool
+else:
+    # in 3.7 and newer, BrokenExecutor is a base class that parents BrokenProcessPool AND BrokenThreadPool
+    from concurrent.futures import BrokenExecutor as _BrokenExecutor
+
+    BrokenStorageExecutorError = _BrokenExecutor
+
+
+def _determine_effective_cpu_limit():
+    """Calculate CPU limit (in number of cores) based on:
+
+    - /sys/fs/cgroup/cpu/cpu.max (if available, cgroup 2)
+    OR
+    - /sys/fs/cgroup/cpu/cpu.cfs_quota_us
+    - /sys/fs/cgroup/cpu/cpu.cfs_period_us
+
+    Returns:
+        > 0 if limit was successfully calculated
+        = 0 if we determined that there is no limit
+        -1 if we failed to determine the limit
+    """
+    try:
+        if platform.system() == "Darwin":
+            # On MacOS, and not in a container
+            # We are assuming it is extremely out-of-the-way to run a Darwin container
+            return 0
+        elif platform.system() == "Linux":
+            # Bare metal Linux, or a Linux container running on either Linux or MacOS system
+            # Linux containers on MacOS have this cpu.max file
+            with open("/sys/fs/cgroup/cpu.max", "rb") as f:
+                parts = f.read().decode("utf-8").split(" ")
+                if len(parts) == 2:
+                    if parts[0] == "max":
+                        return 0
+                    return int(parts[0]) / int(parts[1])
+
+            with open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us", "rb") as f:
+                quota = int(f.read())
+                # this file shows -1 for no limit
+                if quota == -1:
+                    return 0
+                # some other negative number - this is weird...return "undetermined"
+                if quota < 0:
+                    return -1
+            with open("/sys/fs/cgroup/cpu/cpu.cfs_period_us", "rb") as f:
+                period = int(f.read())
+                # should be positive. we don't want div by zero errors.
+                if period <= 0:
+                    return -1
+                return quota / period
+        else:
+            # Not Linux or MacOS...give up and return "undetermined"
+            return -1
+    except Exception:
+        return -1
+
+
+def _noop_for_executor_warm_up():
+    pass
+
+
+def _compute_executor_max_workers():
+    # For processes, let's start conservative. Let's restrict to 4-18 always. Can be configurable one day.
+    min_processes = 4
+    max_processes = 18
+    # make an effort to get cgroup cpu limits
+    effective_cpu_limit = _determine_effective_cpu_limit()
+
+    def _bracket(min_v, v, max_v):
+        assert min_v <= max_v
+        if v < min_v:
+            return min_v
+        if v > max_v:
+            return max_v
+        return v
+
+    if effective_cpu_limit < 0:
+        # We don't know the limit, stick to min
+        processpool_max_workers = min_processes
+    elif effective_cpu_limit == 0:
+        # There is (probably) no limit, use physical core count
+        processpool_max_workers = _bracket(
+            min_processes, os.cpu_count() or 1, max_processes
+        )
+    else:
+        # There is a limit, so let's bracket it within min / max
+        processpool_max_workers = _bracket(
+            min_processes, math.ceil(effective_cpu_limit), max_processes
+        )
+    # Threads a lighter than processes... so just tack on a little more
+    threadpool_max_workers = processpool_max_workers + 4
+    return processpool_max_workers, threadpool_max_workers
+
+
+# TODO keyboard interrupt crazy tracebacks in process pool
+class StorageExecutor(object):
+    """Thin wrapper around a ProcessPoolExecutor, or a ThreadPoolExecutor where
+    the former may be unsafe.
+    """
+
+    def __init__(self, use_processes=False):
+        (
+            processpool_max_workers,
+            threadpool_max_workers,
+        ) = _compute_executor_max_workers()
+        if use_processes:
+            mp_start_method = multiprocessing.get_start_method(allow_none=True)
+            if mp_start_method == "spawn":
+                self._executor = ProcessPoolExecutor(
+                    max_workers=processpool_max_workers
+                )
+            elif sys.version_info[:2] >= (3, 7):
+                self._executor = ProcessPoolExecutor(
+                    mp_context=multiprocessing.get_context("spawn"),
+                    max_workers=processpool_max_workers,
+                )
+            else:
+                raise MetaflowException(
+                    msg="Cannot use ProcessPoolExecutor because Python version is older than 3.7 and multiprocess start method has been set to something other than 'spawn'"
+                )
+        else:
+            self._executor = ThreadPoolExecutor(max_workers=threadpool_max_workers)
+
+    def warm_up(self):
+        # warm up at least one process or thread in the pool.
+        # we don't await future... just let it complete in background
+        self._executor.submit(_noop_for_executor_warm_up)
+
+    def submit(self, *args, **kwargs):
+        return self._executor.submit(*args, **kwargs)
+
+
+def handle_executor_exceptions(func):
+    """
+    Decorator for handling errors that come from an Executor. This decorator should
+    only be used on functions where executor errors are possible. I.e. the function
+    uses StorageExecutor.
+    """
+
+    def inner_function(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except BrokenStorageExecutorError:
+            # This is fatal. So we bail ASAP.
+            # We also don't want to log, because KeyboardInterrupt on worker processes
+            # also take us here, so it's going to be "normal" user operation most of the
+            # time.
+            # BrokenExecutor parents both BrokenThreadPool and BrokenProcessPool.
+            sys.exit(1)
+
+    return inner_function


### PR DESCRIPTION
We add support for the `gs` datastore (to match the `gs://` URL scheme encouraged by Google Cloud Storage).

The thread / process pool executor machinery implemented for Azure Blob Storage has been factored out to be used by `gs` as well.