### PR TITLE
ability to customise log driver and log options

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -193,6 +193,8 @@ class Batch(object):
         tmpfs_path=None,
         num_parallel=0,
         ephemeral_storage=None,
+        log_driver=None,
+        log_options=None,
     ):
         job_name = self._job_name(
             attrs.get("metaflow.user"),
@@ -242,6 +244,8 @@ class Batch(object):
                 tmpfs_path=tmpfs_path,
                 num_parallel=num_parallel,
                 ephemeral_storage=ephemeral_storage,
+                log_driver=log_driver,
+                log_options=log_options,
             )
             .task_id(attrs.get("metaflow.task_id"))
             .environment_variable("AWS_DEFAULT_REGION", self._client.region())
@@ -356,6 +360,8 @@ class Batch(object):
         env={},
         attrs={},
         ephemeral_storage=None,
+        log_driver=None,
+        log_options=None,
     ):
         if queue is None:
             queue = next(self._client.active_job_queues(), None)
@@ -394,6 +400,8 @@ class Batch(object):
             tmpfs_path=tmpfs_path,
             num_parallel=num_parallel,
             ephemeral_storage=ephemeral_storage,
+            log_driver=log_driver,
+            log_options=log_options,
         )
         self.num_parallel = num_parallel
         self.job = job.execute()

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -161,6 +161,19 @@ def kill(ctx, run_id, user, my_runs):
     help="Ephemeral storage (for AWS Batch only)",
 )
 @click.option(
+    "--log-driver",
+    default=None,
+    type=str,
+    help="Log driver for AWS ECS container",
+)
+@click.option(
+    "--log-options",
+    default=None,
+    type=str,
+    multiple=True,
+    help="Log options for the chosen log driver",
+)
+@click.option(
     "--num-parallel",
     default=0,
     type=int,
@@ -193,6 +206,8 @@ def step(
     host_volumes=None,
     efs_volumes=None,
     ephemeral_storage=None,
+    log_driver=None,
+    log_options=None,
     num_parallel=None,
     **kwargs
 ):
@@ -325,6 +340,8 @@ def step(
                 tmpfs_size=tmpfs_size,
                 tmpfs_path=tmpfs_path,
                 ephemeral_storage=ephemeral_storage,
+                log_driver=log_driver,
+                log_options=log_options,
                 num_parallel=num_parallel,
             )
     except Exception as e:

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -159,6 +159,8 @@ class BatchJob(object):
         tmpfs_path,
         num_parallel,
         ephemeral_storage,
+        log_driver,
+        log_options,
     ):
         # identify platform from any compute environment associated with the
         # queue
@@ -194,6 +196,23 @@ class BatchJob(object):
             # This propagates the AWS Batch resource tags to the underlying
             # ECS tasks.
             "propagateTags": True,
+        }
+
+        log_options_dict = {}
+        if log_options:
+            if isinstance(log_options, str):
+                log_options = [log_options]
+            for each_log_option in log_options:
+                k, v = each_log_option.split(":", 1)
+                log_options_dict[k] = v
+
+        job_definition["containerProperties"]["logConfiguration"] = {
+            "logDriver": log_driver if log_driver is not None else "awslogs",
+            "options": log_options_dict
+            if log_options is not None
+            else {
+                "awslogs-group": "aws/batch/job",
+            },
         }
 
         if platform == "FARGATE" or platform == "FARGATE_SPOT":
@@ -456,6 +475,8 @@ class BatchJob(object):
         tmpfs_path,
         num_parallel,
         ephemeral_storage,
+        log_driver,
+        log_options,
     ):
         self.payload["jobDefinition"] = self._register_job_definition(
             image,
@@ -476,6 +497,8 @@ class BatchJob(object):
             tmpfs_path,
             num_parallel,
             ephemeral_storage,
+            log_driver,
+            log_options,
         )
         return self
 

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -91,6 +91,12 @@ class BatchDecorator(StepDecorator):
     ephemeral_storage: int, default None
         The total amount, in GiB, of ephemeral storage to set for the task (21-200)
         This is only relevant for Fargate compute environments
+    log_driver: str, optional, default None
+        The log driver to use for the Amazon ECS container.
+    log_options: List[str], optional, default None
+        List of strings containing options for the chosen log driver. The configurable values
+        depend on the `log driver` chosen. Validation of these options is not supported yet.
+        Example usage: ["awslogs-group:aws/batch/job"]
     """
 
     name = "batch"
@@ -115,6 +121,8 @@ class BatchDecorator(StepDecorator):
         "tmpfs_size": None,
         "tmpfs_path": "/metaflow_temp",
         "ephemeral_storage": None,
+        "log_driver": None,
+        "log_options": None,
     }
     resource_defaults = {
         "cpu": "1",

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -840,6 +840,8 @@ class StepFunctions(object):
                 host_volumes=resources["host_volumes"],
                 efs_volumes=resources["efs_volumes"],
                 ephemeral_storage=resources["ephemeral_storage"],
+                log_driver=resources["log_driver"],
+                log_options=resources["log_options"],
             )
             .attempts(total_retries + 1)
         )


### PR DESCRIPTION
We can now do the following:

- This can expect a list where each string in the list follows `key:value`
```
@batch(log_options=["awslogs-group:try/batch/custom/demo"])
@step
def mid(self):
    print("yayyyy")
    self.next(self.end)
```

or perhaps just a single string of the form `key:value`

```
@batch(log_options="awslogs-group:try/batch/custom/demo")
@step
def mid(self):
    print("yayyyy")
    self.next(self.end)
```

Of course the assumption is that the log group `try/batch/custom/demo` should exist first on Cloudwatch...