### PR TITLE
Safely parse `pandas.DataFrame` for `default` card

### DIFF
--- a/metaflow/plugins/cards/card_modules/convert_to_native_type.py
+++ b/metaflow/plugins/cards/card_modules/convert_to_native_type.py
@@ -295,6 +295,70 @@ class TaskToDict:
     def _parse_range(self, data_object):
         return self._get_repr().repr(data_object)
 
+    def _pandas_column_parser(self, data_object):
+        # There are two types of parsing we do here.
+        # 1. We explicitly parse the types we know how to parse
+        # 2. We try to partially match a type name to the column's type.
+        #   - We do this because `datetime64` can match `datetime64[ns]` and `datetime64[ns, UTC]`
+        #   - We do this because period can match `period[D]` and `period[2D]` etc.
+        #   - There are just too many types to explicitly parse so we go by this heuristic
+        # We have a default parser called `truncate_long_objects` which type casts any column to string
+        # and truncates it to 30 characters.
+        # If there is any form of TypeError or ValueError we set the column value to "Unsupported Type"
+        time_format = "%Y-%m-%dT%H:%M:%SZ"
+        truncate_long_objects = (
+            lambda x: x.astype("string").str.slice(0, 30) + "..."
+            if x.str.len().max() > 30
+            else x.astype("string")
+        )
+        type_parser = {
+            "int64": lambda x: x,
+            "float64": lambda x: x,
+            "bool": lambda x: x,
+            "object": truncate_long_objects,
+            "category": truncate_long_objects,
+        }
+
+        partial_type_name_match_parsers = {
+            "complex": {
+                "complex": lambda x: x.astype("string"),
+            },
+            "datetime": {
+                "datetime64": lambda x: x.dt.strftime(time_format),
+                "timedelta": lambda x: x.dt.total_seconds(),
+            },
+            "interval": {
+                "interval": lambda x: x.astype("string"),
+            },
+            "period": {
+                "period": lambda x: x.astype("string"),
+            },
+        }
+
+        def _match_partial_type(column):
+            for _, type_parsers in partial_type_name_match_parsers.items():
+                for type_name, parser in type_parsers.items():
+                    if type_name in str(col_type):
+                        data_object[column] = parser(data_object[column])
+                        return True
+            return False
+
+        for col in data_object.columns:
+            try:
+                col_type = data_object[col].dtype
+                types_matched = False
+                if col_type in type_parser:
+                    types_matched = True
+                    data_object[col] = type_parser[col_type](data_object[col])
+                else:
+                    types_matched = _match_partial_type(col)
+                if not types_matched:
+                    data_object[col] = truncate_long_objects(data_object[col])
+            except ValueError as e:
+                data_object[col] = "Unsupported type: {0}".format(col_type)
+            except TypeError as e:
+                data_object[col] = "Unsupported type: {0}".format(col_type)
+
     def _parse_pandas_dataframe(self, data_object, truncate=True):
         headers = list(data_object.columns)
         data = data_object
@@ -302,16 +366,14 @@ class TaskToDict:
             data = data_object.head()
         index_column = data.index
         time_format = "%Y-%m-%dT%H:%M:%SZ"
+
         if index_column.dtype == "datetime64[ns]":
             if index_column.__class__.__name__ == "DatetimeIndex":
                 index_column = index_column.strftime(time_format)
             else:
                 index_column = index_column.dt.strftime(time_format)
 
-        for col in data.columns:
-            # we convert datetime columns to strings
-            if data[col].dtype == "datetime64[ns]":
-                data[col] = data[col].dt.strftime(time_format)
+        self._pandas_column_parser(data)
 
         data = data.astype(object).where(data.notnull(), None)
         data_vals = data.values.tolist()

