### PR TITLE
[Ready for review] replace pull_request_target

### DIFF
--- a/.github/workflows/metaflow.s3_tests.yml
+++ b/.github/workflows/metaflow.s3_tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - master
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
We are replacing `pull_request_target` because it could be triggered automatically against untrusted PRs allowing malicious actors to run code and exfiltrate secrets.  Replacing it with `pull_request` could solve the issue.

More in this article: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/