### PR TITLE
[Ready for review] Make Clone-only resume more efficient.

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -791,6 +791,7 @@ def resume(
         max_log_size=max_log_size * 1024 * 1024,
     )
     write_run_id(run_id_file, runtime.run_id)
+    runtime.print_workflow_info()
     runtime.persist_constants()
     runtime.execute()
 
@@ -845,6 +846,7 @@ def run(
     write_run_id(run_id_file, runtime.run_id)
 
     obj.flow._set_constants(obj.graph, kwargs)
+    runtime.print_workflow_info()
     runtime.persist_constants()
     runtime.execute()
 

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -474,13 +474,6 @@ def logs(obj, input_path, stdout=None, stderr=None, both=None, timestamps=False)
     "not execute anything.",
 )
 @click.option(
-    "--clone-wait-only/--no-clone-wait-only",
-    default=False,
-    show_default=True,
-    help="If specified, waits for an external process to clone the task",
-    hidden=True,
-)
-@click.option(
     "--clone-run-id",
     default=None,
     help="Run id of the origin flow, if this task is part of a flow being resumed.",
@@ -519,7 +512,6 @@ def step(
     retry_count=None,
     max_user_code_retries=None,
     clone_only=None,
-    clone_wait_only=False,
     clone_run_id=None,
     decospecs=None,
     ubf_context="none",
@@ -568,6 +560,8 @@ def step(
         ctx.obj.monitor,
         ubf_context,
     )
+    print("step!!!")
+    print("step_name", step_name)
     if clone_only:
         task.clone_only(
             step_name,
@@ -575,7 +569,6 @@ def step(
             task_id,
             clone_only,
             retry_count,
-            wait_only=clone_wait_only,
         )
     else:
         task.run_step(
@@ -719,6 +712,13 @@ def common_run_options(func):
     hidden=True,
     help="If specified, allows this call to be called in parallel",
 )
+@click.option(
+    "--resume-identifier",
+    default=None,
+    show_default=True,
+    hidden=True,
+    help="If specified, it identifies the task that started this resume call",
+)
 @click.argument("step-to-rerun", required=False)
 @cli.command(help="Resume execution of a previous run of this flow.")
 @common_run_options
@@ -736,6 +736,7 @@ def resume(
     max_log_size=None,
     decospecs=None,
     run_id_file=None,
+    resume_identifier=None,
 ):
     before_run(obj, tags, decospecs + obj.environment.decospecs())
 
@@ -758,7 +759,8 @@ def resume(
                 )
             )
         clone_steps = {step_to_rerun}
-
+    if resume_identifier:
+        print("resume_identifier: ", resume_identifier)
     if run_id:
         # Run-ids that are provided by the metadata service are always integers.
         # External providers or run-ids (like external schedulers) always need to
@@ -789,6 +791,7 @@ def resume(
         max_workers=max_workers,
         max_num_splits=max_num_splits,
         max_log_size=max_log_size * 1024 * 1024,
+        resume_identifier=resume_identifier,
     )
     write_run_id(run_id_file, runtime.run_id)
     runtime.print_workflow_info()

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -724,7 +724,7 @@ def common_run_options(func):
     default=None,
     show_default=True,
     hidden=True,
-    help="If specified, it identifies the task that started this resume call",
+    help="If specified, it identifies the task that started this resume call. It is in the form of {step_name}-{task_id}",
 )
 @click.argument("step-to-rerun", required=False)
 @cli.command(help="Resume execution of a previous run of this flow.")

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -474,6 +474,13 @@ def logs(obj, input_path, stdout=None, stderr=None, both=None, timestamps=False)
     "not execute anything.",
 )
 @click.option(
+    "--clone-wait-only/--no-clone-wait-only",
+    default=False,
+    show_default=True,
+    help="If specified, waits for an external process to clone the task",
+    hidden=True,
+)
+@click.option(
     "--clone-run-id",
     default=None,
     help="Run id of the origin flow, if this task is part of a flow being resumed.",
@@ -512,6 +519,7 @@ def step(
     retry_count=None,
     max_user_code_retries=None,
     clone_only=None,
+    clone_wait_only=False,
     clone_run_id=None,
     decospecs=None,
     ubf_context="none",
@@ -567,6 +575,7 @@ def step(
             task_id,
             clone_only,
             retry_count,
+            wait_only=clone_wait_only,
         )
     else:
         task.run_step(
@@ -757,6 +766,7 @@ def resume(
                 )
             )
         clone_steps = {step_to_rerun}
+
     if run_id:
         # Run-ids that are provided by the metadata service are always integers.
         # External providers or run-ids (like external schedulers) always need to

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -560,8 +560,6 @@ def step(
         ctx.obj.monitor,
         ubf_context,
     )
-    print("step!!!")
-    print("step_name", step_name)
     if clone_only:
         task.clone_only(
             step_name,
@@ -759,8 +757,6 @@ def resume(
                 )
             )
         clone_steps = {step_to_rerun}
-    if resume_identifier:
-        print("resume_identifier: ", resume_identifier)
     if run_id:
         # Run-ids that are provided by the metadata service are always integers.
         # External providers or run-ids (like external schedulers) always need to

--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -165,6 +165,8 @@ class TaskDataStore(object):
                     data_obj = self.load_metadata([self.METADATA_DATA_SUFFIX])
                     data_obj = data_obj[self.METADATA_DATA_SUFFIX]
                 elif self._attempt is None or not allow_not_done:
+                    print("self._attempt", self._attempt)
+                    print("allow_not_done", allow_not_done)
                     raise DataException(
                         "No completed attempts of the task was found for task '%s'"
                         % self._path
@@ -532,6 +534,7 @@ class TaskDataStore(object):
             )
         else:
             path = self._storage_impl.path_join(self._path, name)
+        print("has_metadata: ", path, self._storage_impl.is_file([path])[0])
         return self._storage_impl.is_file([path])[0]
 
     @require_mode(None)

--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -165,8 +165,6 @@ class TaskDataStore(object):
                     data_obj = self.load_metadata([self.METADATA_DATA_SUFFIX])
                     data_obj = data_obj[self.METADATA_DATA_SUFFIX]
                 elif self._attempt is None or not allow_not_done:
-                    print("self._attempt", self._attempt)
-                    print("allow_not_done", allow_not_done)
                     raise DataException(
                         "No completed attempts of the task was found for task '%s'"
                         % self._path
@@ -534,7 +532,6 @@ class TaskDataStore(object):
             )
         else:
             path = self._storage_impl.path_join(self._path, name)
-        print("has_metadata: ", path, self._storage_impl.is_file([path])[0])
         return self._storage_impl.is_file([path])[0]
 
     @require_mode(None)

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -787,12 +787,6 @@ class Task(object):
             # At this point, we know we are going to clone
             self._is_cloned = True
 
-            if resume_identifier:
-                self.log(
-                    "Resume identifier is %s." % resume_identifier,
-                    system_msg=True,
-                )
-
             task_id_exists_already = False
             task_completed = False
             if reentrant:
@@ -821,6 +815,15 @@ class Task(object):
                         "Reentrant clone-only resume does not allow for explicit task-id"
                     )
 
+                if resume_identifier:
+                    self.log(
+                        "Resume identifier is %s." % resume_identifier,
+                        system_msg=True,
+                    )
+                else:
+                    raise MetaflowInternalError(
+                        "Reentrant clone-only resume needs a resume identifier."
+                    )
                 # We will use the same task_id as the original task
                 # to use it effectively as a synchronization key
                 clone_task_id = origin.task_id
@@ -1028,7 +1031,7 @@ class Task(object):
 
         # Mark the resume as done. This is called at the end of the resume flow and after
         # the _parameters step was successfully cloned, so we need to 'dangerously' save
-        # this done file, but the risk should be minimum.
+        # this done file, but the risk should be minimal.
         self._ds._dangerous_save_metadata_post_done(
             {"_resume_done": True}, add_attempt=False
         )

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -284,11 +284,16 @@ class MetaflowTask(object):
         task_id,
         clone_origin_task,
         retry_count,
+        wait_only=False,
     ):
         if not clone_origin_task:
             raise MetaflowInternalError(
                 "task.clone_only needs a valid clone_origin_task value."
             )
