### PR TITLE
Fix an issue with aliases in environment escape server mappings.

### DIFF
--- a/metaflow/plugins/env_escape/client_modules.py
+++ b/metaflow/plugins/env_escape/client_modules.py
@@ -8,6 +8,7 @@ import sys
 from .consts import OP_CALLFUNC, OP_GETVAL, OP_SETVAL
 from .client import Client
 from .override_decorators import LocalException
+from .utils import get_canonical_name
 
 
 def _clean_client(client):
@@ -23,6 +24,7 @@ class _WrappedModule(object):
             r"^%s\.([a-zA-Z_][a-zA-Z0-9_]*)$" % prefix.replace(".", r"\.")  # noqa W605
         )
         self._exports = {}
+        self._aliases = exports["aliases"]
         for k in ("classes", "functions", "values"):
             result = []
             for item in exports[k]:
@@ -43,6 +45,11 @@ class _WrappedModule(object):
             return self._prefix
         if name in ("__file__", "__path__"):
             return self._client.name
+
+        # Make the name canonical because the prefix is also canonical.
+        name = get_canonical_name(self._prefix + "." + name, self._aliases)[
+            len(self._prefix) + 1 :
+        ]
         if name in self._exports["classes"]:
             # We load classes lazily
             return self._client.get_local_class("%s.%s" % (self._prefix, name))
@@ -87,6 +94,7 @@ class _WrappedModule(object):
             "_client",
             "_exports",
             "_exception_classes",
+            "_aliases",
         ):
             object.__setattr__(self, name, value)
             return
@@ -95,6 +103,11 @@ class _WrappedModule(object):
             # module when loading
             object.__setattr__(self, name, value)
             return
+
+        # Make the name canonical because the prefix is also canonical.
+        name = get_canonical_name(self._prefix + "." + name, self._aliases)[
+            len(self._prefix) + 1 :
+        ]
         if name in self._exports["values"]:
             self._client.stub_request(
                 None, OP_SETVAL, "%s.%s" % (self._prefix, name), value
@@ -126,7 +139,7 @@ class ModuleImporter(object):
 
     def find_module(self, fullname, path=None):
         if self._handled_modules is not None:
-            if fullname in self._handled_modules:
+            if get_canonical_name(fullname, self._aliases) in self._handled_modules:
                 return self
             return None
         if any([fullname.startswith(prefix) for prefix in self._module_prefixes]):
@@ -224,23 +237,14 @@ class ModuleImporter(object):
                 self._handled_modules[prefix] = _WrappedModule(
                     self, prefix, exports, formed_exception_classes, self._client
                 )
-        fullname = self._get_canonical_name(fullname)
-        module = self._handled_modules.get(fullname)
+        canonical_fullname = get_canonical_name(fullname, self._aliases)
+        # Modules are created canonically but we need to return something for any
+        # of the aliases.
+        module = self._handled_modules.get(canonical_fullname)
         if module is None:
             raise ImportError
         sys.modules[fullname] = module
         return module
-
-    def _get_canonical_name(self, name):
-        # We look at the aliases looking for the most specific match first
-        base_name = self._aliases.get(name)
-        if base_name is not None:
-            return base_name
-        for idx in reversed([pos for pos, char in enumerate(name) if char == "."]):
-            base_name = self._aliases.get(name[:idx])
-            if base_name is not None:
-                return ".".join([base_name, name[idx + 1 :]])
-        return name
 
 
 def create_modules(python_executable, pythonpath, max_pickle_version, path, prefixes):

--- a/metaflow/plugins/env_escape/utils.py
+++ b/metaflow/plugins/env_escape/utils.py
@@ -20,3 +20,15 @@ def get_methods(class_object):
         elif isinstance(attribute, classmethod):
             all_methods["___c___%s" % name] = inspect.getdoc(attribute)
     return all_methods
+
+
+def get_canonical_name(name, aliases):
+    # We look at the aliases looking for the most specific match first
+    base_name = aliases.get(name)
+    if base_name is not None:
+        return base_name
+    for idx in reversed([pos for pos, char in enumerate(name) if char == "."]):
+        base_name = aliases.get(name[:idx])
+        if base_name is not None:
+            return ".".join([base_name, name[idx + 1 :]])
+    return name


### PR DESCRIPTION
We were not properly creating all the aliased classes in the conda environment (only creating the "canonical" one (which is the first one listed in the server_mappings.py file).

Similarly, the hierarchy of exceptions was not properly created in all cases.