### PR TITLE
fix timezone in default card time format string

### DIFF
--- a/metaflow/plugins/cards/card_modules/convert_to_native_type.py
+++ b/metaflow/plugins/cards/card_modules/convert_to_native_type.py
@@ -307,7 +307,7 @@ class TaskToDict:
         # and truncates it to 30 characters.
         # If there is any form of TypeError or ValueError we set the column value to "Unsupported Type"
         # We also set columns which are have null values to "null" strings
-        time_format = "%Y-%m-%dT%H:%M:%SZ"
+        time_format = "%Y-%m-%dT%H:%M:%S%Z"
         truncate_long_objects = (
             lambda x: x.astype("string").str.slice(0, 30) + "..."
             if x.astype("string").str.len().max() > 30


### PR DESCRIPTION
The default card formats timezones in dataframes with `time_format = "%Y-%m-%dT%H:%M:%SZ"`. This should be `time_format = "%Y-%m-%dT%H:%M:%S%Z"`; without the % before the Z the formatted time will end with the literal Z, which means UTC time.