### PR TITLE
remove check for '/envs/' in conda pathname

### DIFF
--- a/metaflow/plugins/conda/conda.py
+++ b/metaflow/plugins/conda/conda.py
@@ -94,7 +94,7 @@ class Conda(object):
         for env in envs:
             name = os.path.basename(env)
             if name.startswith("metaflow_%s" % flow):
-                   ret[name] = env
+               ret[name] = env
         return ret
 
     def package_info(self, env_id):

--- a/metaflow/plugins/conda/conda.py
+++ b/metaflow/plugins/conda/conda.py
@@ -92,11 +92,9 @@ class Conda(object):
         envs = self._info()["envs"]
         ret = {}
         for env in envs:
-            # Named environments are always $CONDA_PREFIX/envs/
-            if "/envs/" in env:
-                name = os.path.basename(env)
-                if name.startswith("metaflow_%s" % flow):
-                    ret[name] = env
+            name = os.path.basename(env)
+            if name.startswith("metaflow_%s" % flow):
+                   ret[name] = env
         return ret
 
     def package_info(self, env_id):

--- a/metaflow/plugins/conda/conda.py
+++ b/metaflow/plugins/conda/conda.py
@@ -94,7 +94,7 @@ class Conda(object):
         for env in envs:
             name = os.path.basename(env)
             if name.startswith("metaflow_%s" % flow):
-               ret[name] = env
+                ret[name] = env
         return ret
 
     def package_info(self, env_id):

--- a/metaflow/plugins/conda/conda.py
+++ b/metaflow/plugins/conda/conda.py
@@ -162,10 +162,9 @@ class Conda(object):
     def _env_path(self, env_id):
         envs = self._info()["envs"]
         for env in envs:
-            if "/envs/" in env:
-                name = os.path.basename(env)
-                if name == env_id:
-                    return env
+            name = os.path.basename(env)
+            if name == env_id:
+                return env
         return None
 
     def _env_lock_file(self, env_id):


### PR DESCRIPTION
This fixes https://github.com/Netflix/metaflow/issues/1293

There shouldn't be a reason to check for the existence of `/env/` in the pathname, because there are already checks to see if the environment matches the flow ID