### PR TITLE
Argo Events support

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -363,6 +363,31 @@ if AWS_SANDBOX_ENABLED:
 
 KUBERNETES_SANDBOX_INIT_SCRIPT = from_conf("METAFLOW_KUBERNETES_SANDBOX_INIT_SCRIPT")
 
+# Argo Events
+EVENT_SOURCE_NAME = from_conf(
+    "METAFLOW_EVENT_SOURCE_NAME"
+)  # Required name of Argo Event source
+EVENT_SOURCE_URL = from_conf(
+    "METAFLOW_EVENT_SOURCE_URL"
+)  # Required: HTTP(S) or NATS URL
+EVENT_SERVICE_ACCOUNT = from_conf(
+    "METAFLOW_EVENT_SERVICE_ACCOUNT"
+)  # Required K8s service account
+EVENT_SOURCE_AUTH_SECRET = from_conf(
+    "METAFLOW_EVENT_AUTH_SECRET"
+)  # Optional name of K8s secret
+EVENT_SOURCE_AUTH_KEY = from_conf(
+    "METAFLOW_EVENT_AUTH_KEY"
+)  # Optional path to auth value within K8s secret
+EVENT_SOURCE_AUTH_TOKEN = from_conf(
+    "METAFLOW_EVENT_SOURCE_AUTH_TOKEN"
+)  # Optional string literal of auth token
+# Note: If auth is enabled on the underlying event source then either both AUTH_SECRET
+# and AUTH_KEY must be populated or AUTH_TOKEN.
+EVENT_DISPATCH_IMAGE = from_conf(
+    "METAFLOW_EVENT_DISPATCH_IMAGE", "kevinob/event-trigger"
+)  # Image used by event dispatch pods
+
 # MAX_ATTEMPTS is the maximum number of attempts, including the first
 # task, retries, and the final fallback task and its retries.
 #

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -125,7 +125,6 @@ from .cards.card_decorator import CardDecorator
 from .frameworks.pytorch import PytorchParallelDecorator
 from .airflow.airflow_decorator import AirflowInternalDecorator
 
