### PR TITLE
feature: add debug_tracing flag

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -346,7 +346,7 @@ CONDA_DEPENDENCY_RESOLVER = from_conf("CONDA_DEPENDENCY_RESOLVER", "conda")
 ###
 # Debug configuration
 ###
-DEBUG_OPTIONS = ["subcommand", "sidecar", "s3client"]
+DEBUG_OPTIONS = ["subcommand", "sidecar", "s3client", "tracing"]
 
 for typ in DEBUG_OPTIONS:
     vars()["DEBUG_%s" % typ.upper()] = from_conf("DEBUG_%s" % typ.upper(), False)

--- a/metaflow/tracing/__init__.py
+++ b/metaflow/tracing/__init__.py
@@ -4,6 +4,7 @@ from metaflow.metaflow_config import (
     ZIPKIN_ENDPOINT,
     CONSOLE_TRACE_ENABLED,
     DISABLE_TRACING,
+    DEBUG_TRACING,
 )
 from functools import wraps
 import contextlib
@@ -65,4 +66,7 @@ if not DISABLE_TRACING and (CONSOLE_TRACE_ENABLED or OTEL_ENDPOINT or ZIPKIN_END
         )
 
     except ImportError as e:
-        print(e.msg, file=sys.stderr)
+        # We keep the errors silent by default so that having tracing environment variables present
+        # does not affect users with no need for tracing.
+        if DEBUG_TRACING:
+            print(e.msg, file=sys.stderr)


### PR DESCRIPTION
add `METAFLOW_DEBUG_TRACING` environment variable flag and silence tracing ImportErrors by default.