### PR TITLE
[@card] Realtime cards (4/N)

### DIFF
--- a/metaflow/plugins/cards/card_cli.py
+++ b/metaflow/plugins/cards/card_cli.py
@@ -965,7 +965,7 @@ def list(
     default=8324,
     show_default=True,
     type=int,
-    help="Port on which Metaflow card server will run",
+    help="Port on which Metaflow card viewer server will run",
 )
 @click.option(
     "--namespace",
@@ -980,14 +980,14 @@ def list(
     default=5,
     show_default=True,
     type=int,
-    help="Polling interval of the card viewer.",
+    help="Polling interval of the card viewer server.",
 )
 @click.option(
     "--max-cards",
     default=30,
     show_default=True,
     type=int,
-    help="Maximum number of cards to be shown at any time by the server",
+    help="Maximum number of cards to be shown at any time by the card viewer server",
 )
 @click.pass_context
 def server(ctx, run_id, port, user_namespace, poll_interval, max_cards):
@@ -1001,7 +1001,7 @@ def server(ctx, run_id, port, user_namespace, poll_interval, max_cards):
         ctx.obj.echo(_status_message, fg="red")
     options = CardServerOptions(
         flow_name=ctx.obj.flow.name,
-        run_object=run, 
+        run_object=run,
         only_running=False,
         follow_resumed=False,
         flow_datastore=ctx.obj.flow_datastore,

--- a/metaflow/plugins/cards/card_cli.py
+++ b/metaflow/plugins/cards/card_cli.py
@@ -1,6 +1,11 @@
 from metaflow.client import Task
 from metaflow import JSONType, namespace
-from metaflow.exception import CommandException
+from metaflow.util import resolve_identity
+from metaflow.exception import (
+    CommandException,
+    MetaflowNotFound,
+    MetaflowNamespaceMismatch,
+)
 import webbrowser
 import re
 from metaflow._vendor import click
@@ -945,3 +950,125 @@ def list(
         show_list_as_json=as_json,
         file=file,
     )
+
+
+@card.command(help="Run local card viewer server")
+@click.option(
+    "--run-id",
+    default=None,
+    show_default=True,
+    type=str,
+    help="Run ID of the flow",
+)
+@click.option(
+    "--port",
+    default=8324,
+    show_default=True,
+    type=int,
+    help="Port on which Metaflow card server will run",
+)
+@click.option(
+    "--namespace",
+    "user_namespace",
+    default=None,
+    show_default=True,
+    type=str,
+    help="Namespace of the flow",
+)
+@click.option(
+    "--poll-interval",
+    default=5,
+    show_default=True,
+    type=int,
+    help="Polling interval of the card viewer.",
+)
+@click.option(
+    "--max-cards",
+    default=30,
+    show_default=True,
+    type=int,
+    help="Maximum number of cards to be shown at any time by the server",
+)
+@click.pass_context
+def server(ctx, run_id, port, user_namespace, poll_interval, max_cards):
+    from .card_server import create_card_server, CardServerOptions
+
+    user_namespace = resolve_identity() if user_namespace is None else user_namespace
+    run, follow_new_runs, _status_message = _get_run_object(
+        ctx.obj, run_id, user_namespace
+    )
+    if _status_message is not None:
+        ctx.obj.echo(_status_message, fg="red")
+    options = CardServerOptions(
+        flow_name=ctx.obj.flow.name,
+        run_object=run, 
+        only_running=False,
+        follow_resumed=False,
+        flow_datastore=ctx.obj.flow_datastore,
+        max_cards=max_cards,
+        follow_new_runs=follow_new_runs,
+        poll_interval=poll_interval,
+    )
+    create_card_server(options, port, ctx.obj)
+
+
+def _get_run_from_cli_set_runid(obj, run_id):
+    # This run-id will be set from the command line args.
+    # So if we hit a MetaflowNotFound exception / Namespace mismatch then
+    # we should raise an exception
+    from metaflow import Run
+
+    flow_name = obj.flow.name
+    if len(run_id.split("/")) > 1:
+        raise CommandException(
+            "run_id should NOT be of the form: `<flowname>/<runid>`. Please provide only run-id"
+        )
+    try:
+        pathspec = "%s/%s" % (flow_name, run_id)
+        # Since we are looking at all namespaces,
+        # we will not
+        namespace(None)
+        return Run(pathspec)
+    except MetaflowNotFound:
+        raise CommandException("No run (%s) found for *%s*." % (run_id, flow_name))
+
+
+def _get_run_object(obj, run_id, user_namespace):
+    from metaflow import Flow
+
+    follow_new_runs = True
+    flow_name = obj.flow.name
+
+    if run_id is not None:
+        follow_new_runs = False
+        run = _get_run_from_cli_set_runid(obj, run_id)
+        obj.echo("Using run-id %s" % run.pathspec, fg="blue", bold=False)
+        return run, follow_new_runs, None
+
+    _msg = "Searching for runs in namespace: %s" % user_namespace
+    obj.echo(_msg, fg="blue", bold=False)
+
+    try:
+        namespace(user_namespace)
+        flow = Flow(pathspec=flow_name)
+        run = flow.latest_run
+    except MetaflowNotFound:
+        # When we have no runs found for the Flow, we need to ensure that
+        # if the `follow_new_runs` is set to True; If `follow_new_runs` is set to True then
+        # we don't raise the Exception and instead we return None and let the
+        # background Thread wait on the Retrieving the run object.
+        _status_msg = "No run found for *%s*." % flow_name
+        return None, follow_new_runs, _status_msg
+
+    except MetaflowNamespaceMismatch:
+        _status_msg = (
+            "No run found for *%s* in namespace *%s*. You can switch the namespace using --namespace"
+            % (
+                flow_name,
+                user_namespace,
+            )
+        )
+        return None, follow_new_runs, _status_msg
+
+    obj.echo("Using run-id %s" % run.pathspec, fg="blue", bold=False)
+    return run, follow_new_runs, None

--- a/metaflow/plugins/cards/card_creator.py
+++ b/metaflow/plugins/cards/card_creator.py
@@ -57,8 +57,11 @@ class CardCreator:
         logger=None,
         mode="render",
         final=False,
+        sync=False,
     ):
-        # warning_message("calling proc for uuid %s" % self._card_uuid, self._logger)
+        # Setting `final` will affect the Reload token set during the card refresh
+        # data creation along with synchronous execution of subprocess.
+        # Setting `sync` will only cause synchronous execution of subprocess.
         if mode != "render" and not runtime_card:
             # silently ignore runtime updates for cards that don't support them
             return
@@ -68,7 +71,6 @@ class CardCreator:
             component_strings = []
         else:
             component_strings = current.card._serialize_components(card_uuid)
-
         data = current.card._get_latest_data(card_uuid, final=final, mode=mode)
         runspec = "/".join([current.run_id, current.step_name, current.task_id])
         self._run_cards_subprocess(
@@ -82,6 +84,7 @@ class CardCreator:
             logger,
             data,
             final=final,
+            sync=sync,
         )
 
     def _run_cards_subprocess(
@@ -96,9 +99,10 @@ class CardCreator:
         logger,
         data=None,
         final=False,
+        sync=False,
     ):
         components_file = data_file = None
-        wait = final
+        wait = final or sync
 
         if len(component_strings) > 0:
             # note that we can't delete temporary files here when calling the subprocess

--- a/metaflow/plugins/cards/card_modules/components.py
+++ b/metaflow/plugins/cards/card_modules/components.py
@@ -211,6 +211,11 @@ class Table(UserComponent):
             )
 
     def _render_subcomponents(self):
