### PR TITLE
[argo] Add k8s labels to tempalte.metadata instead of spec.podMetadata

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -1391,13 +1391,15 @@ class ArgoWorkflows(object):
                     minutes_between_retries=minutes_between_retries,
                 )
                 .metadata(
-                    ObjectMeta().annotation("metaflow/step_name", node.name)
+                    ObjectMeta()
+                    .annotation("metaflow/step_name", node.name)
                     # Unfortunately, we can't set the task_id since it is generated
                     # inside the pod. However, it can be inferred from the annotation
                     # set by argo-workflows - `workflows.argoproj.io/outputs` - refer
                     # the field 'task-id' in 'parameters'
                     # .annotation("metaflow/task_id", ...)
                     .annotation("metaflow/attempt", retry_count)
+                    .labels(self.kubernetes_labels)
                 )
                 # Set emptyDir volume for state management
                 .empty_dir_volume("out")


### PR DESCRIPTION
### Summary
Argo does not propagate the spec.podLabels to the pods. Only the sections under templates from the WorkflowTemplate are propagated to the Workflow and the pods. Their docs are misleading.

Here are related argo issues,
1. https://github.com/argoproj/argo-workflows/issues/7091
2. https://github.com/argoproj/argo-workflows/issues/7013

Particularly, this [comment](https://github.com/argoproj/argo-workflows/issues/7091#issuecomment-978687939) is helpful in demystifying some confusion of the argo terminology


### Testing
I tested against my argo installation. I did not see my custom labels before the change and I saw the labels applied after the change. I used `METAFLOW_KUBERNETES_LABELS` property in the `~/.metaflowconfig/config.json` file.