### PR TITLE
Fix an issue introduced in 2.8.4 that prevented pickled MetaflowObjec…

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -516,10 +516,12 @@ class MetaflowObject(object):
             self._UNPICKLE_FUNC[version](self, state["data"])
         else:
             # For backward compatibility: handles pickled objects that were serialized without a __getstate__ override
+            # We set namespace_check to False if it doesn't exist for the same
+            # reason as the one listed in __getstate__
             self.__init__(
                 pathspec=state.get("_pathspec", None),
                 attempt=state.get("_attempt", None),
-                _namespace_check=state.get("_namespace_check", True),
+                _namespace_check=state.get("_namespace_check", False),
             )
 
     def __getstate__(self):
@@ -531,12 +533,16 @@ class MetaflowObject(object):
         from this object) are pickled (serialized) in a later version of Metaflow, it may not be possible
         to unpickle (deserialize) them in a previous version of Metaflow.
         """
+        # Note that we set _namespace_check to False because we want the user to
+        # be able to access this object even after unpickling it. If we set it to
+        # True, it would check the namespace again at the time of unpickling even
+        # if the user properly got the object in the first place and pickled it.
         return {
             "version": "2.8.4",
             "data": [
                 self.pathspec,
                 self._attempt,
-                self._namespace_check,
+                False,
             ],
         }
 

--- a/test/core/tests/current_singleton.py
+++ b/test/core/tests/current_singleton.py
@@ -99,6 +99,8 @@ class CurrentSingletonTest(MetaflowTest):
 
     def check_results(self, flow, checker):
         run = checker.get_run()
+        from metaflow import get_namespace
+        checker_namespace = get_namespace()
         if run is None:
             # very basic sanity check for CLI
             for step in flow:
@@ -112,6 +114,8 @@ class CurrentSingletonTest(MetaflowTest):
             task_data = run.data.task_data
             for pathspec, uuid in task_data.items():
                 assert_equals(Task(pathspec).data.uuid, uuid)
+
+            # Override the namespace for the pickling/unpickling checks
             namespace("non-existent-namespace-to-test-namespacecheck")
             for step in run:
                 for task in step:
@@ -125,6 +129,8 @@ class CurrentSingletonTest(MetaflowTest):
                     assert_equals(
                         task.data.run_obj[task.data.step_name].id, task.data.step_name
                     )
+            # Restore the original namespace back
+            namespace(checker_namespace)
             assert_equals(run.data.run_obj.pathspec, run.pathspec)
             assert_equals(run.data.project_names, {"current_singleton"})
             assert_equals(run.data.branch_names, {"user.tester"})

--- a/test/core/tests/current_singleton.py
+++ b/test/core/tests/current_singleton.py
@@ -100,6 +100,7 @@ class CurrentSingletonTest(MetaflowTest):
     def check_results(self, flow, checker):
         run = checker.get_run()
         from metaflow import get_namespace
+
         checker_namespace = get_namespace()
         if run is None:
             # very basic sanity check for CLI
@@ -129,7 +130,7 @@ class CurrentSingletonTest(MetaflowTest):
                     assert_equals(
                         task.data.run_obj[task.data.step_name].id, task.data.step_name
                     )
-            # Restore the original namespace back
+            # Restore the original namespace back for these tests
             namespace(checker_namespace)
             assert_equals(run.data.run_obj.pathspec, run.pathspec)
             assert_equals(run.data.project_names, {"current_singleton"})


### PR DESCRIPTION
…t from being accessed after pickling in a different namespace

The core issue is that we now call the constructor when un-pickling which will recheck the namespace. This broke previous behavior where the constructor was not called and no namespace check was done