+        for row in self._data:
+            for col in row:
+                if isinstance(col, VegaChart):
+                    col._chart_inside_table = True
+
         return [
             SectionComponent.render_subcomponents(
                 row,
@@ -685,18 +690,51 @@ class Markdown(UserComponent):
 
 
 class ProgressBar(UserComponent):
+    """
+    A Progress bar for tracking progress of any task.
+
+    Example:
+    ```
+    progress_bar = ProgressBar(
+        max=100,
+        label="Progress Bar",
+        value=0,
+        unit="%",
+        metadata="0.1 items/s"
+    )
+    current.card.append(
+        progress_bar
+    )
+    for i in range(100):
+        progress_bar.update(i, metadata="%s items/s" % i)
+
+    ```
+
+    Parameters
+    ----------
+    text : str
+        Text formatted in Markdown.
+    """
+
     type = "progressBar"
 
     REALTIME_UPDATABLE = True
 
-    def __init__(self, max=100, label=None, value=0, unit=None, metadata=None):
+    def __init__(
+        self,
+        max: int = 100,
+        label: str = None,
+        value: int = 0,
+        unit: str = None,
+        metadata: str = None,
+    ):
         self._label = label
         self._max = max
         self._value = value
         self._unit = unit
         self._metadata = metadata
 
-    def update(self, new_value, metadata=None):
+    def update(self, new_value: int, metadata: str = None):
         self._value = new_value
         if metadata is not None:
             self._metadata = metadata
@@ -724,9 +762,10 @@ class VegaChart(UserComponent):
 
     REALTIME_UPDATABLE = True
 
-    def __init__(self, spec, show_controls=False):
+    def __init__(self, spec: dict, show_controls=False):
         self._spec = spec
         self._show_controls = show_controls
+        self._chart_inside_table = False
 
     def update(self, spec=None):
         if spec is not None:
@@ -761,7 +800,8 @@ class VegaChart(UserComponent):
         }
         if not self._show_controls:
             data["options"] = {"actions": False}
-
-        if "width" not in self._spec:
+        if "width" not in self._spec and not self._chart_inside_table:
             data["spec"]["width"] = "container"
+        if self._chart_inside_table and "autosize" not in self._spec:
+            data["spec"]["autosize"] = "fit-x"
         return data

--- a/metaflow/plugins/cards/card_modules/test_cards.py
+++ b/metaflow/plugins/cards/card_modules/test_cards.py
@@ -154,13 +154,16 @@ class TestRefreshCard(MetaflowCard):
 
     type = "test_refresh_card"
 
-    def render(self, task, data) -> str:
+    def render(self, task) -> str:
+        return self._render_func(task, self.runtime_data)
+
+    def _render_func(self, task, data):
         return self.HTML_TEMPLATE.replace(
             "[REPLACE_CONTENT_HERE]", json.dumps(data["user"])
         ).replace("[PATHSPEC]", task.pathspec)
 
     def render_runtime(self, task, data):
-        return self.render(task, data)
+        return self._render_func(task, data)
 
     def refresh(self, task, data):
         return data
@@ -195,14 +198,14 @@ class TestRefreshComponentCard(MetaflowCard):
     def __init__(self, options={}, components=[], graph=None):
         self._components = components
 
-    def render(self, task, data) -> str:
+    def render(self, task) -> str:
         # Calling `render`/`render_runtime` wont require the `data` object
         return self.HTML_TEMPLATE.replace(
             "[REPLACE_CONTENT_HERE]", json.dumps(self._components)
         ).replace("[PATHSPEC]", task.pathspec)
 
     def render_runtime(self, task, data):
-        return self.render(task, data)
+        return self.render(task)
 
     def refresh(self, task, data):
         # Govers the information passed in the data update

--- a/metaflow/plugins/cards/card_server.py
+++ b/metaflow/plugins/cards/card_server.py
@@ -302,9 +302,9 @@ class CardViewerRoutes(BaseHTTPRequestHandler):
         if card_data is not None:
             self.log_message(
                 "Task Success: %s, Task Finished: %s"
-                % (task_object.successful, task_object.finished)
+                % (task_object.successful, is_complete)
             )
-            if not task_object.successful and task_object.finished:
+            if not task_object.successful and is_complete:
                 status = "Task Failed"
             self._response(
                 {"status": status, "payload": card_data, "is_complete": is_complete},
@@ -330,6 +330,13 @@ class CardViewerRoutes(BaseHTTPRequestHandler):
     ROUTES = {"runinfo": get_runinfo, "card": get_card, "data": get_data}
 
 
+def _is_debug_mode():
+    debug_flag = os.environ.get("METAFLOW_DEBUG_CARD_SERVER")
+    if debug_flag is None:
+        return False
+    return debug_flag.lower() in ["true", "1"]
+
+
 def create_card_server(card_options: CardServerOptions, port, ctx_obj):
     CardViewerRoutes.card_options = card_options
     global _ClickLogger
@@ -346,7 +353,7 @@ def create_card_server(card_options: CardServerOptions, port, ctx_obj):
         bold=True,
     )
     # Disable logging if not in debug mode
-    if "METAFLOW_DEBUG_CARD_SERVER" not in os.environ:
+    if not _is_debug_mode():
         CardViewerRoutes.log_request = lambda *args, **kwargs: None
         CardViewerRoutes.log_message = lambda *args, **kwargs: None
 

--- a/metaflow/plugins/cards/card_server.py
+++ b/metaflow/plugins/cards/card_server.py
@@ -1,0 +1,354 @@
+import os
+import json
+from http.server import BaseHTTPRequestHandler
+from threading import Thread
+from multiprocessing import Pipe
+from multiprocessing.connection import Connection
+from urllib.parse import urlparse
+import time
+
+try:
+    from http.server import ThreadingHTTPServer
+except ImportError:
+    from socketserver import ThreadingMixIn
+    from http.server import HTTPServer
+
+    class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+        daemon_threads = True
+
+
+from .card_client import CardContainer
+from .exception import CardNotPresentException
+from .card_resolver import resolve_paths_from_task
+from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
+from metaflow import namespace
+from metaflow.exception import (
+    CommandException,
+    MetaflowNotFound,
+    MetaflowNamespaceMismatch,
+)
+
+
+VIEWER_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "card_viewer", "viewer.html"
+)
+
+CARD_VIEWER_HTML = open(VIEWER_PATH).read()
+
+TASK_CACHE = {}
+
+_ClickLogger = None
+
+
+class RunWatcher(Thread):
+    """
+    A thread that watches for new runs and sends the run_id to the
+    card server when a new run is detected. It observes the `latest_run`
+    file in the `.metaflow/<flowname>` directory.
+    """
+
+    def __init__(self, flow_name, connection: Connection):
+        super().__init__()
+
+        self._watch_file = os.path.join(
+            os.getcwd(), DATASTORE_LOCAL_DIR, flow_name, "latest_run"
+        )
+        self._current_run_id = self.get_run_id()
+        self.daemon = True
+        self._connection = connection
+
+    def get_run_id(self):
+        if not os.path.exists(self._watch_file):
+            return None
+        with open(self._watch_file, "r") as f:
+            return f.read().strip()
+
+    def watch(self):
+        while True:
+            run_id = self.get_run_id()
+            if run_id != self._current_run_id:
+                self._current_run_id = run_id
+                self._connection.send(run_id)
+            time.sleep(2)
+
+    def run(self):
+        self.watch()
+
+
+class CardServerOptions:
+    def __init__(
+        self,
+        flow_name,
+        run_object,
+        only_running,
+        follow_resumed,
+        flow_datastore,
+        follow_new_runs,
+        max_cards=20,
+        poll_interval=5,
+    ):
+        from metaflow import Run
+
+        self.RunClass = Run
+        self.run_object = run_object
+
+        self.flow_name = flow_name
+        self.only_running = only_running
+        self.follow_resumed = follow_resumed
+        self.flow_datastore = flow_datastore
+        self.max_cards = max_cards
+        self.follow_new_runs = follow_new_runs
+        self.poll_interval = poll_interval
+
+        self._parent_conn, self._child_conn = Pipe()
+
+    def refresh_run(self):
+        if not self.follow_new_runs:
+            return False
+        if not self.parent_conn.poll():
+            return False
+        run_id = self.parent_conn.recv()
+        if run_id is None:
+            return False
+        namespace(None)
+        try:
+            self.run_object = self.RunClass(f"{self.flow_name}/{run_id}")
+            return True
+        except MetaflowNotFound:
+            return False
+
+    @property
+    def parent_conn(self):
+        return self._parent_conn
+
+    @property
+    def child_conn(self):
+        return self._child_conn
+
+
+def cards_for_task(
+    flow_datastore, task_pathspec, card_type=None, card_hash=None, card_id=None
+):
+    try:
+        paths, card_ds = resolve_paths_from_task(
+            flow_datastore,
+            task_pathspec,
+            type=card_type,
+            hash=card_hash,
+            card_id=card_id,
+        )
+    except CardNotPresentException:
+        return None
+    for card in CardContainer(paths, card_ds, origin_pathspec=None):
+        yield card
+
+
+def cards_for_run(
+    flow_datastore,
+    run_object,
+    only_running,
+    card_type=None,
+    card_hash=None,
+    card_id=None,
+    max_cards=20,
+):
+    curr_idx = 0
+    for step in run_object.steps():
+        for task in step.tasks():
+            if only_running and task.finished:
+                continue
+            card_generator = cards_for_task(
+                flow_datastore,
+                task.pathspec,
+                card_type=card_type,
+                card_hash=card_hash,
+                card_id=card_id,
+            )
+            if card_generator is None:
+                continue
+            for card in card_generator:
+                curr_idx += 1
+                if curr_idx >= max_cards:
+                    raise StopIteration
+                yield task.pathspec, card
+
+
+class CardViewerRoutes(BaseHTTPRequestHandler):
+
+    card_options: CardServerOptions = None
+
+    run_watcher: RunWatcher = None
+
+    def do_GET(self):
+        try:
+            _, path = self.path.split("/", 1)
+            try:
+                prefix, suffix = path.split("/", 1)
+            except:
+                prefix = path
+                suffix = None
+        except:
+            prefix = None
+        if prefix in self.ROUTES:
+            self.ROUTES[prefix](self, suffix)
+        else:
+            self._response(open(VIEWER_PATH).read().encode("utf-8"))
+
+    def get_runinfo(self, suffix):
+        run_id_changed = self.card_options.refresh_run()
+        if run_id_changed:
+            self.log_message(
+                "RunID changed in the background to %s"
+                % self.card_options.run_object.pathspec
+            )
+            _ClickLogger(
+                "RunID changed in the background to %s"
+                % self.card_options.run_object.pathspec,
+                fg="blue",
+            )
+
+        if self.card_options.run_object is None:
+            self._response(
+                {"status": "No Run Found", "flow": self.card_options.flow_name},
+                code=404,
+                is_json=True,
+            )
+            return
+
+        task_card_generator = cards_for_run(
+            self.card_options.flow_datastore,
+            self.card_options.run_object,
+            self.card_options.only_running,
+            max_cards=self.card_options.max_cards,
+        )
+        flow_name = self.card_options.run_object.parent.id
+        run_id = self.card_options.run_object.id
+        cards = []
+        for pathspec, card in task_card_generator:
+            step, task = pathspec.split("/")[-2:]
+            _task = self.card_options.run_object[step][task]
+            task_finished = True if _task.finished else False
+            cards.append(
+                dict(
+                    task=pathspec,
+                    label="%s/%s %s" % (step, task, card.hash),
+                    card_object=dict(
+                        hash=card.hash,
+                        type=card.type,
+                        path=card.path,
+                        id=card.id,
+                    ),
+                    finished=task_finished,
+                    card="%s/%s" % (pathspec, card.hash),
+                )
+            )
+        resp = {
+            "status": "ok",
+            "flow": flow_name,
+            "run_id": run_id,
+            "cards": cards,
+            "poll_interval": self.card_options.poll_interval,
+        }
+        self._response(resp, is_json=True)
+
+    def get_card(self, suffix):
+        _suffix = urlparse(self.path).path
+        _, flow, run_id, step, task_id, card_hash = _suffix.strip("/").split("/")
+
+        pathspec = "/".join([flow, run_id, step, task_id])
+        cards = list(
+            cards_for_task(
+                self.card_options.flow_datastore, pathspec, card_hash=card_hash
+            )
+        )
+        if len(cards) == 0:
+            self._response({"status": "Card Not Found"}, code=404)
+            return
+        selected_card = cards[0]
+        self._response(selected_card.get().encode("utf-8"))
+
+    def get_data(self, suffix):
+        _suffix = urlparse(self.path).path
+        _, flow, run_id, step, task_id, card_hash = _suffix.strip("/").split("/")
+        pathspec = "/".join([flow, run_id, step, task_id])
+        cards = list(
+            cards_for_task(
+                self.card_options.flow_datastore, pathspec, card_hash=card_hash
+            )
+        )
+        if len(cards) == 0:
+            self._response(
+                {
+                    "status": "Card Not Found",
+                },
+                is_json=True,
+                code=404,
+            )
+            return
+
+        status = "ok"
+        try:
+            task_object = self.card_options.run_object[step][task_id]
+        except KeyError:
+            return self._response(
+                {"status": "Task Not Found", "is_complete": False},
+                is_json=True,
+                code=404,
+            )
+
+        is_complete = task_object.finished
+        selected_card = cards[0]
+        card_data = selected_card.get_data()
+        if card_data is not None:
+            self.log_message(
+                "Task Success: %s, Task Finished: %s"
+                % (task_object.successful, task_object.finished)
+            )
+            if not task_object.successful and task_object.finished:
+                status = "Task Failed"
+            self._response(
+                {"status": status, "payload": card_data, "is_complete": is_complete},
+                is_json=True,
+            )
+        else:
+            self._response(
+                {"status": "ok", "is_complete": is_complete},
+                is_json=True,
+                code=404,
+            )
+
+    def _response(self, body, is_json=False, code=200):
+        self.send_response(code)
+        mime = "application/json" if is_json else "text/html"
+        self.send_header("Content-type", mime)
+        self.end_headers()
+        if is_json:
+            self.wfile.write(json.dumps(body).encode("utf-8"))
+        else:
+            self.wfile.write(body)
+
+    ROUTES = {"runinfo": get_runinfo, "card": get_card, "data": get_data}
+
+
+def create_card_server(card_options: CardServerOptions, port, ctx_obj):
+    CardViewerRoutes.card_options = card_options
+    global _ClickLogger
+    _ClickLogger = ctx_obj.echo
+    if card_options.follow_new_runs:
+        CardViewerRoutes.run_watcher = RunWatcher(
+            card_options.flow_name, card_options.child_conn
+        )
+        CardViewerRoutes.run_watcher.start()
+    server_addr = ("", port)
+    ctx_obj.echo(
+        "Starting card server on port %d " % (port),
+        fg="green",
+        bold=True,
+    )
+    # Disable logging if not in debug mode
+    if "METAFLOW_DEBUG_CARD_SERVER" not in os.environ:
+        CardViewerRoutes.log_request = lambda *args, **kwargs: None
+        CardViewerRoutes.log_message = lambda *args, **kwargs: None
+
+    server = ThreadingHTTPServer(server_addr, CardViewerRoutes)
+    server.serve_forever()

