### PR TITLE
fix: decorator init order

### DIFF
--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -576,6 +576,7 @@ class MetaflowTask(object):
                     inputs,
                 )
 
+            for deco in decorators:
                 # decorators can actually decorate the step function,
                 # or they can replace it altogether. This functionality
                 # is used e.g. by catch_decorator which switches to a


### PR DESCRIPTION
separate the `task_pre_step` and `task_decorate` in order to support better setup-order of dependent decorators.

Specifically we want the `PATH` patching of conda-decorator to happen early so that other decorators can rely on this *after* `task_pre_step` in the lifecycle.