### PR TITLE
Fixing a MetaflowObject backward compatibility issue

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -326,8 +326,16 @@ class MetaflowObject(object):
         self._user_tags = frozenset(self._object.get("tags") or [])
         self._system_tags = frozenset(self._object.get("system_tags") or [])
 
-        if self._namespace_check and not self.is_in_namespace():
+        if self._get_attribute("_namespace_check", True) and not self.is_in_namespace():
             raise MetaflowNamespaceMismatch(current_namespace)
+
+    def _get_attribute(self, name, default=None):
+        """
+        Returns the attribute if it exists in this object else returns a default
+        """
+        if name in self.__dict__:
+            return self.__dict__[name]
+        return default
 
     def _get_object(self, *path_components):
         result = self._metaflow.metadata.get_object(
@@ -352,7 +360,7 @@ class MetaflowObject(object):
         query_filter = {}
 
         # skip namespace filtering if _namespace_check is unset.
-        if self._namespace_check and current_namespace:
+        if self._get_attribute("_namespace_check", True) and current_namespace:
             query_filter = {"any_tags": current_namespace}
 
         unfiltered_children = self._metaflow.metadata.get_object(
@@ -465,7 +473,7 @@ class MetaflowObject(object):
                 attempt=self._attempt,
                 _object=obj,
                 _parent=self,
-                _namespace_check=self._namespace_check,
+                _namespace_check=self._get_attribute("_namespace_check", True),
             )
         else:
             raise KeyError(id)


### PR DESCRIPTION
The newly added `_namespace_check` attribute in the `MetaflowObject` broke backward compatibility in cases where the object is deserialized from an older version of Metaflow. 

Steps to reproduce this issue:

- Launch a flow with OSS version `2.8.0` that saves the Run object as a flow artifact
- Try to access the artifact (which a Run object) from a new flow that is running on version `2.8.3`
- You will see an error like this `AttributeError: 'Run' object has no attribute '_namespace_check'`

This is because the Run object is pickled in the original flow when it is assigned to an artifact. In the other flow, it is unpickled to the old Run object that does not contain the newly added attribute.

This PR adds a custom implementation of the `__getstate__` and `__setstate__` functions to help with backward compatibility.