--- a/metaflow/plugins/cards/card_viewer/viewer.html
+++ b/metaflow/plugins/cards/card_viewer/viewer.html
@@ -1,0 +1,147 @@
+
+<html>
+    <head>
+    <style type="text/css">
+        body{
+            font-size: 100%;
+            font-family: sans-serif;
+            padding: 0;
+            margin: 0;
+        }
+        iframe{
+            height: 2000;
+            width: 80%;
+            border: 0px;
+        }
+        #header{
+            padding: 20px;
+            padding-top: 10px;
+            margin-bottom: 20px;
+            background: #f6f6f6;
+            color: #666;
+            box-shadow: 0px 5px 10px #eee;
+        }
+        #header h1{
+            font-size: 140%;
+        }
+    </style>
+    <head>
+<body>
+
+<div id="header">
+<h1 id="title">Loading the latest run..</h1>
+
+
+
+<script>
+// TODO : make `DATA_UPDATE_POLL_INTERVAL` configurable when starting the server
+const DATA_UPDATE_POLL_INTERVAL = 5000;
+const RUN_UPDATE_POLL_INTERVAL = 10000;
+async function data_update(frame_src, data_url, update_fun, reload_token){
+    const response = await fetch(data_url);
+    const resp = await response.json();
+    let frame = document.getElementById('cardFrame');
+    // first check the user hasn't switched to another card
+    console.log('data', resp, 'reload_token', reload_token)
+    if (frame.src == frame_src){
+        // do we have valid data?
+        if (resp.status == 'not found')
+            // if not, try again later
+            setTimeout(() => data_update(frame_src, data_url, update_fun, reload_token), DATA_UPDATE_POLL_INTERVAL);
+        else{            
+            console.log("data is valid")
+            // yes, data is valid
+            // do we have the right version of the card content?
+            if (resp.payload.reload_token == reload_token){
+                console.log()
+                // update data and check that the return value is valid. In particular,
+                // the result is undefined if the card has changed and update_fun is invalid
+                if (update_fun(resp.payload.data))
+                    setTimeout(() => data_update(frame_src, data_url, update_fun, reload_token), DATA_UPDATE_POLL_INTERVAL);
+            }else{
+                // card is outdated, reload it. This will re-fetch data, so we will be back
+                // in this function soon
+                frame.contentWindow.location.reload();
+            }
+        }
+    }
+}
+
+function card_loaded(){
+    let frame = document.getElementById('cardFrame');
+    let update_fun = frame.contentWindow.metaflow_card_update;
+    const reload_token = frame.contentWindow.METAFLOW_RELOAD_TOKEN;
+    frame.style.display = 'block';
+    if (update_fun){
+        console.log("Update fn found")
+        console.log(update_fun)
+        let data_url = "/data/" + frame.src.split('/').slice(4).join('/');
+        setTimeout(() => data_update(frame.src, data_url, update_fun, reload_token), DATA_UPDATE_POLL_INTERVAL);
+    }
+}
+
+function load_card(){
+    let cardEl = document.getElementById("cards");
+    let frame = document.getElementById('cardFrame');
+    frame.style.display = 'none';
+    if (cardEl.options.length > 0){
+        const val = cardEl.options[cardEl.selectedIndex].value;
+        frame.src = "/card/" + val;
+    }
+}
+
+async function refresh_cards(){
+    const response = await fetch("/runinfo");
+    const info = await response.json();
+    let shouldUpdate = false;
+    if (info.status == 'ok'){
+        let frame = document.getElementById('cardFrame');
+
+        let cardEl = document.getElementById("cards");
+        let selected;
+        if (cardEl.options[cardEl.selectedIndex])
+            selected = cardEl.options[cardEl.selectedIndex].value;
+        cardEl.innerHTML = '';
+
+        let title = info.flow + "/" + info.run_id;
+        if (title != document.getElementById("title").innerHTML){
+            frame.style.display = 'none';
+            shouldUpdate = true;
+        }
+        document.getElementById("title").innerHTML = title;
+
+        for (let i = 0; i < info.cards.length; i++){
+            let el = document.createElement("option");
+            el.value = info.cards[i].card;
+            el.innerHTML = info.cards[i].label;
+            if (el.innerHTML == selected)
+                el.select
+            cardEl.appendChild(el);
+        }
+        if (!frame.src || shouldUpdate)
+            load_card();
+
+        if (selected)
+            cardEl.value = selected;
+        else if (info.cards.length > 0)
+            cardEl.selectedIndex = 0;
+    }
+    setTimeout(refresh_cards, RUN_UPDATE_POLL_INTERVAL);
+}
+
+window.onload = function(){
+    refresh_cards();
+}
+
+</script>
+
+<select id="cards" onChange="load_card()">
+</select>
+</div>
+
+<div>
+<iframe id="cardFrame" onLoad="card_loaded()"></iframe>
+</div>
+
+<body>
+</html>

