### PR TITLE
Add capability to add custom tags to batch

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -244,6 +244,8 @@ SERVICE_INTERNAL_URL = from_conf("SERVICE_INTERNAL_URL", SERVICE_URL)
 # in all Metaflow deployments. Hopefully, some day we can flip the
 # default to True.
 BATCH_EMIT_TAGS = from_conf("BATCH_EMIT_TAGS", False)
+# Default tags to add to AWS Batch jobs. These are in addition to the defaults set when BATCH_EMIT_TAGS is true.
+BATCH_DEFAULT_TAGS = from_conf("BATCH_DEFAULT_TAGS", {})
 
 ###
 # AWS Step Functions configuration

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -1,12 +1,11 @@
-from metaflow._vendor import click
 import os
 import sys
 import time
 import traceback
 
-from metaflow import util
-from metaflow import R
-from metaflow.exception import CommandException, METAFLOW_EXIT_DISALLOW_RETRY
+from metaflow import R, util
+from metaflow._vendor import click
+from metaflow.exception import METAFLOW_EXIT_DISALLOW_RETRY, CommandException
 from metaflow.metadata.util import sync_local_metadata_from_datastore
 from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
 from metaflow.mflog import TASK_LOG_SOURCE
@@ -146,6 +145,7 @@ def kill(ctx, run_id, user, my_runs):
     help="Activate designated number of elastic fabric adapter devices. "
     "EFA driver must be installed and instance type compatible with EFA",
 )
+@click.option("--aws-tags", multiple=True, default=None, help="AWS tags.")
 @click.option("--use-tmpfs", is_flag=True, help="tmpfs requirement for AWS Batch.")
 @click.option("--tmpfs-tempdir", is_flag=True, help="tmpfs requirement for AWS Batch.")
 @click.option("--tmpfs-size", help="tmpfs requirement for AWS Batch.")
@@ -179,13 +179,14 @@ def step(
     swappiness=None,
     inferentia=None,
     efa=None,
+    aws_tags=None,
     use_tmpfs=None,
     tmpfs_tempdir=None,
     tmpfs_size=None,
     tmpfs_path=None,
     host_volumes=None,
     num_parallel=None,
-    **kwargs
+    **kwargs,
 ):
     def echo(msg, stream="stderr", batch_id=None, **kwargs):
         msg = util.to_unicode(msg)
@@ -311,12 +312,13 @@ def step(
                 attrs=attrs,
                 host_volumes=host_volumes,
                 use_tmpfs=use_tmpfs,
+                tags=aws_tags,
                 tmpfs_tempdir=tmpfs_tempdir,
                 tmpfs_size=tmpfs_size,
                 tmpfs_path=tmpfs_path,
                 num_parallel=num_parallel,
             )
-    except Exception as e:
+    except Exception:
         traceback.print_exc()
         _sync_metadata()
         sys.exit(METAFLOW_EXIT_DISALLOW_RETRY)

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -1,34 +1,32 @@
 import os
-import sys
 import platform
-import requests
+import sys
 import time
 
-from metaflow import util
-from metaflow import R, current
+import requests
 
+from metaflow import R, current
 from metaflow.decorators import StepDecorator
-from metaflow.plugins.resources_decorator import ResourcesDecorator
-from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task
 from metaflow.metadata import MetaDatum
 from metaflow.metadata.util import sync_local_metadata_to_datastore
 from metaflow.metaflow_config import (
-    ECS_S3_ACCESS_IAM_ROLE,
-    BATCH_JOB_QUEUE,
     BATCH_CONTAINER_IMAGE,
     BATCH_CONTAINER_REGISTRY,
-    ECS_FARGATE_EXECUTION_ROLE,
+    BATCH_JOB_QUEUE,
     DATASTORE_LOCAL_DIR,
+    ECS_FARGATE_EXECUTION_ROLE,
+    ECS_S3_ACCESS_IAM_ROLE,
 )
+from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task
 from metaflow.sidecar import Sidecar
 from metaflow.unbounded_foreach import UBF_CONTROL
 
-from .batch import BatchException
 from ..aws_utils import (
     compute_resource_attributes,
     get_docker_registry,
     get_ec2_instance_metadata,
 )
+from .batch import BatchException
 
 
 class BatchDecorator(StepDecorator):
@@ -73,6 +71,9 @@ class BatchDecorator(StepDecorator):
         aggressively. Accepted values are whole numbers between 0 and 100.
     use_tmpfs: bool, default: False
         This enables an explicit tmpfs mount for this step.
+    tags: map, optional
+        Sets arbitrary AWS tags on the AWS Batch compute environment.
+        Set as string key-value pairs.
     tmpfs_tempdir: bool, default: True
         sets METAFLOW_TEMPDIR to tmpfs_path if set for this step.
     tmpfs_size: int, optional
@@ -103,6 +104,7 @@ class BatchDecorator(StepDecorator):
         "efa": None,
         "host_volumes": None,
         "use_tmpfs": False,
+        "tags": None,
         "tmpfs_tempdir": True,
         "tmpfs_size": None,
         "tmpfs_path": "/metaflow_temp",
@@ -346,7 +348,7 @@ class BatchDecorator(StepDecorator):
                             len(flow._control_mapper_tasks),
                         )
                     )
-            except Exception as e:
+            except Exception:
                 pass
         raise Exception(
             "Batch secondary workers did not finish in %s seconds" % TIMEOUT


### PR DESCRIPTION
Fixes https://github.com/Netflix/metaflow/issues/1627.

Adds:
1. `BATCH_DEFAULT_TAGS` to metaflow config - a map of default AWS tags to apply to batch jobs
2. `tags` kwarg to the AWS batch decorator - a map of AWS tags to apply to batch jobs (applied last)
3. `--aws-tags` to the CLI (to avoid clashing with metaflow tags.

All of these only apply when `BATCH_EMIT_TAGS` is set to avoid IAM problems.

I haven't done any manual testing here as I'm not sure the best way to go around that?