### PR TITLE
[@card] [card-core] always call `refresh` after first `render_runtime` (5/N)

### DIFF
--- a/metaflow/plugins/cards/card_cli.py
+++ b/metaflow/plugins/cards/card_cli.py
@@ -965,7 +965,7 @@ def list(
     default=8324,
     show_default=True,
     type=int,
-    help="Port on which Metaflow card server will run",
+    help="Port on which Metaflow card viewer server will run",
 )
 @click.option(
     "--namespace",
@@ -980,14 +980,14 @@ def list(
     default=5,
     show_default=True,
     type=int,
-    help="Polling interval of the card viewer.",
+    help="Polling interval of the card viewer server.",
 )
 @click.option(
     "--max-cards",
     default=30,
     show_default=True,
     type=int,
-    help="Maximum number of cards to be shown at any time by the server",
+    help="Maximum number of cards to be shown at any time by the card viewer server",
 )
 @click.pass_context
 def server(ctx, run_id, port, user_namespace, poll_interval, max_cards):
@@ -1001,7 +1001,7 @@ def server(ctx, run_id, port, user_namespace, poll_interval, max_cards):
         ctx.obj.echo(_status_message, fg="red")
     options = CardServerOptions(
         flow_name=ctx.obj.flow.name,
-        run_object=run, 
+        run_object=run,
         only_running=False,
         follow_resumed=False,
         flow_datastore=ctx.obj.flow_datastore,

--- a/metaflow/plugins/cards/card_creator.py
+++ b/metaflow/plugins/cards/card_creator.py
@@ -57,8 +57,11 @@ class CardCreator:
         logger=None,
         mode="render",
         final=False,
+        sync=False,
     ):
-        # warning_message("calling proc for uuid %s" % self._card_uuid, self._logger)
+        # Setting `final` will affect the Reload token set during the card refresh
+        # data creation along with synchronous execution of subprocess.
+        # Setting `sync` will only cause synchronous execution of subprocess.
         if mode != "render" and not runtime_card:
             # silently ignore runtime updates for cards that don't support them
             return
@@ -68,7 +71,6 @@ class CardCreator:
             component_strings = []
         else:
             component_strings = current.card._serialize_components(card_uuid)
-
         data = current.card._get_latest_data(card_uuid, final=final, mode=mode)
         runspec = "/".join([current.run_id, current.step_name, current.task_id])
         self._run_cards_subprocess(
@@ -82,6 +84,7 @@ class CardCreator:
             logger,
             data,
             final=final,
+            sync=sync,
         )
 
     def _run_cards_subprocess(
@@ -96,9 +99,10 @@ class CardCreator:
         logger,
         data=None,
         final=False,
+        sync=False,
     ):
         components_file = data_file = None
-        wait = final
+        wait = final or sync
 
         if len(component_strings) > 0:
             # note that we can't delete temporary files here when calling the subprocess

--- a/metaflow/plugins/cards/card_modules/components.py
+++ b/metaflow/plugins/cards/card_modules/components.py
@@ -211,6 +211,11 @@ class Table(UserComponent):
             )
 
     def _render_subcomponents(self):
