### PR TITLE
fix: Argo events parameters with spaces

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -1654,7 +1654,7 @@ class ArgoWorkflows(object):
                                                 # Technically, we don't need to create
                                                 # a payload carry-on and can stuff
                                                 # everything within the body.
-                                                data_template="{{body.payload.%s | squote}}"
+                                                data_template="{{ .Input.body.payload.%s | squote }}"
                                                 % v,
                                                 # Unfortunately the sensor needs to
                                                 # record the default values for

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -1018,7 +1018,9 @@ class ArgoWorkflows(object):
                     + [
                         # Parameter names can be hyphenated, hence we use
                         # {{foo.bar['param_name']}}.
-                        "--%s={{workflow.parameters.%s}}"
+                        # https://argoproj.github.io/argo-events/tutorials/02-parameterization/
+                        # http://masterminds.github.io/sprig/strings.html
+                        "--%s={{workflow.parameters.%s | squote}}"
                         % (parameter["name"], parameter["name"])
                         for parameter in self.parameters.values()
                     ]

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -1654,7 +1654,7 @@ class ArgoWorkflows(object):
                                                 # Technically, we don't need to create
                                                 # a payload carry-on and can stuff
                                                 # everything within the body.
-                                                data_template="{{ .Input.body.payload.%s | squote }}"
+                                                data_template="{{ .Input.body.payload.%s | toJson }}"
                                                 % v,
                                                 # Unfortunately the sensor needs to
                                                 # record the default values for

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -1020,7 +1020,7 @@ class ArgoWorkflows(object):
                         # {{foo.bar['param_name']}}.
                         # https://argoproj.github.io/argo-events/tutorials/02-parameterization/
                         # http://masterminds.github.io/sprig/strings.html
-                        "--%s={{workflow.parameters.%s | squote}}"
+                        "--%s={{workflow.parameters.%s}}"
                         % (parameter["name"], parameter["name"])
                         for parameter in self.parameters.values()
                     ]
@@ -1654,7 +1654,8 @@ class ArgoWorkflows(object):
                                                 # Technically, we don't need to create
                                                 # a payload carry-on and can stuff
                                                 # everything within the body.
-                                                data_key="body.payload.%s" % v,
+                                                data_template="{{body.payload.%s | squote}}"
+                                                % v,
                                                 # Unfortunately the sensor needs to
                                                 # record the default values for
                                                 # the parameters - there doesn't seem
@@ -2510,10 +2511,11 @@ class TriggerParameter(object):
         tree = lambda: defaultdict(tree)
         self.payload = tree()
 
-    def src(self, dependency_name, data_key, value):
+    def src(self, dependency_name, value, data_key=None, data_template=None):
         self.payload["src"] = {
             "dependencyName": dependency_name,
             "dataKey": data_key,
+            "dataTemplate": data_template,
             "value": value,
             # explicitly set it to false to ensure proper deserialization
             "useRawData": False,


### PR DESCRIPTION
Fix handling spaces in argo events payload when mapping payload values to parameters.

Tested that this does not re-introduce the double quoting bug for regular parameter usage. Tried out different Sprig functions for escaping, including `squote` and `quote`, but settled with `toJson` in order to escape errant quotes in the middle of the inputs.

Encountered some funky behavior with Argo events parameter handling: when using `dataTemplate`, if the template execution fails (for example due to providing a non-existant jsonpath), the workflow will not fail, instead it will fallback to the default parameter values provided in the sensor. This was a bit of a head scratcher during testing.

Addresses #1458 