### PR TITLE
[bugfix] support `--with environment` in Airflow

### DIFF
--- a/metaflow/plugins/airflow/airflow.py
+++ b/metaflow/plugins/airflow/airflow.py
@@ -277,7 +277,7 @@ class Airflow(object):
         env_deco = [deco for deco in node.decorators if deco.name == "environment"]
         env = {}
         if env_deco:
-            env = env_deco[0].attributes["vars"]
+            env = env_deco[0].attributes["vars"].copy()
 
         # The below if/else block handles "input paths".
         # Input Paths help manage dataflow across the graph.


### PR DESCRIPTION
- There was a bug overwrote the env values set in the environment decorator
- This made the env decorator export all metaflow related env values in the cli instead of the ones set via the cli.