### PR TITLE
Fix the merging of borked lines with MFLOG

### DIFF
--- a/metaflow/mflog/mflog.py
+++ b/metaflow/mflog/mflog.py
@@ -137,7 +137,7 @@ def merge_logs(logs):
             res = MFLogline(
                 False, None, MISSING_TIMESTAMP_STR, None, None, line, MISSING_TIMESTAMP
             )
-            yield res.utc_tstamp_str, res
+            yield res.utc_tstamp_str.encode("utf-8"), res
 
     # note that sorted() below should be a very cheap, often a O(n) operation
     # because Python's Timsort is very fast for already sorted data.

--- a/metaflow/mflog/mflog.py
+++ b/metaflow/mflog/mflog.py
@@ -135,9 +135,15 @@ def merge_logs(logs):
                 missing.append(line)
         for line in missing:
             res = MFLogline(
-                False, None, MISSING_TIMESTAMP_STR, None, None, line, MISSING_TIMESTAMP
+                False,
+                None,
+                MISSING_TIMESTAMP_STR.encode("utf-8"),
+                None,
+                None,
+                line,
+                MISSING_TIMESTAMP,
             )
-            yield res.utc_tstamp_str.encode("utf-8"), res
+            yield res.utc_tstamp_str, res
 
     # note that sorted() below should be a very cheap, often a O(n) operation
     # because Python's Timsort is very fast for already sorted data.


### PR DESCRIPTION
In case there are borked lines in a log file, the current code would not properly merge the logs because borked lines returned a datetime string as a str and not as bytes like non-borked lines.