### PR TITLE
fix: change regex patterns to raw strings

### DIFF
--- a/metaflow/plugins/airflow/airflow_cli.py
+++ b/metaflow/plugins/airflow/airflow_cli.py
@@ -24,7 +24,7 @@ class IncorrectProductionToken(MetaflowException):
     headline = "Incorrect production token"
 
 
-VALID_NAME = re.compile("[^a-zA-Z0-9_\-\.]")
+VALID_NAME = re.compile(r"[^a-zA-Z0-9_\-\.]")
 
 
 def resolve_token(

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -29,7 +29,7 @@ from metaflow.util import get_username, to_bytes, to_unicode, version_parse
 
 from .argo_workflows import ArgoWorkflows
 
-VALID_NAME = re.compile("^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$")
+VALID_NAME = re.compile(r"^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$")
 
 
 class IncorrectProductionToken(MetaflowException):

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -19,7 +19,7 @@ from metaflow.util import get_username, to_bytes, to_unicode, version_parse
 from .step_functions import StepFunctions
 from .production_token import load_token, store_token, new_token
 
-VALID_NAME = re.compile("[^a-zA-Z0-9_\-\.]")
+VALID_NAME = re.compile(r"[^a-zA-Z0-9_\-\.]")
 
 
 class IncorrectProductionToken(MetaflowException):


### PR DESCRIPTION
fix deprecation warnings due to escape characters in some of the regex patterns being used, by changing these to raw strings.