### PR TITLE
feature: add Kubernetes support for PVC mounts

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -268,6 +268,9 @@ KUBERNETES_SERVICE_ACCOUNT = from_conf("KUBERNETES_SERVICE_ACCOUNT")
 # Default node selectors to use by K8S jobs created by Metaflow - foo=bar,baz=bab
 KUBERNETES_NODE_SELECTOR = from_conf("KUBERNETES_NODE_SELECTOR", "")
 KUBERNETES_TOLERATIONS = from_conf("KUBERNETES_TOLERATIONS", "")
+KUBERNETES_PERSISTENT_VOLUME_CLAIMS = from_conf(
+    "KUBERNETES_PERSISTENT_VOLUME_CLAIMS", ""
+)
 KUBERNETES_SECRETS = from_conf("KUBERNETES_SECRETS", "")
 # Default GPU vendor to use by K8S jobs created by Metaflow (supports nvidia, amd)
 KUBERNETES_GPU_VENDOR = from_conf("KUBERNETES_GPU_VENDOR", "nvidia")

--- a/metaflow/plugins/airflow/airflow.py
+++ b/metaflow/plugins/airflow/airflow.py
@@ -642,7 +642,7 @@ class Airflow(object):
             )
             if kube_deco:
                 # Only guard against use_tmpfs and tmpfs_size as these determine if tmpfs is enabled.
-                for attr in ["use_tmpfs", "tmpfs_size"]:
+                for attr in ["use_tmpfs", "tmpfs_size", "persistent_volume_claims"]:
                     if kube_deco[attr]:
                         raise AirflowException(
                             "tmpfs attribute *%s* is currently not supported on Airflow "

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -156,6 +156,7 @@ class Kubernetes(object):
         tmpfs_path=None,
         run_time_limit=None,
         env=None,
+        persistent_volume_claims=None,
         tolerations=None,
     ):
         if env is None:
@@ -193,6 +194,7 @@ class Kubernetes(object):
                 tmpfs_tempdir=tmpfs_tempdir,
                 tmpfs_size=tmpfs_size,
                 tmpfs_path=tmpfs_path,
+                persistent_volume_claims=persistent_volume_claims,
             )
             .environment_variable("METAFLOW_CODE_SHA", code_package_sha)
             .environment_variable("METAFLOW_CODE_URL", code_package_url)

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -91,6 +91,7 @@ def kubernetes():
     default=5 * 24 * 60 * 60,  # Default is set to 5 days
     help="Run time limit in seconds for Kubernetes pod.",
 )
+@click.option("--persistent-volume-claims", default=None, multiple=False)
 @click.option(
     "--tolerations",
     default=None,
@@ -119,6 +120,7 @@ def step(
     tmpfs_size=None,
     tmpfs_path=None,
     run_time_limit=None,
+    persistent_volume_claims=None,
     tolerations=None,
     **kwargs
 ):
@@ -231,6 +233,7 @@ def step(
                 tmpfs_path=tmpfs_path,
                 run_time_limit=run_time_limit,
                 env=env,
+                persistent_volume_claims=persistent_volume_claims,
                 tolerations=tolerations,
             )
     except Exception as e:

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -91,7 +91,9 @@ def kubernetes():
     default=5 * 24 * 60 * 60,  # Default is set to 5 days
     help="Run time limit in seconds for Kubernetes pod.",
 )
-@click.option("--persistent-volume-claims", default=None, multiple=False)
+@click.option(
+    "--persistent-volume-claims", type=JSONTypeClass(), default=None, multiple=False
+)
 @click.option(
     "--tolerations",
     default=None,

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -19,6 +19,7 @@ from metaflow.metaflow_config import (
     KUBERNETES_SERVICE_ACCOUNT,
     KUBERNETES_SECRETS,
     KUBERNETES_FETCH_EC2_METADATA,
+    KUBERNETES_PERSISTENT_VOLUME_CLAIMS,
 )
 from metaflow.plugins.resources_decorator import ResourcesDecorator
 from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task
@@ -96,6 +97,7 @@ class KubernetesDecorator(StepDecorator):
         "tmpfs_tempdir": True,
         "tmpfs_size": None,
         "tmpfs_path": "/metaflow_temp",
+        "persistent_volume_claims": None,  # e.g., {"pvc-name": "/mnt/vol", "another-pvc": "/mnt/vol2"}
     }
     package_url = None
     package_sha = None
