### PR TITLE
fix: validate required configuration for Batch

### DIFF
--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -91,8 +91,8 @@ class BatchDecorator(StepDecorator):
         "gpu": None,
         "memory": None,
         "image": None,
-        "queue": BATCH_JOB_QUEUE,
-        "iam_role": ECS_S3_ACCESS_IAM_ROLE,
+        "queue": BATCH_JOB_QUEUE,  # Will be replaced with an available queue if not provided.
+        "iam_role": ECS_S3_ACCESS_IAM_ROLE,  # Required
         "execution_role": ECS_FARGATE_EXECUTION_ROLE,
         "shared_memory": None,
         "max_swap": None,
@@ -149,6 +149,13 @@ class BatchDecorator(StepDecorator):
         if flow_datastore.TYPE != "s3":
             raise BatchException("The *@batch* decorator requires --datastore=s3.")
 
+        # Require iam_role
+        if self.attributes["iam_role"] is None:
+            raise BatchException(
+                "Executions with AWS Batch require an IAM Role.\n"
+                'Provide one in the decorator with *@batch(iam_role="role-name")* '
+                "or set a default role with the environment variable *METAFLOW_ECS_S3_ACCESS_IAM_ROLE*"
+            )
         # Set internal state.
         self.logger = logger
         self.environment = environment

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -151,10 +151,10 @@ class BatchDecorator(StepDecorator):
 
         # Require iam_role
         if self.attributes["iam_role"] is None:
+            # TODO: Unify messaging on various configuration options.
             raise BatchException(
-                "Executions with AWS Batch require an IAM Role.\n"
-                'Provide one in the decorator with *@batch(iam_role="role-name")* '
-                "or set a default role with the environment variable *METAFLOW_ECS_S3_ACCESS_IAM_ROLE*"
+                "The *@batch* decorator requires an IAM Role that allows AWS Batch job to communicate with Amazon S3 datastore.\n"
+                'You can specify it either with @batch(iam_role="role-name") or by setting METAFLOW_ECS_S3_ACCESS_IAM_ROLE in your configuration.'
             )
         # Set internal state.
         self.logger = logger


### PR DESCRIPTION
add validation for the Batch decorator that checks that an `iam_role` is configured (either through the decorator, or with an environment variable).

Currently if `METAFLOW_ECS_S3_ACCESS_IAM_ROLE` is not configured, trying to run a flow with `--with batch` or deploying with step-functions will fail to an error
```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter containerProperties.jobRoleArn, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
```