### PR TITLE
Add support for Kubernetes tolerations

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -242,7 +242,7 @@ KUBERNETES_NAMESPACE = from_conf("KUBERNETES_NAMESPACE", "default")
 KUBERNETES_SERVICE_ACCOUNT = from_conf("KUBERNETES_SERVICE_ACCOUNT")
 # Default node selectors to use by K8S jobs created by Metaflow - foo=bar,baz=bab
 KUBERNETES_NODE_SELECTOR = from_conf("KUBERNETES_NODE_SELECTOR", "")
-KUBERNETES_TOLERATIONS = from_conf("METAFLOW_KUBERNETES_TOLERATIONS")
+KUBERNETES_TOLERATIONS = from_conf("METAFLOW_KUBERNETES_TOLERATIONS", "")
 KUBERNETES_SECRETS = from_conf("KUBERNETES_SECRETS", "")
 # Default GPU vendor to use by K8S jobs created by Metaflow (supports nvidia, amd)
 KUBERNETES_GPU_VENDOR = from_conf("KUBERNETES_GPU_VENDOR", "nvidia")

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -242,7 +242,7 @@ KUBERNETES_NAMESPACE = from_conf("KUBERNETES_NAMESPACE", "default")
 KUBERNETES_SERVICE_ACCOUNT = from_conf("KUBERNETES_SERVICE_ACCOUNT")
 # Default node selectors to use by K8S jobs created by Metaflow - foo=bar,baz=bab
 KUBERNETES_NODE_SELECTOR = from_conf("KUBERNETES_NODE_SELECTOR", "")
-KUBERNETES_TOLERATIONS = from_conf("METAFLOW_KUBERNETES_TOLERATIONS", "")
+KUBERNETES_TOLERATIONS = from_conf("KUBERNETES_TOLERATIONS", "")
 KUBERNETES_SECRETS = from_conf("KUBERNETES_SECRETS", "")
 # Default GPU vendor to use by K8S jobs created by Metaflow (supports nvidia, amd)
 KUBERNETES_GPU_VENDOR = from_conf("KUBERNETES_GPU_VENDOR", "nvidia")

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -242,6 +242,7 @@ KUBERNETES_NAMESPACE = from_conf("KUBERNETES_NAMESPACE", "default")
 KUBERNETES_SERVICE_ACCOUNT = from_conf("KUBERNETES_SERVICE_ACCOUNT")
 # Default node selectors to use by K8S jobs created by Metaflow - foo=bar,baz=bab
 KUBERNETES_NODE_SELECTOR = from_conf("KUBERNETES_NODE_SELECTOR", "")
+KUBERNETES_TOLERATIONS = from_conf("METAFLOW_KUBERNETES_TOLERATIONS")
 KUBERNETES_SECRETS = from_conf("KUBERNETES_SECRETS", "")
 # Default GPU vendor to use by K8S jobs created by Metaflow (supports nvidia, amd)
 KUBERNETES_GPU_VENDOR = from_conf("KUBERNETES_GPU_VENDOR", "nvidia")

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -853,7 +853,9 @@ class ArgoWorkflows(object):
                         for k in resources.get("node_selector").split(",")
                     }
                 except IndexError:
-                    raise ArgoWorkflowsException(f"Unable to parse node_selector {node_selector}")
+                    raise ArgoWorkflowsException(
+                        f"Unable to parse node_selector {node_selector}"
+                    )
             elif KUBERNETES_NODE_SELECTOR:
                 node_selector = KUBERNETES_NODE_SELECTOR.split(",")
 
@@ -881,7 +883,8 @@ class ArgoWorkflows(object):
                 .retry_strategy(
                     times=total_retries,
                     minutes_between_retries=minutes_between_retries,
-                ).metadata(
+                )
+                .metadata(
                     ObjectMeta().annotation("metaflow/step_name", node.name)
                     # Unfortunately, we can't set the task_id since it is generated
                     # inside the pod. However, it can be inferred from the annotation

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -147,8 +147,12 @@ class Kubernetes(object):
         disk=None,
         memory=None,
         run_time_limit=None,
-        env={},
+        env=None,
+        tolerations=None,
     ):
