### PR TITLE
Expose metaflow logger and monitor via singleton

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -23,6 +23,7 @@ from .metaflow_config import (
     DEFAULT_PACKAGE_SUFFIXES,
 )
 from .metaflow_current import current
+from metaflow.system import _system_monitor, _system_logger
 from .metaflow_environment import MetaflowEnvironment
 from .mflog import LOG_SOURCES, mflog
 from .package import MetaflowPackage
@@ -952,11 +953,13 @@ def start(
         flow=ctx.obj.flow, env=ctx.obj.environment
     )
     ctx.obj.event_logger.start()
+    _system_logger.init_system_logger(ctx.obj.flow.name, ctx.obj.event_logger)
 
     ctx.obj.monitor = MONITOR_SIDECARS[monitor](
         flow=ctx.obj.flow, env=ctx.obj.environment
     )
     ctx.obj.monitor.start()
+    _system_monitor.init_system_monitor(ctx.obj.flow.name, ctx.obj.monitor)
 
     ctx.obj.metadata = [m for m in METADATA_PROVIDERS if m.TYPE == metadata][0](
         ctx.obj.environment, ctx.obj.flow, ctx.obj.event_logger, ctx.obj.monitor

--- a/metaflow/system/__init__.py
+++ b/metaflow/system/__init__.py
@@ -1,0 +1,5 @@
+from .system_monitor import SystemMonitor
+from .system_logger import SystemLogger
+
+_system_logger = SystemLogger()
+_system_monitor = SystemMonitor()

--- a/metaflow/system/system_logger.py
+++ b/metaflow/system/system_logger.py
@@ -66,7 +66,11 @@ class SystemLogger(object):
             Message to log.
 
         """
-        if os.environ.get("METAFLOW_DEBUG_SIDECAR", "0") == "1":
+        if os.environ.get("METAFLOW_DEBUG_SIDECAR", "0").lower() not in (
+            "0",
+            "false",
+            "",
+        ):
             print("system monitor: %s" % msg, file=sys.stderr)
 
     def log_event(

--- a/metaflow/system/system_logger.py
+++ b/metaflow/system/system_logger.py
@@ -1,0 +1,99 @@
+import os
+import sys
+from typing import Dict, Any, Optional, Union
+
+
+class SystemLogger(object):
+    def __init__(self):
+        self._logger = None
+        self._flow_name = None
+        self._context = {}
+        self._is_context_updated = False
+
+    def __del__(self):
+        if self._flow_name == "not_a_real_flow":
+            self.logger.terminate()
+
+    def update_context(self, context: Dict[str, Any]):
+        """
+        Update the global context maintained by the system logger.
+
+        Parameters
+        ----------
+        context : Dict[str, Any]
+            A dictionary containing the context to update.
+
+        """
+        self._is_context_updated = True
+        self._context.update(context)
+
+    def init_system_logger(
+        self, flow_name: str, logger: "metaflow.event_logger.NullEventLogger"
+    ):
+        self._flow_name = flow_name
+        self._logger = logger
+
+    def _init_logger_outside_flow(self):
+        from .system_utils import DummyFlow
+        from .system_utils import init_environment_outside_flow
+        from metaflow.plugins import LOGGING_SIDECARS
+        from metaflow.metaflow_config import DEFAULT_EVENT_LOGGER
+
+        self._flow_name = "not_a_real_flow"
+        _flow = DummyFlow(self._flow_name)
+        _environment = init_environment_outside_flow(_flow)
+        _logger = LOGGING_SIDECARS[DEFAULT_EVENT_LOGGER](_flow, _environment)
+        return _logger
+
+    @property
+    def logger(self) -> Optional["metaflow.event_logger.NullEventLogger"]:
+        if self._logger is None:
+            # This happens if the logger is being accessed outside of a flow
+            # We start a logger with a dummy flow and a default environment
+            self._debug("Started logger outside of a flow")
+            self._logger = self._init_logger_outside_flow()
+            self._logger.start()
+        return self._logger
+
+    @staticmethod
+    def _debug(msg: str):
+        """
+        Log a debug message to stderr.
+
+        Parameters
+        ----------
+        msg : str
+            Message to log.
+
+        """
+        if os.environ.get("METAFLOW_DEBUG_SIDECAR", "0") == "1":
+            print("system monitor: %s" % msg, file=sys.stderr)
+
+    def log_event(
+        self, level: str, module: str, name: str, payload: Optional[Any] = None
+    ):
+        """
+        Log an event to the event logger.
+
+        Parameters
+        ----------
+        level : str
+            Log level of the event. Can be one of "info", "warning", "error", "critical", "debug".
+        module : str
+            Module of the event. Usually the name of the class, function, or module that the event is being logged from.
+        name : str
+            Name of the event. Used to qualify the event type.
+        payload : Optional[Any], default None
+            Payload of the event. Contains the event data.
+        """
+        self.logger.log(
+            {
+                "level": level,
+                "module": module,
+                "name": name,
+                "payload": payload if payload is not None else {},
+                "context": self._context,
+                "is_context_updated": self._is_context_updated,
+            }
+        )
+        self._is_context_updated = False

--- a/metaflow/system/system_monitor.py
+++ b/metaflow/system/system_monitor.py
@@ -26,11 +26,17 @@ class SystemMonitor(object):
 
         """
         from metaflow.sidecar import Message, MessageTypes
+
         self._context.update(context)
-        self.monitor.send(Message(MessageTypes.MUST_SEND, {
-            "is_context_updated": True,
-            **self._context,
-        }))
+        self.monitor.send(
+            Message(
+                MessageTypes.MUST_SEND,
+                {
+                    "is_context_updated": True,
+                    **self._context,
+                },
+            )
+        )
 
     def init_system_monitor(
         self, flow_name: str, monitor: "metaflow.monitor.NullMonitor"

--- a/metaflow/system/system_monitor.py
+++ b/metaflow/system/system_monitor.py
@@ -1,0 +1,122 @@
+import os
+import sys
+from ..debug import debug
+from contextlib import contextmanager
+from typing import Optional, Union, Dict, Any
+
+
+class SystemMonitor(object):
+    def __init__(self):
+        self._monitor = None
+        self._flow_name = None
+        self._context = {}
+
+    def __del__(self):
+        if self._flow_name == "not_a_real_flow":
+            self.monitor.terminate()
+
+    def update_context(self, context: Dict[str, Any]):
+        """
+        Update the global context maintained by the system monitor.
+
+        Parameters
+        ----------
+        context : Dict[str, Any]
+            A dictionary containing the context to update.
+
+        """
+        from metaflow.sidecar import Message, MessageTypes
+        self._context.update(context)
+        self.monitor.send(Message(MessageTypes.MUST_SEND, {
+            "is_context_updated": True,
+            **self._context,
+        }))
+
+    def init_system_monitor(
+        self, flow_name: str, monitor: "metaflow.monitor.NullMonitor"
+    ):
+        self._flow_name = flow_name
+        self._monitor = monitor
+
+    def _init_system_monitor_outside_flow(self):
+        from .system_utils import DummyFlow
+        from .system_utils import init_environment_outside_flow
+        from metaflow.plugins import MONITOR_SIDECARS
+        from metaflow.metaflow_config import DEFAULT_MONITOR
+
+        self._flow_name = "not_a_real_flow"
+        _flow = DummyFlow(self._flow_name)
+        _environment = init_environment_outside_flow(_flow)
+        _monitor = MONITOR_SIDECARS[DEFAULT_MONITOR](_flow, _environment)
+        return _monitor
+
+    @property
+    def monitor(self) -> Optional["metaflow.monitor.NullMonitor"]:
+        if self._monitor is None:
+            # This happens if the monitor is being accessed outside of a flow
+            self._debug("Started monitor outside of a flow")
+            self._monitor = self._init_system_monitor_outside_flow()
+            self._monitor.start()
+        return self._monitor
+
+    @staticmethod
+    def _debug(msg: str):
+        """
+        Log a debug message to stderr.
+
+        Parameters
+        ----------
+        msg : str
+            Message to log.
+
+        """
+        if os.environ.get("METAFLOW_DEBUG_SIDECAR", "0") == "1":
+            print("system monitor: %s" % msg, file=sys.stderr)
+
+    @contextmanager
+    def measure(self, name: str):
+        """
+        Context manager to measure the execution duration and counter of a block of code.
+
+        Parameters
+        ----------
+        name : str
+            The name to associate with the timer and counter.
+
+        Yields
+        ------
+        None
+        """
+        # Delegating the context management to the monitor's measure method
+        with self.monitor.measure(name):
+            yield
+
+    @contextmanager
+    def count(self, name: str):
+        """
+        Context manager to increment a counter.
+
+        Parameters
+        ----------
+        name : str
+            The name of the counter.
+
+        Yields
+        ------
+        None
+        """
+        # Delegating the context management to the monitor's count method
+        with self.monitor.count(name):
+            yield
+
+    def gauge(self, gauge: "metaflow.monitor.Gauge"):
+        """
+        Log a gauge.
+
+        Parameters
+        ----------
+        gauge : metaflow.monitor.Gauge
+            The gauge to log.
+
+        """
+        self.monitor.gauge(gauge)

--- a/metaflow/system/system_monitor.py
+++ b/metaflow/system/system_monitor.py
@@ -76,7 +76,11 @@ class SystemMonitor(object):
             Message to log.
 
         """
-        if os.environ.get("METAFLOW_DEBUG_SIDECAR", "0") == "1":
+        if os.environ.get("METAFLOW_DEBUG_SIDECAR", "0").lower() not in (
+            "0",
+            "false",
+            "",
+        ):
             print("system monitor: %s" % msg, file=sys.stderr)
 
     @contextmanager

--- a/metaflow/system/system_utils.py
+++ b/metaflow/system/system_utils.py
@@ -1,0 +1,19 @@
+from typing import Union
+
+
+class DummyFlow(object):
+    def __init__(self, name="not_a_real_flow"):
+        self.name = name
+
+
+# This function is used to initialize the environment outside a flow.
+def init_environment_outside_flow(
+    flow: Union["metaflow.flowspec.FlowSpec", "metaflow.sidecar.DummyFlow"]
+) -> "metaflow.metaflow_environment.MetaflowEnvironment":
+    from metaflow.plugins import ENVIRONMENTS
+    from metaflow.metaflow_config import DEFAULT_ENVIRONMENT
+    from metaflow.metaflow_environment import MetaflowEnvironment
+
+    return [
+        e for e in ENVIRONMENTS + [MetaflowEnvironment] if e.TYPE == DEFAULT_ENVIRONMENT
+    ][0](flow)

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -4,9 +4,11 @@ import math
 import sys
 import os
 import time
+import traceback
 
 from types import MethodType, FunctionType
 
+from metaflow.sidecar import Message, MessageTypes
 from metaflow.datastore.exceptions import DataException
 
 from .metaflow_config import MAX_ATTEMPTS
@@ -22,6 +24,7 @@ from .unbounded_foreach import UBF_CONTROL
 from .util import all_equal, get_username, resolve_identity, unicode_type
 from .clone_util import clone_task_helper
 from .metaflow_current import current
+from metaflow.system import _system_logger, _system_monitor
 from metaflow.tracing import get_trace_id
 from metaflow.tuple_util import ForeachFrame
 
@@ -280,25 +283,42 @@ class MetaflowTask(object):
                 "task.clone_only needs a valid clone_origin_task value."
             )
         origin_run_id, _, origin_task_id = clone_origin_task.split("/")
-
-        msg = {
-            "task_id": task_id,
-            "msg": "Cloning task from {}/{}/{}/{} to {}/{}/{}/{}".format(
-                self.flow.name,
-                origin_run_id,
-                step_name,
-                origin_task_id,
-                self.flow.name,
-                run_id,
-                step_name,
-                task_id,
-            ),
-            "step_name": step_name,
+        # Update system logger and monitor context
+        # We also pass this context as part of the task payload to support implementations that
+        # can't access the context directly
+        task_payload = {
             "run_id": run_id,
-            "flow_name": self.flow.name,
-            "ts": round(time.time()),
+            "step_name": step_name,
+            "task_id": task_id,
+            "retry_count": retry_count,
+            "project_name": current.get("project_name"),
+            "branch_name": current.get("branch_name"),
+            "is_user_branch": current.get("is_user_branch"),
+            "is_production": current.get("is_production"),
+            "project_flow_name": current.get("project_flow_name"),
+            "origin_run_id": origin_run_id,
+            "origin_task_id": origin_task_id,
         }
-        self.event_logger.log(msg)
+        _system_logger.update_context(task_payload)
+        _system_monitor.update_context(task_payload)
+
+        msg = "Cloning task from {}/{}/{}/{} to {}/{}/{}/{}".format(
+            self.flow.name,
+            origin_run_id,
+            step_name,
+            origin_task_id,
+            self.flow.name,
+            run_id,
+            step_name,
+            task_id,
+        )
+        with _system_monitor.count("metaflow.task.clone"):
+            _system_logger.log_event(
+                level="info",
+                module="metaflow.task",
+                name="clone",
+                payload={**task_payload,"msg": msg},
+            )
         # If we actually have to do the clone ourselves, proceed...
         clone_task_helper(
             self.flow.name,
@@ -502,204 +522,230 @@ class MetaflowTask(object):
                 }
             }
         )
-        logger = self.event_logger
+
+        # 6. Update system logger and monitor context
+        # We also pass this context as part of the task payload to support implementations that
+        # can't access the context directly
+
+        task_payload = {
+            "run_id": run_id,
+            "step_name": step_name,
+            "task_id": task_id,
+            "retry_count": retry_count,
+            "project_name": current.get("project_name"),
+            "branch_name": current.get("branch_name"),
+            "is_user_branch": current.get("is_user_branch"),
+            "is_production": current.get("is_production"),
+            "project_flow_name": current.get("project_flow_name"),
+            "trace_id": trace_id or None,
+        }
+
+        _system_logger.update_context(task_payload)
+        _system_monitor.update_context(task_payload)
         start = time.time()
         self.metadata.start_task_heartbeat(self.flow.name, run_id, step_name, task_id)
-        try:
-            msg = {
-                "task_id": task_id,
-                "msg": "task starting",
-                "step_name": step_name,
-                "run_id": run_id,
-                "flow_name": self.flow.name,
-                "ts": round(time.time()),
-            }
-            logger.log(msg)
-
-            self.flow._current_step = step_name
-            self.flow._success = False
-            self.flow._task_ok = None
-            self.flow._exception = None
-            # Note: All internal flow attributes (ie: non-user artifacts)
-            # should either be set prior to running the user code or listed in
-            # FlowSpec._EPHEMERAL to allow for proper merging/importing of
-            # user artifacts in the user's step code.
-
-            if join_type:
-                # Join step:
-
-                # Ensure that we have the right number of inputs. The
-                # foreach case is checked above.
-                if join_type != "foreach" and len(inputs) != len(node.in_funcs):
-                    raise MetaflowDataMissing(
-                        "Join *%s* expected %d "
-                        "inputs but only %d inputs "
-                        "were found" % (step_name, len(node.in_funcs), len(inputs))
+        with self.monitor.measure("metaflow.task.duration"):
+            try:
+                with self.monitor.count("metaflow.task.start"):
+                    _system_logger.log_event(
+                        level="info",
+                        module="metaflow.task",
+                        name="start",
+                        payload={**task_payload, "msg": "Task started"},
                     )
 
-                # Multiple input contexts are passed in as an argument
-                # to the step function.
-                input_obj = Inputs(self._clone_flow(inp) for inp in inputs)
-                self.flow._set_datastore(output)
-                # initialize parameters (if they exist)
-                # We take Parameter values from the first input,
-                # which is always safe since parameters are read-only
-                current._update_env(
-                    {"parameter_names": self._init_parameters(inputs[0], passdown=True)}
-                )
-            else:
-                # Linear step:
-                # We are running with a single input context.
-                # The context is embedded in the flow.
-                if len(inputs) > 1:
-                    # This should be captured by static checking but
-                    # let's assert this again
-                    raise MetaflowInternalError(
-                        "Step *%s* is not a join "
-                        "step but it gets multiple "
-                        "inputs." % step_name
-                    )
-                self.flow._set_datastore(inputs[0])
-                if input_paths:
+                self.flow._current_step = step_name
+                self.flow._success = False
+                self.flow._task_ok = None
+                self.flow._exception = None
+                # Note: All internal flow attributes (ie: non-user artifacts)
+                # should either be set prior to running the user code or listed in
+                # FlowSpec._EPHEMERAL to allow for proper merging/importing of
+                # user artifacts in the user's step code.
+
+                if join_type:
+                    # Join step:
+
+                    # Ensure that we have the right number of inputs. The
+                    # foreach case is checked above.
+                    if join_type != "foreach" and len(inputs) != len(node.in_funcs):
+                        raise MetaflowDataMissing(
+                            "Join *%s* expected %d "
+                            "inputs but only %d inputs "
+                            "were found" % (step_name, len(node.in_funcs), len(inputs))
+                        )
+
+                    # Multiple input contexts are passed in as an argument
+                    # to the step function.
+                    input_obj = Inputs(self._clone_flow(inp) for inp in inputs)
+                    self.flow._set_datastore(output)
                     # initialize parameters (if they exist)
                     # We take Parameter values from the first input,
                     # which is always safe since parameters are read-only
                     current._update_env(
                         {
                             "parameter_names": self._init_parameters(
-                                inputs[0], passdown=False
+                                inputs[0], passdown=True
                             )
                         }
                     )
+                else:
+                    # Linear step:
+                    # We are running with a single input context.
+                    # The context is embedded in the flow.
+                    if len(inputs) > 1:
+                        # This should be captured by static checking but
+                        # let's assert this again
+                        raise MetaflowInternalError(
+                            "Step *%s* is not a join "
+                            "step but it gets multiple "
+                            "inputs." % step_name
+                        )
+                    self.flow._set_datastore(inputs[0])
+                    if input_paths:
+                        # initialize parameters (if they exist)
+                        # We take Parameter values from the first input,
+                        # which is always safe since parameters are read-only
+                        current._update_env(
+                            {
+                                "parameter_names": self._init_parameters(
+                                    inputs[0], passdown=False
+                                )
+                            }
+                        )
 
-            for deco in decorators:
-                deco.task_pre_step(
-                    step_name,
-                    output,
-                    self.metadata,
-                    run_id,
-                    task_id,
-                    self.flow,
-                    self.flow._graph,
-                    retry_count,
-                    max_user_code_retries,
-                    self.ubf_context,
-                    inputs,
-                )
-
-            for deco in decorators:
-                # decorators can actually decorate the step function,
-                # or they can replace it altogether. This functionality
-                # is used e.g. by catch_decorator which switches to a
-                # fallback code if the user code has failed too many
-                # times.
-                step_func = deco.task_decorate(
-                    step_func,
-                    self.flow,
-                    self.flow._graph,
-                    retry_count,
-                    max_user_code_retries,
-                    self.ubf_context,
-                )
-
-            if join_type:
-                self._exec_step_function(step_func, input_obj)
-            else:
-                self._exec_step_function(step_func)
-
-            for deco in decorators:
-                deco.task_post_step(
-                    step_name,
-                    self.flow,
-                    self.flow._graph,
-                    retry_count,
-                    max_user_code_retries,
-                )
-
-            self.flow._task_ok = True
-            self.flow._success = True
-
-        except Exception as ex:
-            tsk_msg = {
-                "task_id": task_id,
-                "exception_msg": str(ex),
-                "msg": "task failed with exception",
-                "step_name": step_name,
-                "run_id": run_id,
-                "flow_name": self.flow.name,
-            }
-            logger.log(tsk_msg)
-
-            exception_handled = False
-            for deco in decorators:
-                res = deco.task_exception(
-                    ex,
-                    step_name,
-                    self.flow,
-                    self.flow._graph,
-                    retry_count,
-                    max_user_code_retries,
-                )
-                exception_handled = bool(res) or exception_handled
-
-            if exception_handled:
-                self.flow._task_ok = True
-            else:
-                self.flow._task_ok = False
-                self.flow._exception = MetaflowExceptionWrapper(ex)
-                print("%s failed:" % self.flow, file=sys.stderr)
-                raise
-
-        finally:
-            if self.ubf_context == UBF_CONTROL:
-                self._finalize_control_task()
-
-            end = time.time() - start
-
-            msg = {
-                "task_id": task_id,
-                "msg": "task ending",
-                "step_name": step_name,
-                "run_id": run_id,
-                "flow_name": self.flow.name,
-                "ts": round(time.time()),
-                "runtime": round(end),
-            }
-            logger.log(msg)
-
-            attempt_ok = str(bool(self.flow._task_ok))
-            self.metadata.register_metadata(
-                run_id,
-                step_name,
-                task_id,
-                [
-                    MetaDatum(
-                        field="attempt_ok",
-                        value=attempt_ok,
-                        type="internal_attempt_status",
-                        tags=["attempt_id:{0}".format(retry_count)],
+                for deco in decorators:
+                    deco.task_pre_step(
+                        step_name,
+                        output,
+                        self.metadata,
+                        run_id,
+                        task_id,
+                        self.flow,
+                        self.flow._graph,
+                        retry_count,
+                        max_user_code_retries,
+                        self.ubf_context,
+                        inputs,
                     )
-                ],
-            )
 
-            output.save_metadata({"task_end": {}})
-            output.persist(self.flow)
+                for deco in decorators:
+                    # decorators can actually decorate the step function,
+                    # or they can replace it altogether. This functionality
+                    # is used e.g. by catch_decorator which switches to a
+                    # fallback code if the user code has failed too many
+                    # times.
+                    step_func = deco.task_decorate(
+                        step_func,
+                        self.flow,
+                        self.flow._graph,
+                        retry_count,
+                        max_user_code_retries,
+                        self.ubf_context,
+                    )
 
-            # this writes a success marker indicating that the
-            # "transaction" is done
-            output.done()
+                if join_type:
+                    self._exec_step_function(step_func, input_obj)
+                else:
+                    self._exec_step_function(step_func)
 
-            # final decorator hook: The task results are now
-            # queryable through the client API / datastore
-            for deco in decorators:
-                deco.task_finished(
+                for deco in decorators:
+                    deco.task_post_step(
+                        step_name,
+                        self.flow,
+                        self.flow._graph,
+                        retry_count,
+                        max_user_code_retries,
+                    )
+
+                self.flow._task_ok = True
+                self.flow._success = True
+
+            except Exception as ex:
+                with self.monitor.count("metaflow.task.exception"):
+                    _system_logger.log_event(
+                        level="error",
+                        module="metaflow.task",
+                        name="exception",
+                        payload={**task_payload, "msg": traceback.format_exc()},
+                    )
+
+                exception_handled = False
+                for deco in decorators:
+                    res = deco.task_exception(
+                        ex,
+                        step_name,
+                        self.flow,
+                        self.flow._graph,
+                        retry_count,
+                        max_user_code_retries,
+                    )
+                    exception_handled = bool(res) or exception_handled
+
+                if exception_handled:
+                    self.flow._task_ok = True
+                else:
+                    self.flow._task_ok = False
+                    self.flow._exception = MetaflowExceptionWrapper(ex)
+                    print("%s failed:" % self.flow, file=sys.stderr)
+                    raise
+
+            finally:
+                if self.ubf_context == UBF_CONTROL:
+                    self._finalize_control_task()
+
+                # Emit metrics to logger/monitor sidecar implementations
+                with self.monitor.count("metaflow.task.end"):
+                    _system_logger.log_event(
+                        level="info",
+                        module="metaflow.task",
+                        name="end",
+                        payload={**task_payload, "msg": "Task ended"},
+                    )
+
+                attempt_ok = str(bool(self.flow._task_ok))
+                self.metadata.register_metadata(
+                    run_id,
                     step_name,
-                    self.flow,
-                    self.flow._graph,
-                    self.flow._task_ok,
-                    retry_count,
-                    max_user_code_retries,
+                    task_id,
+                    [
+                        MetaDatum(
+                            field="attempt_ok",
+                            value=attempt_ok,
+                            type="internal_attempt_status",
+                            tags=["attempt_id:{0}".format(retry_count)],
+                        )
+                    ],
                 )
 
-            # terminate side cars
-            self.metadata.stop_heartbeat()
+                output.save_metadata({"task_end": {}})
+                output.persist(self.flow)
+
+                # this writes a success marker indicating that the
+                # "transaction" is done
+                output.done()
+
+                # final decorator hook: The task results are now
+                # queryable through the client API / datastore
+                for deco in decorators:
+                    deco.task_finished(
+                        step_name,
+                        self.flow,
+                        self.flow._graph,
+                        self.flow._task_ok,
+                        retry_count,
+                        max_user_code_retries,
+                    )
+
+                # terminate side cars
+                self.metadata.stop_heartbeat()
+
+                # Task duration consists of the time taken to run the task as well as the time taken to
+                # persist the task metadata and data to the datastore.
+                duration = time.time() - start
+                _system_logger.log_event(
+                    level="info",
+                    module="metaflow.task",
+                    name="duration",
+                    payload={**task_payload, "msg": str(duration)},
+                )

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -317,7 +317,7 @@ class MetaflowTask(object):
                 level="info",
                 module="metaflow.task",
                 name="clone",
-                payload={**task_payload,"msg": msg},
+                payload={**task_payload, "msg": msg},
             )
         # If we actually have to do the clone ourselves, proceed...
         clone_task_helper(


### PR DESCRIPTION
## Expose logger and monitor via a `system_current` singleton

Currently, users don't have the ability to use their implementation of logger and monitor sidecars in their own code. Additionally, if platform developers want to instrument their Metaflow extensions, they have to pass in the logger/monitor constructs to each one of their plugins, leading to code duplication.

This PR exposes two new singleton objects called `_system_logger` and `_system_monitor` that can be used to access the monitor and the logger anywhere.  

- The monitor/logger can be accessed both within and outside a Metaflow flow. This allows us to instrument Metaflow plugins like `metaflow.S3`, which is often used outside of a flow as well. 

### Usage
The monitor/logger sidecar can be used in the following manner:

```python
with _system_monitor.count("<your_metric_name>"): 
      # your code
      pass

_system_logger.log(payload):
```