### PR TITLE
allow equal sign in decorator spec values

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -128,7 +128,7 @@ class Decorator(object):
         attrs = {}
         # TODO: Do we really want to allow spaces in the names of attributes?!?
         for a in re.split(""",(?=[\s\w]+=)""", deco_spec):
-            name, val = a.split("=")
+            name, val = a.split("=", 1)
             try:
                 val_parsed = json.loads(val.strip().replace('\\"', '"'))
             except json.JSONDecodeError:


### PR DESCRIPTION
We are running into a `ValueError` setting node selectors with `kubernetes` decorators. The issue is that we're trying to split a string that looks like `node_selector=["node.kubernetes.io/instance-type=g5.xlarge"]`, which happens to have two equal signs. This PR updates to split only on the first one.