### PR TITLE
Verify code hash

### DIFF
--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -144,6 +144,9 @@ class MetaflowEnvironment(object):
             "mflog 'Failed to download code package from %s "
             "after 6 tries. Exiting...' && exit 1; "
             "fi" % code_package_url,
+            "if [ `sha1sum job.tar | cut -d ' ' -f1` != $METAFLOW_CODE_SHA ]; then "
+            "mflog 'Hash does not match for code package from %s. Exiting...' && exit 1; "
+            "fi" % code_package_url,
             "TAR_OPTIONS='--warning=no-timestamp' tar xf job.tar",
             "mflog 'Task is starting.'",
         ]


### PR DESCRIPTION
This PR addresses issue https://github.com/Netflix/metaflow/issues/1172

By verifying the code SHA after it is downloaded, we have additional guarantees that the pipeline code was not tampered with. I've tested this simple implementation with success, both sha1sum and cut are available in the default Python docker image.