### PR TITLE
Use json to dump/load decorator specs.

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -109,7 +109,7 @@ def echo_always(line, **kwargs):
         click.secho(ERASE_TO_EOL, **kwargs)
 
 
-def logger(body="", system_msg=False, head="", bad=False, timestamp=True):
+def logger(body="", system_msg=False, head="", bad=False, timestamp=True, nl=True):
     if timestamp:
         if timestamp is True:
             dt = datetime.now()
@@ -119,7 +119,7 @@ def logger(body="", system_msg=False, head="", bad=False, timestamp=True):
         click.secho(tstamp + " ", fg=LOGGER_TIMESTAMP, nl=False)
     if head:
         click.secho(head, fg=LOGGER_COLOR, nl=False)
-    click.secho(body, bold=system_msg, fg=LOGGER_BAD_COLOR if bad else None)
+    click.secho(body, bold=system_msg, fg=LOGGER_BAD_COLOR if bad else None, nl=nl)
 
 
 @click.group()

--- a/metaflow/debug.py
+++ b/metaflow/debug.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import inspect
 import sys
 
 from functools import partial
@@ -37,7 +38,9 @@ class Debug(object):
             s = args
         else:
             s = " ".join(args)
-        print("debug[%s]: %s" % (typ, s), file=sys.stderr)
+        lineno = inspect.currentframe().f_back.f_lineno
+        filename = inspect.stack()[1][1]
+        print("debug[%s %s:%s]: %s" % (typ, filename, lineno, s), file=sys.stderr)
 
     def noop(self, args):
         pass

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -122,7 +122,6 @@ class Decorator(object):
 
     @classmethod
     def _parse_decorator_spec(cls, deco_spec):
-        # print("REC: TL deco_spec is @@%s@@" % deco_spec)
         if len(deco_spec) == 0:
             return cls()
 
@@ -130,10 +129,6 @@ class Decorator(object):
         # TODO: Do we really want to allow spaces in the names of attributes?!?
         for a in re.split(""",(?=[\s\w]+=)""", deco_spec):
             name, val = a.split("=")
-            # print(
-            #    "REC: GOT @@%s@@ = @@%s@@"
-            #    % (name.strip(), val.strip().replace('\\"', '"'))
-            # )
             try:
                 val_parsed = json.loads(val.strip().replace('\\"', '"'))
             except json.JSONDecodeError:
@@ -148,10 +143,6 @@ class Decorator(object):
                         val_parsed = val.strip()
 
             attrs[name.strip()] = val_parsed
-            # print(
-            #    "REC: Set @@%s@@ = @@%s@@ of type %s"
-            #    % (name.strip(), attrs[name.strip()], type(attrs[name.strip()]))
-            # )
         return cls(attributes=attrs)
 
     def make_decorator_spec(self):
@@ -168,8 +159,6 @@ class Decorator(object):
                     attr_list.append("%s=%s" % (k, json.dumps(v).replace('"', '\\"')))
             attrstr = ",".join(attr_list)
             return "%s:%s" % (self.name, attrstr)
-            # print("SPEC IS @@%s@@" % s)
-            # return s
         else:
             return self.name
 
@@ -491,7 +480,6 @@ def _attach_decorators_to_step(step, decospecs):
 
     decos = {decotype.name: decotype for decotype in STEP_DECORATORS}
 
-    # print("REC: DECOSPECS ARE %s" % str(decospecs))
     for decospec in decospecs:
         splits = decospec.split(":", 1)
         deconame = splits[0]

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -1,4 +1,5 @@
 from functools import partial
+import json
 import re
 import os
 import sys
@@ -118,18 +119,19 @@ class Decorator(object):
         if len(top) == 1:
             return cls()
         else:
-            name, attrspec = top
-            attrs = dict(
-                map(lambda x: x.strip(), a.split("="))
-                for a in re.split(""",(?=[\s\w]+=)""", attrspec.strip("\"'"))
-            )
+            _, attrspec = top
+            attrs = {}
+            for a in re.split(""",(?=[\s\w]+=)""", attrspec):
+                name, val = a.split("=")
+                attrs[name.strip()] = json.loads(val.strip())
             return cls(attributes=attrs)
 
     def make_decorator_spec(self):
         attrs = {k: v for k, v in self.attributes.items() if v is not None}
         if attrs:
