### PR TITLE
Wrap errors importing over the escape hatch as ImportError

### DIFF
--- a/metaflow/plugins/env_escape/client.py
+++ b/metaflow/plugins/env_escape/client.py
@@ -42,7 +42,20 @@ BIND_RETRY = 0
 
 
 class Client(object):
-    def __init__(self, python_executable, pythonpath, max_pickle_version, config_dir):
+    def __init__(
+        self, modules, python_executable, pythonpath, max_pickle_version, config_dir
+    ):
+        # Wrap with ImportError so that if users are just using the escaped module
+        # as optional, the typical logic of catching ImportError works properly
+        try:
+            self.inner_init(
+                python_executable, pythonpath, max_pickle_version, config_dir
+            )
+        except Exception as e:
+            # Typically it's one override per config so we just use the first one.
+            raise ImportError("Error loading module: %s" % str(e), name=modules[0])
+
+    def inner_init(self, python_executable, pythonpath, max_pickle_version, config_dir):
         # Make sure to init these variables (used in __del__) early on in case we
         # have an exception
         self._poller = None

--- a/metaflow/plugins/env_escape/client_modules.py
+++ b/metaflow/plugins/env_escape/client_modules.py
@@ -150,6 +150,7 @@ class ModuleImporter(object):
             max_pickle_version = min(self._max_pickle_version, pickle.HIGHEST_PROTOCOL)
 
             self._client = Client(
+                self._module_prefixes,
                 self._python_executable,
                 self._pythonpath,
                 max_pickle_version,


### PR DESCRIPTION
This allows the pattern:
```
try:
  import foo
except ImportError:
  pass
```

to work as expected. Currently, it could raise a RuntimeError which would then propagate back to the user.