### PR TITLE
add parameter_names property to current with docstring

### DIFF
--- a/metaflow/current.py
+++ b/metaflow/current.py
@@ -16,6 +16,7 @@ class Current(object):
         self._username = None
         self._metadata_str = None
         self._is_running = False
+        self._parameter_names = None
 
         def _raise(ex):
             raise ex
@@ -219,6 +220,18 @@ class Current(object):
             num_nodes=int(os.environ.get("MF_PARALLEL_NUM_NODES", "1")),
             node_index=int(os.environ.get("MF_PARALLEL_NODE_INDEX", "0")),
         )
+
+    @property
+    def parameter_names(self):
+        """
+        The names of the Parameters defined in the current flow.
+
+        Returns
+        -------
+        List[str]
+            Parameter names.
+        """
+        return self._parameter_names
 
     @property
     def tags(self):


### PR DESCRIPTION
See https://outerbounds-community.slack.com/archives/C020U025QJK/p1670331712790799

This will require changes to the docs site too - https://github.com/Netflix/metaflow-docs/blob/master/docs/api/current.ipynb. Happy to open a PR for that after this is merged :) 