### PR TITLE
Cast values to `str` before passing to environment

### DIFF
--- a/metaflow/plugins/environment_decorator.py
+++ b/metaflow/plugins/environment_decorator.py
@@ -1,6 +1,3 @@
-import os
-
-from metaflow.exception import MetaflowException
 from metaflow.decorators import StepDecorator
 
 
@@ -20,4 +17,6 @@ class EnvironmentDecorator(StepDecorator):
     def runtime_step_cli(
         self, cli_args, retry_count, max_user_code_retries, ubf_context
     ):
-        cli_args.env.update(self.attributes["vars"].items())
+        cli_args.env.update(
+            {key: str(value) for key, value in self.attributes["vars"].items()}
+        )


### PR DESCRIPTION
On `master`, running this flow:
``` python
from metaflow import environment  # noqa F0401
from metaflow import FlowSpec, step


class MyFlow(FlowSpec):

    """Test non-str values passed to environment decorator."""

    @environment(vars={"FOO": 1})
    @step
    def start(self):
        """Start."""

        self.next(self.end)

    @step
    def end(self):
        """End."""

        pass
```
elicits an opaque error:
``` python
Metaflow 2.7.22.post2+git2f9e443 executing MyFlow for user:dpoznik
Validating your flow...
    The graph looks good!
Running pylint...
    Pylint is happy!
2023-02-18 00:18:58.104 Workflow starting (run-id 1676708338093700):
2023-02-18 00:18:58.108 Workflow failed.
2023-02-18 00:18:58.108 Terminating 0 active tasks...
2023-02-18 00:18:58.108 Flushing logs...
    Internal error
Traceback (most recent call last):
  File "/Users/dpoznik/repos/metaflow/metaflow/cli.py", line 1172, in main
    start(auto_envvar_prefix="METAFLOW", obj=state)
  File "/Users/dpoznik/repos/metaflow/metaflow/_vendor/click/core.py", line 829, in __call__
    return self.main(args, kwargs)
  File "/Users/dpoznik/repos/metaflow/metaflow/_vendor/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/dpoznik/repos/metaflow/metaflow/_vendor/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/dpoznik/repos/metaflow/metaflow/_vendor/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, ctx.params)
  File "/Users/dpoznik/repos/metaflow/metaflow/_vendor/click/core.py", line 610, in invoke
    return callback(args, kwargs)
  File "/Users/dpoznik/repos/metaflow/metaflow/cli.py", line 691, in wrapper
    return func(args, kwargs)
  File "/Users/dpoznik/repos/metaflow/metaflow/_vendor/click/decorators.py", line 33, in new_func
    return f(get_current_context().obj, args, kwargs)
  File "/Users/dpoznik/repos/metaflow/metaflow/cli.py", line 850, in run
    runtime.execute()
  File "/Users/dpoznik/repos/metaflow/metaflow/runtime.py", line 223, in execute
    self._launch_workers()
  File "/Users/dpoznik/repos/metaflow/metaflow/runtime.py", line 623, in _launch_workers
    self._launch_worker(task)
  File "/Users/dpoznik/repos/metaflow/metaflow/runtime.py", line 649, in _launch_worker
    worker = Worker(task, self._max_log_size)
  File "/Users/dpoznik/repos/metaflow/metaflow/runtime.py", line 1160, in __init__
    self._proc = self._launch()
  File "/Users/dpoznik/repos/metaflow/metaflow/runtime.py", line 1220, in _launch
    return subprocess.Popen(
  File "/Users/dpoznik/.pyenv/versions/3.10.4/lib/python3.10/subprocess.py", line 966, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/Users/dpoznik/.pyenv/versions/3.10.4/lib/python3.10/subprocess.py", line 1762, in _execute_child
    env_list.append(k + b'=' + os.fsencode(v))
  File "/Users/dpoznik/.pyenv/versions/3.10.4/lib/python3.10/os.py", line 810, in fsencode
    filename = fspath(filename)  # Does type-checking of `filename`.
TypeError: expected str, bytes or os.PathLike object, not int
```
Although not clear (to me) from the stack trace, the ultimate cause is attempting to set an environment variable to a non-`str` value.

The small change in this PR precludes this pitfall. With it, the test flow runs fine:
``` python
Metaflow 2.7.22.post3+gitcbd3bea executing MyFlow for user:dpoznik
Validating your flow...
    The graph looks good!
2023-02-18 00:27:54.346 Workflow starting (run-id 1676708874334483):
2023-02-18 00:27:54.356 [1676708874334483/start/1 (pid 12633)] Task is starting.
2023-02-18 00:27:55.015 [1676708874334483/start/1 (pid 12633)] Task finished successfully.
2023-02-18 00:27:55.028 [1676708874334483/end/2 (pid 12638)] Task is starting.
2023-02-18 00:27:55.669 [1676708874334483/end/2 (pid 12638)] Task finished successfully.
2023-02-18 00:27:55.671 Done!
```