### PR TITLE
Setting default time for files in code package to Dec 3, 2019

### DIFF
--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -156,13 +156,16 @@ class MetaflowPackage(object):
         buf.write(json.dumps(env).encode("utf-8"))
         buf.seek(0)
         info.size = len(buf.getvalue())
+        # Setting this default to Dec 3, 2019
+        info.mtime = 1575360000
         tar.addfile(info, buf)
 
     def _make(self):
         def no_mtime(tarinfo):
             # a modification time change should not change the hash of
             # the package. Only content modifications will.
-            tarinfo.mtime = 0
+            # Setting this default to Dec 3, 2019
+            tarinfo.mtime = 1575360000
             return tarinfo
 
         buf = BytesIO()


### PR DESCRIPTION
Currently, when the files in the code package and the `INFO` file have a default timestamp of the UNIX epoch. This breaks certain tools like `zipfile` that throw an error on files that are older than 1980 ([source link](https://github.com/python/cpython/blob/3.7/Lib/zipfile.py#L356)). In this PR, we change the default timestamp to Dec 3, 2019

Here is how the code package looks on a container (equivalent to AWS batch) before and after this change:

**Before**
```
...
-rw-r--r--  1 root root     1147 Jan  1  1970 my_flow.py
-rw-r--r--  1 root root    23383 Jan  1  1970 INFO
...
```

**After**
```
...
-rw-r--r--  1 root root     1147 Dec  3  2019 my_flow.py
-rw-r--r--  1 root root    23383 Dec  3  2019 INFO
...

```