### PR TITLE
Issue 1544: Add support for Kubernetes limits

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -295,6 +295,8 @@ KUBERNETES_IMAGE_PULL_POLICY = from_conf("KUBERNETES_IMAGE_PULL_POLICY", None)
 KUBERNETES_CONTAINER_REGISTRY = from_conf(
     "KUBERNETES_CONTAINER_REGISTRY", DEFAULT_CONTAINER_REGISTRY
 )
+# Specify Kubernetes resource requirements as requests. (If not True, then use limits.)
+KUBERNETES_RESOURCE_REQUESTS = from_conf("KUBERNETES_RESOURCE_REQUESTS", True)
 # Toggle for trying to fetch EC2 instance metadata
 KUBERNETES_FETCH_EC2_METADATA = from_conf("KUBERNETES_FETCH_EC2_METADATA", False)
 

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -299,7 +299,6 @@ class ArgoWorkflows(object):
             "limits": {**x, **y} if KUBERNETES_RESOURCE_REQUESTS else y,
         }
 
-
     def _get_schedule(self):
         schedule = self.flow._flow_decorators.get("schedule")
         if schedule:

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -290,14 +290,13 @@ class ArgoWorkflows(object):
             "ephemeral-storage": "%sM" % str(resources["disk"]),
         }
         y = {
-            "%s.com/gpu".lower()
-            % resources["gpu_vendor"]: str(resources["gpu"])
+            "%s.com/gpu".lower() % resources["gpu_vendor"]: str(resources["gpu"])
             for _ in [0]
             if resources["gpu"] is not None
         }
         return {
-            'requests': x if KUBERNETES_RESOURCE_REQUESTS else {},
-            'limits': {**x, **y} if KUBERNETES_RESOURCE_REQUESTS else y,
+            "requests": x if KUBERNETES_RESOURCE_REQUESTS else {},
+            "limits": {**x, **y} if KUBERNETES_RESOURCE_REQUESTS else y,
         }
 
 

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -296,7 +296,7 @@ class ArgoWorkflows(object):
         }
         return {
             "requests": x if KUBERNETES_RESOURCE_REQUESTS else {},
-            "limits": {**x, **y} if KUBERNETES_RESOURCE_REQUESTS else y,
+            "limits": {**x, **y} if not KUBERNETES_RESOURCE_REQUESTS else y,
         }
 
     def _get_schedule(self):

--- a/metaflow/plugins/kubernetes/kubernetes_job.py
+++ b/metaflow/plugins/kubernetes/kubernetes_job.py
@@ -323,7 +323,7 @@ class KubernetesJob(object):
         }
         return {
             "requests": x if KUBERNETES_RESOURCE_REQUESTS else {},
-            "limits": {**x, **y} if KUBERNETES_RESOURCE_REQUESTS else y,
+            "limits": {**x, **y} if not KUBERNETES_RESOURCE_REQUESTS else y,
         }
 
 

--- a/metaflow/plugins/kubernetes/kubernetes_job.py
+++ b/metaflow/plugins/kubernetes/kubernetes_job.py
@@ -317,15 +317,15 @@ class KubernetesJob(object):
             "ephemeral-storage": "%sM" % str(self._kwargs["disk"]),
         }
         y = {
-            "%s.com/gpu".lower()
-            % self._kwargs["gpu_vendor"]: str(self._kwargs["gpu"])
+            "%s.com/gpu".lower() % self._kwargs["gpu_vendor"]: str(self._kwargs["gpu"])
             for _ in [0]
             if self._kwargs["gpu"] is not None
         }
         return {
-            'requests': x if KUBERNETES_RESOURCE_REQUESTS else {},
-            'limits': {**x, **y} if KUBERNETES_RESOURCE_REQUESTS else y,
+            "requests": x if KUBERNETES_RESOURCE_REQUESTS else {},
+            "limits": {**x, **y} if KUBERNETES_RESOURCE_REQUESTS else y,
         }
+
 
 class RunningJob(object):
 


### PR DESCRIPTION
This PR adds support for specifying limits (as opposed to requests) for workflows on Kubernetes. It addresses issue [1544](https://github.com/Netflix/metaflow/issues/1544).

Notes:
* I've added a single flag in the Metaflow config to cover CPU, RAM & disk space. Not sure if you would prefer different flags for each resource?
* I've tested by performing some manual runs. (I couldn't find any relevant tests, so assume this is the current practice for this part of the code base.)
* There is an open comment on the issue. Not sure how you would like to address that comment?
