### PR TITLE
Fix/863 - Improve error message in metaflow.S3 class when DATATOOLS_S3ROOT is not configured.

### DIFF
--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -495,6 +495,10 @@ class S3(object):
 
     @classmethod
     def get_root_from_config(cls, echo, create_on_absent=True):
+        if DATATOOLS_S3ROOT is None:
+            raise MetaflowS3URLException(
+                "DATATOOLS_S3ROOT is not configured when trying to use S3 storage"
+            )
         return DATATOOLS_S3ROOT
 
     def __init__(
@@ -512,6 +516,10 @@ class S3(object):
 
         if run:
             # 1. use a (current) run ID with optional customizations
+            if DATATOOLS_S3ROOT is None:
+                raise MetaflowS3URLException(
+                    "DATATOOLS_S3ROOT is not configured when trying to use S3 storage"
+                )
             parsed = urlparse(DATATOOLS_S3ROOT)
             if not bucket:
                 bucket = parsed.netloc

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -495,10 +495,6 @@ class S3(object):
 
     @classmethod
     def get_root_from_config(cls, echo, create_on_absent=True):
-        if DATATOOLS_S3ROOT is None:
-            raise MetaflowS3URLException(
-                "DATATOOLS_S3ROOT is not configured when trying to use S3 storage"
-            )
         return DATATOOLS_S3ROOT
 
     def __init__(


### PR DESCRIPTION
I recently encountered the issue raised in I[ssue 863](https://github.com/Netflix/metaflow/issues/683). 

I note that there is an existing [PR](https://github.com/Netflix/metaflow/pull/853) on this issue. However, it is very old and I assume now dead. As a result, I have made a new PR that addresses the comments in the original PR. 