### PR TITLE
Feature/tmpfs for kubernetes and argo

### DIFF
--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -149,6 +149,10 @@ class Kubernetes(object):
         gpu_vendor=None,
         disk=None,
         memory=None,
+        use_tmpfs=None,
+        tmpfs_tempdir=None,
+        tmpfs_size=None,
+        tmpfs_path=None,
         run_time_limit=None,
         env=None,
         tolerations=None,
@@ -185,6 +189,10 @@ class Kubernetes(object):
                 retries=0,
                 step_name=step_name,
                 tolerations=tolerations,
+                use_tmpfs=use_tmpfs,
+                tmpfs_tempdir=tmpfs_tempdir,
+                tmpfs_size=tmpfs_size,
+                tmpfs_path=tmpfs_path,
             )
             .environment_variable("METAFLOW_CODE_SHA", code_package_sha)
             .environment_variable("METAFLOW_CODE_URL", code_package_url)
@@ -236,6 +244,10 @@ class Kubernetes(object):
             # pod; this happens when METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set (
             # see get_datastore_root_from_config in datastore/local.py).
         )
+
+        tmpfs_enabled = use_tmpfs or (tmpfs_size and not use_tmpfs)
+        if tmpfs_enabled and tmpfs_tempdir:
+            job.environment_variable("METAFLOW_TEMPDIR", tmpfs_path)
 
         for name, value in env.items():
             job.environment_variable(name, value)

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -80,6 +80,12 @@ def kubernetes():
 @click.option(
     "--max-user-code-retries", default=0, help="Passed to the top-level 'step'."
 )
+@click.option("--use-tmpfs", is_flag=True, help="tmpfs requirement for Kubernetes pod.")
+@click.option(
+    "--tmpfs-tempdir", is_flag=True, help="tmpfs requirement for Kubernetes pod."
+)
+@click.option("--tmpfs-size", help="tmpfs requirement for Kubernetes pod.")
+@click.option("--tmpfs-path", help="tmpfs requirement for Kubernetes pod.")
 @click.option(
     "--run-time-limit",
     default=5 * 24 * 60 * 60,  # Default is set to 5 days
@@ -108,6 +114,10 @@ def step(
     memory=None,
     gpu=None,
     gpu_vendor=None,
+    use_tmpfs=None,
+    tmpfs_tempdir=None,
+    tmpfs_size=None,
+    tmpfs_path=None,
     run_time_limit=None,
     tolerations=None,
     **kwargs
@@ -215,6 +225,10 @@ def step(
                 memory=memory,
                 gpu=gpu,
                 gpu_vendor=gpu_vendor,
+                use_tmpfs=use_tmpfs,
+                tmpfs_tempdir=tmpfs_tempdir,
+                tmpfs_size=tmpfs_size,
+                tmpfs_path=tmpfs_path,
                 run_time_limit=run_time_limit,
                 env=env,
                 tolerations=tolerations,


### PR DESCRIPTION
- adds tmpfs support for kubernetes and argo-workflows via kube native `emptyDir` volume mount

Note: enforcing the `tmpfs_size` is heavily dependent on the available kubernetes version, as we require support for the `size_limit=` argument for the `emptyDir` to have an effect.