### PR TITLE
add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,4 +13,4 @@
 
 You can disclose vulnerabilities securely through the [Netflix Bugcrowd](https://bugcrowd.com/netflix) site. When reporting a finding, mention the project name or repository in the title and the report will find its way to the correct people.
 
-Please note that at this moment the Metaflow projects do not offer a bounty for any findings.
+Please note that at the moment, the Metaflow project does not offer a bounty for any disclosure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| *       | :white_check_mark: |
+<!-- | 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                | -->
+
+## Reporting a Vulnerability
+
+You can disclose vulnerabilities securely through the [Netflix Bugcrowd](https://bugcrowd.com/netflix) site. When reporting a finding, mention the project name or repository in the title and the report will find its way to the correct people.
+
+Please note that at this moment the Metaflow projects do not offer a bounty for any findings.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,6 @@
 # Security Policy
 
-## Supported Versions
-
-| Version | Supported          |
-| ------- | ------------------ |
-| *       | :white_check_mark: |
-<!-- | 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                | -->
+We currently accept reports for vulnerabilities on all published versions of the project. 
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
- adding a security policy to detail how to safely disclose vulnerabilities.


Discussion:
- Supported versions, are all reports of interest, or should we already have a cut off at some version number?
- As an alternative method we do have the option of reaching out to developers through Slack, but I would rather have us suggest one preferred method for reporting for simplicity.