### PR TITLE
fix: GPU scheduling issue

### DIFF
--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -270,7 +270,8 @@ class KubernetesDecorator(StepDecorator):
                 )
             )
 
-        # Treat gpu=0 as non-requests, but rewrite this as None for simpler handling in Kubernetes job/Argo Workflow templates
+        # Treat gpu=0 as non-requests, but rewrite this as None for simpler handling in Kubernetes job/Argo Workflow templates.
+        # This is important, as adding a gpu limit with a value of 0 will be preferred for gpu nodes by the scheduler.
         if self.attributes["gpu"] is not None and int(self.attributes["gpu"]) == 0:
             self.attributes["gpu"] = None
 

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -270,6 +270,10 @@ class KubernetesDecorator(StepDecorator):
                 )
             )
 
+        # Treat gpu=0 as non-requests, but rewrite this as None for simpler handling in Kubernetes job/Argo Workflow templates
+        if self.attributes["gpu"] is not None and int(self.attributes["gpu"]) == 0:
+            self.attributes["gpu"] = None
+
         if self.attributes["tmpfs_size"]:
             if not (
                 isinstance(self.attributes["tmpfs_size"], (int, unicode, basestring))


### PR DESCRIPTION
Kubernetes jobs are getting preferred for scheduling on gpu nodes in cases where kubernetes or resources decorator sets `gpu=0` when this should not be the case.

Changes so that gpu vendor is not added to limits if the value is None or zero.