### PR TITLE
fix: apply only supported attributes from resources decorator in batch

### DIFF
--- a/metaflow/plugins/aws/aws_utils.py
+++ b/metaflow/plugins/aws/aws_utils.py
@@ -109,6 +109,11 @@ def compute_resource_attributes(decos, compute_deco, resource_defaults):
                 # We use the non None value if there is only one or the larger value
                 # if they are both non None. Note this considers "" to be equivalent to
                 # the value zero.
+                #
+                # Skip attributes that are not supported by the decorator.
+                if k not in resource_defaults:
+                    continue
+
                 if my_val is None and v is None:
                     continue
                 if my_val is not None and v is not None:

--- a/metaflow/plugins/aws/aws_utils.py
+++ b/metaflow/plugins/aws/aws_utils.py
@@ -111,7 +111,7 @@ def compute_resource_attributes(decos, compute_deco, resource_defaults):
                 # the value zero.
                 #
                 # Skip attributes that are not supported by the decorator.
-                if k not in resource_defaults:
+                if k not in [*resource_defaults.keys(), *deco.attributes.keys()]:
                     continue
 
                 if my_val is None and v is None:


### PR DESCRIPTION
Changes the way `BatchDecorator` pulls values from `ResourcesDecorator` if any are set. This limits the values to only ones supported through `resource_defaults` in batchdeco.

Should unblock #1500 which currently breaks for batch as it introduces a `disk=` attribute which is not supported for the batch deco, yet gets pulled in by the current implementation.