### PR TITLE
Check for the first finished parallel proccess

### DIFF
--- a/metaflow/multicore_utils.py
+++ b/metaflow/multicore_utils.py
@@ -76,7 +76,7 @@ def parallel_imap_unordered(func, iterable, max_parallel=None, dir=None):
                 pids.pop(idx)
                 break
         else:
-            time.sleep(1)  # Wait a bit before re-checking
+            time.sleep(0.1)  # Wait a bit before re-checking
             continue
 
         if exit_code:

--- a/test/unit/test_multicore_utils.py
+++ b/test/unit/test_multicore_utils.py
@@ -2,4 +2,11 @@ from metaflow.multicore_utils import parallel_map
 
 
 def test_parallel_map():
-    assert parallel_map(lambda s: s.upper(), ['a', 'b', 'c', 'd', 'e', 'f']) == ['A', 'B', 'C', 'D', 'E', 'F']
+    assert parallel_map(lambda s: s.upper(), ["a", "b", "c", "d", "e", "f"]) == [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F",
+    ]

--- a/test/unit/test_multicore_utils.py
+++ b/test/unit/test_multicore_utils.py
@@ -1,0 +1,5 @@
+from metaflow.multicore_utils import parallel_map
+
+
+def test_parallel_map():
+    assert parallel_map(lambda s: s.upper(), ['a', 'b', 'c', 'd', 'e', 'f']) == ['A', 'B', 'C', 'D', 'E', 'F']


### PR DESCRIPTION
This fixes https://github.com/Netflix/metaflow/issues/1316 to optimize the parallel map runs by checking for the first finished process instead of waiting for the first process before checking others.