--- a/metaflow/plugins/cards/card_viewer/viewer.html
+++ b/metaflow/plugins/cards/card_viewer/viewer.html
@@ -1,147 +1,344 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Metaflow Run</title>
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap");
 
-<html>
-    <head>
-    <style type="text/css">
-        body{
-            font-size: 100%;
-            font-family: sans-serif;
-            padding: 0;
-            margin: 0;
-        }
-        iframe{
-            height: 2000;
-            width: 80%;
-            border: 0px;
-        }
-        #header{
-            padding: 20px;
-            padding-top: 10px;
-            margin-bottom: 20px;
-            background: #f6f6f6;
-            color: #666;
-            box-shadow: 0px 5px 10px #eee;
-        }
-        #header h1{
-            font-size: 140%;
-        }
+      body {
+        font-size: 14px;
+        font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI",
+          "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
+          "Helvetica Neue", sans-serif;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+        width: 100%;
+        overflow: hidden;
+        color: #31302f;
+      }
+
+      header {
+        height: 65px;
+        flex: 0 1 auto;
+        flex-grow: none;
+        background: #f9f9f9;
+        display: flex;
+        justify-content: space-evenly;
+      }
+
+      h1,
+      h2,
+      h3,
+      h4 {
+        font-size: inherit;
+        font-weight: 500;
+        margin: 0;
+        padding: 0;
+      }
+
+      header > * {
+        padding: 20px 25px;
+        flex: 1;
+        display: flex;
+        align-items: center;
+      }
+
+      header > div:nth-child(2) {
+        text-align: center;
+        flex: 1;
+        justify-content: center;
+      }
+
+      header > div:nth-child(3) {
+        text-align: right;
+        justify-content: flex-end;
+        font-weight: 400;
+      }
+
+      .taskStatus {
+        color: #6a6867;
+      }
+
+      .taskStatus.error {
+        color: #e67058;
+      }
+
+      .content {
+        flex: 1 1 auto;
+        overflow-y: scroll;
+      }
+
+      iframe {
+        width: 100%;
+        height: calc(100vh - 65px);
+        outline: none;
+        border: 0;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
+      header select {
+        width: 100%;
+        border: 0;
+        outline: none;
+        font-size: inherit;
+        font-family: inherit;
+        background: transparent;
+        padding: 0 1rem;
+      }
+
+      .selectorContainer {
+        border: 0;
+        outline: none;
+        font-size: inherit;
+        font-family: inherit;
+        border-radius: 8px;
+        background: #ebeaea;
+        padding: 0 1rem;
+        margin: 1rem;
+      }
+
+      .logoContainer {
+        display: none !important;
+      }
+
+      .errorContainer svg {
+        position: relative;
+        top: 3px;
+      }
     </style>
-    <head>
-<body>
+  </head>
+  <body>
+    <header>
+      <h1 id="header-title">Metaflow Run</h1>
+      <div class="selectorContainer">
+        <select id="selector">
+          <option value="" disabled selected>
+            Select a card
+          </option>
+        </select>
+      </div>
+      <div>
+        <div id="task-status" class="taskStatus">Initializing</div>
+        <div id="task-action" class="" style="display: none">Pause</div>
+      </div>
+    </header>
+    <div class="content">
+      <iframe id="card-frame"></iframe>
+    </div>
 
-<div id="header">
-<h1 id="title">Loading the latest run..</h1>
+    <script type="application/javascript">
+      (() => {
+        // setup constants
+        let DATA_UPDATE_POLL_INTERVAL = 5000;
+        let RUN_UPDATE_POLL_INTERVAL = 10000;
 
+        // setup state
+        let currentCardsLength = 0;
+        let currentRunId = "";
+        let selectedCard = "";
 
+        // setup selector
+        const selector = document.getElementById("selector");
+        selector?.addEventListener("change", (event) => {
+          selectedCard = event.target.value;
+          handleLoadCard(event.target.name, event.target.value);
+        });
 
-<script>
-// TODO : make `DATA_UPDATE_POLL_INTERVAL` configurable when starting the server
-const DATA_UPDATE_POLL_INTERVAL = 5000;
-const RUN_UPDATE_POLL_INTERVAL = 10000;
-async function data_update(frame_src, data_url, update_fun, reload_token){
-    const response = await fetch(data_url);
-    const resp = await response.json();
-    let frame = document.getElementById('cardFrame');
-    // first check the user hasn't switched to another card
-    console.log('data', resp, 'reload_token', reload_token)
-    if (frame.src == frame_src){
-        // do we have valid data?
-        if (resp.status == 'not found')
-            // if not, try again later
-            setTimeout(() => data_update(frame_src, data_url, update_fun, reload_token), DATA_UPDATE_POLL_INTERVAL);
-        else{            
-            console.log("data is valid")
-            // yes, data is valid
-            // do we have the right version of the card content?
-            if (resp.payload.reload_token == reload_token){
-                console.log()
-                // update data and check that the return value is valid. In particular,
-                // the result is undefined if the card has changed and update_fun is invalid
-                if (update_fun(resp.payload.data))
-                    setTimeout(() => data_update(frame_src, data_url, update_fun, reload_token), DATA_UPDATE_POLL_INTERVAL);
-            }else{
-                // card is outdated, reload it. This will re-fetch data, so we will be back
-                // in this function soon
-                frame.contentWindow.location.reload();
+        /**
+         * Handle any changes to the status of the page
+         */
+        function handleStatus(status, isComplete = false) {
+          const statusDiv = document.getElementById("task-status");
+
+          // change the text of the status depending if its in progress or not
+          if (statusDiv) {
+            // complete
+            if (isComplete && status === "ok") {
+              statusDiv.innerText = "Task Is Complete";
+              // running
+            } else if (!isComplete && status === "ok") {
+              statusDiv.innerText = "Task Is Running";
+              // error
+            } else {
+              statusDiv.innerHTML = `<div class="errorContainer"><svg width="17" height="17" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <g clip-path="url(#clip0_164_815)"> <circle cx="8.5" cy="8.5" r="8" fill="#E67058"/> <path d="M11.6475 6.0575C11.8422 5.86282 11.8422 5.54718 11.6475 5.3525C11.4528 5.15782 11.1372 5.15782 10.9425 5.3525L8.5 7.795L6.0575 5.3525C5.86282 5.15782 5.54718 5.15782 5.3525 5.3525C5.15782 5.54718 5.15782 5.86282 5.3525 6.0575L7.795 8.5L5.3525 10.9425C5.15782 11.1372 5.15782 11.4528 5.3525 11.6475C5.54718 11.8422 5.86282 11.8422 6.0575 11.6475L8.5 9.205L10.9425 11.6475C11.1372 11.8422 11.4528 11.8422 11.6475 11.6475C11.8422 11.4528 11.8422 11.1372 11.6475 10.9425L9.205 8.5L11.6475 6.0575Z" fill="white"/> </g><defs><clipPath id="clip0_164_815"><rect width="16" height="16" fill="white" transform="translate(0.5 0.5)"/></clipPath></defs></svg>
+       <span>${status}</span></div>
+      `;
             }
+          }
         }
-    }
-}
 
-function card_loaded(){
-    let frame = document.getElementById('cardFrame');
-    let update_fun = frame.contentWindow.metaflow_card_update;
-    const reload_token = frame.contentWindow.METAFLOW_RELOAD_TOKEN;
-    frame.style.display = 'block';
-    if (update_fun){
-        console.log("Update fn found")
-        console.log(update_fun)
-        let data_url = "/data/" + frame.src.split('/').slice(4).join('/');
-        setTimeout(() => data_update(frame.src, data_url, update_fun, reload_token), DATA_UPDATE_POLL_INTERVAL);
-    }
-}
+        /**
+         * Handle any changes to the cards
+         */
+        function onCardsLoaded(runInfo) {
+          const { cards, flow, run_id } = runInfo;
+          if (!Array.isArray(cards) || !flow || !run_id) {
+            console.log("Data was not in the correct format");
+            return;
+          }
+          // console.log("Running ON CARDS LOADED", cards, flow, run_id)
 
-function load_card(){
-    let cardEl = document.getElementById("cards");
-    let frame = document.getElementById('cardFrame');
-    frame.style.display = 'none';
-    if (cardEl.options.length > 0){
-        const val = cardEl.options[cardEl.selectedIndex].value;
-        frame.src = "/card/" + val;
-    }
-}
+          // reset
+          currentCardsLength = cards.length;
+          selector.innerHTML = "";
+          // if the task has finished, change to the next card
+          changeToNewCardIfTaskHasFinished(runInfo);
 
-async function refresh_cards(){
-    const response = await fetch("/runinfo");
-    const info = await response.json();
-    let shouldUpdate = false;
-    if (info.status == 'ok'){
-        let frame = document.getElementById('cardFrame');
+          // create select options for each card
+          cards.reverse().forEach((card) => {
+            const option = document.createElement("option");
+            option.value = card.card;
+            option.innerText = card.label.split(" ")?.[0] || card.label;
+            option.selected = card.card === selectedCard;
+            selector.appendChild(option);
+          });
 
-        let cardEl = document.getElementById("cards");
-        let selected;
-        if (cardEl.options[cardEl.selectedIndex])
-            selected = cardEl.options[cardEl.selectedIndex].value;
-        cardEl.innerHTML = '';
-
-        let title = info.flow + "/" + info.run_id;
-        if (title != document.getElementById("title").innerHTML){
-            frame.style.display = 'none';
-            shouldUpdate = true;
+          // get card-title element and change it to name
+          const title = document.getElementById("header-title");
+          title.innerText = `${flow}/${run_id}`;
         }
-        document.getElementById("title").innerHTML = title;
 
-        for (let i = 0; i < info.cards.length; i++){
-            let el = document.createElement("option");
-            el.value = info.cards[i].card;
-            el.innerHTML = info.cards[i].label;
-            if (el.innerHTML == selected)
-                el.select
-            cardEl.appendChild(el);
+        /**
+         * This function will determine if changes need to be made to the
+         * card and if so, will we do it by push or by reload
+         */
+
+        async function watchForCardChanges(iframe) {
+          // replace the /card/ url with the data url
+          const dataUri = iframe.src.replace(/.*\/card\//, "/data/");
+          let resp;
+          try {
+            const req = await fetch(dataUri);
+            resp = await req.json();
+            // setup UI to show complete and status
+            handleStatus(resp.status, resp?.is_complete);
+
+            // grab update fn from iframe
+            const update = iframe.contentWindow?.metaflow_card_update;
+            // make sure we're able to update the card
+            if (resp.status !== "ok" || !update || !resp.payload?.data) {
+              console.log(
+                "Data-updates not taking place because either : status is not `ok` or update function is not available or data is not available",
+                resp,
+                update
+              );
+            } else {
+              // make appropriate updates by pushing if the reload token matches
+              update &&
+              resp.payload?.reload_token ===
+                iframe.contentWindow.METAFLOW_RELOAD_TOKEN
+                ? update(resp.payload.data)
+                : iframe.contentWindow.location.reload();
+            }
+            // If there is no Update function than we don't need to wire the
+            // periodic updates
+            if (!update) {
+              console.log(
+                "No metaflow_card_update function available. So not running any periodic updates"
+              );
+              return;
+            }
+          } catch (error) {
+            console.error(error);
+          }
+          // if this update is not the last one, run it again!
+          if (!(resp.payload?.reload_token === "final")) {
+            setTimeout(
+              () => watchForCardChanges(iframe),
+              DATA_UPDATE_POLL_INTERVAL
+            );
+          }
         }
-        if (!frame.src || shouldUpdate)
-            load_card();
 
-        if (selected)
-            cardEl.value = selected;
-        else if (info.cards.length > 0)
-            cardEl.selectedIndex = 0;
-    }
-    setTimeout(refresh_cards, RUN_UPDATE_POLL_INTERVAL);
-}
+        /**
+         * Setup a new card and start the watcher
+         */
+        function handleLoadCard(name, value) {
+          document.getElementsByTagName("title").innerHTML = name;
+          const iframe = document.getElementById("card-frame");
+          iframe.src = `/card/${value}?embed=true`;
+          iframe.onload = () => {
+            watchForCardChanges(iframe);
+          };
+        }
 
-window.onload = function(){
-    refresh_cards();
-}
+        function changeToNewCardIfTaskHasFinished(runInfo) {
+          // search for the selectedCard in the runInfo
+          const card = runInfo.cards.find((card) => card.card === selectedCard);
+          // if the card object contains `finished` === True, then change to the next card that has not finished
+          if (card?.finished) {
+            // find the index of the current card
+            const currentCardIndex = runInfo.cards.findIndex(
+              (card) => card.card === selectedCard
+            );
+            // find the next card that has not finished
+            const nextCard = runInfo.cards.find((card) => !card.finished);
+            // if there is a next card, change to it
 
-</script>
+            console.log("nextCard", nextCard);
+            if (nextCard) {
+              selectedCard = nextCard.card;
+              handleLoadCard(nextCard.label, nextCard.card);
+            }
+          }
+        }
 
-<select id="cards" onChange="load_card()">
-</select>
-</div>
+        /**
+         * Main loop function
+         */
+        async function main() {
+          try {
+            // get info on the entire run
+            const runInfoRequest = await fetch("/runinfo");
+            const runInfo = await runInfoRequest.json();
 
-<div>
-<iframe id="cardFrame" onLoad="card_loaded()"></iframe>
-</div>
+            // reset the state if the run_id changes or on first time
+            if (currentRunId !== runInfo.run_id) {
+              currentRunId = runInfo.run_id;
+              currentCardsLength = 0;
+              selectedCard = "";
+              console.log("runInfo", runInfo);
+            }
+            if (runInfo.poll_interval * 1000 !== DATA_UPDATE_POLL_INTERVAL) {
+              DATA_UPDATE_POLL_INTERVAL = runInfo.poll_interval * 1000;
+            }
+            if (runInfo.poll_interval * 1000 !== RUN_UPDATE_POLL_INTERVAL) {
+              RUN_UPDATE_POLL_INTERVAL = runInfo.poll_interval * 1000;
+            }
+            if (runInfo?.status === "ok") {
+              // only make changes if the cards length has changed
+              if (runInfo?.cards.length !== currentCardsLength) {
+                onCardsLoaded(runInfo);
+              }
+              // if there is no selected card, select the first one
+              if (!selectedCard) {
+                selectedCard = runInfo.cards[0].card;
+                handleLoadCard(runInfo.cards[0].label, runInfo.cards[0].card);
+              }
+            } else {
+              handleStatus(runInfo?.status, false);
+            }
+          } catch (error) {
+            console.error(error);
+          }
+          // always run the main loop, because a user can start a new run,
+          // or restart the web server, and we want the page to continue working
+          setTimeout(main, RUN_UPDATE_POLL_INTERVAL);
+        }
 
-<body>
+        // start the main loop
+        window.onload = () => {
+          main();
+        };
+      })();
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## [card-server] cli command to expose a card server to view realtime updates

- Modified card datastore to accomodate retrieval of runtime data updates
- Added a card viewer html file
- Created a simple HTTP based card server that will help showcase the realtime cards from querying the server
- Card datastore's read and write path retrieval methods now explicitly are given the suffix they retrieve from. We do this because the suffix determines if we are extracting a card or a data update
- Added a private method in the `Card` (user-interface) to get the data related to a card.