### PR TITLE
Pass the user-defined executable to environment's `executable`

### DIFF
--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -193,7 +193,9 @@ class MetaflowEnvironment(object):
             env[ext_key] = ext_val
         return env
 
-    def executable(self, step_name):
+    def executable(self, step_name, default=None):
+        if default is not None:
+            return default
         return self._python()
 
     def _python(self):

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -190,8 +190,7 @@ def step(
     if R.use_r():
         entrypoint = R.entrypoint()
     else:
-        if executable is None:
-            executable = ctx.obj.environment.executable(step_name)
+        executable = ctx.obj.environment.executable(step_name, executable)
         entrypoint = "%s -u %s" % (executable, os.path.basename(sys.argv[0]))
 
     top_args = " ".join(util.dict_to_cli_options(ctx.parent.parent.params))

--- a/metaflow/plugins/conda/conda_environment.py
+++ b/metaflow/plugins/conda/conda_environment.py
@@ -96,12 +96,12 @@ class CondaEnvironment(MetaflowEnvironment):
         config.append("--disable=F0401")
         return config
 
-    def executable(self, step_name):
+    def executable(self, step_name, default=None):
         # Get relevant python interpreter for step
         executable = self._get_executable(step_name)
         if executable is not None:
             return executable
-        return self.base_env.executable(step_name)
+        return self.base_env.executable(step_name, default)
 
     @classmethod
     def get_client_info(cls, flow_name, metadata):

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -141,8 +141,7 @@ def step(
     node = ctx.obj.graph[step_name]
 
     # Construct entrypoint CLI
-    if executable is None:
-        executable = ctx.obj.environment.executable(step_name)
+    executable = ctx.obj.environment.executable(step_name, executable)
 
     # Set environment
     env = {}


### PR DESCRIPTION
This allows a user to specify an executable and have that executable only be used for non Conda steps.

Note that currently there is no direct way to specify the executable for batch/kube although the functionality is half present.