### PR TITLE
chore: add pypi base decorator

### DIFF
--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -58,6 +58,7 @@ FLOW_DECORATORS_DESC = [
     ("project", ".project_decorator.ProjectDecorator"),
     ("trigger", ".events_decorator.TriggerDecorator"),
     ("trigger_on_finish", ".events_decorator.TriggerOnFinishDecorator"),
+    ("pypi_base", ".pypi.pypi_decorator.PyPIFlowDecorator"),
     ("conda_base", ".pypi.conda_decorator.CondaFlowDecorator"),
 ]
 


### PR DESCRIPTION
add `pypi_base` decorator.

TODO can be handled in this PR if support for `disabled` and `python` attributes gets merged in first.