### PR TITLE
feat: add ephemeral_storage parameter for Batch (Fargate-only)

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -191,6 +191,7 @@ class Batch(object):
         tmpfs_size=None,
         tmpfs_path=None,
         num_parallel=0,
+        ephemeral_storage=None,
     ):
         job_name = self._job_name(
             attrs.get("metaflow.user"),
@@ -239,6 +240,7 @@ class Batch(object):
                 tmpfs_size=tmpfs_size,
                 tmpfs_path=tmpfs_path,
                 num_parallel=num_parallel,
+                ephemeral_storage=ephemeral_storage,
             )
             .task_id(attrs.get("metaflow.task_id"))
             .environment_variable("AWS_DEFAULT_REGION", self._client.region())
@@ -351,6 +353,7 @@ class Batch(object):
         num_parallel=0,
         env={},
         attrs={},
+        ephemeral_storage=None,
     ):
         if queue is None:
             queue = next(self._client.active_job_queues(), None)
@@ -388,6 +391,7 @@ class Batch(object):
             tmpfs_size=tmpfs_size,
             tmpfs_path=tmpfs_path,
             num_parallel=num_parallel,
+            ephemeral_storage=ephemeral_storage,
         )
         self.num_parallel = num_parallel
         self.job = job.execute()

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -155,6 +155,12 @@ def kill(ctx, run_id, user, my_runs):
 @click.option("--host-volumes", multiple=True)
 @click.option("--efs-volumes", multiple=True)
 @click.option(
+    "--ephemeral-storage",
+    default=None,
+    type=int,
+    help="Ephemeral storage (for AWS Batch only)",
+)
+@click.option(
     "--num-parallel",
     default=0,
     type=int,
@@ -186,6 +192,7 @@ def step(
     tmpfs_path=None,
     host_volumes=None,
     efs_volumes=None,
+    ephemeral_storage=None,
     num_parallel=None,
     **kwargs
 ):
@@ -317,6 +324,7 @@ def step(
                 tmpfs_tempdir=tmpfs_tempdir,
                 tmpfs_size=tmpfs_size,
                 tmpfs_path=tmpfs_path,
+                ephemeral_storage=ephemeral_storage,
                 num_parallel=num_parallel,
             )
     except Exception as e:

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -158,6 +158,7 @@ class BatchJob(object):
         tmpfs_size,
         tmpfs_path,
         num_parallel,
+        ephemeral_storage,
     ):
         # identify platform from any compute environment associated with the
         # queue
@@ -210,6 +211,10 @@ class BatchJob(object):
             job_definition["containerProperties"]["networkConfiguration"] = {
                 "assignPublicIp": "ENABLED"
             }
+            if ephemeral_storage:
+                job_definition["containerProperties"]["ephemeralStorage"] = {
+                    "sizeInGiB": ephemeral_storage
+                }
 
         if platform == "EC2" or platform == "SPOT":
             if "linuxParameters" not in job_definition["containerProperties"]:
@@ -254,6 +259,10 @@ class BatchJob(object):
                     job_definition["containerProperties"]["linuxParameters"][
                         "maxSwap"
                     ] = int(max_swap)
+            if ephemeral_storage:
+                raise BatchJobException(
+                    "The ephemeral_storage parameter is only available for FARGATE compute environments"
+                )
 
         if inferentia:
             if not (isinstance(inferentia, (int, unicode, basestring))):
@@ -315,6 +324,8 @@ class BatchJob(object):
                         {"sourceVolume": name, "containerPath": container_path}
                     )
 
+        if use_tmpfs and (platform == "FARGATE" or platform == "FARGATE_SPOT"):
+            raise BatchJobException("tmpfs is not available for Fargate compute resources")
         if use_tmpfs or (tmpfs_size and not use_tmpfs):
             if tmpfs_size:
                 if not (isinstance(tmpfs_size, (int, unicode, basestring))):
