### PR TITLE
allow multiple environment decorators

### DIFF
--- a/metaflow/plugins/airflow/airflow.py
+++ b/metaflow/plugins/airflow/airflow.py
@@ -279,8 +279,9 @@ class Airflow(object):
         # Add env vars from the optional @environment decorator.
         env_deco = [deco for deco in node.decorators if deco.name == "environment"]
         env = {}
+
         if env_deco:
-            env = env_deco[0].attributes["vars"].copy()
+            type(env_deco[0]).merge_vars(env_deco, env)
 
         # The below if/else block handles "input paths".
         # Input Paths help manage dataflow across the graph.

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -1226,11 +1226,9 @@ class ArgoWorkflows(object):
             #   (2) Metaflow runtime specific environment variables
             #   (3) @kubernetes, @argo_workflows_internal bookkeeping environment
             #       variables
-            env = dict(
-                [deco for deco in node.decorators if deco.name == "environment"][
-                    0
-                ].attributes["vars"]
-            )
+            env_deco = [deco for deco in node.decorators if deco.name == "environment"]
+            env = {}
+            type(env_deco[0]).merge_vars(env_deco, env)
 
             # Temporary passing of *some* environment variables. Do not rely on this
             # mechanism as it will be removed in the near future

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -272,10 +272,9 @@ def step(
     ]
 
     env_deco = [deco for deco in node.decorators if deco.name == "environment"]
+    env = {}
     if env_deco:
-        env = env_deco[0].attributes["vars"]
-    else:
-        env = {}
+        type(env_deco[0]).merge_vars(env_deco, env)
 
     # Add the environment variables related to the input-paths argument
     if split_vars:

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -556,7 +556,7 @@ class StepFunctions(object):
         env_deco = [deco for deco in node.decorators if deco.name == "environment"]
         env = {}
         if env_deco:
-            env = env_deco[0].attributes["vars"].copy()
+            type(env_deco[0]).merge_vars(env_deco, env)
 
         # add METAFLOW_S3_ENDPOINT_URL
         if S3_ENDPOINT_URL is not None:

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -151,7 +151,7 @@ def step(
     env = {}
     env_deco = [deco for deco in node.decorators if deco.name == "environment"]
     if env_deco:
-        env = env_deco[0].attributes["vars"]
+        type(env_deco[0]).merge_vars(env_deco, env)
 
     # Set input paths.
     input_paths = kwargs.get("input_paths")


### PR DESCRIPTION
Allow multiple environment decorators. When multiple environment decorators are supplied, the `vars` for each decorator are set in order. A message is logged in the case of conflicting values.

I've tested with the following example flow:

```{python}
import os

from metaflow import (
     environment,
     step,
     FlowSpec,
)


class EnvFlow(FlowSpec):
    @environment(vars={"VAR1": "val1"})
    @environment(vars={"VAR2": "val1"})
    @environment(vars={"VAR3": "val1"})
    @step
    def start(self):
        print(f"VAR1 = {os.getenv('VAR1')}")
        print(f"VAR2 = {os.getenv('VAR2')}")
        print(f"VAR3 = {os.getenv('VAR3')}")
        self.next(self.end)

    @environment(vars={"VAR1": "val2", "VAR2": "val3"})
    @step
    def end(self):
        print(f"VAR1 = {os.getenv('VAR1')}")
        print(f"VAR2 = {os.getenv('VAR2')}")
        pass


if __name__ == "__main__":
    EnvFlow()
```
I've run `--with environment:vars='{"VAR1":"val4", "VAR2":"val3"}'` both locally and on Argo Workflows. Environment variables have the correct values in both cases, though in the case of Argo, the messages about the conflicting values are logged when `argo-workflows create` is run, rather than when the workflow is run.