### PR TITLE
Reduce multiple metadata service rtts using cached version.

### DIFF
--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -137,9 +137,10 @@ class ServiceMetadataProvider(MetadataProvider):
             payload[HB_URL_KEY] = self.url_run_template.format(**data)
         else:
             raise Exception("invalid heartbeat type")
-        payload["service_version"] = self.version()
+        service_version = self.version()
+        payload["service_version"] = service_version
         # start sidecar
-        if self.version() is None or LooseVersion(self.version()) < LooseVersion(
+        if service_version is None or LooseVersion(service_version) < LooseVersion(
             "2.0.4"
         ):
             # if old version of the service is running


### PR DESCRIPTION
The code for starting the heartbeat calls version() multiple times even when the actual value of the version is already available. Each call to version() makes a round-trip to the metadata-service which increases the overall latency.

This change simply uses the value of the first call to version() in subsequent checks avoids 2 extra rtts the metadata service.