### PR TITLE
[TRIS-299] enable server-side-encryption for s3 uploads

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -68,6 +68,7 @@ CLIENT_CACHE_MAX_TASKDATASTORE_COUNT = from_conf(
 ###
 S3_ENDPOINT_URL = from_conf("S3_ENDPOINT_URL")
 S3_VERIFY_CERTIFICATE = from_conf("S3_VERIFY_CERTIFICATE")
+S3_SERVER_SIDE_ENCRYPTION = from_conf("S3_SERVER_SIDE_ENCRYPTION")
 
 # S3 retry configuration
 # This is useful if you want to "fail fast" on S3 operations; use with caution


### PR DESCRIPTION
Tested this by running metaflow-sandbox/helloworld.py in the ml-training-pipeline repository.
Local .metalfowconfig/config.json set-up: 
{
    "METAFLOW_DATASTORE_SYSROOT_S3": "s3://zendesk-numbats-adhoc-staging-use1",
    "METAFLOW_DATATOOLS_SYSROOT_S3": "s3://zendesk-numbats-adhoc-staging-use1",
    "METAFLOW_DEFAULT_DATASTORE": "s3",
    "METAFLOW_S3_SERVER_SIDE_ENCRYPTION": "AES256"
}