### PR TITLE
fix: stdout k8s and batch formatting

### DIFF
--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -177,7 +177,7 @@ def step(
         msg = util.to_unicode(msg)
         if batch_id:
             msg = "[%s] %s" % (batch_id, msg)
-        ctx.obj.echo_always(msg, err=(stream == sys.stderr))
+        ctx.obj.echo_always(msg, err=(stream == sys.stderr), no_bold=True)
 
     if R.use_r():
         entrypoint = R.entrypoint()

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -116,7 +116,7 @@ def step(
         msg = util.to_unicode(msg)
         if job_id:
             msg = "[%s] %s" % (job_id, msg)
-        ctx.obj.echo_always(msg, err=(stream == sys.stderr))
+        ctx.obj.echo_always(msg, err=(stream == sys.stderr), no_bold=True)
 
     node = ctx.obj.graph[step_name]
 


### PR DESCRIPTION
Strips styling from stdout text wrapped in asterisks from kubernetes_cli and batch_cli in order for the terminal output to be a 1-to-1 match with what is stored in the log files, and what is visible in MFGUI. 