+
+        if env is None:
+            env = {}
 
         job = (
             KubernetesClient()
@@ -177,6 +181,7 @@ class Kubernetes(object):
                 # Retries are handled by Metaflow runtime
                 retries=0,
                 step_name=step_name,
+                tolerations=tolerations,
             )
             .environment_variable("METAFLOW_CODE_SHA", code_package_sha)
             .environment_variable("METAFLOW_CODE_URL", code_package_url)

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -11,6 +11,7 @@ from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
 from metaflow.mflog import TASK_LOG_SOURCE
 
 from .kubernetes import Kubernetes, KubernetesKilledException
+from .kubernetes_decorator import KubernetesDecorator
 
 
 @click.group()
@@ -172,6 +173,9 @@ def step(
     )
     stdout_location = ds.get_log_location(TASK_LOG_SOURCE, "stdout")
     stderr_location = ds.get_log_location(TASK_LOG_SOURCE, "stderr")
+
+    # Here node_selector is a tuple of strings, convert it to a dictionary
+    node_selector = KubernetesDecorator.parse_node_selector(node_selector)
 
     def _sync_metadata():
         if ctx.obj.metadata.TYPE == "local":

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -3,7 +3,7 @@ import sys
 import time
 import traceback
 
-from metaflow import util
+from metaflow import util, JSONTypeClass
 from metaflow._vendor import click
 from metaflow.exception import METAFLOW_EXIT_DISALLOW_RETRY, CommandException
 from metaflow.metadata.util import sync_local_metadata_from_datastore
@@ -84,6 +84,12 @@ def kubernetes():
     default=5 * 24 * 60 * 60,  # Default is set to 5 days
     help="Run time limit in seconds for Kubernetes pod.",
 )
+@click.option(
+    "--tolerations",
+    default=None,
+    type=JSONTypeClass(),
+    multiple=False,
+)
 @click.pass_context
 def step(
     ctx,
@@ -102,6 +108,7 @@ def step(
     gpu=None,
     gpu_vendor=None,
     run_time_limit=None,
+    tolerations=None,
     **kwargs
 ):
     def echo(msg, stream="stderr", job_id=None):
@@ -206,6 +213,7 @@ def step(
                 gpu_vendor=gpu_vendor,
                 run_time_limit=run_time_limit,
                 env=env,
+                tolerations=tolerations,
             )
     except Exception as e:
         traceback.print_exc(chain=False)

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -174,7 +174,7 @@ def step(
     stdout_location = ds.get_log_location(TASK_LOG_SOURCE, "stdout")
     stderr_location = ds.get_log_location(TASK_LOG_SOURCE, "stderr")
 
-    # Here node_selector is a tuple of strings, convert it to a dictionary
+    # `node_selector` is a tuple of strings, convert it to a dictionary
     node_selector = KubernetesDecorator.parse_node_selector(node_selector)
 
     def _sync_metadata():

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -108,9 +108,15 @@ class KubernetesDecorator(StepDecorator):
             self.attributes["node_selector"] = self.parse_node_selector(self.attributes["node_selector"].split(","))
 
         if self.attributes["tolerations"]:
-            from kubernetes.client import V1Toleration
+            attribute_map = [
+                "effect",
+                "key",
+                "operator",
+                "toleration_seconds",
+                "value",
+            ]
             for toleration in self.attributes["tolerations"]:
-                invalid_keys = [k for k in toleration.keys() if k not in V1Toleration.attribute_map.keys()]
+                invalid_keys = [k for k in toleration.keys() if k not in attribute_map]
                 if len(invalid_keys) > 0:
                     raise KubernetesException(f"Tolerations parameter contains invalid keys: {invalid_keys}")
 

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -82,7 +82,7 @@ class KubernetesDecorator(StepDecorator):
         "namespace": None,
         "gpu": None,  # value of 0 implies that the scheduled node should not have GPUs
         "gpu_vendor": None,
-        "tolerations": None,  # e.g., [{"key": "arch", "operator": "Equal", "value": "amd"}],
+        "tolerations": None,  # e.g., [{"key": "arch", "operator": "Equal", "value": "amd"},
                               #        {"key": "foo", "operator": "Equal", "value": "bar"}]
     }
     package_url = None

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -107,6 +107,13 @@ class KubernetesDecorator(StepDecorator):
         if isinstance(self.attributes["node_selector"], str):
             self.attributes["node_selector"] = self.parse_node_selector(self.attributes["node_selector"].split(","))
 
+        if self.attributes["tolerations"]:
+            from kubernetes.client import V1Toleration
+            for toleration in self.attributes["tolerations"]:
+                invalid_keys = [k for k in toleration.keys() if k not in V1Toleration.attribute_map.keys()]
+                if len(invalid_keys) > 0:
+                    raise KubernetesException(f"Tolerations parameter contains invalid keys: {invalid_keys}")
+
         # If no docker image is explicitly specified, impute a default image.
         if not self.attributes["image"]:
             # If metaflow-config specifies a docker image, just use that.

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -100,7 +100,7 @@ class KubernetesDecorator(StepDecorator):
         if not self.attributes["gpu_vendor"]:
             self.attributes["gpu_vendor"] = KUBERNETES_GPU_VENDOR
         if not self.attributes["node_selector"] and KUBERNETES_NODE_SELECTOR:
-            self.attributes["node_selector"] = KUBERNETES_NODE_SELECTOR
+            self.attributes["node_selector"] = KUBERNETES_NODE_SELECTOR.split(",")
         if not self.attributes["tolerations"] and KUBERNETES_TOLERATIONS:
             self.attributes["tolerations"] = KUBERNETES_TOLERATIONS
 
@@ -255,11 +255,10 @@ class KubernetesDecorator(StepDecorator):
             for k, v in self.attributes.items():
                 if k == "namespace":
                     cli_args.command_options["k8s_namespace"] = v
+                elif k == "tolerations":
+                    cli_args.command_options[k] = json.dumps(v)
                 else:
-                    if isinstance(v, (dict, list)):
-                        cli_args.command_options[k] = json.dumps(v)
-                    else:
-                        cli_args.command_options[k] = v
+                    cli_args.command_options[k] = v
             cli_args.command_options["run-time-limit"] = self.run_time_limit
             cli_args.entrypoint[0] = sys.executable
 

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -110,19 +110,16 @@ class KubernetesDecorator(StepDecorator):
             )
 
         if self.attributes["tolerations"]:
