### PR TITLE
feat: add ipython autocomplete support for MetaflowObject instances

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -384,6 +384,10 @@ class MetaflowObject(object):
             if all(tag in child.tags for tag in tags):
                 yield child
 
+    def _ipython_key_completions_(self):
+        """Returns available options for ipython auto-complete."""
+        return [child.id for child in self._filtered_children()]
+
     @classmethod
     def _url_token(cls):
         return "%ss" % cls._NAME


### PR DESCRIPTION
relates to #1114 

The autocomplete for objects works with this simple addition of returning children ids. Suggestions when initiating classes like `Flow("` could be helpful too but I couldn't find a way to do this. But for the class instances of Flow, Run, Step, Task, the autocomplete works and for reference the options are printed by calling the function that ipython would use.

Any thoughts @romain-intel ?

```
from metaflow import Flow, Metaflow

Metaflow().flows
>>> [Flow('HelloFlow'), Flow('MovieStatsFlow')]

flow = Flow('HelloFlow') # No autocomplete here
flow._ipython_key_completions_()
>>> 
['1680815181013681',
 '1680815178214737',
 '1680432265121345',
 '1680430310127401']

run = flow["1680815178214737"]
run._ipython_key_completions_()
>>> ['end', 'hello', 'start']

step = run["hello"]
step._ipython_key_completions_()
>>> ['2']

task = step["2"]
task._ipython_key_completions_()
>>> ['name']

data = task["name"]
data._ipython_key_completions_()
>>> Error (since no childern), so autcomplete just list unrelated things
```