### PR TITLE
Enable`Distributed` mode for Step Function maps

### DIFF
--- a/metaflow/plugins/aws/step_functions/dynamo_db_client.py
+++ b/metaflow/plugins/aws/step_functions/dynamo_db_client.py
@@ -41,22 +41,3 @@ class DynamoDbClient(object):
             ConsistentRead=True,
         )
         return response["Item"]["parent_task_ids_for_foreach_join"]["SS"]
-
-    def save_root_run_id(
-        self, foreach_split_task_id, root_run_id,
-    ):
-        return self._client.update_item(
-            TableName=self.name,
-            Key={"pathspec": {"S": foreach_split_task_id}},
-            UpdateExpression="ADD root_run_id :val",
-            ExpressionAttributeValues={":val": {"SS": [foreach_join_parent_task_id]}},
-        )
-
-    def get_root_run_id(self, foreach_split_task_id):
-        response = self._client.get_item(
-            TableName=self.name,
-            Key={"pathspec": {"S": foreach_split_task_id}},
-            ProjectionExpression="root_run_id",
-            ConsistentRead=True,
-        )
-        return response["Item"]["root_run_id"]["SS"]

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -173,6 +173,7 @@ class StepFunctions(object):
             )
 
         return schedule_deleted, sfn_deleted
+
     @classmethod
     def trigger(cls, name, parameters):
         try:

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -76,7 +76,7 @@ class StepFunctions(object):
         self.username = username
         self.max_workers = max_workers
         self.workflow_timeout = workflow_timeout
-        self.use_disributed_map = use_distributed_map
+        self.use_distributed_map = use_distributed_map
 
         self._client = StepFunctionsClient()
         self._workflow = self._compile()
@@ -314,7 +314,7 @@ class StepFunctions(object):
                 iterator_name = "*%s" % node.out_funcs[0]
                 workflow.add_state(cardinality_state.next(iterator_name))
                 workflow.add_state(
-                    Map(iterator_name, self.use_disributed_map)
+                    Map(iterator_name, self.use_distributed_map)
                     .items_path("$.Result.Item.for_each_cardinality.NS")
                     .parameter("JobId.$", "$.JobId")
                     .parameter("SplitParentTaskId.$", "$.JobId")

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -666,7 +666,7 @@ class StepFunctions(object):
         env["METAFLOW_FLOW_NAME"] = attrs["metaflow.flow_name"]
         env["METAFLOW_STEP_NAME"] = attrs["metaflow.step_name"]
         if node.is_inside_foreach is True:
-            env["METAFLOW_RUN_ID"] = attrs["root_run_id.$"]1
+            env["METAFLOW_RUN_ID"] = attrs["root_run_id.$"]
         else:
             env["METAFLOW_RUN_ID"] = attrs["metaflow.run_id.$"]
         env["METAFLOW_PRODUCTION_TOKEN"] = self.production_token

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -167,7 +167,7 @@ class StepFunctions(object):
 
         sfn_deleted = StepFunctionsClient().delete(name)
 
-        if sfn_deleted is None:1
+        if sfn_deleted is None:
             raise StepFunctionsException(
                 "The workflow *%s* doesn't exist on AWS Step Functions." % name
             )

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -159,7 +159,7 @@ class StepFunctions(object):
             )
         except Exception as e:
             raise StepFunctionsSchedulingException(repr(e))
-        
+
     @classmethod
     def delete(cls, name):
         # Always attempt to delete the event bridge rule.
@@ -167,7 +167,7 @@ class StepFunctions(object):
 
         sfn_deleted = StepFunctionsClient().delete(name)
 
-        if sfn_deleted is None:
+        if sfn_deleted is None:1
             raise StepFunctionsException(
                 "The workflow *%s* doesn't exist on AWS Step Functions." % name
             )
@@ -321,7 +321,7 @@ class StepFunctions(object):
                     .parameter("Parameters.$", "$.Parameters")
                     .parameter("Index.$", "$$.Map.Item.Value")
                     .parameter("RootRunId.$", "$.Result.Item.root_run_id.S")
-                    .next(f"{iterator_name}_GetManifest" if workflow.use_distributed_map else node.matching_join)
+                    .next(f"{iterator_name}_GetManifest" if self.use_distributed_map else node.matching_join)
                     .iterator(
                         _visit(
                             self.graph[node.out_funcs[0]],
@@ -330,7 +330,7 @@ class StepFunctions(object):
                         )
                     )
                     .max_concurrency(self.max_workers)
