### PR TITLE
Temporary way of passing *some* environment variables to remote nodes

### DIFF
--- a/metaflow/plugins/airflow/airflow.py
+++ b/metaflow/plugins/airflow/airflow.py
@@ -32,6 +32,9 @@ from metaflow.metaflow_config import (
     SERVICE_HEADERS,
     SERVICE_INTERNAL_URL,
 )
+
+from metaflow.metaflow_config_funcs import config_values
+
 from metaflow.parameters import (
     DelayedEvaluationParameter,
     JSONTypeClass,
@@ -334,6 +337,16 @@ class Airflow(object):
         metaflow_version["flow_name"] = self.graph.name
         metaflow_version["production_token"] = self.production_token
         env["METAFLOW_VERSION"] = json.dumps(metaflow_version)
+
+        # Temporary passing of *some* environment variables. Do not rely on this
+        # mechanism as it will be removed in the near future
+        env.update(
+            {
+                k: v
+                for k, v in config_values()
+                if k.startswith("METAFLOW_CONDA_") or k.startswith("METAFLOW_DEBUG_")
+            }
+        )
 
         # Extract the k8s decorators for constructing the arguments of the K8s Pod Operator on Airflow.
         k8s_deco = [deco for deco in node.decorators if deco.name == "kubernetes"][0]

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -42,6 +42,9 @@ from metaflow.metaflow_config import (
     UI_URL,
     ARGO_WORKFLOWS_UI_URL,
 )
+
+from metaflow.metaflow_config_funcs import config_values
+
 from metaflow.mflog import BASH_SAVE_LOGS, bash_capture_logs, export_mflog_env_vars
 from metaflow.parameters import deploy_time_eval
 from metaflow.plugins.kubernetes.kubernetes import (
@@ -1164,6 +1167,18 @@ class ArgoWorkflows(object):
                     0
                 ].attributes["vars"]
             )
+
+            # Temporary passing of *some* environment variables. Do not rely on this
+            # mechanism as it will be removed in the near future
+            env.update(
+                {
+                    k: v
+                    for k, v in config_values()
+                    if k.startswith("METAFLOW_CONDA_")
+                    or k.startswith("METAFLOW_DEBUG_")
+                }
+            )
+
             env.update(
                 {
                     **{

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -23,6 +23,9 @@ from metaflow.metaflow_config import (
     AWS_SECRETS_MANAGER_DEFAULT_REGION,
     S3_SERVER_SIDE_ENCRYPTION,
 )
+
+from metaflow.metaflow_config_funcs import config_values
+
 from metaflow.mflog import (
     export_mflog_env_vars,
     bash_capture_logs,
@@ -249,6 +252,13 @@ class Batch(object):
             .environment_variable("METAFLOW_CARD_S3ROOT", CARD_S3ROOT)
             .environment_variable("METAFLOW_RUNTIME_ENVIRONMENT", "aws-batch")
         )
+
+        # Temporary passing of *some* environment variables. Do not rely on this
+        # mechanism as it will be removed in the near future
+        for k, v in config_values():
+            if k.startswith("METAFLOW_CONDA_") or k.startswith("METAFLOW_DEBUG_"):
+                job.environment_variable(k, v)
+
         if DEFAULT_SECRETS_BACKEND_TYPE is not None:
             job.environment_variable(
                 "METAFLOW_DEFAULT_SECRETS_BACKEND_TYPE", DEFAULT_SECRETS_BACKEND_TYPE

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -34,6 +34,8 @@ from metaflow.metaflow_config import (
     SERVICE_INTERNAL_URL,
     S3_SERVER_SIDE_ENCRYPTION,
 )
+from metaflow.metaflow_config_funcs import config_values
+
 from metaflow.mflog import (
     BASH_SAVE_LOGS,
     bash_capture_logs,
@@ -258,6 +260,12 @@ class Kubernetes(object):
             # pod; this happens when METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set (
             # see get_datastore_root_from_config in datastore/local.py).
         )
+
+        # Temporary passing of *some* environment variables. Do not rely on this
+        # mechanism as it will be removed in the near future
+        for k, v in config_values():
+            if k.startswith("METAFLOW_CONDA_") or k.startswith("METAFLOW_DEBUG_"):
+                job.environment_variable(k, v)
 
         if S3_SERVER_SIDE_ENCRYPTION is not None:
             job.environment_variable(


### PR DESCRIPTION
This will be revisited with a more generalized solution where each individual decorator will be able to set the variables it wants to pass along