### PR TITLE
[pypi][bug fix] dependency comparison operator fix

### DIFF
--- a/metaflow/plugins/pypi/micromamba.py
+++ b/metaflow/plugins/pypi/micromamba.py
@@ -85,8 +85,12 @@ class Micromamba(object):
             for channel in self.info()["channels"] or ["conda-forge"]:
                 cmd.append("--channel=%s" % channel)
 
+            available_operators = [">=", "<=", "==", ">", "<"]
             for package, version in packages.items():
-                cmd.append("%s==%s" % (package, version))
+                operator = "=="
+                if any(op in version for op in available_operators):
+                    operator = ""
+                cmd.append("%s%s%s" % (package, operator, version))
             if python:
                 cmd.append("python==%s" % python)
             # TODO: Ensure a human readable message is returned when the environment


### PR DESCRIPTION
- Earlier the micromamba package solver would just statically set `{package}=={version}`
- But some packages have a version which may not be pinned such as `boto3` / `requests`
- This can cause package resolution to fail with errors like this :

```
Bootstrapping virtual environment(s) ...
    Micromamba ran into an error while setting up environment:
    command '/home/ubuntu/.local/bin/micromamba create --yes --quiet --dry-run --no-extra-safety-checks --repodata-ttl=86400 --retry-clean-cache --prefix=/tmp/tmp46ih0kgy/prefix --channel=conda-forge requests==>=2.21.0 boto3==>=1.14.0 python==3.10.12'
```
- this commit tries to handle different scenarios where different operators maybe specified in the `version` value of `packages` dictionary.

Test Flow to verify the fix (Try running before this commit and then after this commit):
```
from metaflow import FlowSpec, step, pypi
class PypiPackageFailFlow(FlowSpec):

    @pypi(packages={"huggingface-hub":"0.16.4"})
    @step
    def start(self):
        print('Starting')
        self.next(self.end)

    @step
    def end(self):
        pass

if __name__ == "__main__":
    PypiPackageFailFlow()
```