### PR TITLE
allow disabling dependency installation 

### DIFF
--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -138,12 +138,20 @@ class MetaflowEnvironment(object):
                 % datastore_type
             )
         return " && ".join(cmds)
+    
+        
+    def _should_install_dependencies(self):
+        return os.environ.get("METAFLOW_INSTALL_DEPENDENCIES", True)
 
     def get_package_commands(self, code_package_url, datastore_type):
+        if self._should_install_dependencies():
+            install_dependencies_cmd = self._get_install_dependencies_cmd(datastore_type)
+        else:
+            install_dependencies_cmd = "mflog 'Skipping installation of Metaflow dependencies.'"
         cmds = [
             BASH_MFLOG,
             "mflog 'Setting up task environment.'",
-            self._get_install_dependencies_cmd(datastore_type),
+            install_dependencies_cmd,
             "mkdir metaflow",
             "cd metaflow",
             "mkdir .metaflow",  # mute local datastore creation log

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -139,7 +139,6 @@ class MetaflowEnvironment(object):
             )
         return " && ".join(cmds)
     
-        
     def _should_install_dependencies(self):
         return os.environ.get("METAFLOW_INSTALL_DEPENDENCIES", True)
 
@@ -147,7 +146,9 @@ class MetaflowEnvironment(object):
         if self._should_install_dependencies():
             install_dependencies_cmd = self._get_install_dependencies_cmd(datastore_type)
         else:
-            install_dependencies_cmd = "mflog 'Skipping installation of Metaflow dependencies.'"
+            install_dependencies_cmd = (
+                "mflog 'Skipping installation of Metaflow dependencies.'"
+            )
         cmds = [
             BASH_MFLOG,
             "mflog 'Setting up task environment.'",


### PR DESCRIPTION
Currently Metaflow installs some dependencies at run time, which can increase latency. For production use cases, it will usually be preferable to have these dependencies pre-installed in a Docker image. This PR adds an environment variable `METAFLOW_INSTALL_DEPENDENCIES` to allow disabling the dependency installation.