### PR TITLE
Addressing max-value-size getting used when a file argument is passed

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -234,8 +234,17 @@ def output_dot(obj):
 )
 @click.pass_obj
 def dump(obj, input_path, private=None, max_value_size=None, include=None, file=None):
-
     output = {}
+    
+    if file is not None and max_value_size is not None:
+        raise ValueError("max_value_size set to None when a file variable is provided will get replace the file variable")
+    elif file is None and max_value_size is None:
+        echo("max_value_size will be set to 1000 when neither file nor max_value_size is set to prevent all information being printed to stdout")
+        max_value_size = 1000
+    elif file is not None:
+        echo("if file is specified we set max_value_size to infinity to ensure all information is written to the file")
+        max_value_size = float('inf')
+    
     kwargs = {
         "show_private": private,
         "max_value_size": max_value_size,

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -237,7 +237,7 @@ def dump(obj, input_path, private=None, max_value_size=None, include=None, file=
     output = {}
     
     if file is not None and max_value_size is not None:
-        raise ValueError("max_value_size set to None when a file variable is provided will get replace the file variable")
+        raise CommandException("max_value_size set to None when a file variable is provided will get replace the file variable")
     elif file is None and max_value_size is None:
         echo("max_value_size will be set to 1000 when neither file nor max_value_size is set to prevent all information being printed to stdout")
         max_value_size = 1000


### PR DESCRIPTION
adding code to alert users that when a --file argument is provided the --max-value-size gets set to None as well as updating the max_value_size var

This PR addresses issue https://github.com/Netflix/metaflow/issues/524 and also adds logging to let users know that the --file argument will override the --max-value-size argument when used in conjunction to prevent values getting overwritten.