### PR TITLE
Env escape improvements and bug fixes

### DIFF
--- a/metaflow/plugins/env_escape/client.py
+++ b/metaflow/plugins/env_escape/client.py
@@ -51,10 +51,11 @@ class Client(object):
         data_transferer.defaultProtocol = max_pickle_version
 
         self._config_dir = config_dir
+        server_path, server_config = os.path.split(config_dir)
         # The client launches the server when created; we use
         # Unix sockets for now
         server_module = ".".join([__package__, "server"])
-        self._socket_path = "/tmp/%s_%d" % (os.path.basename(config_dir), os.getpid())
+        self._socket_path = "/tmp/%s_%d" % (server_config, os.getpid())
         if os.path.exists(self._socket_path):
             raise RuntimeError("Existing socket: %s" % self._socket_path)
         env = os.environ.copy()
@@ -66,9 +67,10 @@ class Client(object):
                 "-m",
                 server_module,
                 str(max_pickle_version),
+                server_config,
                 self._socket_path,
             ],
-            cwd=config_dir,
+            cwd=server_path,
             env=env,
             stdout=PIPE,
             stderr=PIPE,

--- a/metaflow/plugins/env_escape/client_modules.py
+++ b/metaflow/plugins/env_escape/client_modules.py
@@ -157,10 +157,9 @@ class ModuleImporter(object):
             )
             atexit.register(_clean_client, self._client)
 
+            # Get information about overrides and what the server knows about
             exports = self._client.get_exports()
-            sys.path.insert(0, self._config_dir)
-            overrides = importlib.import_module("overrides")
-            sys.path = sys.path[1:]
+            ex_overrides = self._client.get_local_exception_overrides()
 
             prefixes = set()
             export_classes = exports.get("classes", [])
@@ -173,15 +172,6 @@ class ModuleImporter(object):
             ):
                 splits = name.rsplit(".", 1)
                 prefixes.add(splits[0])
-
-            # Look for any exception overrides
-            ex_overrides = {}
-            for override in overrides.__dict__.values():
-                if isinstance(override, LocalException):
-                    cur_ex = ex_overrides.get(override.class_path, None)
-                    if cur_ex is not None:
-                        raise ValueError("Exception %s redefined" % override.class_path)
-                    ex_overrides[override.class_path] = override.wrapped_class
 
             # Now look at the exceptions coming from the server
             formed_exception_classes = {}

--- a/metaflow/plugins/env_escape/communication/socket_bytestream.py
+++ b/metaflow/plugins/env_escape/communication/socket_bytestream.py
@@ -58,6 +58,9 @@ class SocketByteStream(ByteStream):
                         m,
                         min(count, MAX_MSG_SIZE),
                     )
+                    # If we don't receive anything, we reached EOF
+                    if nbytes == 0:
+                        raise socket.error()
                     count -= nbytes
                     m = m[nbytes:]
                 except socket.timeout:

--- a/metaflow/plugins/env_escape/data_transferer.py
+++ b/metaflow/plugins/env_escape/data_transferer.py
@@ -5,7 +5,7 @@ import sys
 
 from collections import OrderedDict, defaultdict, namedtuple
 from copy import copy
-from datetime import datetime
+from datetime import datetime, timedelta
 
 ObjReference = namedtuple("ObjReference", "value_type class_name identifier")
 
@@ -38,13 +38,14 @@ _types = [
     defaultdict,
     OrderedDict,
     datetime,
+    timedelta,
 ]
 
 _container_types = (list, tuple, set, frozenset, dict, defaultdict, OrderedDict)
 
 if sys.version_info[0] >= 3:
     _types.extend([InvalidLong, InvalidUnicode])
