### PR TITLE
[Ready for Review] Support more convenient foreach variable/value search-ability.

### DIFF
--- a/metaflow/flowspec.py
+++ b/metaflow/flowspec.py
@@ -504,7 +504,7 @@ class FlowSpec(object):
             )
             raise InvalidNextException(msg)
 
-    def _get_foreach_item_value(self, item):
+    def _get_foreach_item_value(self, item: Any):
         """
         Get the unique value for the item in the foreach iterator.  If no suitable value
         is found, return the value formatted by reprlib, which is at most 30 characters long.

--- a/metaflow/flowspec.py
+++ b/metaflow/flowspec.py
@@ -17,6 +17,7 @@ from .exception import (
 )
 from .graph import FlowGraph
 from .unbounded_foreach import UnboundedForeachInput
+from .metaflow_config import INCLUDE_FOREACH_STACK
 
 # For Python 3 compatibility
 try:
@@ -503,27 +504,15 @@ class FlowSpec(object):
             )
             raise InvalidNextException(msg)
 
-    def _get_foreach_item_value(self, item, foreach_var):
+    def _get_foreach_item_value(self, item):
         """
-        Get the unique value for the item in the foreach iterator. We will use
-        the following order of precedence:
-
-        1) If the item is a primitive type, use the item itself.
-        2) If the item is a dictionary and has a key named `foreach_var`, use the value of that key.
-        3) If the item is a dictionary and has a key named `key`, use the value of that key.
-        4) If the item has an attribute named `key`, use the value of that attribute.
-
-        If no suitable value is found, return the value formatted by reprlib, which is at
-        most 30 characters long.
+        Get the unique value for the item in the foreach iterator.  If no suitable value
+        is found, return the value formatted by reprlib, which is at most 30 characters long.
 
         Parameters
         ----------
         item : Any
             The item to get the value from.
-        foreach_var : str
-            The name of the variable that is being iterated over.
-        default_value : str
-            The default value to use if no suitable value is found.
 
         Returns
         -------
@@ -539,23 +528,7 @@ class FlowSpec(object):
                 or isinstance(item, bool)
             )
 
-        value = reprlib.Repr().repr(item)
-        if _is_primitive_type(item):
-            value = item
-        elif (
-            isinstance(item, dict)
-            and foreach_var in item
-            and _is_primitive_type(item[foreach_var])
-        ):
-            value = item[foreach_var]
-        elif (
-            isinstance(item, dict)
-            and "value" in item
-            and _is_primitive_type(item["value"])
-        ):
-            value = item["value"]
-        elif hasattr(item, "value") and _is_primitive_type(item.value):
-            value = item.value
+        value = item if _is_primitive_type(item) else reprlib.Repr().repr(item)
         return basestring(value)
 
     def next(self, *dsts: Callable[..., None], **kwargs) -> None:
@@ -674,12 +647,14 @@ class FlowSpec(object):
                 self._validate_ubf_step(funcs[0])
             else:
                 try:
-                    self._foreach_values = []
-                    for item in foreach_iter:
-                        value = self._get_foreach_item_value(item, foreach)
-                        self._foreach_values.append(value)
-                    self._foreach_num_splits = len(self._foreach_values)
-
+                    if INCLUDE_FOREACH_STACK:
+                        self._foreach_values = []
+                        for item in foreach_iter:
+                            value = self._get_foreach_item_value(item)
+                            self._foreach_values.append(value)
+                        self._foreach_num_splits = len(self._foreach_values)
+                    else:
+                        self._foreach_num_splits = sum(1 for _ in foreach_iter)
                 except Exception as e:
                     msg = (
                         "Foreach variable *self.{var}* in step *{step}* "
@@ -688,12 +663,6 @@ class FlowSpec(object):
                         )
                     )
                     raise InvalidNextException(msg)
