### PR TITLE
Allow a flow to customize the content of the package

### DIFF
--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -132,9 +132,16 @@ class MetaflowPackage(object):
         for path_tuple in self.environment.add_to_package():
             yield path_tuple
 
+        flowdir = os.path.dirname(os.path.abspath(sys.argv[0])) + "/"
         if "packager" in self._flow._flow_decorators:
-            for path_tuple in self._flow._flow_decorators["packager"][0].path_tuples():
-                yield path_tuple
+            packager = self._flow._flow_decorators["packager"][0]
+            for suffixes, source, target in packager.path_tuples(flowdir):
+                if suffixes is None:
+                    yield source, target
+                else:
+                    for fname, tname in self._walk(source, suffixes=suffixes):
+                        yield fname, os.path.join(target, os.path.relpath(tname, source))
+
             flow_file = os.path.abspath(sys.argv[0])
             yield flow_file, os.path.basename(flow_file)
         elif R.use_r():
@@ -148,7 +155,6 @@ class MetaflowPackage(object):
                 yield path_tuple
         else:
             # the user's working directory
-            flowdir = os.path.dirname(os.path.abspath(sys.argv[0])) + "/"
             for path_tuple in self._walk(flowdir, suffixes=self.suffixes):
                 yield path_tuple
 

--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -139,8 +139,8 @@ class MetaflowPackage(object):
                 if suffixes is None:
                     yield source, target
                 else:
-                    for fname, tname in self._walk(source, suffixes=suffixes):
-                        yield fname, os.path.join(target, os.path.relpath(tname, source))
+                    for fname, _ in self._walk(source, suffixes=suffixes):
+                        yield fname, os.path.join(target, os.path.relpath(fname, source))
 
             flow_file = os.path.abspath(sys.argv[0])
             yield flow_file, os.path.basename(flow_file)

--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -131,7 +131,13 @@ class MetaflowPackage(object):
         # the package folders for environment
         for path_tuple in self.environment.add_to_package():
             yield path_tuple
