### PR TITLE
fix: batch tmpfs enabling logic

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -257,7 +257,7 @@ class Batch(object):
                 AWS_SECRETS_MANAGER_DEFAULT_REGION,
             )
 
-        tmpfs_enabled = use_tmpfs or (tmpfs_size and use_tmpfs is None)
+        tmpfs_enabled = use_tmpfs or (tmpfs_size and not use_tmpfs)
 
         if tmpfs_enabled and tmpfs_tempdir:
             job.environment_variable("METAFLOW_TEMPDIR", tmpfs_path)

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -287,7 +287,7 @@ class BatchJob(object):
                     {"sourceVolume": name, "containerPath": host_path}
                 )
 
-        if use_tmpfs or (tmpfs_size and use_tmpfs is None):
+        if use_tmpfs or (tmpfs_size and not use_tmpfs):
             if tmpfs_size:
                 if not (isinstance(tmpfs_size, (int, unicode, basestring))):
                     raise BatchJobException(


### PR DESCRIPTION
tmpfs folder is not correctly being set by only passing `tmpfs_size=` in the batch decorator.

example:
`@batch(memory=500, tmpfs_size=1100)`
the `current.tempdir` will remain as `.` instead of changing to `/metaflow_temp` 

cause for the issue is due to `use_tmpfs` having "False" as a default from the decorator, not the assumed `None` that is being passed around elsewhere