### PR TITLE
Support @parallel on Kubernetes with jobsets

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -836,6 +836,11 @@ class ArgoWorkflows(object):
     # Visit every node and yield the uber DAGTemplate(s).
     def _dag_templates(self):
         def _visit(node, exit_node=None, templates=None, dag_tasks=None):
+            if node.parallel_foreach:
+                raise ArgoWorkflowsException(
+                    "Deploying flows with @parallel decorator(s) "
+                    "as Argo Workflows is not supported currently."
+                )
             # Every for-each node results in a separate subDAG and an equivalent
             # DAGTemplate rooted at the child of the for-each node. Each DAGTemplate
             # has a unique name - the top-level DAGTemplate is named as the name of

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -108,6 +108,13 @@ def kubernetes():
     multiple=False,
 )
 @click.option("--shared-memory", default=None, help="Size of shared memory in MiB")
+@click.option("--ubf-context", default=None, type=click.Choice([None, "ubf_control"]))
+@click.option(
+    "--num-parallel",
+    default=None,
+    type=int,
+    help="Number of parallel nodes to run as a multi-node job.",
+)
 @click.pass_context
 def step(
     ctx,
@@ -134,6 +141,7 @@ def step(
     persistent_volume_claims=None,
     tolerations=None,
     shared_memory=None,
+    num_parallel=None,
     **kwargs
 ):
     def echo(msg, stream="stderr", job_id=None, **kwargs):
@@ -248,6 +256,7 @@ def step(
                 persistent_volume_claims=persistent_volume_claims,
                 tolerations=tolerations,
                 shared_memory=shared_memory,
+                num_parallel=num_parallel,
             )
     except Exception as e:
         traceback.print_exc(chain=False)

--- a/metaflow/plugins/kubernetes/kubernetes_client.py
+++ b/metaflow/plugins/kubernetes/kubernetes_client.py
@@ -4,7 +4,7 @@ import time
 
 from metaflow.exception import MetaflowException
 
-from .kubernetes_job import KubernetesJob
+from .kubernetes_job import KubernetesJob, KubernetesJobSet
 
 
 CLIENT_REFRESH_INTERVAL_SECONDS = 300
@@ -60,6 +60,9 @@ class KubernetesClient(object):
             self._refresh_client()
 
         return self._client
+
+    def jobset(self, **kwargs):
+        return KubernetesJobSet(self, **kwargs)
 
     def job(self, **kwargs):
         return KubernetesJob(self, **kwargs)


### PR DESCRIPTION
This commit adds support for @parallel when flows are run `--with kubernetes` Support for Argo workflows will follow in a separate commit.

A user can run a flow with the following:

    @step
    def start(self):
        self.next(self.parallel_step, num_parallel=3)

    @kubernetes(cpu=1, memory=512)
    @parallel
    @step
    def parallel_step(self):
    ...

Testing Done:
- Ran a flow with @parallel on Kubernetes. Verified that it works correctly
- Ran a flow without @parallel on Kubernetes. Verified that it works as expected.
- Verified that jobsets based @parallel step gets scaled down if user kills it with a Ctrl-C