-            attribute_map = [
-                "effect",
-                "key",
-                "operator",
-                "toleration_seconds",
-                "value",
-            ]
-            for toleration in self.attributes["tolerations"]:
-                invalid_keys = [k for k in toleration.keys() if k not in attribute_map]
-                if len(invalid_keys) > 0:
-                    raise KubernetesException(
-                        "Tolerations parameter contains invalid keys: %s" % invalid_keys
-                    )
+            try:
+                from kubernetes.client import V1Toleration
+                for toleration in self.attributes["tolerations"]:
+                    invalid_keys = [k for k in toleration.keys() if k not in V1Toleration.attribute_map.keys()]
+                    if len(invalid_keys) > 0:
+                        raise KubernetesException(
+                            "Tolerations parameter contains invalid keys: %s" % invalid_keys
+                        )
+            except (NameError, ImportError):
+                pass
 
         # If no docker image is explicitly specified, impute a default image.
         if not self.attributes["image"]:

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -21,7 +21,7 @@ from metaflow.plugins import ResourcesDecorator
 from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task
 from metaflow.sidecar import Sidecar
 
-from metaflow.plugins.aws.aws_utils import get_docker_registry
+from ..aws.aws_utils import get_docker_registry
 
 from .kubernetes import KubernetesException
 

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -64,6 +64,10 @@ class KubernetesDecorator(StepDecorator):
         Kubernetes secrets to use when launching pod in Kubernetes. These
         secrets are in addition to the ones defined in `METAFLOW_KUBERNETES_SECRETS`
         in Metaflow configuration.
