### PR TITLE
Fix: Validate pathspec argument for MetaflowObject

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -22,6 +22,7 @@ from metaflow.exception import (
     MetaflowNotFound,
     MetaflowNamespaceMismatch,
     MetaflowInternalError,
+    MetaflowInvalidPathspec,
 )
 from metaflow.includefile import IncludedFile
 from metaflow.metaflow_config import DEFAULT_METADATA, MAX_ATTEMPTS
@@ -290,23 +291,44 @@ class MetaflowObject(object):
         if pathspec:
             ids = pathspec.split("/")
 
+            if self._NAME == "flow" and len(ids) != 1:
+                raise MetaflowInvalidPathspec("Expects Flow('FlowName')")
+            elif self._NAME == "run" and len(ids) != 2:
+                raise MetaflowInvalidPathspec("Expects Run('FlowName/RunID')")
+            elif self._NAME == "step" and len(ids) != 3:
+                raise MetaflowInvalidPathspec(
+                    " Expects Step('FlowName/RunID/StepName')"
+                )
+            elif self._NAME == "task" and len(ids) != 4:
+                raise MetaflowInvalidPathspec(
+                    " Expects Task('FlowName/RunID/StepName/TaskID')"
+                )
+            elif self._NAME == "artifact" and len(ids) != 5:
+                raise MetaflowInvalidPathspec(
+                    " Expects DataArtifact('FlowName/RunID/StepName/TaskID/ArtifactName')"
+                )
+
             self.id = ids[-1]
             self._pathspec = pathspec
             self._object = self._get_object(*ids)
         else:
             self._object = _object
             self._pathspec = pathspec
+            if not isinstance(self._object, MetaflowObject):
+                raise MetaflowInternalError(
+                    msg="MetaflowObject is expected but recieved %s" % self._object
+                )
 
-        if self._NAME in ("flow", "task"):
-            self.id = str(self._object[self._NAME + "_id"])
-        elif self._NAME == "run":
-            self.id = str(self._object["run_number"])
-        elif self._NAME == "step":
-            self.id = str(self._object["step_name"])
-        elif self._NAME == "artifact":
-            self.id = str(self._object["name"])
-        else:
-            raise MetaflowInternalError(msg="Unknown type: %s" % self._NAME)
+            if self._NAME in ("flow", "task"):
+                self.id = str(self._object[self._NAME + "_id"])
+            elif self._NAME == "run":
+                self.id = str(self._object["run_number"])
+            elif self._NAME == "step":
+                self.id = str(self._object["step_name"])
+            elif self._NAME == "artifact":
+                self.id = str(self._object["name"])
+            else:
+                raise MetaflowInternalError(msg="Unknown type: %s" % self._NAME)
 
         self._created_at = datetime.fromtimestamp(self._object["ts_epoch"] / 1000.0)
 

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -296,16 +296,14 @@ class MetaflowObject(object):
             elif self._NAME == "run" and len(ids) != 2:
                 raise MetaflowInvalidPathspec("Expects Run('FlowName/RunID')")
             elif self._NAME == "step" and len(ids) != 3:
-                raise MetaflowInvalidPathspec(
-                    " Expects Step('FlowName/RunID/StepName')"
-                )
+                raise MetaflowInvalidPathspec("Expects Step('FlowName/RunID/StepName')")
             elif self._NAME == "task" and len(ids) != 4:
                 raise MetaflowInvalidPathspec(
-                    " Expects Task('FlowName/RunID/StepName/TaskID')"
+                    "Expects Task('FlowName/RunID/StepName/TaskID')"
                 )
             elif self._NAME == "artifact" and len(ids) != 5:
                 raise MetaflowInvalidPathspec(
-                    " Expects DataArtifact('FlowName/RunID/StepName/TaskID/ArtifactName')"
+                    "Expects DataArtifact('FlowName/RunID/StepName/TaskID/ArtifactName')"
                 )
 
             self.id = ids[-1]

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -314,10 +314,6 @@ class MetaflowObject(object):
         else:
             self._object = _object
             self._pathspec = pathspec
-            if not isinstance(self._object, MetaflowObject):
-                raise MetaflowInternalError(
-                    msg="MetaflowObject is expected but recieved %s" % self._object
-                )
 
             if self._NAME in ("flow", "task"):
                 self.id = str(self._object[self._NAME + "_id"])

--- a/metaflow/exception.py
+++ b/metaflow/exception.py
@@ -92,7 +92,7 @@ class MetaflowNamespaceMismatch(MetaflowException):
 
 
 class MetaflowInvalidPathspec(MetaflowException):
-    headline = "Invalid pathspec for the MetaflowObject type"
+    headline = "Invalid pathspec"
 
     def __init__(self, msg):
         super(MetaflowInvalidPathspec, self).__init__(msg)

--- a/metaflow/exception.py
+++ b/metaflow/exception.py
@@ -91,6 +91,13 @@ class MetaflowNamespaceMismatch(MetaflowException):
         super(MetaflowNamespaceMismatch, self).__init__(msg)
 
 
+class MetaflowInvalidPathspec(MetaflowException):
+    headline = "Invalid pathspec for the MetaflowObject type"
+
+    def __init__(self, msg):
+        super(MetaflowInvalidPathspec, self).__init__(msg)
+
+
 class MetaflowInternalError(MetaflowException):
     headline = "Internal error"
 


### PR DESCRIPTION
related to #948 


- Adds `MetaflowInvalidPathspec` exception
- Validates `pathspec` for all 5 MetaflowObjects - Flow to Artifact
- Changes unnecessary id re-assignment for MetaflowObjects created using `pathspec`

I have looked into writing test case but couldn't see that there are any specifically for testing metadata. Please let me know. Thanks