### PR TITLE
Remove validate_environment from task lifecycle

### DIFF
--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -53,9 +53,6 @@ class MetaflowTask(object):
         self.ubf_context = ubf_context
 
     def _exec_step_function(self, step_function, input_obj=None):
-        self.environment.validate_environment(
-            self.console_logger, self.flow_datastore.TYPE
-        )
         if input_obj is None:
             step_function()
         else:


### PR DESCRIPTION
Has no utility at its current spot and makes the lifecycle.png diagram more accurate.