### PR TITLE
Airflow Token creation bug fix

### DIFF
--- a/metaflow/plugins/airflow/airflow.py
+++ b/metaflow/plugins/airflow/airflow.py
@@ -109,8 +109,8 @@ class Airflow(object):
     @classmethod
     def get_existing_deployment(cls, name, flow_datastore):
         _backend = flow_datastore._storage_impl
-        token_exits, _ = _backend.info_file(cls.get_token_path(name))
-        if not token_exits:
+        token_exists = _backend.is_file([cls.get_token_path(name)])
+        if not token_exists[0]:
             return None
         with _backend.load_bytes([cls.get_token_path(name)]) as get_results:
             for _, path, _ in get_results:

--- a/metaflow/plugins/airflow/airflow_cli.py
+++ b/metaflow/plugins/airflow/airflow_cli.py
@@ -101,7 +101,7 @@ def resolve_token(
                 )
         obj.echo("")
         obj.echo("A new production token generated.")
-        Airflow.save_deployment_token(get_username(), token, obj.flow_datastore)
+        Airflow.save_deployment_token(get_username(), name, token, obj.flow_datastore)
     else:
         token = prev_token
 


### PR DESCRIPTION
There was a bug in the token retrieval code that would never retrieve the token. This PR fixes it. It uses `is_file` instead of `list_content` to check for token existence. Using `list_content` was the main cause of the bug. 