-                    .output_path("$" if workflow.use_distributed_map else "$.[0]")
+                    .output_path("$" if self.use_distributed_map else "$.[0]")
                 )
 
                 # If we are using DistributedMap we need to obtain the Parameters
@@ -338,7 +338,7 @@ class StepFunctions(object):
                 # we can't just pull the value from the OutputPath, instead
                 # we need to write the results to S3 and then get the data from S3.
                 # These additional states are how we pull the data from S3.
-                if workflow.use_distributed_map:
+                if self.use_distributed_map:
                     workflow.add_state_hack(f"{iterator_name}_GetManifest", {
                         "Type": "Task",
                         "Next": f"{iterator_name}_Map",

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -13,6 +13,7 @@ from metaflow.decorators import flow_decorators
 from metaflow.exception import MetaflowException, MetaflowInternalError
 from metaflow.metaflow_config import (
     EVENTS_SFN_ACCESS_IAM_ROLE,
+    DATASTORE_SYSROOT_S3,
     S3_ENDPOINT_URL,
     SFN_DYNAMO_DB_TABLE,
     SFN_EXECUTION_LOG_GROUP_ARN,
@@ -1048,8 +1049,8 @@ class Map(object):
             self.payload["ResultWriter"] = {
                 "Resource": "arn:aws:states:::s3:putObject",
                 "Parameters": {
-                    "Bucket": "metaflow-s3-ddbg89vp",
-                    "Prefix": "resultwriter"
+                    "Bucket": DATASTORE_SYSROOT_S3.split("/")[2],
+                    "Prefix": "distributed_map_output"
                 }
             }
         self.payload["Iterator"] = workflow.payload

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -121,6 +121,11 @@ def step_functions(obj, name=None):
     help="Log AWS Step Functions execution history to AWS CloudWatch "
     "Logs log group.",
 )
+@click.option(
+    "--use-distributed-map",
+    is_flag=True,
+    help="Use the DistributedMap state instead of Map",
+)
 @click.pass_obj
 def create(
     obj,
@@ -133,6 +138,7 @@ def create(
     max_workers=None,
     workflow_timeout=None,
     log_execution_history=False,
+    use_distributed_map=False,
 ):
     validate_tags(tags)
 
@@ -162,6 +168,7 @@ def create(
         max_workers,
         workflow_timeout,
         obj.is_project,
+        use_distributed_map,
     )
 
     if only_json:
@@ -270,7 +277,7 @@ def resolve_state_machine_name(obj, name):
 
 
 def make_flow(
-    obj, token, name, tags, namespace, max_workers, workflow_timeout, is_project
+    obj, token, name, tags, namespace, max_workers, workflow_timeout, is_project, use_distributed_map,
 ):
     if obj.flow_datastore.TYPE != "s3":
         raise MetaflowException("AWS Step Functions requires --datastore=s3.")
@@ -306,6 +313,7 @@ def make_flow(
         username=get_username(),
         workflow_timeout=workflow_timeout,
         is_project=is_project,
+        use_distributed_map=use_distributed_map,
     )
 
 
@@ -556,7 +564,6 @@ def list_runs(
                 % (obj.state_machine_name)
             )
 
-
 @step_functions.command(help="Delete a workflow")
 @click.option(
     "--authorize",
@@ -618,7 +625,6 @@ def delete(obj, authorize=None):
 def validate_token(name, token_prefix, authorize, instruction_fn=None):
     """
     Validate that the production token matches that of the deployed flow.
-
     In case both the user and token do not match, raises an error.
     Optionally outputs instructions on token usage via the provided instruction_fn(flow_name, prev_user)
     """

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -124,7 +124,7 @@ def step_functions(obj, name=None):
 @click.option(
     "--use-distributed-map",
     is_flag=True,
-    help="Use the DistributedMap state instead of Map",
+    help="Use the Distributed Map instead of an Inline Map",
 )
 @click.pass_obj
 def create(
@@ -564,6 +564,7 @@ def list_runs(
                 % (obj.state_machine_name)
             )
 
+
 @step_functions.command(help="Delete a workflow")
 @click.option(
     "--authorize",
@@ -625,6 +626,7 @@ def delete(obj, authorize=None):
 def validate_token(name, token_prefix, authorize, instruction_fn=None):
     """
     Validate that the production token matches that of the deployed flow.
+
     In case both the user and token do not match, raises an error.
     Optionally outputs instructions on token usage via the provided instruction_fn(flow_name, prev_user)
     """

--- a/metaflow/plugins/aws/step_functions/step_functions_decorator.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_decorator.py
@@ -12,18 +12,18 @@ class StepFunctionsInternalDecorator(StepDecorator):
     name = "step_functions_internal"
 
     def task_pre_step(
-            self,
-            step_name,
-            task_datastore,
-            metadata,
-            run_id,
-            task_id,
-            flow,
-            graph,
-            retry_count,
-            max_user_code_retries,
-            ubf_context,
-            inputs,
+        self,
+        step_name,
+        task_datastore,
+        metadata,
+        run_id,
+        task_id,
+        flow,
+        graph,
+        retry_count,
+        max_user_code_retries,
+        ubf_context,
+        inputs,
     ):
         meta = {}
         meta["aws-step-functions-execution"] = os.environ["METAFLOW_RUN_ID"]
@@ -38,7 +38,7 @@ class StepFunctionsInternalDecorator(StepDecorator):
         metadata.register_metadata(run_id, step_name, task_id, entries)
 
     def task_finished(
-            self, step_name, flow, graph, is_task_ok, retry_count, max_user_code_retries
+        self, step_name, flow, graph, is_task_ok, retry_count, max_user_code_retries
     ):
         if not is_task_ok:
             # The task finished with an exception - execution won't
@@ -69,9 +69,9 @@ class StepFunctionsInternalDecorator(StepDecorator):
         # instead write the task ids from the parent task to DynamoDb and read
         # it back in the foreach join
         elif graph[step_name].is_inside_foreach and any(
-                graph[n].type == "join"
-                and graph[graph[n].split_parents[-1]].type == "foreach"
-                for n in graph[step_name].out_funcs
+            graph[n].type == "join"
+            and graph[graph[n].split_parents[-1]].type == "foreach"
+            for n in graph[step_name].out_funcs
         ):
             self._save_parent_task_id_for_foreach_join(
                 os.environ["METAFLOW_SPLIT_PARENT_TASK_ID_FOR_FOREACH_JOIN"],
@@ -79,14 +79,14 @@ class StepFunctionsInternalDecorator(StepDecorator):
             )
 
     def _save_foreach_cardinality(
-            self, foreach_split_task_id, for_each_cardinality, ttl, root_run_id,
+        self, foreach_split_task_id, for_each_cardinality, ttl, root_run_id,
     ):
         DynamoDbClient().save_foreach_cardinality(
             foreach_split_task_id, for_each_cardinality, ttl, root_run_id,
         )
 
     def _save_parent_task_id_for_foreach_join(
-            self, foreach_split_task_id, foreach_join_parent_task_id
+        self, foreach_split_task_id, foreach_join_parent_task_id
     ):
         DynamoDbClient().save_parent_task_id_for_foreach_join(
             foreach_split_task_id, foreach_join_parent_task_id

--- a/metaflow/plugins/aws/step_functions/step_functions_decorator.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_decorator.py
@@ -12,18 +12,18 @@ class StepFunctionsInternalDecorator(StepDecorator):
     name = "step_functions_internal"
 
     def task_pre_step(
-        self,
-        step_name,
-        task_datastore,
-        metadata,
-        run_id,
-        task_id,
-        flow,
-        graph,
-        retry_count,
-        max_user_code_retries,
-        ubf_context,
-        inputs,
+            self,
+            step_name,
+            task_datastore,
+            metadata,
+            run_id,
+            task_id,
+            flow,
+            graph,
+            retry_count,
+            max_user_code_retries,
+            ubf_context,
+            inputs,
     ):
         meta = {}
         meta["aws-step-functions-execution"] = os.environ["METAFLOW_RUN_ID"]
@@ -38,7 +38,7 @@ class StepFunctionsInternalDecorator(StepDecorator):
         metadata.register_metadata(run_id, step_name, task_id, entries)
 
     def task_finished(
-        self, step_name, flow, graph, is_task_ok, retry_count, max_user_code_retries
+            self, step_name, flow, graph, is_task_ok, retry_count, max_user_code_retries
     ):
         if not is_task_ok:
             # The task finished with an exception - execution won't
@@ -57,7 +57,7 @@ class StepFunctionsInternalDecorator(StepDecorator):
             # and execution history is available for 90 days after the
             # execution.
             self._save_foreach_cardinality(
-                os.environ["AWS_BATCH_JOB_ID"], flow._foreach_num_splits, self._ttl()
+                os.environ["AWS_BATCH_JOB_ID"], flow._foreach_num_splits, self._ttl(), os.environ["METAFLOW_RUN_ID"],
             )
         # The parent task ids need to be available in a foreach join so that
         # we can construct the input path. Unfortunately, while AWS Step
@@ -66,9 +66,9 @@ class StepFunctionsInternalDecorator(StepDecorator):
         # instead write the task ids from the parent task to DynamoDb and read
         # it back in the foreach join
         elif graph[step_name].is_inside_foreach and any(
-            graph[n].type == "join"
-            and graph[graph[n].split_parents[-1]].type == "foreach"
-            for n in graph[step_name].out_funcs
+                graph[n].type == "join"
+                and graph[graph[n].split_parents[-1]].type == "foreach"
+                for n in graph[step_name].out_funcs
         ):
             self._save_parent_task_id_for_foreach_join(
                 os.environ["METAFLOW_SPLIT_PARENT_TASK_ID_FOR_FOREACH_JOIN"],
@@ -76,14 +76,21 @@ class StepFunctionsInternalDecorator(StepDecorator):
             )
 
     def _save_foreach_cardinality(
-        self, foreach_split_task_id, for_each_cardinality, ttl
+            self, foreach_split_task_id, for_each_cardinality, ttl, root_run_id,
     ):
         DynamoDbClient().save_foreach_cardinality(
-            foreach_split_task_id, for_each_cardinality, ttl
+            foreach_split_task_id, for_each_cardinality, ttl, root_run_id,
         )
 
     def _save_parent_task_id_for_foreach_join(
-        self, foreach_split_task_id, foreach_join_parent_task_id
+            self, foreach_split_task_id, foreach_join_parent_task_id
+    ):
+        DynamoDbClient().save_parent_task_id_for_foreach_join(
+            foreach_split_task_id, foreach_join_parent_task_id
+        )
+
+    def _save_root_run_id(
+            self, foreach_split_task_id, root_run_id
     ):
         DynamoDbClient().save_parent_task_id_for_foreach_join(
             foreach_split_task_id, foreach_join_parent_task_id

--- a/metaflow/plugins/aws/step_functions/step_functions_decorator.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_decorator.py
@@ -57,7 +57,10 @@ class StepFunctionsInternalDecorator(StepDecorator):
             # and execution history is available for 90 days after the
             # execution.
             self._save_foreach_cardinality(
-                os.environ["AWS_BATCH_JOB_ID"], flow._foreach_num_splits, self._ttl(), os.environ["METAFLOW_RUN_ID"],
+                os.environ["AWS_BATCH_JOB_ID"],
+                flow._foreach_num_splits,
+                self._ttl(),
+                os.environ["METAFLOW_RUN_ID"],
             )
         # The parent task ids need to be available in a foreach join so that
         # we can construct the input path. Unfortunately, while AWS Step
@@ -84,13 +87,6 @@ class StepFunctionsInternalDecorator(StepDecorator):
 
     def _save_parent_task_id_for_foreach_join(
             self, foreach_split_task_id, foreach_join_parent_task_id
-    ):
-        DynamoDbClient().save_parent_task_id_for_foreach_join(
-            foreach_split_task_id, foreach_join_parent_task_id
-        )
-
-    def _save_root_run_id(
-            self, foreach_split_task_id, root_run_id
     ):
         DynamoDbClient().save_parent_task_id_for_foreach_join(
             foreach_split_task_id, foreach_join_parent_task_id


### PR DESCRIPTION
This PR introduces a way to utilize the "Distributed" type of Map (vs "Inline") to enable Step Functions to scale to larger sizes (issue: https://github.com/Netflix/metaflow/issues/1216).

### How it works

* Add in a new flag `--use-distributed-map` when creating a step function (ie `python helloworld.py step-functions create --use-distributed-map`)
* All map steps are then turned to use `Distributed` mode (vs the `Inline`) mode
* Distributed Map values are written to S3 and then we need to run some additional steps (fetch the S3 manifest and run a second Distributed Map step to extract the value)
* Lastly, the Run ID of the initial step function is passed down to maps so that it can be accessed on child Step Functions so data can be found in the S3 bucket. This is achieved by passing it into the Dynamo table.

### Additional Notes

This PR works for my test flows (one that maps to 1k values to test the scale, and another that does a map -> map -> join -> join).