### PR TITLE
remove METAFLOW_DATATOOLS_SYSROOT_S3 from configuration command

### DIFF
--- a/metaflow/cmd/configure_cmd.py
+++ b/metaflow/cmd/configure_cmd.py
@@ -248,18 +248,6 @@ def configure_s3_datastore(existing_env):
         default=existing_env.get("METAFLOW_DATASTORE_SYSROOT_S3"),
         show_default=True,
     )
-    # Set Amazon S3 folder for datatools.
-    env["METAFLOW_DATATOOLS_SYSROOT_S3"] = click.prompt(
-        cyan("[METAFLOW_DATATOOLS_SYSROOT_S3]")
-        + yellow(" (optional)")
-        + " Amazon S3 folder for Metaflow datatools "
-        + "(s3://<bucket>/<prefix>).",
-        default=existing_env.get(
-            "METAFLOW_DATATOOLS_SYSROOT_S3",
-            os.path.join(env["METAFLOW_DATASTORE_SYSROOT_S3"], "data"),
-        ),
-        show_default=True,
-    )
     return env
 
 


### PR DESCRIPTION
This PR removes `METAFLOW_DATATOOLS_SYSROOT_S3` from the Metaflow configuration. This piece of configuration is not used. See this issue for more context - [https://github.com/Netflix/metaflow/issues/999](https://github.com/Netflix/metaflow/issues/999)