### PR TITLE
[Ready for review] Ignore _foreach_values in merge artifacts

### DIFF
--- a/metaflow/flowspec.py
+++ b/metaflow/flowspec.py
@@ -28,6 +28,8 @@ except NameError:
 
 from .datastore.inputs import Inputs
 
+INTERNAL_ARTIFACTS_SET = set(["_foreach_values"])
+
 
 class InvalidNextException(MetaflowException):
     headline = "Invalid self.next() transition detected"
@@ -419,8 +421,6 @@ class FlowSpec(object):
             This exception is thrown in case an artifact specified in `include` cannot
             be found.
         """
-        INTERNAL_ARTIFACTS_SET = set(["_foreach_values"])
-
         include = include or []
         exclude = exclude or []
         node = self._graph[self._current_step]

--- a/metaflow/flowspec.py
+++ b/metaflow/flowspec.py
@@ -419,6 +419,8 @@ class FlowSpec(object):
             This exception is thrown in case an artifact specified in `include` cannot
             be found.
         """
+        INTERNAL_ARTIFACTS_SET = set(["_foreach_values"])
+
         include = include or []
         exclude = exclude or []
         node = self._graph[self._current_step]
@@ -446,7 +448,9 @@ class FlowSpec(object):
                 available_vars = (
                     (var, sha)
                     for var, sha in inp._datastore.items()
-                    if (var not in exclude) and (not hasattr(self, var))
+                    if (var not in exclude)
+                    and (not hasattr(self, var))
+                    and (var not in INTERNAL_ARTIFACTS_SET)
                 )
             for var, sha in available_vars:
                 _, previous_sha = to_merge.setdefault(var, (inp, sha))


### PR DESCRIPTION
`_foreach_values` is now stored as artifacts for each step but this is not intended for users to consume. In merge artifacts, however, we will try to merge them by default, which could fail if the foreach are dynamic. This PR will make merge artifacts skip the foreach value (at join step). This foreach value will have no meaning after joining anyways, so there should be no impact to the entire flow.
