### PR TITLE
allow to customize env var name in @secrets

### DIFF
--- a/metaflow/plugins/aws/secrets_manager/aws_secrets_manager_secrets_provider.py
+++ b/metaflow/plugins/aws/secrets_manager/aws_secrets_manager_secrets_provider.py
@@ -147,7 +147,11 @@ class AwsSecretsManagerSecretsProvider(SecretsProvider):
                         "Secret string could not be parsed as JSON"
                     )
             else:
-                _sanitize_and_add_entry_to_result(secret_name, secret_str)
+                if options.get("env_var_name"):
+                    env_var_name = options["env_var_name"]
+                else:
+                    env_var_name = secret_name
+                _sanitize_and_add_entry_to_result(env_var_name, secret_str)
 
         elif "SecretBinary" in response:
             # boto3 docs say response gives base64 encoded, but it's wrong.
@@ -157,8 +161,12 @@ class AwsSecretsManagerSecretsProvider(SecretsProvider):
             # bytes.
             #
             # The trailing decode gives us a final UTF-8 string.
+            if options.get("env_var_name"):
+                env_var_name = options["env_var_name"]
+            else:
+                env_var_name = secret_name
             _sanitize_and_add_entry_to_result(
-                secret_name, base64.b64encode(response["SecretBinary"]).decode()
+                env_var_name, base64.b64encode(response["SecretBinary"]).decode()
             )
         else:
             raise MetaflowAWSSecretsManagerBadResponse(


### PR DESCRIPTION
Follow up for https://github.com/Netflix/metaflow/pull/1470. This adds an option to customize environment variable name to use to store secret value when used with AWS version of `@secrets` decorator, and it only applies when the secret is _not_  formatted as a JSON dict (otherwise we just use JSON key as env var as before).