### PR TITLE
fix: conda environment counts as disabled with implicit decorator

### DIFF
--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -186,7 +186,7 @@ class CondaEnvironment(MetaflowEnvironment):
             if decorator.name in ["conda", "pypi"]:
                 # handle @conda/@pypi(disabled=True)
                 disabled = decorator.attributes["disabled"]
-                return disabled or str(disabled).lower() != "false"
+                return str(disabled).lower() == "true"
         return False
 
     @functools.lru_cache(maxsize=None)


### PR DESCRIPTION
Fixes issue where conda environments are wrongly treated as disabled if the decorator is implicitly applied.

The underlying reason is that due to the lifecycle of decorators, the `disabled` attribute gets cast to string early enough, that the `is_disabled` check fails.

Can test this by slapping the following at the end of `step_init` in conda decorator
```python
print(f"has conda decorator: {step} - disabled: {self.disabled} - type: {type(self.disabled)}")
``` 


closes #1667