### PR TITLE
Fix the `logs` command in cases where the step/task hasn't finished

### DIFF
--- a/metaflow/datastore/datastore_set.py
+++ b/metaflow/datastore/datastore_set.py
@@ -22,8 +22,7 @@ class TaskDataStoreSet(object):
         prefetch_data_artifacts=None,
         allow_not_done=False,
     ):
-
-        task_datastores = flow_datastore.get_latest_task_datastores(
+        self.task_datastores = flow_datastore.get_latest_task_datastores(
             run_id, steps=steps, pathspecs=pathspecs, allow_not_done=allow_not_done
         )
 
@@ -43,9 +42,10 @@ class TaskDataStoreSet(object):
 
         self.pathspec_index_cache = {}
         self.pathspec_cache = {}
-        for ds in task_datastores:
-            self.pathspec_index_cache[ds.pathspec_index] = ds
-            self.pathspec_cache[ds.pathspec] = ds
+        if not allow_not_done:
+            for ds in self.task_datastores:
+                self.pathspec_index_cache[ds.pathspec_index] = ds
+                self.pathspec_cache[ds.pathspec] = ds
 
     def get_with_pathspec(self, pathspec):
         return self.pathspec_cache.get(pathspec, None)
@@ -54,7 +54,7 @@ class TaskDataStoreSet(object):
         return self.pathspec_index_cache.get(pathspec_index, None)
 
     def __iter__(self):
-        for v in self.pathspec_cache.values():
+        for v in self.task_datastores:
             yield v
 
 

--- a/metaflow/datastore/datastore_set.py
+++ b/metaflow/datastore/datastore_set.py
@@ -29,7 +29,7 @@ class TaskDataStoreSet(object):
         if prefetch_data_artifacts:
             # produce a set of SHA keys to prefetch based on artifact names
             prefetch = set()
-            for ds in task_datastores:
+            for ds in self.task_datastores:
                 prefetch.update(ds.keys_for_artifacts(prefetch_data_artifacts))
             # ignore missing keys
             prefetch.discard(None)

--- a/metaflow/datastore/flow_datastore.py
+++ b/metaflow/datastore/flow_datastore.py
@@ -172,7 +172,7 @@ class FlowDataStore(object):
         else:
             latest_to_fetch = latest_started_attempts & done_attempts
         latest_to_fetch = [
-            (v[0], v[1], v[2], v[3], data_objs[v], "r", allow_not_done)
+            (v[0], v[1], v[2], v[3], data_objs.get(v), "r", allow_not_done)
             for v in latest_to_fetch
         ]
         return list(itertools.starmap(self.get_task_datastore, latest_to_fetch))
@@ -187,7 +187,6 @@ class FlowDataStore(object):
         mode="r",
         allow_not_done=False,
     ):
-
         return TaskDataStore(
             self,
             run_id,


### PR DESCRIPTION
When the `logs` command was invoked, it would go and figure out the task_datastores it needed to get the logs from. In some cases (when an attempt was started but not finished), it would try to access the data file for the datastore (even though it didn't exist). It is actually not needed in this particular case so this PR modifies the code to ignore that.