### PR TITLE
CatchDecorator: Fix function signature

### DIFF
--- a/metaflow/plugins/catch_decorator.py
+++ b/metaflow/plugins/catch_decorator.py
@@ -98,7 +98,7 @@ class CatchDecorator(StepDecorator):
         return 0, NUM_FALLBACK_RETRIES
 
     def task_decorate(
-        self, step_func, func, graph, retry_count, max_user_code_retries, ubf_context
+        self, step_func, flow, graph, retry_count, max_user_code_retries, ubf_context
     ):
 
         # if the user code has failed max_user_code_retries times, @catch


### PR DESCRIPTION
The `task_decorate` method of the `CatchDecorator` has a typo, with the `flow` argument mistyped as `func`. 

All other step decorators have `flow` for this argument and the data type does seem to be flow, so assuming it is a typo. 