### PR TITLE
Remove encoding for JSON.loads

### DIFF
--- a/metaflow/plugins/env_escape/communication/channel.py
+++ b/metaflow/plugins/env_escape/communication/channel.py
@@ -36,7 +36,7 @@ class Channel(object):
             sz_bytes = self._stream.read(self._fmt.size, timeout)
             msg_sz = self._fmt.unpack(sz_bytes)[0]
             obj_bytes = self._stream.read(msg_sz, timeout)
-            return json.loads(obj_bytes, encoding="utf-8")
+            return json.loads(obj_bytes)
         except EOFError as e:
             raise RuntimeError("Cannot receive object over streaming interface: %s" % e)
         except BaseException as e:


### PR DESCRIPTION
JSON.loads api changed in version 3.9: The keyword argument encoding has been removed.
See detail in https://docs.python.org/3.9/library/json.html?highlight=json%20loads#json.load
Remove the encoding should be find, since "utf-8" is the default encoding.