### PR TITLE
Add a uid for the kubernetes job creation

### DIFF
--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -2,11 +2,11 @@ import json
 import math
 import os
 import re
-import secrets
 import shlex
 import time
 from typing import Dict, List, Optional
-
+import uuid
+from uuid import uuid4
 
 from metaflow import current, util
 from metaflow.exception import MetaflowException
@@ -180,7 +180,7 @@ class Kubernetes(object):
         job = (
             KubernetesClient()
             .job(
-                generate_name="t-{entropy}".format(entropy=secrets.token_hex(2)),
+                generate_name="t-{uid}".format(uid=str(uuid4())[:3]),
                 namespace=namespace,
                 service_account=service_account,
                 secrets=secrets,

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -180,7 +180,7 @@ class Kubernetes(object):
         job = (
             KubernetesClient()
             .job(
-                generate_name="t-{uid}".format(uid=str(uuid4())[:3]),
+                generate_name="t-{uid}-".format(uid=str(uuid4())[:8]),
                 namespace=namespace,
                 service_account=service_account,
                 secrets=secrets,

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -2,10 +2,11 @@ import json
 import math
 import os
 import re
+import secrets
 import shlex
 import time
 from typing import Dict, List, Optional
-import uuid
+
 
 from metaflow import current, util
 from metaflow.exception import MetaflowException
@@ -179,7 +180,7 @@ class Kubernetes(object):
         job = (
             KubernetesClient()
             .job(
-                generate_name="t-{uid}".format(uid=str(uuid.uuid4())),
+                generate_name="t-{entropy}".format(entropy=secrets.token_hex(2)),
                 namespace=namespace,
                 service_account=service_account,
                 secrets=secrets,

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -5,6 +5,7 @@ import re
 import shlex
 import time
 from typing import Dict, List, Optional
+import uuid
 
 from metaflow import current, util
 from metaflow.exception import MetaflowException
@@ -178,7 +179,7 @@ class Kubernetes(object):
         job = (
             KubernetesClient()
             .job(
-                generate_name="t-",
+                generate_name="t-{uid}".format(uid=str(uuid.uuid4())),
                 namespace=namespace,
                 service_account=service_account,
                 secrets=secrets,


### PR DESCRIPTION
Fixes #1554 

When running large for-each branches (3000+) Metaflow will sometimes cause job name collisions on kubernetes. This adds a UUID to the prefix which should add sufficient entropy to prevent this from happening.