### PR TITLE
Initialize token for IMDSv1 ec2-metadata

### DIFF
--- a/metaflow/plugins/aws/aws_utils.py
+++ b/metaflow/plugins/aws/aws_utils.py
@@ -24,6 +24,7 @@ def get_ec2_instance_metadata():
     # Having a long default timeout here introduces unnecessary delay in launching tasks when the
     # instance is unreachable.
     timeout = (1, 10)
+    token = None
     try:
         # Try to get an IMDSv2 token.
         token = requests.put(


### PR DESCRIPTION
A fix for https://github.com/Netflix/metaflow/pull/1808.. After merging, realized that this'll break IMDSv1, since token will always be undefined and raise. This fixes that issue.