### PR TITLE
boto client instantiation outside of call to worker processes

### DIFF
--- a/metaflow/plugins/datatools/s3/s3op.py
+++ b/metaflow/plugins/datatools/s3/s3op.py
@@ -153,7 +153,7 @@ def normalize_client_error(err):
 # S3 worker pool
 
 
-def worker(result_file_name, queue, mode, s3config):
+def worker(result_file_name, queue, mode, s3, client_error):
     # Interpret mode, it can either be a single op or something like
     # info_download or info_upload which implies:
     #  - for download: we need to return the information as well
@@ -193,13 +193,6 @@ def worker(result_file_name, queue, mode, s3config):
 
     with open(result_file_name, "w") as result_file:
         try:
-            from metaflow.plugins.datatools.s3.s3util import get_s3_client
-
-            s3, client_error = get_s3_client(
-                s3_role_arn=s3config.role,
-                s3_session_vars=s3config.session_vars,
-                s3_client_params=s3config.client_params,
-            )
             while True:
                 url, idx = queue.get()
                 if url is None:
@@ -360,11 +353,19 @@ def start_workers(mode, urls, num_workers, inject_failure, s3config):
 
     # 3. start processes
     with TempDir() as output_dir:
+        from metaflow.plugins.datatools.s3.s3util import get_s3_client
+
+        s3, client_error = get_s3_client(
+            s3_role_arn=s3config.role,
+            s3_session_vars=s3config.session_vars,
+            s3_client_params=s3config.client_params,
+        )
+
         for i in range(num_workers):
             file_path = os.path.join(output_dir, str(i))
             p = Process(
                 target=worker,
-                args=(file_path, queue, mode, s3config),
+                args=(file_path, queue, mode, s3, client_error),
             )
             p.start()
             procs[p] = file_path


### PR DESCRIPTION
Fixes #1572 

Passes the instantiated boto client to the sub-processes instead of instantiating a new boto3 client object within each subprocess. Details for why this is needed are in the above linked issue.