### PR TITLE
issue 1040 fix: apply _sanitize to template names in Argo workflows

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -130,6 +130,13 @@ class ArgoWorkflows(object):
         except Exception as e:
             raise ArgoWorkflowsException(str(e))
 
+    @staticmethod
+    def _sanitize(name):
+        # Metaflow allows underscores in node names, which are disallowed in Argo
+        # Workflow template names - so we swap them with hyphens which are not
+        # allowed by Metaflow - guaranteeing uniqueness.
+        return name.replace("_", "-")
+
     @classmethod
     def trigger(cls, name, parameters={}):
         try:
@@ -369,12 +376,6 @@ class ArgoWorkflows(object):
 
     # Visit every node and yield the uber DAGTemplate(s).
     def _dag_templates(self):
-        def _sanitize(name):
-            # Metaflow allows underscores in node names, which are disallowed in Argo
-            # Workflow template names - so we swap them with hyphens which are not
-            # allowed by Metaflow - guaranteeing uniqueness.
-            return name.replace("_", "-")
-
         def _visit(node, exit_node=None, templates=[], dag_tasks=[]):
             # Every for-each node results in a separate subDAG and an equivalent
             # DAGTemplate rooted at the child of the for-each node. Each DAGTemplate
@@ -388,7 +389,7 @@ class ArgoWorkflows(object):
 
             if node.name == "start":
                 # Start node has no dependencies.
-                dag_task = DAGTask(_sanitize(node.name)).template(node.name)
+                dag_task = DAGTask(self._sanitize(node.name)).template(self._sanitize(node.name))
             elif (
                 node.is_inside_foreach
                 and self.graph[node.in_funcs[0]].type == "foreach"
@@ -400,8 +401,8 @@ class ArgoWorkflows(object):
                     Parameter("split-index").value("{{inputs.parameters.split-index}}"),
                 ]
                 dag_task = (
-                    DAGTask(_sanitize(node.name))
-                    .template(node.name)
+                    DAGTask(self._sanitize(node.name))
+                    .template(self._sanitize(node.name))
                     .arguments(Arguments().parameters(parameters))
                 )
             else:
@@ -411,16 +412,16 @@ class ArgoWorkflows(object):
                         compress_list(
                             [
                                 "argo-{{workflow.name}}/%s/{{tasks.%s.outputs.parameters.task-id}}"
-                                % (n, _sanitize(n))
+                                % (n, self._sanitize(n))
                                 for n in node.in_funcs
                             ]
                         )
                     )
                 ]
                 dag_task = (
-                    DAGTask(_sanitize(node.name))
-                    .dependencies([_sanitize(in_func) for in_func in node.in_funcs])
-                    .template(node.name)
+                    DAGTask(self._sanitize(node.name))
+                    .dependencies([self._sanitize(in_func) for in_func in node.in_funcs])
+                    .template(self._sanitize(node.name))
                     .arguments(Arguments().parameters(parameters))
                 )
             dag_tasks.append(dag_task)
@@ -441,7 +442,7 @@ class ArgoWorkflows(object):
                 )
             # For foreach nodes generate a new sub DAGTemplate
             elif node.type == "foreach":
-                foreach_template_name = _sanitize(
+                foreach_template_name = self._sanitize(
                     "%s-foreach-%s"
                     % (
                         node.name,
@@ -450,14 +451,14 @@ class ArgoWorkflows(object):
                 )
                 foreach_task = (
                     DAGTask(foreach_template_name)
-                    .dependencies([_sanitize(node.name)])
+                    .dependencies([self._sanitize(node.name)])
                     .template(foreach_template_name)
                     .arguments(
                         Arguments().parameters(
                             [
                                 Parameter("input-paths").value(
                                     "argo-{{workflow.name}}/%s/{{tasks.%s.outputs.parameters.task-id}}"
-                                    % (node.name, _sanitize(node.name))
+                                    % (node.name, self._sanitize(node.name))
                                 ),
                                 Parameter("split-index").value("{{item}}"),
                             ]
@@ -465,7 +466,7 @@ class ArgoWorkflows(object):
                     )
                     .with_param(
                         "{{tasks.%s.outputs.parameters.num-splits}}"
-                        % _sanitize(node.name)
+                        % self._sanitize(node.name)
                     )
                 )
                 dag_tasks.append(foreach_task)
@@ -485,7 +486,7 @@ class ArgoWorkflows(object):
                                 Parameter("task-id").valueFrom(
                                     {
                                         "parameter": "{{tasks.%s.outputs.parameters.task-id}}"
-                                        % _sanitize(
+                                        % self._sanitize(
                                             self.graph[node.matching_join].in_funcs[0]
                                         )
                                     }
@@ -496,7 +497,7 @@ class ArgoWorkflows(object):
                     .dag(DAGTemplate().fail_fast().tasks(dag_tasks_1))
                 )
                 join_foreach_task = (
-                    DAGTask(_sanitize(self.graph[node.matching_join].name))
+                    DAGTask(self._sanitize(self.graph[node.matching_join].name))
                     .template(self.graph[node.matching_join].name)
                     .dependencies([foreach_template_name])
                     .arguments(
@@ -835,7 +836,7 @@ class ArgoWorkflows(object):
             # twice, but due to issues with variable substitution, we will have to
             # live with this routine.
             yield (
-                Template(node.name)
+                Template(self._sanitize(node.name))
                 # Set @timeout values
                 .active_deadline_seconds(run_time_limit)
                 # Set service account


### PR DESCRIPTION
Resolves #1040 

- make `_sanitize` a static method so that it can be used by both `_dag_templates` and `_container_templates`
- apply `_sanitize` to the Template name in both `_dag_templates` and `_container_templates`

Prior to these changes, Argo Workflows will attempt to submit a pod with a name containing an underscore, which Kubernetes will reject

## Tested with
#### Versions
Metaflow 2.7.13
Argo Workflows 3.4.0
Kubernetes 1.25.3

#### Flow script
```python
# test_flow.py
from metaflow import FlowSpec, step, kubernetes

class TestFlow(FlowSpec):
    @kubernetes(cpu=1, memory=1000)
    @step
    def start(self):
        self.next(self.task_with_underscores)

    @kubernetes(cpu=1, memory=1000)
    @step
    def task_with_underscores(self):
        self.next(self.end)

    @kubernetes(cpu=1, memory=1000)
    @step
    def end(self):
        pass

if __name__ == "__main__":
    TestFlow()
```

#### CLI submission
```shell
python test_flow.py argo-workflows create
python test_flow.py argo-workflows trigger
```