+        for row in self._data:
+            for col in row:
+                if isinstance(col, VegaChart):
+                    col._chart_inside_table = True
+
         return [
             SectionComponent.render_subcomponents(
                 row,
@@ -685,18 +690,51 @@ class Markdown(UserComponent):
 
 
 class ProgressBar(UserComponent):
+    """
+    A Progress bar for tracking progress of any task.
+
+    Example:
+    ```
+    progress_bar = ProgressBar(
+        max=100,
+        label="Progress Bar",
+        value=0,
+        unit="%",
+        metadata="0.1 items/s"
+    )
+    current.card.append(
+        progress_bar
+    )
+    for i in range(100):
+        progress_bar.update(i, metadata="%s items/s" % i)
+
+    ```
+
+    Parameters
+    ----------
+    text : str
+        Text formatted in Markdown.
+    """
+
     type = "progressBar"
 
     REALTIME_UPDATABLE = True
 
-    def __init__(self, max=100, label=None, value=0, unit=None, metadata=None):
+    def __init__(
+        self,
+        max: int = 100,
+        label: str = None,
+        value: int = 0,
+        unit: str = None,
+        metadata: str = None,
+    ):
         self._label = label
         self._max = max
         self._value = value
         self._unit = unit
         self._metadata = metadata
 
-    def update(self, new_value, metadata=None):
+    def update(self, new_value: int, metadata: str = None):
         self._value = new_value
         if metadata is not None:
             self._metadata = metadata
@@ -724,9 +762,10 @@ class VegaChart(UserComponent):
 
     REALTIME_UPDATABLE = True
 
-    def __init__(self, spec, show_controls=False):
+    def __init__(self, spec: dict, show_controls=False):
         self._spec = spec
         self._show_controls = show_controls
+        self._chart_inside_table = False
 
     def update(self, spec=None):
         if spec is not None:
@@ -761,7 +800,8 @@ class VegaChart(UserComponent):
         }
         if not self._show_controls:
             data["options"] = {"actions": False}
-
-        if "width" not in self._spec:
+        if "width" not in self._spec and not self._chart_inside_table:
             data["spec"]["width"] = "container"
+        if self._chart_inside_table and "autosize" not in self._spec:
+            data["spec"]["autosize"] = "fit-x"
         return data

--- a/metaflow/plugins/cards/card_modules/test_cards.py
+++ b/metaflow/plugins/cards/card_modules/test_cards.py
@@ -154,13 +154,16 @@ class TestRefreshCard(MetaflowCard):
 
     type = "test_refresh_card"
 
-    def render(self, task, data) -> str:
+    def render(self, task) -> str:
+        return self._render_func(task, self.runtime_data)
+
+    def _render_func(self, task, data):
         return self.HTML_TEMPLATE.replace(
             "[REPLACE_CONTENT_HERE]", json.dumps(data["user"])
         ).replace("[PATHSPEC]", task.pathspec)
 
     def render_runtime(self, task, data):
-        return self.render(task, data)
+        return self._render_func(task, data)
 
     def refresh(self, task, data):
         return data
@@ -195,14 +198,14 @@ class TestRefreshComponentCard(MetaflowCard):
     def __init__(self, options={}, components=[], graph=None):
         self._components = components
 
-    def render(self, task, data) -> str:
+    def render(self, task) -> str:
         # Calling `render`/`render_runtime` wont require the `data` object
         return self.HTML_TEMPLATE.replace(
             "[REPLACE_CONTENT_HERE]", json.dumps(self._components)
         ).replace("[PATHSPEC]", task.pathspec)
 
     def render_runtime(self, task, data):
-        return self.render(task, data)
+        return self.render(task)
 
     def refresh(self, task, data):
         # Govers the information passed in the data update

--- a/metaflow/plugins/cards/card_server.py
+++ b/metaflow/plugins/cards/card_server.py
@@ -302,9 +302,9 @@ class CardViewerRoutes(BaseHTTPRequestHandler):
         if card_data is not None:
             self.log_message(
                 "Task Success: %s, Task Finished: %s"
-                % (task_object.successful, task_object.finished)
+                % (task_object.successful, is_complete)
             )
-            if not task_object.successful and task_object.finished:
+            if not task_object.successful and is_complete:
                 status = "Task Failed"
             self._response(
                 {"status": status, "payload": card_data, "is_complete": is_complete},
@@ -330,6 +330,13 @@ class CardViewerRoutes(BaseHTTPRequestHandler):
     ROUTES = {"runinfo": get_runinfo, "card": get_card, "data": get_data}
 
 
+def _is_debug_mode():
+    debug_flag = os.environ.get("METAFLOW_DEBUG_CARD_SERVER")
+    if debug_flag is None:
+        return False
+    return debug_flag.lower() in ["true", "1"]
+
+
 def create_card_server(card_options: CardServerOptions, port, ctx_obj):
     CardViewerRoutes.card_options = card_options
     global _ClickLogger
@@ -346,7 +353,7 @@ def create_card_server(card_options: CardServerOptions, port, ctx_obj):
         bold=True,
     )
     # Disable logging if not in debug mode
-    if "METAFLOW_DEBUG_CARD_SERVER" not in os.environ:
+    if not _is_debug_mode():
         CardViewerRoutes.log_request = lambda *args, **kwargs: None
         CardViewerRoutes.log_message = lambda *args, **kwargs: None
 


### PR DESCRIPTION
- Added a `sync` argument to the card creator

## Why make this change 

Lets assume the case that the user is only doing `current.card.append` followed by `refresh`. In this case, there will be no process executed in `refresh` mode since only the `layout_has_changed` will always be true and we will keep running `render_runtime` instead of any `refresh` call. As a result, there will be no data update that informs the UI of the `METAFLOW_RELOAD_TOKEN` change. In the meantime the UI will be trying to seek for the data update object but it will constantly find None. Due to this the card Iframe will not reload and keep being in it's initial state.

This change ensures that after the first `render_runtime`, any time a `render_runtime` is called, we follow it up with a subsequent SYNCHRONOUS `refresh` call. This will ensure that the UI is always updated with the latest card.