### PR TITLE
Adding 'disk' parameter to @resources decorator

### DIFF
--- a/metaflow/plugins/resources_decorator.py
+++ b/metaflow/plugins/resources_decorator.py
@@ -25,7 +25,7 @@ class ResourcesDecorator(StepDecorator):
         Number of CPUs required for this step.
     gpu : int, default: 0
         Number of GPUs required for this step.
-    disk : int, default: 10240
+    disk : int, optional
         Disk size (in MB) required for this step. Only applies on Kubernetes.
     memory : int, default: 4096
         Memory size (in MB) required for this step.
@@ -38,7 +38,7 @@ class ResourcesDecorator(StepDecorator):
     defaults = {
         "cpu": "1",
         "gpu": "0",
-        "disk": "10240",
+        "disk": None,
         "memory": "4096",
         "shared_memory": None,
     }

--- a/metaflow/plugins/resources_decorator.py
+++ b/metaflow/plugins/resources_decorator.py
@@ -25,6 +25,8 @@ class ResourcesDecorator(StepDecorator):
         Number of CPUs required for this step.
     gpu : int, default: 0
         Number of GPUs required for this step.
+    disk : int, default: 10240
+        Disk size (in MB) required for this step. Only applies on Kubernetes.
     memory : int, default: 4096
         Memory size (in MB) required for this step.
     shared_memory : int, optional
@@ -36,7 +38,7 @@ class ResourcesDecorator(StepDecorator):
     defaults = {
         "cpu": "1",
         "gpu": "0",
+        "disk": "10240",
         "memory": "4096",
         "shared_memory": None,
-        "disk": "10240",
     }

--- a/metaflow/plugins/resources_decorator.py
+++ b/metaflow/plugins/resources_decorator.py
@@ -33,4 +33,10 @@ class ResourcesDecorator(StepDecorator):
     """
 
     name = "resources"
-    defaults = {"cpu": "1", "gpu": "0", "memory": "4096", "shared_memory": None}
+    defaults = {
+        "cpu": "1",
+        "gpu": "0",
+        "memory": "4096",
+        "shared_memory": None,
+        "disk": "10240",
+    }


### PR DESCRIPTION
We would like to use the @resources decorator instead of @kubernetes to specify resource requirements for our job so we can run flows locally or on Kubernetes by using `--with kubernetes` instead of modifying the code. The @resources decorator only supports cpu, gpu, memory and shared_memory at the moment.

This PR just adds the disk parameter. Default value (10240mb) is the same as the one in @kubernetes.