### PR TITLE
fix: Argo workflows joins failing with wide foreach flows 

### DIFF
--- a/metaflow/plugins/argo/process_input_paths.py
+++ b/metaflow/plugins/argo/process_input_paths.py
@@ -11,7 +11,7 @@ def process_input_paths(input_paths):
     flow, run_id, task_ids = input_paths.split("/")
     task_ids = re.sub("[\[\]{}]", "", task_ids)
     task_ids = task_ids.split(",")
-    tasks = [t.split(":")[1] for t in task_ids]
+    tasks = [t.split(":")[1].strip('"') for t in task_ids]
     return "{}/{}/:{}".format(flow, run_id, ",".join(tasks))
 
 


### PR DESCRIPTION
Partial remedy to the issue with large foreach flows input-paths being repeated in the `ARGO_TEMPLATE` multiple times, exceeding the max size for it.

closes #1538 