### PR TITLE
Add deployed-at timestamp in annotations for argo-workflows

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -622,7 +622,7 @@ class ArgoWorkflows(object):
             "metaflow/owner": self.username,
             "metaflow/user": "argo-workflows",
             "metaflow/flow_name": self.flow.name,
-            "metaflow/latest_deployment": str(datetime.now(timezone.utc).isoformat()),
+            "metaflow/deployment_timestamp": str(datetime.now(timezone.utc).isoformat()),
         }
 
         if self.parameters:

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -622,7 +622,7 @@ class ArgoWorkflows(object):
             "metaflow/owner": self.username,
             "metaflow/user": "argo-workflows",
             "metaflow/flow_name": self.flow.name,
-            "metaflow/updated_at": str(datetime.now(timezone.utc).isoformat()),
+            "metaflow/latest_deployment": str(datetime.now(timezone.utc).isoformat()),
         }
 
         if self.parameters:

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -622,7 +622,9 @@ class ArgoWorkflows(object):
             "metaflow/owner": self.username,
             "metaflow/user": "argo-workflows",
             "metaflow/flow_name": self.flow.name,
-            "metaflow/deployment_timestamp": str(datetime.now(timezone.utc).isoformat()),
+            "metaflow/deployment_timestamp": str(
+                datetime.now(timezone.utc).isoformat()
+            ),
         }
 
         if self.parameters:

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -615,11 +615,14 @@ class ArgoWorkflows(object):
         # generate container templates at the top level (in WorkflowSpec) and maintain
         # references to them within the DAGTask.
 
+        from datetime import datetime
+
         annotations = {
             "metaflow/production_token": self.production_token,
             "metaflow/owner": self.username,
             "metaflow/user": "argo-workflows",
             "metaflow/flow_name": self.flow.name,
+            "metaflow/updated_at": str(datetime.now().timestamp()),
         }
 
         if self.parameters:

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -615,14 +615,14 @@ class ArgoWorkflows(object):
         # generate container templates at the top level (in WorkflowSpec) and maintain
         # references to them within the DAGTask.
 
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         annotations = {
             "metaflow/production_token": self.production_token,
             "metaflow/owner": self.username,
             "metaflow/user": "argo-workflows",
             "metaflow/flow_name": self.flow.name,
-            "metaflow/updated_at": str(datetime.now().timestamp()),
+            "metaflow/updated_at": str(datetime.now(timezone.utc).isoformat()),
         }
 
         if self.parameters:


### PR DESCRIPTION
This can be used by downstream automation to determine when the flow was last updated in argo-workflows

Sample workflow template snippet YAML:
```yaml
  annotations:
    metaflow/flow_name: AHelloFlow
    metaflow/owner: rohan.outerbounds@gmail.com
    metaflow/production_token: ahelloflow-0-qpdi
    metaflow/latest_deployment: '2023-11-14T02:47:54.202588+00:00'
    metaflow/user: argo-workflows
```