### PR TITLE
Replace instances of "INFO" with a constant

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -30,6 +30,7 @@ from metaflow.unbounded_foreach import CONTROL_TASK_TAG
 from metaflow.util import cached_property, resolve_identity, to_unicode, is_stringish
 
 from .filecache import FileCache
+from .. import INFO_FILE
 
 try:
     # python2
@@ -708,7 +709,9 @@ class MetaflowCode(object):
         code_obj = BytesIO(blobdata)
         self._tar = tarfile.open(fileobj=code_obj, mode="r:gz")
         # The JSON module in Python3 deals with Unicode. Tar gives bytes.
-        info_str = self._tar.extractfile("INFO").read().decode("utf-8")
+        info_str = (
+            self._tar.extractfile(os.path.basename(INFO_FILE)).read().decode("utf-8")
+        )
         self._info = json.loads(info_str)
         self._flowspec = self._tar.extractfile(self._info["script"]).read()
 

--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -10,7 +10,7 @@ from .extension_support import EXT_PKG, package_mfext_all
 from .metaflow_config import DEFAULT_PACKAGE_SUFFIXES
 from .exception import MetaflowException
 from .util import to_unicode
-from . import R
+from . import R, INFO_FILE
 
 DEFAULT_SUFFIXES_LIST = DEFAULT_PACKAGE_SUFFIXES.split(",")
 METAFLOW_SUFFIXES_LIST = [".py", ".html", ".css", ".js"]
@@ -147,7 +147,7 @@ class MetaflowPackage(object):
                 yield path_tuple
 
     def _add_info(self, tar):
-        info = tarfile.TarInfo("INFO")
+        info = tarfile.TarInfo(os.path.basename(INFO_FILE))
         env = self.environment.get_environment_info()
         buf = BytesIO()
         buf.write(json.dumps(env).encode("utf-8"))


### PR DESCRIPTION
The name "INFO" was used in disparate parts of the code and could leade to inconsistencies. This homogeneizes the use