### PR TITLE
Add parameter info to argo workflow template annotations

### DIFF
--- a/metaflow/parameters.py
+++ b/metaflow/parameters.py
@@ -40,7 +40,7 @@ context_proto = None
 
 
 class JSONTypeClass(click.ParamType):
-    name = __name__ = "JSON"
+    name = "JSON"
 
     def convert(self, value, param, ctx):
         if not isinstance(value, strtype):

--- a/metaflow/parameters.py
+++ b/metaflow/parameters.py
@@ -40,7 +40,7 @@ context_proto = None
 
 
 class JSONTypeClass(click.ParamType):
-    name = "JSON"
+    name = __name__ = "JSON"
 
     def convert(self, value, param, ctx):
         if not isinstance(value, strtype):

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -574,6 +574,11 @@ class ArgoWorkflows(object):
             "metaflow/user": "argo-workflows",
             "metaflow/flow_name": self.flow.name,
         }
+
+        for name, parameter in self.parameters.items():
+            if parameter["is_required"]:
+                annotations[f"metaflow/parameter-required-{name}"] = "true"
+    
         if current.get("project_name"):
             annotations.update(
                 {

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from hashlib import sha1
 
 from metaflow import current, JSONType
+from metaflow.includefile import FilePathClass
 from metaflow.decorators import flow_decorators
 from metaflow.exception import MetaflowException
 from metaflow.metaflow_config import (
@@ -401,7 +402,9 @@ class ArgoWorkflows(object):
                 )
             seen.add(norm)
 
-            if param.kwargs.get("type") == JSONType:
+            if param.kwargs.get("type") == JSONType or isinstance(
+                param.kwargs.get("type"), FilePathClass
+            ):
                 # Special-case this to avoid touching core
                 param_type = str(param.kwargs.get("type").name)
             else:

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -7,7 +7,7 @@ import sys
 from collections import defaultdict
 from hashlib import sha1
 
-from metaflow import current
+from metaflow import current, JSONType
 from metaflow.decorators import flow_decorators
 from metaflow.exception import MetaflowException
 from metaflow.metaflow_config import (
@@ -401,7 +401,11 @@ class ArgoWorkflows(object):
                 )
             seen.add(norm)
 
-            param_type = str(param.kwargs.get("type").__name__)
+            if param.kwargs.get("type") == JSONType:
+                # Special-case this to avoid touching core
+                param_type = str(param.kwargs.get("type").name)
+            else:
+                param_type = str(param.kwargs.get("type").__name__)
 
             is_required = param.kwargs.get("required", False)
             # Throw an exception if a schedule is set for a flow with required

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -583,11 +583,7 @@ class ArgoWorkflows(object):
         }
 
         if self.parameters:
-            annotations.update(
-                {
-                    "metaflow/parameters": json.dumps(self.parameters)
-                }
-            )
+            annotations.update({"metaflow/parameters": json.dumps(self.parameters)})
 
         if current.get("project_name"):
             annotations.update(

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -575,10 +575,16 @@ class ArgoWorkflows(object):
             "metaflow/flow_name": self.flow.name,
         }
 
+        required_params = ""
+
         for name, parameter in self.parameters.items():
             if parameter["is_required"]:
-                annotations[f"metaflow/parameter-required-{name}"] = "true"
+                if len(required_params) > 0:
+                    required_params += ","
+                required_params += name
     
+        annotations[f"metaflow/required-parameters"] = required_params
+
         if current.get("project_name"):
             annotations.update(
                 {


### PR DESCRIPTION
This PR adds information on which parameters are required, to the annotations section of argo-workflow templates.  This can be used to validate the well-formed-ness of workflow submissions before submitting the workflow to argo-workflows.  Before this PR the only way to validate parameters was to submit the workflow and wait until metaflow runs within the argo-workflow, only to fail at parameter validation.  After this change, we can fail-fast and, in the process, save on compute as well as etcd storage.


Manually tested for the following parameter types both locally and in argo-workflows:
- [x] String
- [x] Int
- [x] Float
- [x] Boolean
- [x] JSON
- [x] IncludeFile
- [x] [Deploy-time parameter evaluation](https://docs.metaflow.org/production/scheduling-metaflow-flows/scheduling-with-argo-workflows#deploy-time-parameters)