### PR TITLE
Set parameters for running flow instead of any imported

### DIFF
--- a/metaflow/parameters.py
+++ b/metaflow/parameters.py
@@ -31,11 +31,7 @@ ParameterContext = NamedTuple(
     ],
 )
 
-# currently we execute only one flow per process, so we can treat
-# Parameters globally. If this was to change, it should/might be
-# possible to move these globals in a FlowSpec (instance) specific
-# closure.
-parameters = []
+parameters = []  # Set by FlowSpec.__init__()
 context_proto = None
 
 
@@ -48,7 +44,7 @@ class JSONTypeClass(click.ParamType):
             return value
         try:
             return json.loads(value)
-        except:
+        except Exception:
             self.fail("%s is not a valid JSON object" % value, param, ctx)
 
     def __str__(self):
@@ -113,7 +109,7 @@ class DeployTimeField(object):
                 val = self.fun(ctx, deploy_time)
             except TypeError:
                 val = self.fun(ctx)
-        except:
+        except Exception:
             raise ParameterFieldFailed(self.parameter_name, self.field)
         else:
             return self._check_type(val, deploy_time)
@@ -210,7 +206,7 @@ class DelayedEvaluationParameter(object):
     def __call__(self, return_str=False):
         try:
             return self._fun(return_str=return_str)
-        except Exception as e:
+        except Exception:
             raise ParameterFieldFailed(self._name, self._field)
 
 
@@ -335,7 +331,6 @@ class Parameter(object):
                 "Parameter *%s*: Separator is only allowed "
                 "for string parameters." % name
             )
-        parameters.append(self)
 
     def option_kwargs(self, deploy_mode):
         kwargs = self.kwargs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 license_files = LICENSE
+
+[flake8]
+max-line-length = 120

--- a/test_runner
+++ b/test_runner
@@ -5,7 +5,7 @@ set -o errexit -o nounset -o pipefail
 install_deps() {
   for version in 2 3;
   do
-    python$version -m pip install . 
+    python$version -m pip install -e .
   done
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,4 @@
 [testenv]
 allowlist_externals = ./test_runner
 commands = ./test_runner
-
+usedevelop = True


### PR DESCRIPTION
This fixes the [issue where parameters for multiple imported flows are displayed](https://github.com/Netflix/metaflow/issues/1648) instead of the running one when multple flows are in the same file with parameters.

Also:
1. Change to use Exception as bare except is bad practice / fails flake8.
2. Switch to editable/develop install so any code changes would be effective without reinstalling. Much faster to iterate changes.

Note: I didn't add a test for this as this feature is already tested by many existing tests and they worked fine with this change, but happy to add one specifically for the mentioned issue if desired. 