### PR TITLE
sanitize / in secret names

### DIFF
--- a/metaflow/plugins/aws/secrets_manager/aws_secrets_manager_secrets_provider.py
+++ b/metaflow/plugins/aws/secrets_manager/aws_secrets_manager_secrets_provider.py
@@ -37,7 +37,7 @@ def _sanitize_key_as_env_var(key):
     Also, it's TBD whether all possible providers will share the same sanitization logic.
     Therefore we will keep this function private for now
     """
-    return key.replace("-", "_").replace(".", "_").replace("/", "_") 
+    return key.replace("-", "_").replace(".", "_").replace("/", "_")
 
 
 class AwsSecretsManagerSecretsProvider(SecretsProvider):

--- a/metaflow/plugins/aws/secrets_manager/aws_secrets_manager_secrets_provider.py
+++ b/metaflow/plugins/aws/secrets_manager/aws_secrets_manager_secrets_provider.py
@@ -37,7 +37,7 @@ def _sanitize_key_as_env_var(key):
     Also, it's TBD whether all possible providers will share the same sanitization logic.
     Therefore we will keep this function private for now
     """
-    return key.replace("-", "_").replace(".", "_")
+    return key.replace("-", "_").replace(".", "_").replace("/", "_") 
 
 
 class AwsSecretsManagerSecretsProvider(SecretsProvider):


### PR DESCRIPTION
Its not uncommon and even seems to be recommended by AWS to use `/` in AWS Secret Manager secret names. If used in conjunction with non-JSON secrets, it leads to issues here since we use secret name as environment variable name, and that can't contain `/`