### PR TITLE
fix: GitHub Workflow security recommendations

### DIFF
--- a/.github/workflows/metaflow.s3_tests.yml
+++ b/.github/workflows/metaflow.s3_tests.yml
@@ -23,12 +23,12 @@ jobs:
         ver: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11',]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       with:
         ref: refs/pull/${{ github.event.pull_request.number }}/merge
         submodules: recursive
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
       with:
         python-version: ${{ matrix.ver }}
     - name: Install Python ${{ matrix.ver }} dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
     - name: Set up Python 3.x
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20 # v1.2.3
       with:
         python-version: '3.x'
     - name: Install Python 3.x dependencies
@@ -22,7 +22,7 @@ jobs:
       run: |
         python3 setup.py sdist bdist_wheel --universal
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@9b8e7336db3f96a2939a3e9fa827c62f466ca60d # master
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.3
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+    - uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
+    - uses: pre-commit/action@9b88afc9cd57fd75b655d5c71bd38146d07135fe # v2.0.3
 
   Python:
     name: core / Python ${{ matrix.ver }} on ${{ matrix.os }}
@@ -28,10 +28,10 @@ jobs:
         ver: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11',]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
       with:
         python-version: ${{ matrix.ver }}
 
@@ -53,9 +53,9 @@ jobs:
         ver: ['4.0']
    
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
     - name: Set up ${{ matrix.ver }}
-      uses: r-lib/actions/setup-r@v2
+      uses: r-lib/actions/setup-r@33f03a860e4659235eb60a4d87ebc0b2ea65f722 # v2.4.0
       with:
         r-version: ${{ matrix.ver }}
     


### PR DESCRIPTION
Pin action versions with hashes in GitHub actions as per security recommendations

in preparation for #1333