--- a/metaflow/plugins/cards/card_modules/convert_to_native_type.py
+++ b/metaflow/plugins/cards/card_modules/convert_to_native_type.py
@@ -308,7 +308,7 @@ class TaskToDict:
         time_format = "%Y-%m-%dT%H:%M:%SZ"
         truncate_long_objects = (
             lambda x: x.astype("string").str.slice(0, 30) + "..."
-            if x.str.len().max() > 30
+            if x.astype("string").str.len().max() > 30
             else x.astype("string")
         )
         type_parser = {


### PR DESCRIPTION
This PR helps close #1319 . Here is a test flow to verify that things are working okay: 

```python
from metaflow import FlowSpec, step, Parameter, IncludeFile, catch, card
import math, time, uuid, datetime, random, string, sys
from decimal import Decimal
import requests

class CustomClass():

    def __str__(self):
        return 'a' * int(1024**2)

    def __repr__(self):
        return str(self)

class DefaultCardFlow(FlowSpec):

    str_param = Parameter('str_param', default='刺身は美味しい')

    file_param = IncludeFile('file_param')

    json_param = Parameter('json_param', default='{"states": {[{"CA", 0}, {"NY", 1}]}')

    float_param = Parameter('float_param', default=math.pi)

    @card
    @step
    def start(self):
        """
        This step creates a bunch of artifacts of various kinds. They
        should show up nicely on the default card 🔬.
        """
        self.python_objects()
        self.images()
        self.raise_exception()
        self.large_python_objects()
        self.custom_python_objects()
        self.pandas()
        self.numpy()
        self.next(self.end)

    @step
    def end(self):
        """
        The end.
        """
        pass

    def python_objects(self):
        self.py_int = 434
        self.py_float = math.pi
        self.py_complex = complex(1,2)
        self.py_list = [1,2,3]
        self.py_tuple = (1,2,3)
        self.py_range = range(10)
        self.py_str = '刺身は美味しい'
        self.py_bytes = b'\x00\x01\x02'
        self.py_bytearray = bytearray(b'\xf0\xf1\xf2')
        self.py_set = {1,2,3}
        self.py_frozenset = frozenset({4,5,6})
        self.py_dict = {'a': 1, 'null': None, True: False}
        self.py_type = type(str)
        self.py_bool = True
        self.py_none = None

    def large_python_objects(self):
        self.large_dict = {}
        for suit in ['clubs', 'diamonds', 'hearts', 'spades']:
            self.large_dict[suit] = ['ace'] +\
                                    list(range(2, 10)) +\
                                    ['jack', 'queen', 'king']

        self.large_int = 2**65

        # Large string (may be truncated)
        self.large_str = requests.get('https://www.usconstitution.net/const.txt').text

        # Large dictionary with many keys (may be truncated)
        self.large_dict_many_keys = {str(uuid.uuid4()): time.time()
                                     for _ in range(1000000)}

        # Large dictionary with a large value (may be truncated)
        self.large_dict_large_val = {'constitution': self.large_str}

        # Large dictionary (may be truncated)
        self.large_dict_deep = d = {}
        for i in range(100):
            d[i] = d = {}
        d['bottom!'] = True

        # Large blob
        self.large_blob = b'\x00' * (100 * 1024**2)

    def custom_python_objects(self):
        # A python object from stdlib (just print repr())
        self.custom_datetime = datetime.datetime.utcnow()
        # A custom Python object
        self.custom_class = CustomClass()
        # A custom Python object (just print repr())
        self.custom_decimal = Decimal(0.1)

    def images(self):
        # A gif file
        self.img_gif = requests.get('https://www.gif-vif.com/hacker-cat.gif').content
        # A jpg file
        self.img_jpg = requests.get('https://www.nasa.gov/centers/goddard/images/content/638831main_globe_east_2048.jpg').content
        # A png file
        self.img_png = requests.get('https://datavisdotblog.files.wordpress.com/2019/08/small-multiples.png').content

    def raise_exception(self):
        try:
            raise Exception('This is an exception!')
        except Exception as x:
            # Exception object
            # We could print traceback too:
            # traceback.format_tb(self.exception.__traceback__)
            self.exception = x

    def pandas(self):
        from datetime import datetime
        import pandas
        d = {'this is column %s' % x: [random.randint(1, 10**i) for _ in range(1000)]
             for i, x in enumerate(string.ascii_uppercase)}
        d['nulls'] = [None] * 1000
        d['times'] = [datetime.utcnow()] * 1000
        # Pandas series of timestamps
        d['timestamps'] = pandas.date_range('1/1/2000', periods=1000)

        self.dataframe = pandas.DataFrame(d)

        import pandas as pd
        import numpy as np
        from datetime import datetime

        # Create sample data
        data = {
            'Integers': [1, 2, 3, 4, 5],
            'Floats': [1.1, 2.2, 3.3, 4.4, 5.5],
            'Strings': ['A', 'B', 'C', 'D', 'E'],
            'Booleans': [True, False, True, False, True],
            'DateTime': [datetime(2021, 1, 1), datetime(2021, 2, 1), datetime(2021, 3, 1), datetime(2021, 4, 1), datetime(2021, 5, 1)],
            'Timedelta': pd.to_timedelta([1, 2, 3, 4, 5], unit='D'),
            'Categorical': pd.Categorical(['cat', 'dog', 'fish', 'bird', 'snake']),
            'Object': [np.random.random((10,10)), np.array([3, 4]), np.array([5, 6]), np.array([7, 8]), np.array([9, 10])],
            'Period': [pd.Period('2021Q1'), pd.Period('2021Q2'), pd.Period('2021Q3'), pd.Period('2021Q4'), pd.Period('2022Q1')],
            'Sparse': pd.Series(pd.arrays.SparseArray([0, 1, 0, 2, 0])),
            'Intervals': pd.arrays.IntervalArray.from_tuples([(1, 2), (2, 3), (4, 5), (6, 7), (8, 9)]),
            'Complex': [1 + 2j, 2 + 3j, 3 + 4j, 4 + 5j, 5 + 6j],
            'Bytes': [b'A', b'B', b'C', b'D', b'E'],
            "Nulls": [None, None, None, None, None],
            'Timestamp': [pd.Timestamp('2021-01-01'), pd.Timestamp('2021-02-01'), pd.Timestamp('2021-03-01'), pd.Timestamp('2021-04-01'), pd.Timestamp('2021-05-01')]
        }

        # Create DataFrame
        self.dataframe2 = pd.DataFrame(data)

    def numpy(self):
        import numpy
        self.np_array = numpy.arange(10000000, dtype='u8')

if __name__ == '__main__':
    DefaultCardFlow()
```