-            attrstr = ",".join("%s=%s" % x for x in attrs.items())
-            return "%s:%s" % (self.name, attrstr)
+            attrstr = ",".join("%s=%s" % (k, json.dumps(v)) for k, v in attrs.items())
+            s = "%s:%s" % (self.name, attrstr)
+            return s
         else:
             return self.name
 

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -120,6 +120,7 @@ from .test_unbounded_foreach_decorator import (
     InternalTestUnboundedForeachDecorator,
     InternalTestUnboundedForeachInput,
 )
+from .foo import FooDecorator
 from .conda.conda_step_decorator import CondaStepDecorator
 from .cards.card_decorator import CardDecorator
 from .frameworks.pytorch import PytorchParallelDecorator
@@ -137,6 +138,7 @@ STEP_DECORATORS = [
     KubernetesDecorator,
     StepFunctionsInternalDecorator,
     CondaStepDecorator,
+    FooDecorator,
     ParallelDecorator,
     PytorchParallelDecorator,
     InternalTestUnboundedForeachDecorator,

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -120,7 +120,6 @@ from .test_unbounded_foreach_decorator import (
     InternalTestUnboundedForeachDecorator,
     InternalTestUnboundedForeachInput,
 )
-from .foo import FooDecorator
 from .conda.conda_step_decorator import CondaStepDecorator
 from .cards.card_decorator import CardDecorator
 from .frameworks.pytorch import PytorchParallelDecorator
@@ -138,7 +137,6 @@ STEP_DECORATORS = [
     KubernetesDecorator,
     StepFunctionsInternalDecorator,
     CondaStepDecorator,
-    FooDecorator,
     ParallelDecorator,
     PytorchParallelDecorator,
     InternalTestUnboundedForeachDecorator,

--- a/metaflow/plugins/cards/card_decorator.py
+++ b/metaflow/plugins/cards/card_decorator.py
@@ -93,20 +93,7 @@ class CardDecorator(StepDecorator):
         self._logger = logger
         self.card_options = None
 
-        # Populate the defaults which may be missing.
-        missing_keys = set(self.defaults.keys()) - set(self.attributes.keys())
-        for k in missing_keys:
-            self.attributes[k] = self.defaults[k]
-
-        # when instantiation happens from the CLI we sometimes get stringified JSON and sometimes a dict for the
-        # `options` attributes. Hence we need to check for both and serialized.
-        if type(self.attributes["options"]) is str:
-            try:
-                self.card_options = json.loads(self.attributes["options"])
-            except json.decoder.JSONDecodeError:
-                self.card_options = self.defaults["options"]
-        else:
-            self.card_options = self.attributes["options"]
+        self.card_options = self.attributes["options"]
 
         evt_name = "step-init"
         # `'%s-%s'%(evt_name,step_name)` ensures that we capture this once per @card per @step.
@@ -253,8 +240,7 @@ class CardDecorator(StepDecorator):
         if self._user_set_card_id is not None:
             cmd += ["--id", str(self._user_set_card_id)]
 
-        # Doing this because decospecs parse information as str, since some non-runtime decorators pass it as bool we parse bool to str
-        if str(self.attributes["save_errors"]) == "True":
+        if self.attributes["save_errors"]:
             cmd += ["--render-error-card"]
 
         if temp_file is not None:

--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -95,13 +95,7 @@ class CondaStepDecorator(StepDecorator):
         base_deps = self.base_attributes["libraries"]
         deps.update(base_deps)
         step_deps = self.attributes["libraries"]
-        if isinstance(step_deps, (unicode, basestring)):
-            step_deps = step_deps.strip("\"{}'")
-            if step_deps:
-                step_deps = dict(
-                    map(lambda x: x.strip().strip("\"'"), a.split(":"))
-                    for a in step_deps.split(",")
-                )
+
         deps.update(step_deps)
         return deps
 


### PR DESCRIPTION
This cleaned up a few uses of the decospec where individual plugins were having to parse the decospec.

Two other minor changes to improve error message and allow for echoing without a nl