### PR TITLE
Fix: Check all steps for MetaflowCode and return if any

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -669,7 +669,7 @@ class MetaflowData(object):
 class MetaflowCode(object):
     """
     Snapshot of the code used to execute this `Run`. Instantiate the object through
-    `Run(...).code` (if all steps are executed remotely) or `Task(...).code` for an
+    `Run(...).code` (if any step is executed remotely) or `Task(...).code` for an
     individual task. The code package is the same for all steps of a `Run`.
 
     `MetaflowCode` includes a package of the user-defined `FlowSpec` class and supporting
@@ -1648,16 +1648,17 @@ class Run(MetaflowObject):
     def code(self) -> Optional[MetaflowCode]:
         """
         Returns the MetaflowCode object for this run, if present.
-
-        Not all runs save their code so this call may return None in those cases.
+        Code is packed if atleast one `Step` runs remotely, else None is returned.
 
         Returns
         -------
         MetaflowCode, optional
             Code package for this run
         """
-        if "start" in self:
-            return self["start"].task.code
+        for step in self:
+            code = step.task.code
+            if code:
+                return code
 
     @property
     def data(self) -> Optional[MetaflowData]:


### PR DESCRIPTION
Loops over steps of the run and return step.task.code if present.

Test flow with intermediate non-local step.

```
from metaflow import step, FlowSpec, conda_base, kubernetes


class HelloFlow(FlowSpec):
    @step
    def start(self):
        print("Starting 👋")
        self.next(self.eat)

    @kubernetes
    @step
    def eat(self):
        print("Eating 🍜")
        self.next(self.end)

    @step
    def end(self):
        print("Done! 🏁")


if __name__ == "__main__":
    HelloFlow()
```

Checking code with metadata

```
In [1]: from metaflow import Flow

In [2]: run = Flow("HelloFlow").latest_successful_run

In [3]: run.code
Out[3]: <metaflow.client.core.MetaflowCode at 0x7f28273010a0>
```


closes #1322 