### PR TITLE
fix: ensure linuxParameters dict entry exists when creating tmpfs

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -327,6 +327,9 @@ class BatchJob(object):
                 # default tmpfs behavior - https://man7.org/linux/man-pages/man5/tmpfs.5.html
                 tmpfs_size = int(float(memory)) / 2
 
+            if "linuxParameters" not in job_definition["containerProperties"]:
+                job_definition["containerProperties"]["linuxParameters"] = {}
+
             job_definition["containerProperties"]["linuxParameters"]["tmpfs"] = [
                 {
                     "containerPath": tmpfs_path,


### PR DESCRIPTION
Had some discussion on [metaflow chat](https://outerbounds-community.slack.com/archives/C02116BBNTU/p1708015812312309?thread_ts=1707995984.923579&cid=C02116BBNTU) about an error I was getting on 2.9.7:

File ".../metaflow/plugins/aws/batch/batch_client.py", line 302, in _register_job_definition
job_definition["containerProperties"]["linuxParameters"]["tmpfs"] = [
KeyError: 'linuxParameters'

I couldn't see anything that would fix it in master, so have put in this PR, but would be good if anyone else can confirm the bug in their environment. 