+        if wait_only:
+            print("Not cloning anything in wait_only mode.")
+            return
+
         # If we actually have to do the clone ourselves, proceed...
         # 1. initialize output datastore
         output = self.flow_datastore.get_task_datastore(

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -285,7 +285,6 @@ class MetaflowTask(object):
         clone_origin_task,
         retry_count,
     ):
-        print(step_name, ": clone only start")
         if not clone_origin_task:
             raise MetaflowInternalError(
                 "task.clone_only needs a valid clone_origin_task value."
@@ -331,7 +330,6 @@ class MetaflowTask(object):
             ],
         )
         output.done()
-        print(step_name, ": clone only end")
 
     def _finalize_control_task(self):
         # Update `_transition` which is expected by the NativeRuntime.

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -286,6 +286,7 @@ class MetaflowTask(object):
         retry_count,
         wait_only=False,
     ):
+        print(step_name, ": clone only start")
         if not clone_origin_task:
             raise MetaflowInternalError(
                 "task.clone_only needs a valid clone_origin_task value."
@@ -348,6 +349,7 @@ class MetaflowTask(object):
             ],
         )
         output.done()
+        print(step_name, ": clone only end")
 
     def _finalize_control_task(self):
         # Update `_transition` which is expected by the NativeRuntime.

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -284,30 +284,12 @@ class MetaflowTask(object):
         task_id,
         clone_origin_task,
         retry_count,
-        wait_only=False,
     ):
         print(step_name, ": clone only start")
         if not clone_origin_task:
             raise MetaflowInternalError(
                 "task.clone_only needs a valid clone_origin_task value."
             )
-        if wait_only:
-            # In this case, we are actually going to wait for the clone to be done
-            # by someone else. To do this, we just get the task_datastore in "r" mode
-            while True:
-                try:
-                    ds = self.flow_datastore.get_task_datastore(
-                        run_id, step_name, task_id
-                    )
-                    if not ds["_task_ok"]:
-                        raise MetaflowInternalError(
-                            "Externally cloned task did not succeed"
-                        )
-                    break
-                except DataException:
-                    # No need to get fancy with the sleep here.
-                    time.sleep(5)
-            return
         # If we actually have to do the clone ourselves, proceed...
         # 1. initialize output datastore
         output = self.flow_datastore.get_task_datastore(


### PR DESCRIPTION
Current clone-only resume has a few flaws we need to solve:

1. Each task to be resume will create a resume runtime and they all want to resume the previously completed execution tree in topological order. This resulted in unnecessary competition between resume tasks.
2. If one resume wins the race (registered new task id) but never completed the cloning, the future attempts will never run and the resume will never finish.

To tackle this, we decided to elect a resume leader (whichever tasks register _parameters task first) and also remembers the resume leader path. All non-leader will need to wait for the leader to finish resuming (which essentially is copying the datastore pointer to new place).

In the case of a failed clone, we will check whether task_id is registered and task is complete to ensure that we will still clone the old run when task_id is already registered but never complete.

To test this, one can try this [flow](https://gist.github.com/darinyu/315ad0b85cc0979a6cad1a4fbc91d76c).
```
python flow.py run
python flow.py resume
```