### PR TITLE
Add test that orig module is accessible

### DIFF
--- a/test/core/metaflow_extensions/test_org/plugins/frameworks/pytorch.py
+++ b/test/core/metaflow_extensions/test_org/plugins/frameworks/pytorch.py
@@ -1,0 +1,5 @@
+from metaflow.plugins.frameworks._orig.pytorch import PytorchParallelDecorator, setup_torch_distributed
+
+
+class NewPytorchParallelDecorator(PytorchParallelDecorator):
+    pass

--- a/test/core/metaflow_extensions/test_org/plugins/mfextinit_test_org.py
+++ b/test/core/metaflow_extensions/test_org/plugins/mfextinit_test_org.py
@@ -6,4 +6,4 @@ from .test_step_decorator import TestStepDecorator
 
 STEP_DECORATORS = [TestStepDecorator]
 
-__mf_promote_submodules__ = ["nondecoplugin"]
+__mf_promote_submodules__ = ["nondecoplugin", "frameworks"]

--- a/test/core/tests/extensions.py
+++ b/test/core/tests/extensions.py
@@ -16,6 +16,7 @@ class ExtensionsTest(MetaflowTest):
         from metaflow.plugins.nondecoplugin import my_value
 
         from metaflow.exception import MetaflowTestException
+        from metaflow.plugins.frameworks.pytorch import NewPytorchParallelDecorator
 
         self.plugin_value = my_value
         self.tl_value = tl_value


### PR DESCRIPTION
This PR adds a test that checks that the `_orig` module is accessible when a module is overwritten through extensions framework.