### PR TITLE
Properly validate a config value against the type of its default

### DIFF
--- a/metaflow/metaflow_config_funcs.py
+++ b/metaflow/metaflow_config_funcs.py
@@ -79,6 +79,12 @@ def from_conf(name, default=None, validate_fn=None):
                     raise ValueError(
                         "Expected a valid JSON for %s, got: %s" % (env_name, value)
                     )
+                if type(value) != type(default):
+                    raise ValueError(
+                        "Expected value of type '%s' for %s, got: %s"
+                        % (type(default), env_name, value)
+                    )
+                is_default = value == default
             _all_configs[env_name] = ConfigValue(
                 value=value,
                 serializer=json.dumps,
@@ -87,9 +93,7 @@ def from_conf(name, default=None, validate_fn=None):
             return value
         elif isinstance(default, (bool, int, float)) or is_stringish(default):
             try:
-                value = type(default)(value)
-                # Here we can compare values
-                is_default = value == default
+                is_default = type(default)(value) == default
             except ValueError:
                 raise ValueError(
                     "Expected a %s for %s, got: %s" % (type(default), env_name, value)
@@ -98,6 +102,8 @@ def from_conf(name, default=None, validate_fn=None):
             raise RuntimeError(
                 "Default of type %s for %s is not supported" % (type(default), env_name)
             )
+    else:
+        is_default = value is None
     _all_configs[env_name] = ConfigValue(
         value=value,
         serializer=str,


### PR DESCRIPTION
We also properly calculate the `is_default` field. It used to be mostly True which caused some environment variables to not be included in config_vars