### PR TITLE
raw strings to fix deprecation warnings

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -129,7 +129,7 @@ class Decorator(object):
 
         attrs = {}
         # TODO: Do we really want to allow spaces in the names of attributes?!?
-        for a in re.split(""",(?=[\s\w]+=)""", deco_spec):
+        for a in re.split(r""",(?=[\s\w]+=)""", deco_spec):
             name, val = a.split("=", 1)
             try:
                 val_parsed = json.loads(val.strip().replace('\\"', '"'))

--- a/metaflow/plugins/aws/aws_utils.py
+++ b/metaflow/plugins/aws/aws_utils.py
@@ -38,7 +38,7 @@ def get_ec2_instance_metadata():
 
 
 def get_docker_registry(image_uri):
-    """
+    r"""
     Explanation:
         (.+?(?:[:.].+?)\/)? - [GROUP 0] REGISTRY
             .+?                 - A registry must start with at least one character


### PR DESCRIPTION
Similar to https://github.com/Netflix/metaflow/pull/1645, fixes a couple more deprecation warnings I'd come across
```
.../python-3.10/lib/python3.10/site-packages/metaflow/decorators.py:132: DeprecationWarning: invalid escape sequence '\s'
    for a in re.split(""",(?=[\s\w]+=)""", deco_spec):

.../python-3.10/lib/python3.10/site-packages/metaflow/plugins/aws/aws_utils.py:42: DeprecationWarning: invalid escape sequence '\/'
```