### PR TITLE
Make the contact information displayed by the Metaflow command configurable

### DIFF
--- a/metaflow/cmd/main_cli.py
+++ b/metaflow/cmd/main_cli.py
@@ -4,7 +4,8 @@ from metaflow._vendor import click
 
 from metaflow.extension_support.cmd import process_cmds, resolve_cmds
 from metaflow.plugins.datastores.local_storage import LocalStorage
-from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
+from metaflow.metaflow_config import DATASTORE_LOCAL_DIR, CONTACT_INFO
+from metaflow.metaflow_version import get_version
 
 from .util import echo_always
 
@@ -80,24 +81,18 @@ def start(ctx):
     echo("Metaflow ", fg="magenta", bold=True, nl=False)
 
     if ctx.invoked_subcommand is None:
-        echo("(%s): " % metaflow.__version__, fg="magenta", bold=False, nl=False)
+        echo("(%s): " % get_version(), fg="magenta", bold=False, nl=False)
     else:
-        echo("(%s)\n" % metaflow.__version__, fg="magenta", bold=False)
+        echo("(%s)\n" % get_version(), fg="magenta", bold=False)
 
     if ctx.invoked_subcommand is None:
         echo("More data science, less engineering\n", fg="magenta")
 
-        # metaflow URL
-        echo("http://docs.metaflow.org", fg="cyan", nl=False)
-        echo(" - Read the documentation")
-
-        # metaflow chat
-        echo("http://chat.metaflow.org", fg="cyan", nl=False)
-        echo(" - Chat with us")
-
-        # metaflow help email
-        echo("help@metaflow.org", fg="cyan", nl=False)
-        echo("        - Get help by email\n")
+        lnk_sz = max(len(lnk) for lnk in CONTACT_INFO.values()) + 1
+        for what, lnk in CONTACT_INFO.items():
+            echo("%s%s" % (lnk, " " * (lnk_sz - len(lnk))), fg="cyan", nl=False)
+            echo("- %s" % what)
+        echo("")
 
         print(ctx.get_help())
 

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -193,7 +193,18 @@ DEFAULT_CONTAINER_IMAGE = from_conf("DEFAULT_CONTAINER_IMAGE")
 # Default container registry
 DEFAULT_CONTAINER_REGISTRY = from_conf("DEFAULT_CONTAINER_REGISTRY")
 
+###
+# Organization customizations
+###
 UI_URL = from_conf("UI_URL")
+CONTACT_INFO = from_conf(
+    "CONTACT_INFO",
+    {
+        "Read the documentation": "http://docs.metaflow.org",
+        "Chat with us": "http://chat.metaflow.org",
+        "Get help by email": "help@metaflow.org",
+    },
+)
 
 ###
 # AWS Batch configuration

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -197,6 +197,12 @@ DEFAULT_CONTAINER_REGISTRY = from_conf("DEFAULT_CONTAINER_REGISTRY")
 # Organization customizations
 ###
 UI_URL = from_conf("UI_URL")
+
+# Contact information displayed when running the `metaflow` command.
+# Value should be a dictionary where:
+#  - key is a string describing contact method
+#  - value is a string describing contact itself (email, web address, etc.)
+# The default value shows an example of this
 CONTACT_INFO = from_conf(
     "CONTACT_INFO",
     {


### PR DESCRIPTION
Also minor change to display the proper Metaflow version (including extension info) in the command line tool