### PR TITLE
Enable `Distributed` mode for Step Function maps (v2)

### DIFF
--- a/metaflow/plugins/aws/step_functions/dynamo_db_client.py
+++ b/metaflow/plugins/aws/step_functions/dynamo_db_client.py
@@ -10,7 +10,9 @@ class DynamoDbClient(object):
         self._client = get_aws_client("dynamodb")
         self.name = SFN_DYNAMO_DB_TABLE
 
-    def save_foreach_cardinality(self, foreach_split_task_id, foreach_cardinality, ttl):
+    def save_foreach_cardinality(
+        self, foreach_split_task_id, foreach_cardinality, ttl, root_run_id
+    ):
         return self._client.put_item(
             TableName=self.name,
             Item={
@@ -18,6 +20,7 @@ class DynamoDbClient(object):
                 "for_each_cardinality": {
                     "NS": list(map(str, range(foreach_cardinality)))
                 },
+                "root_run_id": {"S": root_run_id},
                 "ttl": {"N": str(ttl)},
             },
         )

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -120,6 +120,11 @@ def step_functions(obj, name=None):
     help="Log AWS Step Functions execution history to AWS CloudWatch "
     "Logs log group.",
 )
+@click.option(
+    "--use-distributed-map",
+    is_flag=True,
+    help="Use the Distributed Map instead of an Inline Map",
+)
 @click.pass_obj
 def create(
     obj,
@@ -132,6 +137,7 @@ def create(
     max_workers=None,
     workflow_timeout=None,
     log_execution_history=False,
+    use_distributed_map=False,
 ):
     validate_tags(tags)
 
@@ -161,6 +167,7 @@ def create(
         max_workers,
         workflow_timeout,
         obj.is_project,
+        use_distributed_map,
     )
 
     if only_json:
@@ -269,7 +276,7 @@ def resolve_state_machine_name(obj, name):
 
 
 def make_flow(
-    obj, token, name, tags, namespace, max_workers, workflow_timeout, is_project
+    obj, token, name, tags, namespace, max_workers, workflow_timeout, is_project, use_distributed_map,
 ):
     if obj.flow_datastore.TYPE != "s3":
         raise MetaflowException("AWS Step Functions requires --datastore=s3.")
@@ -305,6 +312,7 @@ def make_flow(
         username=get_username(),
         workflow_timeout=workflow_timeout,
         is_project=is_project,
+        use_distributed_map=use_distributed_map,
     )
 
 

--- a/metaflow/plugins/aws/step_functions/step_functions_decorator.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_decorator.py
@@ -57,7 +57,10 @@ class StepFunctionsInternalDecorator(StepDecorator):
             # and execution history is available for 90 days after the
             # execution.
             self._save_foreach_cardinality(
-                os.environ["AWS_BATCH_JOB_ID"], flow._foreach_num_splits, self._ttl()
+                os.environ["AWS_BATCH_JOB_ID"],
+                flow._foreach_num_splits,
+                self._ttl(),
+                os.environ["METAFLOW_RUN_ID"],
             )
         # The parent task ids need to be available in a foreach join so that
         # we can construct the input path. Unfortunately, while AWS Step
@@ -76,10 +79,17 @@ class StepFunctionsInternalDecorator(StepDecorator):
             )
 
     def _save_foreach_cardinality(
-        self, foreach_split_task_id, for_each_cardinality, ttl
+        self,
+        foreach_split_task_id,
+        for_each_cardinality,
+        ttl,
+        root_run_id,
     ):
         DynamoDbClient().save_foreach_cardinality(
-            foreach_split_task_id, for_each_cardinality, ttl
+            foreach_split_task_id,
+            for_each_cardinality,
+            ttl,
+            root_run_id,
         )
 
     def _save_parent_task_id_for_foreach_join(


### PR DESCRIPTION
This PR introduces a way to utilize the "Distributed" type of Map (vs "Inline") to enable Step Functions to scale to larger sizes (issue: https://github.com/Netflix/metaflow/issues/1216).

## How it works
* Add in a new flag --use-distributed-map when creating a step function (ie python helloworld.py step-functions create --use-distributed-map)
* All map steps are then turned to use Distributed mode (vs the Inline) mode
* Distributed Map values are written to S3 and then we need to run some additional steps (fetch the S3 manifest and run a second Distributed Map step to extract the value)
* The Run ID of the initial step function is passed down to maps so that it can be accessed on child Step Functions so data can be found in the S3 bucket. This is achieved by passing it into the Dynamo table.
* Adds a retry (with jitter) for creating too many batch requests as it only permits 50 req/sec 

## Infra changes

To support the new mode you need to ensure you have updated the `step_functions_role` (from https://github.com/outerbounds/terraform-aws-metaflow) to have `states:StartExecution` and `kms:GenerateDataKey`

## Additional Notes
* This PR replaces #1576 and addresses the issues from issue #1216.