### PR TITLE
fix: resource decorator step functions issue

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -216,7 +216,7 @@ class BatchJob(object):
             if shared_memory is not None:
                 if not (
                     isinstance(shared_memory, (int, unicode, basestring))
-                    and int(shared_memory) > 0
+                    and int(float(shared_memory)) > 0
                 ):
                     raise BatchJobException(
                         "Invalid shared memory size value ({}); "
@@ -225,7 +225,7 @@ class BatchJob(object):
                 else:
                     job_definition["containerProperties"]["linuxParameters"][
                         "sharedMemorySize"
-                    ] = int(shared_memory)
+                    ] = int(float(shared_memory))
             if swappiness is not None:
                 if not (
                     isinstance(swappiness, (int, unicode, basestring))
@@ -298,7 +298,7 @@ class BatchJob(object):
                     )
             else:
                 # default tmpfs behavior - https://man7.org/linux/man-pages/man5/tmpfs.5.html
-                tmpfs_size = int(memory) / 2
+                tmpfs_size = int(float(memory)) / 2
 
             job_definition["containerProperties"]["linuxParameters"]["tmpfs"] = [
                 {

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -4,13 +4,11 @@ import os
 import random
 import string
 import sys
-import time
-import uuid
 from collections import defaultdict
 
 from metaflow import R
 from metaflow.decorators import flow_decorators
-from metaflow.exception import MetaflowException, MetaflowInternalError
+from metaflow.exception import MetaflowException
 from metaflow.metaflow_config import (
     EVENTS_SFN_ACCESS_IAM_ROLE,
     S3_ENDPOINT_URL,
@@ -19,10 +17,7 @@ from metaflow.metaflow_config import (
     SFN_IAM_ROLE,
 )
 from metaflow.parameters import deploy_time_eval
-from metaflow.plugins.aws.batch.batch_decorator import BatchDecorator
-from metaflow.plugins.resources_decorator import ResourcesDecorator
-from metaflow.plugins.retry_decorator import RetryDecorator
-from metaflow.util import compress_list, dict_to_cli_options, to_pascalcase
+from metaflow.util import dict_to_cli_options, to_pascalcase
 
 from ..batch.batch import Batch
 from .event_bridge_client import EventBridgeClient

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -24,7 +24,6 @@ from metaflow.plugins.resources_decorator import ResourcesDecorator
 from metaflow.plugins.retry_decorator import RetryDecorator
 from metaflow.util import compress_list, dict_to_cli_options, to_pascalcase
 
-from ..aws_utils import compute_resource_attributes
 from ..batch.batch import Batch
 from .event_bridge_client import EventBridgeClient
 from .step_functions_client import StepFunctionsClient
@@ -664,11 +663,6 @@ class StepFunctions(object):
         batch_deco = [deco for deco in node.decorators if deco.name == "batch"][0]
         resources = {}
         resources.update(batch_deco.attributes)
-        resources.update(
-            compute_resource_attributes(
-                node.decorators, batch_deco, batch_deco.resource_defaults
-            )
-        )
         # Resolve retry strategy.
         user_code_retries, total_retries = self._get_retries(node)
 


### PR DESCRIPTION
fixes the use of `shared_memory` and `use_tmpfs` in combination with a resources decorator for step-functions.

closes #1609 