+    tolerations : List[str]
+        Kubernetes tolerations to use when launching pod in Kubernetes. If
+        not specified, the value of `METAFLOW_KUBERNETES_TOLERATIONS` is used
+        from Metaflow configuration.
     """
 
     name = "kubernetes"

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -84,7 +84,7 @@ class KubernetesDecorator(StepDecorator):
         "gpu": None,  # value of 0 implies that the scheduled node should not have GPUs
         "gpu_vendor": None,
         "tolerations": None,  # e.g., [{"key": "arch", "operator": "Equal", "value": "amd"},
-                              #        {"key": "foo", "operator": "Equal", "value": "bar"}]
+        #                              {"key": "foo", "operator": "Equal", "value": "bar"}]
     }
     package_url = None
     package_sha = None
@@ -105,7 +105,9 @@ class KubernetesDecorator(StepDecorator):
             self.attributes["tolerations"] = json.loads(KUBERNETES_TOLERATIONS)
 
         if isinstance(self.attributes["node_selector"], str):
-            self.attributes["node_selector"] = self.parse_node_selector(self.attributes["node_selector"].split(","))
+            self.attributes["node_selector"] = self.parse_node_selector(
+                self.attributes["node_selector"].split(",")
+            )
 
         if self.attributes["tolerations"]:
             attribute_map = [
@@ -118,7 +120,9 @@ class KubernetesDecorator(StepDecorator):
             for toleration in self.attributes["tolerations"]:
                 invalid_keys = [k for k in toleration.keys() if k not in attribute_map]
                 if len(invalid_keys) > 0:
-                    raise KubernetesException(f"Tolerations parameter contains invalid keys: {invalid_keys}")
+                    raise KubernetesException(
+                        f"Tolerations parameter contains invalid keys: {invalid_keys}"
+                    )
 
         # If no docker image is explicitly specified, impute a default image.
         if not self.attributes["image"]:
@@ -272,7 +276,9 @@ class KubernetesDecorator(StepDecorator):
                 if k == "namespace":
                     cli_args.command_options["k8s_namespace"] = v
                 elif k == "node_selector":
-                    cli_args.command_options[k] = ",".join(["=".join([key, str(val)]) for key, val in v.items()])
+                    cli_args.command_options[k] = ",".join(
+                        ["=".join([key, str(val)]) for key, val in v.items()]
+                    )
                 elif k == "tolerations":
                     cli_args.command_options[k] = json.dumps(v)
                 else:

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -112,6 +112,7 @@ class KubernetesDecorator(StepDecorator):
         if self.attributes["tolerations"]:
             try:
                 from kubernetes.client import V1Toleration
+
                 for toleration in self.attributes["tolerations"]:
                     try:
                         invalid_keys = [
@@ -391,6 +392,5 @@ class KubernetesDecorator(StepDecorator):
             }
         except (AttributeError, IndexError):
             raise KubernetesException(
-                "Unable to parse node_selector: %s"
-                % node_selector
+                "Unable to parse node_selector: %s" % node_selector
             )

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -78,7 +78,8 @@ class KubernetesDecorator(StepDecorator):
         "namespace": None,
         "gpu": None,  # value of 0 implies that the scheduled node should not have GPUs
         "gpu_vendor": None,
-        "tolerations": None,  # e.g., [{"key": "arch", "operator": "Equal", "value": "amd"}]
+        "tolerations": None,  # e.g., [{"key": "arch", "operator": "Equal", "value": "amd"}],
+                              #        {"key": "foo", "operator": "Equal", "value": "bar"}]
     }
     package_url = None
     package_sha = None

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -1,3 +1,4 @@
+import json
 import os
 import platform
 import sys
@@ -255,7 +256,10 @@ class KubernetesDecorator(StepDecorator):
                 if k == "namespace":
                     cli_args.command_options["k8s_namespace"] = v
                 else:
-                    cli_args.command_options[k] = v
+                    if isinstance(v, (dict, list)):
+                        cli_args.command_options[k] = json.dumps(v)
+                    else:
+                        cli_args.command_options[k] = v
             cli_args.command_options["run-time-limit"] = self.run_time_limit
             cli_args.entrypoint[0] = sys.executable
 

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -113,10 +113,15 @@ class KubernetesDecorator(StepDecorator):
             try:
                 from kubernetes.client import V1Toleration
                 for toleration in self.attributes["tolerations"]:
-                    invalid_keys = [k for k in toleration.keys() if k not in V1Toleration.attribute_map.keys()]
+                    invalid_keys = [
+                        k
+                        for k in toleration.keys()
+                        if k not in V1Toleration.attribute_map.keys()
+                    ]
                     if len(invalid_keys) > 0:
                         raise KubernetesException(
-                            "Tolerations parameter contains invalid keys: %s" % invalid_keys
+                            "Tolerations parameter contains invalid keys: %s"
+                            % invalid_keys
                         )
             except (NameError, ImportError):
                 pass

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -121,7 +121,7 @@ class KubernetesDecorator(StepDecorator):
                 invalid_keys = [k for k in toleration.keys() if k not in attribute_map]
                 if len(invalid_keys) > 0:
                     raise KubernetesException(
-                        f"Tolerations parameter contains invalid keys: {invalid_keys}"
+                        "Tolerations parameter contains invalid keys: %s" % invalid_keys
                     )
 
         # If no docker image is explicitly specified, impute a default image.

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -102,7 +102,7 @@ class KubernetesDecorator(StepDecorator):
         if not self.attributes["node_selector"] and KUBERNETES_NODE_SELECTOR:
             self.attributes["node_selector"] = KUBERNETES_NODE_SELECTOR.split(",")
         if not self.attributes["tolerations"] and KUBERNETES_TOLERATIONS:
-            self.attributes["tolerations"] = KUBERNETES_TOLERATIONS
+            self.attributes["tolerations"] = json.loads(KUBERNETES_TOLERATIONS)
 
         # If no docker image is explicitly specified, impute a default image.
         if not self.attributes["image"]:

--- a/metaflow/plugins/kubernetes/kubernetes_job.py
+++ b/metaflow/plugins/kubernetes/kubernetes_job.py
@@ -74,7 +74,10 @@ class KubernetesJob(object):
             try:
                 tolerations.append(client.V1Toleration(**toleration))
             except TypeError:
-                raise KubernetesJobException("Toleration definition contains invalid keys: %s" % toleration.keys())
+                raise KubernetesJobException(
+                    "Toleration definition contains invalid keys: %s"
+                    % toleration.keys()
+                )
 
         try:
             node_selector = {

--- a/metaflow/plugins/kubernetes/kubernetes_job.py
+++ b/metaflow/plugins/kubernetes/kubernetes_job.py
@@ -69,15 +69,6 @@ class KubernetesJob(object):
         # Note: This implementation ensures that there is only one unique Pod
         # (unique UID) per Metaflow task attempt.
         client = self._client.get()
-        tolerations = []
-        for toleration in self._kwargs.get("tolerations") or []:
-            try:
-                tolerations.append(client.V1Toleration(**toleration))
-            except TypeError:
-                raise KubernetesJobException(
-                    "Toleration definition contains invalid keys: %s"
-                    % toleration.keys()
-                )
 
         self._job = client.V1Job(
             api_version="batch/v1",
@@ -186,7 +177,8 @@ class KubernetesJob(object):
                         service_account_name=self._kwargs["service_account"],
                         # Terminate the container immediately on SIGTERM
                         termination_grace_period_seconds=0,
-                        tolerations=tolerations,
+                        tolerations=[client.V1Toleration(**toleration)
+                                     for toleration in self._kwargs.get("tolerations") or []],
                         # volumes=?,
                         # TODO (savin): Set termination_message_policy
                     ),

--- a/metaflow/plugins/kubernetes/kubernetes_job.py
+++ b/metaflow/plugins/kubernetes/kubernetes_job.py
@@ -79,14 +79,6 @@ class KubernetesJob(object):
                     % toleration.keys()
                 )
 
-        try:
-            node_selector = {
-                str(k.split("=", 1)[0]): str(k.split("=", 1)[1])
-                for k in self._kwargs.get("node_selector")
-            }
-        except IndexError:
-            raise KubernetesJobException(f"Unable to parse node_selector {self._kwargs.get('node_selector')}")
-
         self._job = client.V1Job(
             api_version="batch/v1",
             kind="Job",
@@ -179,7 +171,7 @@ class KubernetesJob(object):
                                 ),
                             )
                         ],
-                        node_selector=node_selector,
+                        node_selector=self._kwargs.get("node_selector"),
                         # TODO (savin): Support image_pull_secrets
                         # image_pull_secrets=?,
                         # TODO (savin): Support preemption policies

--- a/metaflow/plugins/kubernetes/kubernetes_job.py
+++ b/metaflow/plugins/kubernetes/kubernetes_job.py
@@ -177,8 +177,10 @@ class KubernetesJob(object):
                         service_account_name=self._kwargs["service_account"],
                         # Terminate the container immediately on SIGTERM
                         termination_grace_period_seconds=0,
-                        tolerations=[client.V1Toleration(**toleration)
-                                     for toleration in self._kwargs.get("tolerations") or []],
+                        tolerations=[
+                            client.V1Toleration(**toleration)
+                            for toleration in self._kwargs.get("tolerations") or []
+                        ],
                         # volumes=?,
                         # TODO (savin): Set termination_message_policy
                     ),


### PR DESCRIPTION
This PR adds support for `tolerations` in the Kubernetes and Argo plugins.

Testing Done:

Using the script `flow.py`
```python
DEFAULT_RESOURCES = {"cpu": "1", "gpu": "0", "memory": "1"}

from metaflow import (
    FlowSpec,
    step,
    timeout,
    kubernetes,
    resources,
)


class TestTolerationsFlow(FlowSpec):
    @resources(**DEFAULT_RESOURCES)
    @step
    def start(self):
        """
        This is the 'start' step. All flows must have a step named 'start' that
        is the first step in the flow.

        """
        self.next(self.end)

    @resources(**DEFAULT_RESOURCES)
    @step
    def end(self):
        """
        This is the 'end' step. All flows must have an 'end' step, which is the
        last step in the flow.

        """
        print("TestTolerationsFlow is all done.")


if __name__ == "__main__":
    TestTolerationsFlow()
```
Tested the following commands:
- `python3 flow.py run --with kubernetes`
- `python3 flow.py run --with kubernetes:node_selector=app=cpu`
- `python3 flow.py run --with kubernetes:node_selector=app=cpu,tolerations='[{"key":"app","value":"cpu","effect":"NoSchedule"}]'`
- `METAFLOW_KUBERNETES_TOLERATIONS='[{"key":"app","value":"cpu","effect":"NoSchedule"}]' python3 flow.py run --with kubernetes`
- `METAFLOW_KUBERNETES_TOLERATIONS='[{"key":"app","value":"cpu","effect":"NoSchedule"}]' METAFLOW_KUBERNETES_NODE_SELECTOR='app=cpu' python3 flow.py run --with kubernetes`
- `METAFLOW_KUBERNETES_TOLERATIONS='[{"key":"app","value":"cpu","effect":"NoSchedule"}]' METAFLOW_KUBERNETES_NODE_SELECTOR='app=cpu' python3 flow.py argo-workflows create`
- `python3 flow.py argo-workflows trigger`


With the script `flow_decorator.py`
```python
DEFAULT_RESOURCES = {"cpu": "1", "gpu": "0", "memory": "1"}
NODE_GROUP = "cpu"
KUBERNETES_NODE_SELECTOR = f"app={NODE_GROUP}"
KUBERNETES_TOLERATIONS = [{"key": "app", "effect": "NoSchedule", "value": NODE_GROUP}]

from metaflow import (
    FlowSpec,
    step,
    timeout,
    kubernetes,
    resources,
)


class TestTolerationsFlow(FlowSpec):
    @resources(**DEFAULT_RESOURCES)
    @kubernetes(node_selector=KUBERNETES_NODE_SELECTOR, tolerations=KUBERNETES_TOLERATIONS)
    @step
    def start(self):
        """
        This is the 'start' step. All flows must have a step named 'start' that
        is the first step in the flow.

        """
        self.next(self.end)

    @resources(**DEFAULT_RESOURCES)
    @kubernetes(node_selector=KUBERNETES_NODE_SELECTOR, tolerations=KUBERNETES_TOLERATIONS)
    @step
    def end(self):
        """
        This is the 'end' step. All flows must have an 'end' step, which is the
        last step in the flow.

        """
        print("TestTolerationsFlow is all done.")


if __name__ == "__main__":
    TestTolerationsFlow()
```

- `python3 flow_decorator.py run`
- `python3 flow_decorator.py argo-workflows create`
- `python3 flow_decorator.py argo-workflows trigger`

In all the executions, verified that the pods have the expected `Tolerations` and `nodeSelectors`