### PR TITLE
chore: use metadata url mapping to install from local cache for PyPI environments

### DIFF
--- a/metaflow/plugins/pypi/pip.py
+++ b/metaflow/plugins/pypi/pip.py
@@ -128,6 +128,7 @@ class Pip(object):
     def create(self, id_, packages, python, platform):
         prefix = self.micromamba.path_to_environment(id_)
         installation_marker = INSTALLATION_MARKER.format(prefix=prefix)
+        url_mappings = self.metadata(id_, packages, python, platform)
         # install packages only if they haven't been installed before
         if os.path.isfile(installation_marker):
             return
@@ -143,7 +144,7 @@ class Pip(object):
                 "--quiet",
             ]
             for package in packages:
-                cmd.append("{url}".format(**package))
+                cmd.append(url_mappings[package["url"]])
             self._call(prefix, cmd)
         with open(installation_marker, "w") as file:
             file.write(json.dumps({"id": id_}))


### PR DESCRIPTION
Use the metadata url -> local path mapping for PyPI environments during the environment creation instead of relying on pip http cache to have packages available.

Extracted from #1559 

benchmarked changes with the following change to environment resolving:
```python
# First resolve environments through Conda, before PyPI.
start_ts = time.time()
echo("Bootstrapping virtual environment(s) ...")
...
end_ts = time.time()
echo(f"Bootstraping took: {end_ts-start_ts}")
```
timings for environment resolving (seconds):
|http cache|local paths|
|---|---|
|111.19|115.22|
|119.00|113.97|
|123.63|117.73|

which are within margin to consider that the change should not result in adverse performance.