### PR TITLE
[k8s/argo support] Add tunables for TTL behavior of kubernetes jobs and argo workflows

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -258,7 +258,14 @@ KUBERNETES_CONTAINER_IMAGE = from_conf(
 KUBERNETES_CONTAINER_REGISTRY = from_conf(
     "KUBERNETES_CONTAINER_REGISTRY", DEFAULT_CONTAINER_REGISTRY
 )
-
+# Remove job after a week by default
+# https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/
+KUBERNETES_JOB_TTL_SECONDS_AFTER_FINISHED = from_conf(
+    "KUBERNETES_JOB_TTL_SECONDS_AFTER_FINISHED",
+    7 * 60 * 60 * 24,
+)
+# https://argoproj.github.io/argo-workflows/fields/#ttlstrategy
+ARGO_WORKFLOWS_TTL_STRATEGY = from_conf("ARGO_WORKFLOWS_TTL_STRATEGY", {})
 ARGO_WORKFLOWS_KUBERNETES_SECRETS = from_conf("ARGO_WORKFLOWS_KUBERNETES_SECRETS", "")
 ARGO_WORKFLOWS_ENV_VARS_TO_SKIP = from_conf("ARGO_WORKFLOWS_ENV_VARS_TO_SKIP", "")
 

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -28,6 +28,7 @@ from metaflow.metaflow_config import (
     AWS_SECRETS_MANAGER_DEFAULT_REGION,
     ARGO_WORKFLOWS_KUBERNETES_SECRETS,
     ARGO_WORKFLOWS_ENV_VARS_TO_SKIP,
+    ARGO_WORKFLOWS_TTL_STRATEGY,
 )
 from metaflow.mflog import BASH_SAVE_LOGS, bash_capture_logs, export_mflog_env_vars
 from metaflow.parameters import deploy_time_eval
@@ -341,6 +342,8 @@ class ArgoWorkflows(object):
                 # .image_pull_secrets(...)
                 # Limit workflow parallelism
                 .parallelism(self.max_workers)
+                # Possibly have Argo Workflows controller clean up old Workflows
+                .ttl_strategy(ARGO_WORKFLOWS_TTL_STRATEGY)
                 # TODO: Support Prometheus metrics for Argo
                 # .metrics(...)
                 # TODO: Support PodGC and DisruptionBudgets
@@ -1111,6 +1114,11 @@ class WorkflowSpec(object):
     def parallelism(self, parallelism):
         # Set parallelism at Workflow level
         self.payload["parallelism"] = int(parallelism)
+        return self
+
+    def ttl_strategy(self, ttl_strategy={}):
+        if ttl_strategy != {}:
+            self.payload["ttlStrategy"] = ttl_strategy
         return self
 
     def pod_metadata(self, metadata):

--- a/metaflow/plugins/kubernetes/kubernetes_job.py
+++ b/metaflow/plugins/kubernetes/kubernetes_job.py
@@ -4,7 +4,10 @@ import random
 import time
 
 from metaflow.exception import MetaflowException
-from metaflow.metaflow_config import KUBERNETES_SECRETS
+from metaflow.metaflow_config import (
+    KUBERNETES_SECRETS,
+    KUBERNETES_JOB_TTL_SECONDS_AFTER_FINISHED,
+)
 
 CLIENT_REFRESH_INTERVAL_SECONDS = 300
 
@@ -87,10 +90,7 @@ class KubernetesJob(object):
                 # when Argo Workflows is responsible for the execution.
                 backoff_limit=self._kwargs.get("retries", 0),
                 completions=1,  # A single non-indexed pod job
-                ttl_seconds_after_finished=7
-                * 60
-                * 60  # Remove job after a week. TODO: Make this configurable
-                * 24,
+                ttl_seconds_after_finished=KUBERNETES_JOB_TTL_SECONDS_AFTER_FINISHED,
                 template=client.V1PodTemplateSpec(
                     metadata=client.V1ObjectMeta(
                         annotations=self._kwargs.get("annotations", {}),


### PR DESCRIPTION
Two new config vars to control k8s job (`METAFLOW_KUBERNETES_JOB_TTL_SECONDS_AFTER_FINISHED`) or workflow (`METAFLOW_ARGO_WORKFLOWS_TTL_STRATEGY`)TTLs.  If unset, default behavior matches current.