-
 STEP_DECORATORS = [
     CatchDecorator,
     TimeoutDecorator,
@@ -164,12 +163,13 @@ _merge_lists(METADATA_PROVIDERS, _ext_plugins["METADATA_PROVIDERS"], "TYPE")
 from .conda.conda_flow_decorator import CondaFlowDecorator
 from .aws.step_functions.schedule_decorator import ScheduleDecorator
 from .project_decorator import ProjectDecorator
-
+from .argo.event_decorators import TriggerOnDecorator
 
 FLOW_DECORATORS = [
     CondaFlowDecorator,
     ScheduleDecorator,
     ProjectDecorator,
+    TriggerOnDecorator,
 ]
 _merge_lists(FLOW_DECORATORS, _ext_plugins["FLOW_DECORATORS"], "name")
 

--- a/metaflow/plugins/argo/argo_client.py
+++ b/metaflow/plugins/argo/argo_client.py
@@ -203,3 +203,146 @@ class ArgoClient(object):
             raise ArgoClientException(
                 json.loads(e.body)["message"] if e.body is not None else e.reason
             )
+
+    def register_trigger_on_template(self, name, sensor_template):
+        try:
+            sensor_template["metadata"][
+                "resourceVersion"
+            ] = self._client.CustomObjectsApi().get_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="sensors",
+                name=name,
+            )[
+                "metadata"
+            ][
+                "resourceVersion"
+            ]
+        except self._client.rest.ApiException as e:
+            if e.status == 404:
+                try:
+                    return (
+                        self._client.CustomObjectsApi().create_namespaced_custom_object(
+                            group=self._group,
+                            version=self._version,
+                            namespace=self._namespace,
+                            plural="sensors",
+                            body=sensor_template,
+                        )
+                    )
+                except self._client.rest.ApiException as e:
+                    raise ArgoClientException(
+                        json.loads(e.body)["message"]
+                        if e.body is not None
+                        else e.reason
+                    )
+            else:
+                raise ArgoClientException(
+                    json.loads(e.body)["message"] if e.body is not None else e.reason
+                )
+        try:
+            return self._client.CustomObjectsApi().replace_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="sensors",
+                name=name,
+                body=sensor_template,
+            )
+        except self._client.rest.ApiException as e:
+            raise ArgoClientException(
+                json.loads(e.body)["message"] if e.body is not None else e.reason
+            )
+
+    def remove_existing_trigger_on_template(self, name, dry_run=False):
+        if dry_run:
+            return self._describe_remove_existing_trigger_on_template(name)
+        else:
+            return self._remove_existing_trigger_on_template(name)
+
+    def _remove_existing_trigger_on_template(self, name):
+        try:
+            self._client.CustomObjectsApi().delete_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="sensors",
+                name=name,
+                grace_period_seconds=0,
+            )
+            return (True,)
+        except self._client.rest.ApiException as e:
+            if e.status == 404:
+                return (False,)
+
+            raise ArgoClientException(
+                json.loads(e.body)["message"] if e.body is not None else e.reason
+            )
+
+    def _describe_remove_existing_trigger_on_template(self, name):
+        try:
+            results = self._client.CustomObjectsApi().list_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="sensors",
+                watch=False,
+            )
+            templates = results["items"]
+            for t in templates:
+                if t["metadata"]["name"] == name:
+                    annotations = t["metadata"]["annotations"]
+                    triggered_by = annotations["metaflow/triggered_by"]
+                    trigger_status = annotations["metaflow/trigger_status"]
+                    return (True, triggered_by, trigger_status)
+            return (False,)
+        except self._client.rest.ApiException as e:
+            if e.status == 404:
+                return (False,)
+
+            raise ArgoClientException(
+                json.loads(e.body)["message"] if e.body is not None else e.reason
+            )
+
+    def remove_existing_workflow_template(self, flow_name, dry_run=False):
+        if dry_run:
+            return self._describe_remove_existing_workflow_template(flow_name)
+        else:
+            return self._remove_existing_workflow_template(flow_name)
+
+    def _describe_remove_existing_workflow_template(self, name):
+        try:
+            self._client.CustomObjectsApi().get_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="workflowtemplates",
+                name=name,
+            )
+            return True
+        except self._client.rest.ApiException as e:
+            if e.status == 404:
+                return False
+
+            raise ArgoClientException(
+                json.loads(e.body)["message"] if e.body is not None else e.reason
+            )
+
+    def _remove_existing_workflow_template(self, flow_name):
+        try:
+            self._client.CustomObjectsApi().delete_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="workflowtemplates",
+                name=flow_name,
+            )
+            return True
+        except self._client.rest.ApiException as e:
+            if e.status == 404:
+                return False
+
+            raise ArgoClientException(
+                json.loads(e.body)["message"] if e.body is not None else e.reason
+            )

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -8,10 +8,20 @@ from hashlib import sha1
 
 from metaflow import JSONType, current, decorators, parameters
 from metaflow._vendor import click
-from metaflow.metaflow_config import METADATA_SERVICE_VERSION_CHECK
+from metaflow.metaflow_config import (
+    METADATA_SERVICE_VERSION_CHECK,
+    KUBERNETES_NAMESPACE,
+)
 from metaflow.exception import MetaflowException, MetaflowInternalError
 from metaflow.package import MetaflowPackage
 from metaflow.plugins import EnvironmentDecorator, KubernetesDecorator
