### PR TITLE
Fix/doctring

### DIFF
--- a/metaflow/includefile.py
+++ b/metaflow/includefile.py
@@ -256,7 +256,7 @@ class IncludeFile(Parameter):
         `required=True` implies that the `default` is not used.
     help : str, optional
         Help text to show in `run --help`.
-    
+
     Other Parameters
     ----------
     default(str) : str or a function

--- a/metaflow/includefile.py
+++ b/metaflow/includefile.py
@@ -259,11 +259,9 @@ class IncludeFile(Parameter):
     
     Other Parameters
     ----------
-    **kwargs : dict
-        A dictory of other paramters to pass to the function. For example:
-        default : str or a function
-            Default path to a local file. A function
-            implies that the parameter corresponds to a *deploy-time parameter*.
+    default(str) : str or a function
+        Default path to a local file. A function
+        implies that the parameter corresponds to a *deploy-time parameter*.
     """
 
     def __init__(

--- a/metaflow/includefile.py
+++ b/metaflow/includefile.py
@@ -246,9 +246,6 @@ class IncludeFile(Parameter):
     ----------
     name : str
         User-visible parameter name.
-    default : str or a function
-        Default path to a local file. A function
-        implies that the parameter corresponds to a *deploy-time parameter*.
     is_text : bool, default: True
         Convert the file contents to a string using the provided `encoding`.
         If False, the artifact is stored in `bytes`.
@@ -259,8 +256,14 @@ class IncludeFile(Parameter):
         `required=True` implies that the `default` is not used.
     help : str, optional
         Help text to show in `run --help`.
-    show_default : bool, default: True
-        If True, show the default value in the help text.
+    
+    Other Parameters
+    ----------
+    **kwargs : dict
+        A dictory of other paramters to pass to the function. For example:
+        default : str or a function
+            Default path to a local file. A function
+            implies that the parameter corresponds to a *deploy-time parameter*.
     """
 
     def __init__(


### PR DESCRIPTION
Internal netflix is using Griffe format for all documentation. This doc string failed because not all parameters listed in the comment are in the init() function. This PR is to remove unused parameters from the comments 