### PR TITLE
support timezone when scheduling with Argo workflows

### DIFF
--- a/metaflow/plugins/argo/argo_client.py
+++ b/metaflow/plugins/argo/argo_client.py
@@ -116,7 +116,7 @@ class ArgoClient(object):
                 json.loads(e.body)["message"] if e.body is not None else e.reason
             )
 
-    def schedule_workflow_template(self, name, schedule=None):
+    def schedule_workflow_template(self, name, schedule=None, timezone=None):
         # Unfortunately, Kubernetes client does not handle optimistic
         # concurrency control by itself unlike kubectl
         client = self._kubernetes_client.get()
@@ -127,6 +127,7 @@ class ArgoClient(object):
             "spec": {
                 "suspend": schedule is None,
                 "schedule": schedule,
+                "timezone": timezone,
                 "workflowSpec": {"workflowTemplateRef": {"name": name}},
             },
         }

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -120,6 +120,7 @@ class ArgoWorkflows(object):
         self.parameters = self._process_parameters()
         self._workflow_template = self._compile()
         self._cron = self._cron()
+        self._timezone = self._timezone()
 
     def __str__(self):
         return str(self._workflow_template)
@@ -179,10 +180,14 @@ class ArgoWorkflows(object):
             return " ".join(schedule.schedule.split()[:5])
         return None
 
+    def _timezone(self):
+        schedule = self.flow._flow_decorators.get("schedule")
+        return schedule.timezone if schedule else None
+
     def schedule(self):
         try:
             ArgoClient(namespace=KUBERNETES_NAMESPACE).schedule_workflow_template(
-                self.name, self._cron
+                self.name, self._cron, self._timezone
             )
         except Exception as e:
             raise ArgoWorkflowsSchedulingException(str(e))

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -120,7 +120,6 @@ class ArgoWorkflows(object):
         self.parameters = self._process_parameters()
         self._workflow_template = self._compile()
         self._cron = self._cron()
-        self._timezone = self._timezone()
 
     def __str__(self):
         return str(self._workflow_template)
@@ -177,17 +176,14 @@ class ArgoWorkflows(object):
         schedule = self.flow._flow_decorators.get("schedule")
         if schedule:
             # Remove the field "Year" if it exists
-            return " ".join(schedule.schedule.split()[:5])
+            return " ".join(schedule.schedule.split()[:5]), schedule.timezone
         return None
-
-    def _timezone(self):
-        schedule = self.flow._flow_decorators.get("schedule")
-        return schedule.timezone if schedule else None
 
     def schedule(self):
         try:
+            cron, timezone = self._cron
             ArgoClient(namespace=KUBERNETES_NAMESPACE).schedule_workflow_template(
-                self.name, self._cron, self._timezone
+                self.name, cron, timezone
             )
         except Exception as e:
             raise ArgoWorkflowsSchedulingException(str(e))

--- a/metaflow/plugins/aws/step_functions/schedule_decorator.py
+++ b/metaflow/plugins/aws/step_functions/schedule_decorator.py
@@ -18,6 +18,9 @@ class ScheduleDecorator(FlowDecorator):
     cron : str
         Run the workflow at [a custom Cron schedule](https://docs.aws.amazon.com/eventbridge/latest/userguide/scheduled-events.html#cron-expressions)
         specified by this expression.
+    timezone : str
+        Timezone on which the schedule runs (default: None). Currently supported only for Argo workflows,
+        which accepts timezones in [IANA format](https://nodatime.org/TimeZones).
     """
 
     name = "schedule"

--- a/metaflow/plugins/aws/step_functions/schedule_decorator.py
+++ b/metaflow/plugins/aws/step_functions/schedule_decorator.py
@@ -21,7 +21,13 @@ class ScheduleDecorator(FlowDecorator):
     """
 
     name = "schedule"
-    defaults = {"cron": None, "weekly": False, "daily": True, "hourly": False, "timezone": None}
+    defaults = {
+        "cron": None,
+        "weekly": False,
+        "daily": True,
+        "hourly": False,
+        "timezone": None,
+    }
 
     def flow_init(
         self, flow, graph, environment, flow_datastore, metadata, logger, echo, options

--- a/metaflow/plugins/aws/step_functions/schedule_decorator.py
+++ b/metaflow/plugins/aws/step_functions/schedule_decorator.py
@@ -21,7 +21,7 @@ class ScheduleDecorator(FlowDecorator):
     """
 
     name = "schedule"
-    defaults = {"cron": None, "weekly": False, "daily": True, "hourly": False}
+    defaults = {"cron": None, "weekly": False, "daily": True, "hourly": False, "timezone": None}
 
     def flow_init(
         self, flow, graph, environment, flow_datastore, metadata, logger, echo, options
@@ -38,3 +38,5 @@ class ScheduleDecorator(FlowDecorator):
             self.schedule = "0 0 * * ? *"
         else:
             self.schedule = None
+
+        self.timezone = self.attributes["timezone"]

--- a/metaflow/plugins/aws/step_functions/schedule_decorator.py
+++ b/metaflow/plugins/aws/step_functions/schedule_decorator.py
@@ -45,4 +45,5 @@ class ScheduleDecorator(FlowDecorator):
         else:
             self.schedule = None
 
+        # Argo Workflows supports the IANA timezone standard, e.g. America/Los_Angeles
         self.timezone = self.attributes["timezone"]

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -328,6 +328,7 @@ class StepFunctions(object):
 
     def _cron(self):
         schedule = self.flow._flow_decorators.get("schedule")
+        assert schedule.timezone is None, "Step Functions does not support scheduling with a timezone."
         if schedule:
             return schedule.schedule
         return None

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -328,8 +328,8 @@ class StepFunctions(object):
 
     def _cron(self):
         schedule = self.flow._flow_decorators.get("schedule")
-        assert schedule.timezone is None, "Step Functions does not support scheduling with a timezone."
         if schedule:
+            assert schedule.timezone is None, "Step Functions does not support scheduling with a timezone."
             return schedule.schedule
         return None
 

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -329,9 +329,10 @@ class StepFunctions(object):
     def _cron(self):
         schedule = self.flow._flow_decorators.get("schedule")
         if schedule:
-            assert (
-                schedule.timezone is None
-            ), "Step Functions does not support scheduling with a timezone."
+            if schedule.timezone is not None:
+                raise StepFunctionsException(
+                    "Step Functions does not support scheduling with a timezone."
+                )
             return schedule.schedule
         return None
 

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -329,7 +329,9 @@ class StepFunctions(object):
     def _cron(self):
         schedule = self.flow._flow_decorators.get("schedule")
         if schedule:
-            assert schedule.timezone is None, "Step Functions does not support scheduling with a timezone."
+            assert (
+                schedule.timezone is None
+            ), "Step Functions does not support scheduling with a timezone."
             return schedule.schedule
         return None
 


### PR DESCRIPTION
This PR adds support for specifying a timezone when scheduling Argo workflows.

The relevant Argo documentation is here: https://argoproj.github.io/argo-workflows/cron-workflows/#cronworkflow-options
