### PR TITLE
[Ready for review] make default s3 worker count configurable

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -81,7 +81,7 @@ S3_SERVER_SIDE_ENCRYPTION = from_conf("S3_SERVER_SIDE_ENCRYPTION")
 # so setting it to 0 means each operation will be tried once.
 S3_RETRY_COUNT = from_conf("S3_RETRY_COUNT", 7)
 
-# S3 worker configuration. Number of concurrent S3 connections.
+# Number of concurrent S3 processes for parallel operations.
 S3_WORKER_COUNT = from_conf("S3_WORKER_COUNT", 64)
 
 # Number of retries on *transient* failures (such as SlowDown errors). Note

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -81,6 +81,9 @@ S3_SERVER_SIDE_ENCRYPTION = from_conf("S3_SERVER_SIDE_ENCRYPTION")
 # so setting it to 0 means each operation will be tried once.
 S3_RETRY_COUNT = from_conf("S3_RETRY_COUNT", 7)
 
+# S3 worker configuration. Number of concurrent S3 connections.
+S3_WORKER_COUNT = from_conf("S3_WORKER_COUNT", 64)
+
 # Number of retries on *transient* failures (such as SlowDown errors). Note
 # that if after S3_TRANSIENT_RETRY_COUNT times, all operations haven't been done,
 # it will try up to S3_RETRY_COUNT again so the total number of tries can be up to

--- a/metaflow/plugins/datatools/s3/s3op.py
+++ b/metaflow/plugins/datatools/s3/s3op.py
@@ -44,8 +44,9 @@ from metaflow.plugins.datatools.s3.s3util import (
     TRANSIENT_RETRY_START_LINE,
 )
 import metaflow.tracing as tracing
-
-NUM_WORKERS_DEFAULT = 64
+from metaflow.metaflow_config import (
+    S3_WORKER_COUNT,
+)
 
 DOWNLOAD_FILE_THRESHOLD = 2 * TransferConfig().multipart_threshold
 DOWNLOAD_MAX_CHUNK = 2 * 1024 * 1024 * 1024 - 1
@@ -656,7 +657,7 @@ def common_options(func):
     )
     @click.option(
         "--num-workers",
-        default=NUM_WORKERS_DEFAULT,
+        default=S3_WORKER_COUNT,
         show_default=True,
         help="Number of concurrent connections.",
     )


### PR DESCRIPTION
No-op to current behavior, but configuration on S3 parallel process count at top level.