### PR TITLE
fix: allow dot files with `--package-suffixes`

### DIFF
--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -88,8 +88,6 @@ class MetaflowPackage(object):
             # if path and (path[0] == '.' or './' in path):
             #    continue
             for fname in files:
-                if fname[0] == ".":
-                    continue
                 if any(fname.endswith(suffix) for suffix in suffixes):
                     p = os.path.join(path, fname)
                     yield p, p[prefixlen:]

--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -88,7 +88,10 @@ class MetaflowPackage(object):
             # if path and (path[0] == '.' or './' in path):
             #    continue
             for fname in files:
-                if any(fname.endswith(suffix) for suffix in suffixes):
+                if (fname[0] == "." and fname in suffixes) or (
+                    fname[0] != "."
+                    and any(fname.endswith(suffix) for suffix in suffixes)
+                ):
                     p = os.path.join(path, fname)
                     yield p, p[prefixlen:]
 


### PR DESCRIPTION
allow files that start with . to be added via `--package-suffixes`

closes #1741