### PR TITLE
add alert details using slack block kit

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -1647,7 +1647,7 @@ class ArgoWorkflows(object):
             )
 
         return links
-    
+
     def _get_slack_blocks(self, message):
         """
         Use Slack's Block Kit to add general information about the environment and
@@ -1664,7 +1664,6 @@ class ArgoWorkflows(object):
                     "text": ":metaflow: Environment details"
                 },
                 "fields": [
-                    # Add @project metadata when available.
                     {
                         "type": "mrkdwn",
                         "text": f"*Project:* {current.project_name}"
@@ -1699,7 +1698,7 @@ class ArgoWorkflows(object):
                 "type": "divider"
             },
         ]
-    
+
         if message:
             blocks += [
                 {
@@ -1716,39 +1715,31 @@ class ArgoWorkflows(object):
     def _slack_error_template(self):
         if self.notify_slack_webhook_url is None:
             return None
-        
-        message =  f":rotating_light: _{self.flow.name}/argo-{{{{workflow.name}}}}_ failed!"
+
+        message = (
+            f":rotating_light: _{self.flow.name}/argo-{{{{workflow.name}}}}_ failed!"
+        )
         payload = {"text": message}
         if UI_URL:
             blocks = self._get_slack_blocks(message)
-            payload = {
-                "text": message,
-                "blocks": blocks
-            }
+            payload = {"text": message, "blocks": blocks}
 
         return Template("notify-slack-on-error").http(
-            Http("POST")
-            .url(self.notify_slack_webhook_url)
-            .body(json.dumps(payload))
+            Http("POST").url(self.notify_slack_webhook_url).body(json.dumps(payload))
         )
 
     def _slack_success_template(self):
         if self.notify_slack_webhook_url is None:
             return None
-        
-        message =  f":white_check_mark: _{self.flow.name}/argo-{{{{workflow.name}}}}_ succeeded!"
+
+        message = f":white_check_mark: _{self.flow.name}/argo-{{{{workflow.name}}}}_ succeeded!"
         payload = {"text": message}
         if UI_URL:
             blocks = self._get_slack_blocks(message)
-            payload = {
-                "text": message,
-                "blocks": blocks
-            }
-        
+            payload = {"text": message, "blocks": blocks}
+
         return Template("notify-slack-on-success").http(
-            Http("POST")
-            .url(self.notify_slack_webhook_url)
-            .body(json.dumps(payload))
+            Http("POST").url(self.notify_slack_webhook_url).body(json.dumps(payload))
         )
 
     def _compile_sensor(self):

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -1653,7 +1653,7 @@ class ArgoWorkflows(object):
         Use Slack's Block Kit to add general information about the environment and
         execution metadata, including a link to the UI and an optional message.
         """
-        ui_link = f"{UI_URL}{self.flow.name}/argo-{{{{workflow.name}}}}"
+        ui_link = "%s%s/argo-{{workflow.name}}" % (UI_URL, self.flow.name)
         # fmt: off
         if getattr(current, "project_name", None):
             # Add @project metadata when available.
@@ -1666,11 +1666,11 @@ class ArgoWorkflows(object):
                 "fields": [
                     {
                         "type": "mrkdwn",
-                        "text": f"*Project:* {current.project_name}"
+                        "text": "*Project:* %s" % current.project_name 
                     },
                     {
                         "type": "mrkdwn",
-                        "text": f"*Project Branch:* {current.branch_name}"
+                        "text": "*Project Branch:* %s" % current.branch_name
                     }
                 ]
             }
@@ -1690,7 +1690,7 @@ class ArgoWorkflows(object):
                 "elements": [
                     {
                         "type": "mrkdwn",
-                        "text": f" :information_source: *<{ui_link}>*",
+                        "text": " :information_source: *<%s>*" % ui_link,
                     }
                 ],
             },
@@ -1717,7 +1717,7 @@ class ArgoWorkflows(object):
             return None
 
         message = (
-            f":rotating_light: _{self.flow.name}/argo-{{{{workflow.name}}}}_ failed!"
+            ":rotating_light: _%s/argo-{{workflow.name}}_ failed!" % self.flow.name
         )
         payload = {"text": message}
         if UI_URL:
@@ -1732,7 +1732,9 @@ class ArgoWorkflows(object):
         if self.notify_slack_webhook_url is None:
             return None
 
-        message = f":white_check_mark: _{self.flow.name}/argo-{{{{workflow.name}}}}_ succeeded!"
+        message = (
+            ":white_check_mark: _%s/argo-{{workflow.name}}_ succeeded!" % self.flow.name
+        )
         payload = {"text": message}
         if UI_URL:
             blocks = self._get_slack_blocks(message)


### PR DESCRIPTION
Adds more details to the slack webhook alerts sent when using `--notify-on-error` or `--notify-on-success` using [Slack's block kit](https://api.slack.com/block-kit) as part of the argo workflow template creation

Before the messages would simply be:
> :rotating_light: TestFlow/argo-testflow-z7mtw failed!

Now they include a link to the UI and conditionally add `@project` metadata when available, e.g. triggering an argo workflow created from the following:
```
from metaflow import FlowSpec, project, step


@project(name="test")
class TestFlow(FlowSpec):
    @step
    def start(self):
        self.next(self.end)

    @step
    def end(self):
        pass


if __name__ == "__main__":
    TestFlow()
```
![CleanShot 2024-02-20 at 18 05 33](https://github.com/Netflix/metaflow/assets/6701617/ac43182a-578e-4487-be86-37f5ded6ad20)
