### PR TITLE
fix bug where client can not access foreach stack

### DIFF
--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -143,6 +143,9 @@ from .client import (
     DataArtifact,
 )
 
+# Data class needed for Client.
+from .tuple_util import ForeachFrame
+
 __version_addl__ = []
 _ext_debug("Loading top-level modules")
 for m in _tl_modules:

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -21,7 +21,6 @@ from metaflow.metaflow_config import (
     TEMPDIR,
 )
 from metaflow.util import (
-    namedtuple_with_defaults,
     is_stringish,
     to_bytes,
     to_unicode,
@@ -29,6 +28,7 @@ from metaflow.util import (
     url_quote,
     url_unquote,
 )
+from metaflow.tuple_util import namedtuple_with_defaults
 from metaflow.exception import MetaflowException
 from metaflow.debug import debug
 import metaflow.tracing as tracing

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -23,18 +23,7 @@ from .util import all_equal, get_username, resolve_identity, unicode_type
 from .clone_util import clone_task_helper
 from .metaflow_current import current
 from metaflow.tracing import get_trace_id
-from metaflow.util import namedtuple_with_defaults
-
-foreach_frame_field_list = [
-    ("step", str),
-    ("var", str),
-    ("num_splits", int),
-    ("index", int),
-    ("value", str),
-]
-ForeachFrame = namedtuple_with_defaults(
-    "ForeachFrame", foreach_frame_field_list, (None,) * (len(foreach_frame_field_list))
-)
+from metaflow.tuple_util import ForeachFrame
 
 # Maximum number of characters of the foreach path that we store in the metadata.
 MAX_FOREACH_PATH_LENGTH = 256

--- a/metaflow/util.py
+++ b/metaflow/util.py
@@ -51,21 +51,6 @@ except NameError:
     from shlex import quote as _quote
 
 
-from typing import NamedTuple
-
-
-def namedtuple_with_defaults(typename, field_descr, defaults=()):
-    T = NamedTuple(typename, field_descr)
-    T.__new__.__defaults__ = tuple(defaults)
-
-    # Adding the following to ensure the named tuple can be (un)pickled correctly.
-    import __main__
-
-    setattr(__main__, T.__name__, T)
-    T.__module__ = "__main__"
-    return T
-
-
 class TempDir(object):
     # Provide a temporary directory since Python 2.7 does not have it inbuilt
     def __enter__(self):


### PR DESCRIPTION
To reproduce, have a flow with foreach task, and then  In python client, do
```
>>> task = Task("ForeachFlow/123/foreach_step/task-00000000")
>>> tp.index
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/metaflow/metaflow/client/core.py", line 1166, in index
    return self["_foreach_stack"].data[-1].index
  File "/root/metaflow/metaflow/client/core.py", line 875, in data
    obj = filecache.get_artifact(ds_type, location[6:], meta, *components)
  File "/root/metaflow/metaflow/client/filecache.py", line 207, in get_artifact
    _, obj = next(
  File "/root/metaflow/metaflow/datastore/task_datastore.py", line 370, in load_artifacts
    yield name, pickle.loads(blob)
AttributeError: Can't get attribute 'ForeachFrame' on <module '__main__' (built-in)>
```

This is because this ForeachFrame is loaded to __main__, and defined in `task.py`. Without a flow, this ForeachFrame is not imported.  This PR refactors the namedtuple util to top level (with minimum dependency) and import it at top level.