### PR TITLE
Sensor name convention hashed

### DIFF
--- a/metaflow/plugins/aws/step_functions/step_functions_client.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_client.py
@@ -82,8 +82,18 @@ class StepFunctionsClient(object):
         )
 
     def terminate_execution(self, state_machine_arn, execution_arn):
-        # TODO
-        pass
+        try:
+            # Use the AWS Step Functions client to stop the execution
+            response = self._client.stop_execution(
+                executionArn=execution_arn
+            )
+            return response
+        except self._client.exceptions.ExecutionDoesNotExist:
+            # Handle the case where the execution doesn't exist
+            raise ValueError(f"The execution ARN {execution_arn} does not exist.")
+        except Exception as e:
+            # Handle other potential errors
+            raise e
 
     def _default_logging_configuration(self, log_execution_history):
         if log_execution_history:


### PR DESCRIPTION
Made a new implementation for the naming convention of the sensor objects with a hash, to ensure all instances fit within th 63 character limit as issue #1591 outlined that metaflow executed normal operations despite the object not being deployed. 

Label added to sensor object to maintain data integrity of the original workflow name.