### PR TITLE
fix overwrite of neuron devices when efa devices are also specified

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -346,8 +346,13 @@ class BatchJob(object):
             else:
                 if "linuxParameters" not in job_definition["containerProperties"]:
                     job_definition["containerProperties"]["linuxParameters"] = {}
-                if "devices" not in job_definition["containerProperties"]["linuxParameters"]:
-                    job_definition["containerProperties"]["linuxParameters"]["devices"] = []
+                if (
+                    "devices"
+                    not in job_definition["containerProperties"]["linuxParameters"]
+                ):
+                    job_definition["containerProperties"]["linuxParameters"][
+                        "devices"
+                    ] = []
                 if (num_parallel or 0) > 1:
                     # Multi-node parallel jobs require the container path and permissions explicitly specified in Job definition
                     for i in range(int(efa)):

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -344,7 +344,10 @@ class BatchJob(object):
                     "Invalid efa value: ({}) (should be 0 or greater)".format(efa)
                 )
             else:
-                job_definition["containerProperties"]["linuxParameters"]["devices"] = []
+                if "linuxParameters" not in job_definition["containerProperties"]:
+                    job_definition["containerProperties"]["linuxParameters"] = {}
+                if "devices" not in job_definition["containerProperties"]["linuxParameters"]:
+                    job_definition["containerProperties"]["linuxParameters"]["devices"] = []
                 if (num_parallel or 0) > 1:
                     # Multi-node parallel jobs require the container path and permissions explicitly specified in Job definition
                     for i in range(int(efa)):

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -271,7 +271,7 @@ class BatchJob(object):
                         {
                             "containerPath": "/dev/neuron{}".format(i),
                             "hostPath": "/dev/neuron{}".format(i),
-                            "permissions": ["read", "write"],
+                            "permissions": ["READ", "WRITE"],
                         }
                     )
 


### PR DESCRIPTION
When `@batch` contains both `inferentia` and `efa` arguments, the list of `/dev/neuron{N}` (for inferentia and trainium) specifications in `nodeProperties.nodeRangeProperties.container.linuxParameters.devices` are currently being overwritten by the list of  `/dev/infiniband/uverbs{N}` (for efa eni's) devices. 