### PR TITLE
Fix escaping of strings and None values in argo workflow parameters

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -446,11 +446,11 @@ class ArgoWorkflows(object):
                 )
             default_value = deploy_time_eval(param.kwargs.get("default"))
             # If the value is not required and the value is None, we set the value to
-            # the JSON equivalent of None to please argo-workflows. Unfortunately it
-            # has the side effect of casting the parameter value to string null during
-            # execution - which needs to be fixed imminently.
-            if not is_required or default_value is not None:
-                default_value = json.dumps(default_value)
+            # an empty string to please argo-workflows.  This works fine for strings.
+            # For non-strings, an unspecified value on trigger will result in a workflow failure
+            # for invalid typing.
+            if not is_required and default_value is None:
+                default_value = ""
             parameters[param.name] = dict(
                 name=param.name,
                 value=default_value,


### PR DESCRIPTION
The original code appears to have a bug where the comment says `and` but the code says `or`.  I believe the original intent is to handle the case where, for a parameter that was not required, there was no default value specified for it (hence the `defaultValue` evaluates to the python `None`).  This translates to a JSON `null` (unescaped) which Argo-workflows does not like as a default parameter value in its arguments.  In order to work around this, the code intended to create some non-null value but ended up creating the string `"null"` rather than something that represents no value.  It's unclear what consequences this has had on non-required parameters that were not specified at trigger time.

Moreover, because of the logical bug in the code, the JSON encoding was being applied to non-required string parameters with a non-null default value as well.  The resulting JSON had a bunch of extra escaped quotes (eg: `\"\\\"defaultStringValue\\\"\"` instead of `\"defaultStringValue\"` which is both unnecessary and confusing.

To fix this, we're assigning unspecified default values for non-required parameters to an empty string.  This works as intended for strings - an unspecified parameter default resolves to an empty string (where it previously resolved to the non-null string value `"null"`).  This new behavior is arguably more intuitive than the old.

NOTE: For non-strings this behavior is unchanged because the previous default value of `"null"` was also a string.  Python's typing of the parameter from the creation of the FlowSpec object, will result in a type assignment failure eg: `Error: Invalid value for '--notRequiredIntParameterWithNoDefault':  is not a valid integer` which the user can then see and correct.