-    _simple_types = (bool, int, float, complex, bytearray, bytes, datetime)
+    _simple_types = (bool, int, float, complex, bytearray, bytes, datetime, timedelta)
 else:
     _types.extend([long, unicode])  # noqa F821
     _simple_types = (
@@ -57,6 +58,7 @@ else:
         unicode,  # noqa F821
         long,  # noqa F821
         datetime,
+        timedelta,
     )
 
 _types_to_encoding = {x: idx for idx, x in enumerate(_types)}

--- a/metaflow/plugins/env_escape/server.py
+++ b/metaflow/plugins/env_escape/server.py
@@ -117,18 +117,19 @@ class Server(object):
         for override in override_values:
             if isinstance(override, (RemoteAttrOverride, RemoteOverride)):
                 for obj_name, obj_funcs in override.obj_mapping.items():
+                    obj_type = self._known_classes.get(
+                        obj_name, self._proxied_types.get(obj_name)
+                    )
+                    if obj_type is None:
+                        raise ValueError(
+                            "%s does not refer to a proxied or exported type" % obj_name
+                        )
                     if isinstance(override, RemoteOverride):
-                        override_dict = self._overrides.setdefault(
-                            self._known_classes[obj_name], {}
-                        )
+                        override_dict = self._overrides.setdefault(obj_type, {})
                     elif override.is_setattr:
-                        override_dict = self._setattr_overrides.setdefault(
-                            self._known_classes[obj_name], {}
-                        )
+                        override_dict = self._setattr_overrides.setdefault(obj_type, {})
                     else:
-                        override_dict = self._getattr_overrides.setdefault(
-                            self._known_classes[obj_name], {}
-                        )
+                        override_dict = self._getattr_overrides.setdefault(obj_type, {})
                     if isinstance(obj_funcs, str):
                         obj_funcs = (obj_funcs,)
                     for name in obj_funcs:

--- a/metaflow/plugins/env_escape/server.py
+++ b/metaflow/plugins/env_escape/server.py
@@ -60,19 +60,20 @@ BIND_RETRY = 1
 
 
 class Server(object):
-    def __init__(self, max_pickle_version):
+    def __init__(self, config_dir, max_pickle_version):
 
         self._max_pickle_version = data_transferer.defaultProtocol = max_pickle_version
         try:
-            mappings = importlib.import_module("server_mappings")
+            mappings = importlib.import_module(".server_mappings", package=config_dir)
         except Exception as e:
             raise RuntimeError(
                 "Cannot import server_mappings from '%s': %s" % (sys.path[0], str(e))
             )
         try:
-            # We know this is the "right" overrides since we are launched in the
-            # directory containing it.
-            override_module = importlib.import_module("overrides")
+            # Import module as a relative package to make sure that it is consistent
+            # with how the client does it -- this enables us to do the same type of
+            # relative imports in overrides
+            override_module = importlib.import_module(".overrides", package=config_dir)
             override_values = override_module.__dict__.values()
         except ImportError:
             # We ignore so the file can be non-existent if not needed
@@ -478,6 +479,7 @@ class Server(object):
 
 if __name__ == "__main__":
     max_pickle_version = int(sys.argv[1])
-    socket_path = sys.argv[2]
-    s = Server(max_pickle_version)
+    config_dir = sys.argv[2]
+    socket_path = sys.argv[3]
+    s = Server(config_dir, max_pickle_version)
     s.serve(path=socket_path)

--- a/metaflow/plugins/env_escape/server.py
+++ b/metaflow/plugins/env_escape/server.py
@@ -70,6 +70,8 @@ class Server(object):
                 "Cannot import server_mappings from '%s': %s" % (sys.path[0], str(e))
             )
         try:
+            # We know this is the "right" overrides since we are launched in the
+            # directory containing it.
             override_module = importlib.import_module("overrides")
             override_values = override_module.__dict__.values()
         except ImportError:


### PR DESCRIPTION
  - Properly handle the case of multiple `overrides` for different escaped libraries (previously, only the first override was considered)
  - Add datetime.timedelta to the list of simple types transferred
  - Allow the specification of override functions (and getattr/setattr) on additional proxied types.