### PR TITLE
[bug fix] Flow decorator click option names fix

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -518,7 +518,8 @@ def _init_flow_decorators(
         else:
             # Each "non-multiple" flow decorator is only allowed to have one set of options
             deco_flow_init_options = {
-                option: deco_options[option] for option in deco.options
+                option: deco_options[option.replace("-", "_")]
+                for option in deco.options
             }
         for deco in decorators:
             deco.flow_init(


### PR DESCRIPTION
- When we expose flow decorator options with a `-` in the name, the code crashes at setting `deco_flow_init_options` with a KeyError on `deco_options`. The `deco_options` as passed down from Click which converts any `option` with `-` to `_`.
- translating the `-` to `_` ensures the `option` can match the value in `deco_options` and doesn't result in KeyError. This is only the case **when options contain `-`**
- Already present flow decorators will have no issues anyways since this only effects flow deco options that have a `-` in the name (which currently none of them do).
- This doesn't handle the case where option names have `_`. But opens up creation of options with `-`'s.