### PR TITLE
When packaging `metaflow_extensions`, add an empty `__init__.py` file.

### DIFF
--- a/metaflow/extension_support/__init__.py
+++ b/metaflow/extension_support/__init__.py
@@ -149,6 +149,14 @@ def package_mfext_package(package_name):
 
 
 def package_mfext_all():
+    # When packaging extensions, we always add a __init__.py to make
+    # the packaged metaflow_extensions directory "self-contained" so that
+    # python doesn't go and search other parts of the system for more
+    # metaflow_extensions.
+    yield os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "_empty_file.py"
+    ), os.path.join(EXT_PKG, "__init__.py")
+
     for p in _all_packages:
         for path_tuple in package_mfext_package(p):
             yield path_tuple
@@ -752,7 +760,6 @@ def _get_extension_packages():
 
     # We have the load order globally; we now figure it out per extension point.
     for k, v in extension_points_to_pkg.items():
-
         # v is a dict distributionName/packagePath -> (dict tl_name -> MFPackage)
         l = [v[pkg].values() for pkg in mf_pkg_list if pkg in v]
         # In the case of the plugins.cards extension we allow those packages

--- a/metaflow/extension_support/_empty_file.py
+++ b/metaflow/extension_support/_empty_file.py
@@ -1,0 +1,2 @@
+# This file serves as a __init__.py for metaflow_extensions when it is packaged
+# and needs to remain empty.

--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -108,7 +108,10 @@ class MetaflowPackage(object):
 
         # Metaflow extensions; for now, we package *all* extensions but this may change
         # at a later date; it is possible to call `package_mfext_package` instead of
-        # `package_mfext_all`
+        # `package_mfext_all` but in that case, make sure to also add a
+        # metaflow_extensions/__init__.py file to properly "close" the metaflow_extensions
+        # package and prevent other extensions from being loaded that may be
+        # present in the rest of the system
         for path_tuple in package_mfext_all():
             yield path_tuple
 


### PR DESCRIPTION
This will force the packaged `metaflow_extensions` package to not be a namespace package and therefore prevent python from looking for other extensions that may be present on the remote system thereby giving the user the exact same metaflow environment as the one they had locally.

In particular, this closes off a sort of "code injection" possibility.