### PR TITLE
Allow a flow to specify the root directory of the package

### DIFF
--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -56,6 +56,7 @@ FLOW_DECORATORS_DESC = [
     ("conda_base", ".conda.conda_flow_decorator.CondaFlowDecorator"),
     ("schedule", ".aws.step_functions.schedule_decorator.ScheduleDecorator"),
     ("project", ".project_decorator.ProjectDecorator"),
+    ("packager", ".packager_decorator.PackagerDecorator"),
 ]
 
 # Add environments here

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -64,6 +64,7 @@ class Kubernetes(object):
     def _command(
         self,
         flow_name,
+        flow_dir,
         run_id,
         step_name,
         task_id,
@@ -91,6 +92,7 @@ class Kubernetes(object):
                 + step_cmds
             )
         )
+        cd_expr = "cd %s" % flow_dir if flow_dir else "true"
 
         # Construct an entry point that
         # 1) initializes the mflog environment (mflog_expr)
@@ -100,10 +102,11 @@ class Kubernetes(object):
         # The `true` command is to make sure that the generated command
         # plays well with docker containers which have entrypoint set as
         # eval $@
-        cmd_str = "true && mkdir -p %s && %s && %s && %s; " % (
+        cmd_str = "true && mkdir -p %s && %s && %s && %s && %s; " % (
             LOGS_DIR,
             mflog_expr,
             init_expr,
+            cd_expr,
             step_expr,
         )
         # After the task has finished, we save its exit code (fail/success)
@@ -139,6 +142,7 @@ class Kubernetes(object):
         code_package_ds,
         step_cli,
         docker_image,
+        flow_dir=None,
         service_account=None,
         secrets=None,
         node_selector=None,
@@ -166,6 +170,7 @@ class Kubernetes(object):
                 node_selector=node_selector,
                 command=self._command(
                     flow_name=flow_name,
+                    flow_dir=flow_dir,
                     run_id=run_id,
                     step_name=step_name,
                     task_id=task_id,

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -66,6 +66,7 @@ def kubernetes():
 @click.option("--memory", help="Memory requirement for Kubernetes pod.")
 @click.option("--gpu", help="GPU requirement for Kubernetes pod.")
 @click.option("--gpu-vendor", help="GPU vendor requirement for Kubernetes pod.")
+@click.option("--flow-dir", help="Location of the flow file in the code package.")
 @click.option("--run-id", help="Passed to the top-level 'step'.")
 @click.option("--task-id", help="Passed to the top-level 'step'.")
 @click.option("--input-paths", help="Passed to the top-level 'step'.")
@@ -98,6 +99,7 @@ def step(
     code_package_sha,
     code_package_url,
     executable=None,
+    flow_dir=None,
     image=None,
     service_account=None,
     secrets=None,
@@ -196,6 +198,7 @@ def step(
         with ctx.obj.monitor.measure("metaflow.kubernetes.launch_job"):
             kubernetes.launch_job(
                 flow_name=ctx.obj.flow.name,
+                flow_dir=flow_dir,
                 run_id=kwargs["run_id"],
                 step_name=step_name,
                 task_id=kwargs["task_id"],

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -84,6 +84,7 @@ class KubernetesDecorator(StepDecorator):
     }
     package_url = None
     package_sha = None
+    package_flow_dir = None
     run_time_limit = None
 
     def __init__(self, attributes=None, statically_defined=False):
@@ -275,6 +276,9 @@ class KubernetesDecorator(StepDecorator):
             cli_args.command_args.append(self.package_sha)
             cli_args.command_args.append(self.package_url)
 
+            if self.package_flow_dir:
+                cli_args.command_options["flow-dir"] = self.package_flow_dir
+
             # --namespace is used to specify Metaflow namespace (a different
             # concept from k8s namespace).
             for k, v in self.attributes.items():
@@ -398,6 +402,7 @@ class KubernetesDecorator(StepDecorator):
             cls.package_url, cls.package_sha = flow_datastore.save_data(
                 [package.blob], len_hint=1
             )[0]
+            cls.package_flow_dir = package.package_flow_dir
 
     @staticmethod
     def parse_node_selector(node_selector: list):

--- a/metaflow/plugins/packager_decorator.py
+++ b/metaflow/plugins/packager_decorator.py
@@ -1,0 +1,15 @@
+import os
+from pathlib import Path
+from metaflow.metaflow_config import DEFAULT_PACKAGE_SUFFIXES
+from metaflow.decorators import FlowDecorator
+
+class PackagerDecorator(FlowDecorator):
+    name = "packager"
+    defaults = {
+        "root": None
+    }
+
+    def flow_init(
+        self, flow, graph, environment, flow_datastore, metadata, logger, echo, options
+    ):
+        self.root = self.attributes.get("root")


### PR DESCRIPTION
This PR is intended to address #355 and is an alternative approach to the one implemented in #1260. It is not finished and should serve as a discussion point.

A new flow-level decorator is introduced which allows the user to specify a relative path:
```
@packager(root="..")
class MyFlow(FlowSpec):
  ....
```

When an explicit value for the root is specified, the content of the package is taken from that value as opposed to the directory of the flow file.

In its current state this PR will only work for the Kubernetes runner.