-
-                # If values are not unique, we need to fallback to using the index.
-                if len(self._foreach_values) != len(set(self._foreach_values)):
-                    self._foreach_values = list(
-                        map(str, range(self._foreach_num_splits))
-                    )
 
                 if self._foreach_num_splits == 0:
                     msg = (

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -203,6 +203,7 @@ DEFAULT_CONTAINER_IMAGE = from_conf("DEFAULT_CONTAINER_IMAGE")
 # Default container registry
 DEFAULT_CONTAINER_REGISTRY = from_conf("DEFAULT_CONTAINER_REGISTRY")
 # Controls whether to include foreach stack information in metadata.
+# TODO(Darin, 05/01/24): Remove this flag once we are confident with this feature.
 INCLUDE_FOREACH_STACK = from_conf("INCLUDE_FOREACH_STACK", False)
 
 ###

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -202,6 +202,8 @@ SERVICE_VERSION_CHECK = from_conf("SERVICE_VERSION_CHECK", True)
 DEFAULT_CONTAINER_IMAGE = from_conf("DEFAULT_CONTAINER_IMAGE")
 # Default container registry
 DEFAULT_CONTAINER_REGISTRY = from_conf("DEFAULT_CONTAINER_REGISTRY")
+# Controls whether to include foreach stack information in metadata.
+INCLUDE_FOREACH_STACK = from_conf("INCLUDE_FOREACH_STACK", False)
 
 ###
 # Organization customizations

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -1026,8 +1026,8 @@ class Task(object):
 
     @property
     def finished_id(self):
-        # note: id is not available before the task has finished
-        # index already identifies the task within the foreach,
+        # note: id is not available before the task has finished.
+        # Index already identifies the task within the foreach,
         # we will remove foreach value so that it is easier to
         # identify siblings within a foreach.
         foreach_stack_tuple = tuple(

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -427,7 +427,7 @@ class NativeRuntime(object):
                 else:
                     # Update _finished since these tasks were successfully
                     # run elsewhere so that join will be unblocked.
-                    step_name, foreach_stack = task.finished_id
+                    _, foreach_stack = task.finished_id
                     top = foreach_stack[-1]
                     bottom = list(foreach_stack[:-1])
                     for i in range(num_splits):
@@ -437,7 +437,7 @@ class NativeRuntime(object):
 
             # Find and check status of control task and retrieve its pathspec
             # for retrieving unbounded foreach cardinality.
-            step_name, foreach_stack = task.finished_id
+            _, foreach_stack = task.finished_id
             top = foreach_stack[-1]
             bottom = list(foreach_stack[:-1])
             s = tuple(bottom + [top._replace(index=None)])
@@ -466,7 +466,7 @@ class NativeRuntime(object):
         else:
             # matching_split is the split-parent of the finished task
             matching_split = self._graph[self._graph[next_step].split_parents[-1]]
-            step_name, foreach_stack = task.finished_id
+            _, foreach_stack = task.finished_id
 
             if matching_split.type == "foreach":
                 # next step is a foreach join
@@ -1027,7 +1027,13 @@ class Task(object):
     @property
     def finished_id(self):
         # note: id is not available before the task has finished
-        return (self.step, tuple(self.results["_foreach_stack"]))
+        # index already identifies the task within the foreach,
+        # we will remove foreach value so that it is easier to
+        # identify siblings within a foreach.
+        foreach_stack_tuple = tuple(
+            [s._replace(value=0) for s in self.results["_foreach_stack"]]
+        )
+        return (self.step, foreach_stack_tuple)
 
     @property
     def is_cloned(self):

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -24,7 +24,9 @@ from .current import current
 from metaflow.tracing import get_trace_id
 from collections import namedtuple
 
-ForeachFrame = namedtuple("ForeachFrame", ["step", "var", "num_splits", "index"])
+ForeachFrame = namedtuple(
+    "ForeachFrame", ["step", "var", "num_splits", "index", "value"]
+)
 
 
 class MetaflowTask(object):
@@ -188,10 +190,10 @@ class MetaflowTask(object):
                     if join_type == "foreach":
                         top = i["_foreach_stack"][-1]
                         bottom = i["_foreach_stack"][:-1]
-                        # the topmost indices in the stack are all
-                        # different naturally, so ignore them in the
+                        # the topmost indices and values in the stack are
+                        # all different naturally, so ignore them in the
                         # assertion
-                        yield bottom + [top._replace(index=0)]
+                        yield bottom + [top._replace(index=0, value=0)]
                     else:
                         yield i["_foreach_stack"]
 
@@ -249,6 +251,7 @@ class MetaflowTask(object):
                 inputs[0]["_foreach_var"],
                 inputs[0]["_foreach_num_splits"],
                 split_index,
+                inputs[0]["_foreach_values"][split_index],
             )
 
             stack = inputs[0]["_foreach_stack"]

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -22,19 +22,18 @@ from .unbounded_foreach import UBF_CONTROL
 from .util import all_equal, get_username, resolve_identity, unicode_type
 from .current import current
 from metaflow.tracing import get_trace_id
-from collections import namedtuple
+from metaflow.util import namedtuple_with_defaults
 
-foreach_frame_field_list = ["step", "var", "num_splits", "index", "value"]
-ForeachFrame = namedtuple(
-    "ForeachFrame",
-    foreach_frame_field_list,
-    defaults=(None,) * len(foreach_frame_field_list),
+foreach_frame_field_list = [
+    ("step", str),
+    ("var", str),
+    ("num_splits", int),
+    ("index", int),
+    ("value", str),
+]
+ForeachFrame = namedtuple_with_defaults(
+    "ForeachFrame", foreach_frame_field_list, (None,) * (len(foreach_frame_field_list))
 )
-ForeachFrame.__reduce__ = lambda frame: (construct_frame, tuple(frame))
-# To be backwards compatible.
-def construct_frame(*args):
-    return ForeachFrame(*args[: len(ForeachFrame._fields)])
-
 
 # Maximum number of characters of the foreach path that we store in the metadata.
 MAX_FOREACH_PATH_LENGTH = 256

--- a/metaflow/util.py
+++ b/metaflow/util.py
@@ -57,6 +57,12 @@ from typing import NamedTuple
 def namedtuple_with_defaults(typename, field_descr, defaults=()):
     T = NamedTuple(typename, field_descr)
     T.__new__.__defaults__ = tuple(defaults)
+
+    # Adding the following to ensure the named tuple can be (un)pickled correctly.
+    import __main__
+
+    setattr(__main__, T.__name__, T)
+    T.__module__ = "__main__"
     return T
 
 


### PR DESCRIPTION
In this change, we

1. add values of foreach items to flowspec for convenient access to values in foreach steps. 
2. Update foreach stack to include value.
3. Add formatted foreach stack (path from root to current level) to metadata, guarded by a flag.

Currently,  we try to get "value" of the for each in the following order:
1. If the item is list of primitive types like `["a", "b", "c"]`, we will use the literal value directly
2. Otherwise, we use replib to get a serialized value of the iterable, limited to 30 charactors.

The end result will be of the form `[value]`.  We will then

1. Use the list of value (generated in a split/parent node) in the `task_finish` function inside a custom decorator.  
2. Use the list of value when constructing foreach stack, which will eventually be used to construct the for-loop path in metadata.

An example for the updated search UI is like the following.
![Metaflow-UI (2)](https://github.com/Netflix/metaflow/assets/5545942/767bfa56-ac97-4aa3-978b-706a6f703136)