-        if R.use_r():
+
+        if "packager" in self._flow._flow_decorators:
+            for path_tuple in self._flow._flow_decorators["packager"][0].path_tuples():
+                yield path_tuple
+            flow_file = os.path.abspath(sys.argv[0])
+            yield flow_file, os.path.basename(flow_file)
+        elif R.use_r():
             # the R working directory
             for path_tuple in self._walk(
                 "%s/" % R.working_dir(), suffixes=self.suffixes

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -55,6 +55,7 @@ FLOW_DECORATORS_DESC = [
     ("conda_base", ".conda.conda_flow_decorator.CondaFlowDecorator"),
     ("schedule", ".aws.step_functions.schedule_decorator.ScheduleDecorator"),
     ("project", ".project_decorator.ProjectDecorator"),
+    ("packager", ".packager_decorator.PackagerDecorator"),
 ]
 
 # Add environments here

--- a/metaflow/plugins/packager_decorator.py
+++ b/metaflow/plugins/packager_decorator.py
@@ -1,0 +1,12 @@
+from metaflow.decorators import FlowDecorator
+
+class PackagerDecorator(FlowDecorator):
+    name = "packager"
+    defaults = {"generator": None}
+
+    def flow_init(self, flow, graph, environment, flow_datastore, metadata, logger, echo, options):
+        self._generator = self.attributes.get("generator")
+
+    def path_tuples(self):
+        for path_tuple in self._generator():
+            yield path_tuple

--- a/metaflow/plugins/packager_decorator.py
+++ b/metaflow/plugins/packager_decorator.py
@@ -1,12 +1,26 @@
+import os
+from pathlib import Path
+from metaflow.metaflow_config import DEFAULT_PACKAGE_SUFFIXES
 from metaflow.decorators import FlowDecorator
 
 class PackagerDecorator(FlowDecorator):
     name = "packager"
-    defaults = {"generator": None}
+    defaults = {"generator": None, "content": None, "suffixes": DEFAULT_PACKAGE_SUFFIXES.split(",")}
 
     def flow_init(self, flow, graph, environment, flow_datastore, metadata, logger, echo, options):
-        self._generator = self.attributes.get("generator")
+        self._content  = self.attributes.get("content")
+        self._suffixes = self.attributes.get("suffixes")
 
-    def path_tuples(self):
-        for path_tuple in self._generator():
-            yield path_tuple
+    def path_tuples(self, flowdir):
+        _flowdir = Path(flowdir)
+        if type(self._content) in { list, tuple, set, frozenset }:
+            for path in self._content:
+                source   = (_flowdir / path).resolve()
+                target   = str(source.relative_to(_flowdir)) if source.is_relative_to(_flowdir) else source.parts[-1]
+                suffixes = self._suffixes if os.path.isdir(source) else None
+                yield (suffixes, str(source), target)
+        elif type(self._content) is dict:
+            for path, target in self._content.items():
+                source   = (_flowdir / path).resolve()
+                suffixes = self._suffixes if os.path.isdir(source) else None
+                yield (suffixes, str(source), target)

--- a/test/core/metaflow_test/__init__.py
+++ b/test/core/metaflow_test/__init__.py
@@ -171,6 +171,11 @@ class MetaflowCheck(object):
     def replace_tags(self, tags_to_remove, tags_to_add):
         raise NotImplementedError()
 
+    def assert_package_file_exists(self, filename):
+        raise NotImplementedError()
+
+    def assert_package_file_content(self, filename, content):
+        raise NotImplementedError()
 
 def new_checker(flow):
     from . import cli_check, metadata_check

--- a/test/core/metaflow_test/cli_check.py
+++ b/test/core/metaflow_test/cli_check.py
@@ -242,16 +242,21 @@ class CliCheck(MetaflowCheck):
                 with tarfile.open(tmp.name, "r:gz") as tar:
                     tar.extractall(path=tmpdir)
 
-                # load each file from the temporary directory into a dict
-                return {
-                    f: open(os.path.join(tmpdir, f), "rb").read()
-                    for f in os.listdir(tmpdir)
-                    if os.path.isfile(os.path.join(tmpdir, f))
-                }
+                files = []
+                for r, d, f in os.walk(tmpdir):
+                    for file in f:
+                        files.append(os.path.join(r, file))
 
-    def assert_package_file_exists(self, filename):
+                return { f.replace(f"{tmpdir}/", ""): open(f, "rb").read() for f in files }
+
+    def assert_package_file_existence(self, filename, exists=True):
         package_content = self._get_package_content()
-        assert filename in package_content, "File %s not found in package" % filename
+        if exists:
+            assert filename in package_content, "File %s not found in package" % filename
+        else:
+            assert (
+                filename not in package_content
+            ), "File %s unexpectedly found in package" % filename
 
     def assert_package_file_content(self, filename, content):
         package_content = self._get_package_content()

--- a/test/core/metaflow_test/metadata_check.py
+++ b/test/core/metaflow_test/metadata_check.py
@@ -201,7 +201,7 @@ class MetadataCheck(MetaflowCheck):
         return self.run.replace_tags(tags_to_remove, tags_to_add)
 
     # is the package file part of the Python API?
-    def assert_package_file_exists(self, filename):
+    def assert_package_file_existence(self, filename, exists=True):
         return
 
     def assert_package_file_content(self, filename, content):

--- a/test/core/metaflow_test/metadata_check.py
+++ b/test/core/metaflow_test/metadata_check.py
@@ -199,3 +199,10 @@ class MetadataCheck(MetaflowCheck):
 
     def replace_tags(self, tags_to_remove, tags_to_add):
         return self.run.replace_tags(tags_to_remove, tags_to_add)
+
+    # is the package file part of the Python API?
+    def assert_package_file_exists(self, filename):
+        return
+
+    def assert_package_file_content(self, filename, content):
+        return

--- a/test/core/tests/custom_packager.py
+++ b/test/core/tests/custom_packager.py
@@ -1,0 +1,29 @@
+from metaflow_test import MetaflowTest, ExpectationFailed, steps, tag
+
+class CustomPackagerTest(MetaflowTest):
+  """
+  Test that a user provided packager works.
+  """
+
+  PRIORITY = 3
+
+  HEADER = """
+import os, sys
+from metaflow import packager
+
+with open('input.txt', mode='w') as f:
+  f.write("Regular Text File")
+
+def my_package_generator():
+  yield ("input.txt", "target.txt")
+
+@packager(generator=my_package_generator)
+"""
+
+  @steps(1, ["all"])
+  def step_all(self):
+    pass
+
+  def check_results(self, flow, checker):
+    checker.assert_package_file_exists("test_flow.py")
+    checker.assert_package_file_content("target.txt", b"Regular Text File")


### PR DESCRIPTION
This PR is intended to address #355 and to some extend #124.

We run Metaflow jobs as part of our CI/CD on a k8s cluster which requires more control of the version of the dependencies to be bundled in the package. This PR adds a `@packager` flow level decorator to define the content of the package.

The decorator takes a `content=` parameter which can either be a list-like object or a dict. The following example illustrates the function for a list-like object:
```
@packager(content=["subdirectory", "../peer-level-directory", "dataset.txt"])
```

- the directory `subdirectory` is walked and all files matching the default suffixes are placed at `subdirectory`
- the same applies to the directory `../peer-level-directory` is placed at `peer-level-directory`
- if a file is specified directly it is placed in the appropriate directory (at the top-level in this case) regardless of suffix

Using a dict as an argument this can be customized as follows:
```
@packager(content={ "../peer-level-directory": "package1", "subdirectory": "package2" })
```
