### PR TITLE
Since we're now providing type annotations, add typed marker as per PEP-561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     py_modules=[
         "metaflow",
     ],
-    package_data={"metaflow": ["tutorials/*/*"]},
+    package_data={"metaflow": ["tutorials/*/*", "py.typed"]},
     entry_points="""
         [console_scripts]
         metaflow=metaflow.cmd.main_cli:start


### PR DESCRIPTION
Without this, if you run mypy on code that uses Metaflow, it will [complain](https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-library-stubs-or-py-typed-marker) about type stubs missing. 

https://peps.python.org/pep-0561/#packaging-type-information