### PR TITLE
feature: add validation for what flow the run_id belongs to

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -306,7 +306,13 @@ class ArgoWorkflows(object):
                     workflow["metadata"]["annotations"]["metaflow/owner"],
                     workflow["metadata"]["annotations"]["metaflow/production_token"],
                     workflow["metadata"]["annotations"]["metaflow/flow_name"],
-                    workflow["spec"]["workflowTemplateRef"]["name"],
+                    workflow["metadata"]["annotations"].get(
+                        "metaflow/branch_name", None
+                    ),
+                    workflow["metadata"]["annotations"].get(
+                        "metaflow/project_name", None
+                    ),
+                    # workflow["spec"]["workflowTemplateRef"]["name"],
                 )
             except KeyError:
                 raise ArgoWorkflowsException(

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -312,7 +312,6 @@ class ArgoWorkflows(object):
                     workflow["metadata"]["annotations"].get(
                         "metaflow/project_name", None
                     ),
-                    # workflow["spec"]["workflowTemplateRef"]["name"],
                 )
             except KeyError:
                 raise ArgoWorkflowsException(

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -297,6 +297,24 @@ class ArgoWorkflows(object):
                 )
         return None
 
+    @classmethod
+    def get_execution(cls, name):
+        workflow = ArgoClient(namespace=KUBERNETES_NAMESPACE).get_workflow(name)
+        if workflow is not None:
+            try:
+                return (
+                    workflow["metadata"]["annotations"]["metaflow/owner"],
+                    workflow["metadata"]["annotations"]["metaflow/production_token"],
+                    workflow["metadata"]["annotations"]["metaflow/flow_name"],
+                    workflow["spec"]["workflowTemplateRef"]["name"],
+                )
+            except KeyError:
+                raise ArgoWorkflowsException(
+                    "A non-metaflow workflow *%s* already exists in Argo Workflows."
+                    % name
+                )
+        return None
+
     def _process_parameters(self):
         parameters = {}
         has_schedule = self.flow._flow_decorators.get("schedule") is not None

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -726,13 +726,15 @@ def validate_run_id(workflow_name, run_id):
     """
     # Verify that user is trying to change an Argo workflow
     if not run_id.startswith("argo-"):
-        raise MetaflowException("Argo workflow execution id's start with 'argo-'")
+        raise MetaflowException(
+            "Run IDs for flows executed through Argo Workflows begin with 'argo-'"
+        )
 
     # Verify that run_id belongs to the Flow, and that branches match
     name = run_id[5:]
     workflow = ArgoWorkflows.get_execution(name)
     if workflow is None:
-        raise MetaflowException("Could not find the workflow *%s*" % run_id)
+        raise MetaflowException("Could not find workflow *%s* on Argo Workflows" % name)
 
     _owner, _token, deployed_flow_name, deployed_workflow_template_name = workflow
 


### PR DESCRIPTION
The new CLI commands for argo-workflows that accept a `run_id` have had a pending issue regarding production token authorization, and lacking any guard against passing an arbitrary run_id to a flow file that the user has a valid production token for.

This PR introduces checks for
- the run_id is of the same flow_name as the CLI command was issued on
- the run_id is of the same project and branch as the CLI command was issued on
- the user issuing the command has a production token for the workflow with the run_id
- the run_id is for an Argo Workflow (existing prefix check, simply moved it to the same validation function)