### PR TITLE
feature: add argo workflows list-runs command

### DIFF
--- a/metaflow/plugins/argo/argo_client.py
+++ b/metaflow/plugins/argo/argo_client.py
@@ -50,7 +50,6 @@ class ArgoClient(object):
                 namespace=self._namespace,
                 plural="workflows",
                 label_selector=",".join(filters),
-                limit=10,
             )["items"]
         except client.rest.ApiException as e:
             raise ArgoClientException(

--- a/metaflow/plugins/argo/argo_client.py
+++ b/metaflow/plugins/argo/argo_client.py
@@ -45,14 +45,14 @@ class ArgoClient(object):
         #
         # but status can be filtered through labels.
         # it would seem that the only way to filter with workflow template name is to do it in-memory
-        filters = ["status.phase=%s" % state for state in states]
+        filters = ["workflows.argoproj.io/phase=%s" % state for state in states]
         try:
             return client.CustomObjectsApi().list_namespaced_custom_object(
                 group=self._group,
                 version=self._version,
                 namespace=self._namespace,
                 plural="workflows",
-                # field_selector=",".join(filters),
+                label_selector=",".join(filters),
                 limit=10,
             )["items"]
         except client.rest.ApiException as e:

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -276,6 +276,23 @@ class ArgoWorkflows(object):
                 )
         return None
 
+    @classmethod
+    def list(cls, name, states):
+        client = ArgoClient(namespace=KUBERNETES_NAMESPACE)
+        try:
+            workflow_template = client.get_workflow_template(name)
+        except Exception as e:
+            raise ArgoWorkflowsException(str(e))
+        if workflow_template is None:
+            raise ArgoWorkflowsException(
+                "The workflow *%s* doesn't exist on Argo Workflows in namespace *%s*. "
+                "Please deploy your flow first." % (name, KUBERNETES_NAMESPACE)
+            )
+
+        executions = client.list_executions(name, states)
+
+        return executions
+
     def _process_parameters(self):
         parameters = {}
         has_schedule = self.flow._flow_decorators.get("schedule") is not None

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -530,6 +530,7 @@ class ArgoWorkflows(object):
                     Metadata()
                     .label("app.kubernetes.io/name", "metaflow-run")
                     .label("app.kubernetes.io/part-of", "metaflow")
+                    .label("workflows.argoproj.io/workflow-template", self.name)
                     .annotations(
                         {**annotations, **{"metaflow/run_id": "argo-{{workflow.name}}"}}
                     )


### PR DESCRIPTION
- add command for listing runs (and filtering by status) for argo-workflows

Note: due to API limitations, this feature required adding a custom label to workflows with the workflow-template as a value, as labels are the only available filter for custom fields on objects. This makes the feature not backwards compatible, as the necessary label does not exist on older runs.