### PR TITLE
fix: support email in argo workflow names

### DIFF
--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -326,6 +326,8 @@ def resolve_workflow_name(obj, name):
         # by default. Also, while project and branch allow for underscores, Argo
         # Workflows doesn't (DNS Subdomain names as defined in RFC 1123) - so we will
         # remove any underscores as well as convert the name to lower case.
+        # Also remove + and @ as not allowed characters, which can be part of the
+        # project branch due to using email addresses as user names.
         if len(workflow_name) > 253:
             name_hash = to_unicode(
                 base64.b32encode(sha1(to_bytes(workflow_name)).digest())
@@ -337,6 +339,8 @@ def resolve_workflow_name(obj, name):
                 re.compile(r"^[^A-Za-z0-9]+")
                 .sub("", workflow_name)
                 .replace("_", "")
+                .replace("@", "")
+                .replace("+", "")
                 .lower()
             )
             obj._is_workflow_name_modified = True
@@ -367,6 +371,8 @@ def resolve_workflow_name(obj, name):
                 re.compile(r"^[^A-Za-z0-9]+")
                 .sub("", workflow_name)
                 .replace("_", "")
+                .replace("@", "")
+                .replace("+", "")
                 .lower()
             )
             obj._is_workflow_name_modified = True


### PR DESCRIPTION
- strip @ and + from workflow names to support project branches that use email addresses as usernames.