@@ -114,6 +116,13 @@ class KubernetesDecorator(StepDecorator):
             self.attributes["node_selector"] = KUBERNETES_NODE_SELECTOR
         if not self.attributes["tolerations"] and KUBERNETES_TOLERATIONS:
             self.attributes["tolerations"] = json.loads(KUBERNETES_TOLERATIONS)
+        if (
+            not self.attributes["persistent_volume_claims"]
+            and KUBERNETES_PERSISTENT_VOLUME_CLAIMS
+        ):
+            self.attributes["persistent_volume_claims"] = json.loads(
+                KUBERNETES_PERSISTENT_VOLUME_CLAIMS
+            )
 
         if isinstance(self.attributes["node_selector"], str):
             self.attributes["node_selector"] = self.parse_node_selector(

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -326,7 +326,7 @@ class KubernetesDecorator(StepDecorator):
                     cli_args.command_options[k] = ",".join(
                         ["=".join([key, str(val)]) for key, val in v.items()]
                     )
-                elif k == "tolerations":
+                elif k in ["tolerations", "persistent_volume_claims"]:
                     cli_args.command_options[k] = json.dumps(v)
                 else:
                     cli_args.command_options[k] = v

--- a/metaflow/plugins/kubernetes/kubernetes_job.py
+++ b/metaflow/plugins/kubernetes/kubernetes_job.py
@@ -1,4 +1,3 @@
-from ast import literal_eval
 import json
 import math
 import random
@@ -246,7 +245,6 @@ class KubernetesJob(object):
         if pvcs is None:
             return [], []
 
-        pvcs = dict(literal_eval(pvcs))
         container_mounts = []
         volumes = []
 

--- a/metaflow/plugins/kubernetes/kubernetes_job.py
+++ b/metaflow/plugins/kubernetes/kubernetes_job.py
@@ -1,3 +1,4 @@
+from ast import literal_eval
 import json
 import math
 import random
@@ -71,12 +72,15 @@ class KubernetesJob(object):
         client = self._client.get()
 
         tmpfs_mounts, tmpfs_volumes = self.tmpfs_volumes()
+        pvc_mounts, pvc_volumes = self.pvc_volumes()
 
         volume_mounts = []
         volume_mounts.extend(tmpfs_mounts)
+        volume_mounts.extend(pvc_mounts)
 
         volumes = []
         volumes.extend(tmpfs_volumes)
+        volumes.extend(pvc_volumes)
 
         self._job = client.V1Job(
             api_version="batch/v1",
@@ -231,6 +235,32 @@ class KubernetesJob(object):
             if tmpfs_enabled
             else []
         )
+
+        return container_mounts, volumes
+
+    def pvc_volumes(self):
+        client = self._client.get()
+
+        pvcs = self._kwargs["persistent_volume_claims"]
+
+        if pvcs is None:
+            return [], []
+
+        pvcs = dict(literal_eval(pvcs))
+        container_mounts = []
+        volumes = []
+
+        for claim, path in pvcs.items():
+            container_mounts.append(client.V1VolumeMount(mount_path=path, name=claim))
+
+            volumes.append(
+                client.V1Volume(
+                    name=claim,
+                    persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(
+                        claim_name=claim
+                    ),
+                )
+            )
 
         return container_mounts, volumes
 


### PR DESCRIPTION
- Add support for Kubernetes (and Argo Workflows) to mount existing PersistentVolumeClaims for pods.

Addressing #1117 and possibly the use-case in #1362 as well.

Feature checklist and usage reference
- [x] `@kubernetes(persistent_volume_claims={"test-pvc-feature-claim": "/mnt/testvol"})`
- [x] `python test.py --with kubernetes:persistent_volume_claims='{"test-pvc-feature-claim": "/mnt/testvol"}' run`
- [x] `METAFLOW_KUBERNETES_PERSISTENT_VOLUME_CLAIMS='{"test-pvc-feature-claim": "/mnt/testvol"}' python test.py run`
- [x] `METAFLOW_KUBERNETES_PERSISTENT_VOLUME_CLAIMS='{"test-pvc-feature-claim": "/mnt/testvol"}' python test.py argo-workflows create`