### PR TITLE
feature: add list-templates command for argo workflows

### DIFF
--- a/metaflow/plugins/argo/argo_client.py
+++ b/metaflow/plugins/argo/argo_client.py
@@ -52,6 +52,35 @@ class ArgoClient(object):
                 json.loads(e.body)["message"] if e.body is not None else e.reason
             )
 
+    def get_workflow_templates(self, flow_name=None):
+        """
+        Return a list of workflow template names for a given Flow name.
+        Returns all workflow template names if no name is provided
+        """
+        client = self._client.get()
+        try:
+            results = client.CustomObjectsApi().list_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="workflowtemplates",
+            )["items"]
+            return [
+                result["metadata"]["name"]
+                for result in results
+                if flow_name is None
+                or flow_name
+                == result["metadata"]
+                .get("annotations", {})
+                .get("metaflow/flow_name", None)
+            ]
+        except client.rest.ApiException as e:
+            if e.status == 404:
+                return None
+            raise ArgoClientException(
+                json.loads(e.body)["message"] if e.body is not None else e.reason
+            )
+
     def register_workflow_template(self, name, workflow_template):
         # Unfortunately, Kubernetes client does not handle optimistic
         # concurrency control by itself unlike kubectl

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -184,6 +184,19 @@ class ArgoWorkflows(object):
         return name.replace("_", "-")
 
     @staticmethod
+    def list_templates(flow_name, all=False):
+        client = ArgoClient(namespace=KUBERNETES_NAMESPACE)
+
+        search = None if all else flow_name
+        results = client.get_workflow_templates(search)
+        if results is None:
+            return []
+
+        template_names = [template_name for template_name in results]
+
+        return template_names
+
+    @staticmethod
     def delete(name):
         client = ArgoClient(namespace=KUBERNETES_NAMESPACE)
 

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -833,19 +833,17 @@ def terminate(obj, run_id, authorize=None):
         obj.echo("\nRun terminated.")
 
 
-@argo_workflows.command(help="Terminate flow execution on Argo Workflows.")
+@argo_workflows.command(help="List Argo Workflow templates for the flow.")
 @click.option(
     "--all",
     default=False,
     is_flag=True,
     type=bool,
-    help="list all Workflow templates (not limited to this Flow)",
+    help="list all Argo Workflow Templates (not just limited to this flow)",
 )
 @click.pass_obj
 def list_templates(obj, all=None):
     templates = ArgoWorkflows.list_templates(obj.flow.name, all)
-    if templates:
-        obj.echo("Argo Workflow Templates:")
     for template_name in templates:
         obj.echo(template_name)
 

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -833,6 +833,23 @@ def terminate(obj, run_id, authorize=None):
         obj.echo("\nRun terminated.")
 
 
+@argo_workflows.command(help="Terminate flow execution on Argo Workflows.")
+@click.option(
+    "--all",
+    default=False,
+    is_flag=True,
+    type=bool,
+    help="list all Workflow templates (not limited to this Flow)",
+)
+@click.pass_obj
+def list_templates(obj, all=None):
+    templates = ArgoWorkflows.list_templates(obj.flow.name, all)
+    if templates:
+        obj.echo("Argo Workflow Templates:")
+    for template_name in templates:
+        obj.echo(template_name)
+
+
 def validate_run_id(
     workflow_name, token_prefix, authorize, run_id, instructions_fn=None
 ):


### PR DESCRIPTION
Adds a command for listing Argo workflow templates

`python testflow.py argo-workflows list-templates`
will list all workflow templates that have the same flow name as testflow.py. These will include all projects using the flow, production deployments, non-project deployments etc.

`python testflow.py argo-workflows list-templates --all`
will remove scoping to the flow file from the command and return a complete list of workflow templates

TODO: the API call for listing the objects needs consideration. Presumably the amount of objects even for large organisations shouldn't be extremely massive, as this is fetching workflow templates, and not workflows. Nevertheless some caution here, possibly requiring pagination in the future.