@@ -442,6 +453,7 @@ class BatchJob(object):
         tmpfs_size,
         tmpfs_path,
         num_parallel,
+        ephemeral_storage,
     ):
         self.payload["jobDefinition"] = self._register_job_definition(
             image,
@@ -461,6 +473,7 @@ class BatchJob(object):
             tmpfs_size,
             tmpfs_path,
             num_parallel,
+            ephemeral_storage,
         )
         return self
 

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -72,7 +72,8 @@ class BatchDecorator(StepDecorator):
         necessary. A swappiness value of 100 causes pages to be swapped very
         aggressively. Accepted values are whole numbers between 0 and 100.
     use_tmpfs : bool, default False
-        This enables an explicit tmpfs mount for this step.
+        This enables an explicit tmpfs mount for this step. Note that tmpfs is not
+        available on Fargate compute type queues
     tmpfs_tempdir : bool, default True
         sets METAFLOW_TEMPDIR to tmpfs_path if set for this step.
     tmpfs_size : int, optional, default None
@@ -85,6 +86,8 @@ class BatchDecorator(StepDecorator):
         Number of Inferentia chips required for this step.
     efa : int, default 0
         Number of elastic fabric adapter network devices to attach to container
+    ephemeral_storage: int, default None
+        The total amount, in GiB, of ephemeral storage to set for the task (21-200)
     """
 
     name = "batch"
@@ -107,6 +110,7 @@ class BatchDecorator(StepDecorator):
         "tmpfs_tempdir": True,
         "tmpfs_size": None,
         "tmpfs_path": "/metaflow_temp",
+        "ephemeral_storage": None,
     }
     resource_defaults = {
         "cpu": "1",

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -72,8 +72,8 @@ class BatchDecorator(StepDecorator):
         necessary. A swappiness value of 100 causes pages to be swapped very
         aggressively. Accepted values are whole numbers between 0 and 100.
     use_tmpfs : bool, default False
-        This enables an explicit tmpfs mount for this step. Note that tmpfs is not
-        available on Fargate compute type queues
+        This enables an explicit tmpfs mount for this step. Note that tmpfs is
+        not available on Fargate compute environments
     tmpfs_tempdir : bool, default True
         sets METAFLOW_TEMPDIR to tmpfs_path if set for this step.
     tmpfs_size : int, optional, default None
@@ -88,6 +88,7 @@ class BatchDecorator(StepDecorator):
         Number of elastic fabric adapter network devices to attach to container
     ephemeral_storage: int, default None
         The total amount, in GiB, of ephemeral storage to set for the task (21-200)
+        This is only relevant for Fargate compute environments
     """
 
     name = "batch"

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -756,6 +756,7 @@ class StepFunctions(object):
                 attrs=attrs,
                 host_volumes=resources["host_volumes"],
                 efs_volumes=resources["efs_volumes"],
+                ephemeral_storage=resources["ephemeral_storage"],
             )
             .attempts(total_retries + 1)
         )


### PR DESCRIPTION
Fixes issue #1738.

Please note I have not been able to test this for real as I don't have the right permissions in our AWS environment yet, but these are the parameters the code gives to the `register_job_definition` call:

`{'type': 'container', 'containerProperties': {'image': 'public.ecr.aws/docker/library/python:3.11', 'jobRoleArn': 'arn:aws:iam::xxxx', 'command': ['echo', 'hello world'], 'resourceRequirements': [{'value': '1', 'type': 'VCPU'}, {'value': '4096', 'type': 'MEMORY'}], 'executionRoleArn': 'arn:aws:iam::xxxx', 'networkConfiguration': {'assignPublicIp': 'ENABLED'}, 'ephemeralStorage': {'sizeInGiB': 50}}, 'propagateTags': True, 'platformCapabilities': ['FARGATE'], 'jobDefinitionName': 'metaflow_xxxx'}`

Also fixes some documentation for the tempfs parameter, and clarifies where this parameter can be used.