### PR TITLE
fix: output ImportError for tracing module to stderr

### DIFF
--- a/metaflow/tracing/__init__.py
+++ b/metaflow/tracing/__init__.py
@@ -1,3 +1,4 @@
+import sys
 from metaflow.metaflow_config import (
     OTEL_ENDPOINT,
     ZIPKIN_ENDPOINT,
@@ -64,4 +65,4 @@ if not DISABLE_TRACING and (CONSOLE_TRACE_ENABLED or OTEL_ENDPOINT or ZIPKIN_END
         )
 
     except ImportError as e:
-        print(e.msg)
+        print(e.msg, file=sys.stderr)


### PR DESCRIPTION
output the exception info to stderr instead of stdout.

also closes #1620