+from .util import (
+    current_flow_name,
+    format_flow_name,
+    parse_flow_name,
+    format_sensor_name,
+    status_present_tense,
+)
 
 # TODO: Move production_token to utils
 from metaflow.plugins.aws.step_functions.production_token import (
@@ -23,6 +33,7 @@ from metaflow.util import get_username, to_bytes, to_unicode
 from metaflow.tagging_util import validate_tags
 
 from .argo_workflows import ArgoWorkflows
+from .argo_client import ArgoClient
 
 VALID_NAME = re.compile("^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$")
 
@@ -128,6 +139,7 @@ def argo_workflows(obj, name=None):
     "are processed first if Argo Workflows controller is configured to process limited "
     "number of workflows in parallel",
 )
+@click.option("--ignore-events", is_flag=True, help="Skip event setup")
 @click.pass_obj
 def create(
     obj,
@@ -140,10 +152,19 @@ def create(
     max_workers=None,
     workflow_timeout=None,
     workflow_priority=None,
+    ignore_events=False,
 ):
     validate_tags(tags)
 
     obj.echo("Deploying *%s* to Argo Workflows..." % obj.workflow_name, bold=True)
+    if ignore_events:
+        obj.echo("Workflow trigger setup and event dispatch will be skipped.")
+    else:
+        data = current.get("trigger_on_error")
+        if data is not None:
+            err = MetaflowException(msg=data["message"])
+            err.headline = data["headline"]
+            raise err
 
     if METADATA_SERVICE_VERSION_CHECK:
         # TODO: Consider dispelling with this check since it's been 2 years since the
@@ -171,10 +192,14 @@ def create(
         max_workers,
         workflow_timeout,
         workflow_priority,
+        ignore_events,
     )
 
     if only_json:
         obj.echo_always(str(flow), err=False, no_bold=True)
+        if flow.trigger_on_template() is not None:
+            obj.echo_always("", err=False, no_bold=True)
+            obj.echo_always(str(flow.trigger_on_template()), err=False, no_bold=True)
     else:
         flow.deploy()
         obj.echo(
@@ -324,7 +349,15 @@ def resolve_workflow_name(obj, name):
 
 
 def make_flow(
-    obj, token, name, tags, namespace, max_workers, workflow_timeout, workflow_priority
+    obj,
+    token,
+    name,
+    tags,
+    namespace,
+    max_workers,
+    workflow_timeout,
+    workflow_priority,
+    ignore_events,
 ):
     # TODO: Make this check less specific to Amazon S3 as we introduce
     #       support for more cloud object stores.
@@ -370,6 +403,7 @@ def make_flow(
         username=get_username(),
         workflow_timeout=workflow_timeout,
         workflow_priority=workflow_priority,
+        ignore_events=ignore_events,
     )
 
 
@@ -512,3 +546,75 @@ def trigger(obj, run_id_file=None, **kwargs):
         "(run-id *{run_id}*).".format(name=obj.workflow_name, run_id=run_id),
         bold=True,
     )
+
+
+@argo_workflows.command(
+    help="Remove any Argo Workflows template and sensors for this workflow."
+)
+@click.option(
+    "--dry-run",
+    default=False,
+    is_flag=True,
+    help="Display what would be deleted without performing deletion",
+)
+@click.option(
+    "--project", default=None, show_default=False, type=str, help="Project name"
+)
+@click.option("--branch", default=None, show_default=True, type=str, help="Branch name")
+@click.pass_obj
+def delete(obj, dry_run=False, project=None, branch=None):
+    current_user = get_username()
+    parsed = list(parse_flow_name(current_flow_name()))
+    if project is not None:
+        parsed[0] = project
+    if branch is not None:
+        parsed[1] = branch
+    else:
+        parsed[1] = ".".join(["user", get_username()])
+    submitted_flow_name = format_flow_name(
+        parsed[2], project_name=parsed[0], branch_name=parsed[1]
+    )[0]
+    sensor_name = format_sensor_name(submitted_flow_name)
+    client = ArgoClient(namespace=KUBERNETES_NAMESPACE)
+    result = client.remove_existing_trigger_on_template(sensor_name, dry_run=dry_run)
+    if dry_run:
+        if result[0]:
+            obj.echo(
+                "DELETE trigger *{sensor_name}* (executed when {workflow_name} {status}).".format(
+                    sensor_name=sensor_name,
+                    workflow_name=result[1],
+                    status=status_present_tense(result[2]),
+                ),
+            )
+        else:
+            obj.echo(
+                "Trigger for *{workflow_name}* not found.".format(
+                    workflow_name=submitted_flow_name
+                )
+            )
+    else:
+        if result[0]:
+            obj.echo("Deleted trigger *{sensor_name}*.".format(sensor_name=sensor_name))
+    result = client.remove_existing_workflow_template(
+        submitted_flow_name, dry_run=dry_run
+    )
+    if dry_run:
+        if result:
+            obj.echo(
+                "DELETE workflow template *{workflow_name}*.".format(
+                    workflow_name=submitted_flow_name
+                )
+            )
+        else:
+            obj.echo(
+                "Workflow template *{workflow_name}* not found.".format(
+                    workflow_name=submitted_flow_name
+                )
+            )
+    else:
+        if result:
+            obj.echo(
+                "Deleted workflow template *{workflow_name}*.".format(
+                    workflow_name=submitted_flow_name
+                )
+            )

--- a/metaflow/plugins/argo/event_decorators.py
+++ b/metaflow/plugins/argo/event_decorators.py
@@ -1,0 +1,63 @@
+from metaflow import current
+from metaflow.decorators import FlowDecorator, StepDecorator
+from metaflow.exception import MetaflowException
+from .util import are_events_configured, valid_statuses
+
+ERR_MSG = """Make sure configuration entries METAFLOW_EVENT_SOURCE_NAME, METAFLOW_EVENT_SOURCE_URL, and 
+METAFLOW_EVENT_SERVICE_ACCOUNT are correct.
+
+Authentication (Optional)
+=========================
+If authentication is required and credentials are stored in a Kubernetes secret, check
+METAFLOW_EVENT_AUTH_SECRET and METAFLOW_EVENT_AUTH_KEY.
+
+If an authentication token is used, verify METAFLOW_EVENT_AUTH_TOKEN has the correct value.
+"""
+
+
+class TriggerOnDecorator(FlowDecorator):
+
+    name = "trigger_on"
+    defaults = {"flow": None, "status": "succeeded"}
+    options = {
+        "flow": dict(
+            is_flag=False,
+            show_default=True,
+            help="Trigger the current flow when this flow completes.",
+        ),
+        "status": dict(
+            is_flag=False,
+            show_default=True,
+            help="Status of triggering flow. Valid values are 'succeeded', 'failed'",
+        ),
+    }
+
+    def flow_init(
+        self, flow, graph, environment, flow_datastore, metadata, logger, echo, options
+    ):
+        if are_events_configured():
+            self._option_values = options
+            flow_name = self.attributes.get("flow")
+            if flow_name is None:
+                raise MetaflowException(msg="@trigger_on needs a flow.")
+            status = self.attributes.get("status").lower()
+            if status not in valid_statuses():
+                raise MetaflowException(
+                    msg=(
+                        "@trigger_on requires status to be one of: %s."
+                        % (", ".join(valid_statuses()))
+                    )
+                )
+            # @project use is detected and flow name altered to fit
+            # when Argo Workflow templates are generated
+            current._update_env({"trigger_on": {"flow": flow_name, "status": status}})
+        else:
+            # Defer raising an error in case user has specified --ignore-triggers
+            current._update_env(
+                {
+                    "trigger_on_error": {
+                        "message": ERR_MSG,
+                        "headline": "@trigger_on requires eventing support",
+                    }
+                }
+            )

--- a/metaflow/plugins/argo/util.py
+++ b/metaflow/plugins/argo/util.py
@@ -1,0 +1,92 @@
+import os
+import re
+
+from metaflow.metaflow_config import (
+    EVENT_SOURCE_URL,
+    EVENT_SOURCE_NAME,
+    EVENT_SERVICE_ACCOUNT,
+)
+from metaflow.current import current
+from metaflow.exception import MetaflowException
+
+
+class BadEventConfig(MetaflowException):
+    headline = "Event configuration error"
+
+
+STATUS_TENSES = {"succeeded": "succeeds", "failed": "fails"}
+
+
+def event_topic():
+    if EVENT_SOURCE_URL is None:
+        raise BadEventConfig(msg="Required config entry EVENT_SOURCE_URL is missing.")
+    chunks = EVENT_SOURCE_URL.split("//")
+    if len(chunks) < 2:
+        raise BadEventConfig(msg="Unknown EVENT_SOURCE_URL format.")
+    url_chunks = chunks[1].split("/")
+    if len(url_chunks) < 2:
+        raise BadEventConfig(msg="EVENT_SOURCE_URL missing topic.")
+    return url_chunks[-1]
+
+
+def current_flow_name():
+    flow_name = current.get("project_flow_name")
+    if flow_name is None:
+        flow_name = current.flow_name
+    return flow_name.replace("_", "-").lower()
+
+
+# Parses a flow name into its constituent parts
+# Returns a tuple of (project_name, branch_name, flow_name)
+def parse_flow_name(flow_name):
+    chunks = flow_name.split(".")
+    chunk_count = len(chunks)
+    if chunk_count == 1:
+        return (None, None, chunks[0])
+    elif chunk_count == 3:
+        return (chunks[0], chunks[1], chunks[2])
+    elif chunk_count == 4:
+        return (chunks[0], ".".join((chunks[1], chunks[2])), chunks[3])
+    else:
+        raise MetaflowException(
+            msg="Unknown flow name format. "
+            + "Expected 1, 3, or 4 chunks and have %d" % chunk_count
+        )
+
+
+# This is a streamlined version of the logic from project_decorator.format_name()
+# Validation has been removed since the only time this function should return the
+# default flow name if the project decorator isn't used.
+def format_flow_name(flow_name, project_name=None, branch_name=None):
+    argo_name = flow_name.replace("_", "-").lower()
+    if not project_name:
+        return (flow_name, argo_name)
+
+    return (
+        ".".join((project_name, branch_name, flow_name)),
+        ".".join((project_name, branch_name, argo_name)),
+    )
+
+
+# Creates the Argo Event sensor name for a given workflow
+def format_sensor_name(flow_name):
+    updated = flow_name.replace("_", "-").lower()
+    return "mf-" + updated + "-after"
+
+
+def are_events_configured():
+    return (
+        EVENT_SOURCE_NAME is not None
+        and EVENT_SOURCE_URL is not None
+        and EVENT_SERVICE_ACCOUNT is not None
+    )
+
+
+# Translates workflow status into present tense
+# Ex: 'succeeded' becomes 'succeeds'
+def status_present_tense(status):
+    return STATUS_TENSES[status]
+
+
+def valid_statuses():
+    return list(STATUS_TENSES.keys())


### PR DESCRIPTION
This commit introduces event-triggering support for Argo Worklows orchestrated runs based on the status of another run by using Argo Events.

Given two flows, A and B, users can express:

* When A succeeds B should run
* When A fails B should run

When event support is enabled all flows will emit `metaflow_flow_run_succeeded` and `metaflow_flow_run_failed` events. Downstream flows, such as B in the above example, can declare a dependency on their upstream flow's success or failure by using the new `@trigger_on decorator`. Eventing support can be temporarily disabled with the `--ignore-events` CLI flag.

Argo Events support requirements:

* Argo Events installed and configured correctly
* Argo Event event source in the target K8s namespace (NATS and webhook event sources are supported)
* Ability to pull 3rd party images from Docker Hub

The last requirement is necessary due to Argo Events' design. It provides an API for creating event sources and sensors which listen for events from sources but assumes events will be sent to the source by an external system. Source for the event trigger image used here can be found at https://github.com/kevsmith/event-trigger.