### PR TITLE
 Add docstring style to contribution code style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ We welcome contributions to Metaflow. Please see our [contribution guide](https:
 
 We use [black](https://black.readthedocs.io/en/stable/) as a code formatter. The easiest way to ensure your commits are always formatted with the correct version of `black` it is to use [pre-commit](https://pre-commit.com/): install it and then run `pre-commit install` once in your local copy of the repo.
 
+We also follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) docstring style to enable automatic documentation using [Sphinx](https://www.sphinx-doc.org/en/master/).


### PR DESCRIPTION
Since it appears the docstring standard has been chosen (correct me if I'm wrong), it would help contributors to have this information available alongside the specification of black formatting.