### PR TITLE
fix: github tests

### DIFF
--- a/.github/workflows/test-stubs.yml
+++ b/.github/workflows/test-stubs.yml
@@ -26,8 +26,6 @@ jobs:
             ver: "3.11"
           - os: macos-latest
             ver: "3.10"
-          - os: macos-latest
-            ver: "3.9"
 
     steps:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0

--- a/.github/workflows/test-stubs.yml
+++ b/.github/workflows/test-stubs.yml
@@ -17,8 +17,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04]
         ver: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        include:
+          - os: macos-latest
+            ver: "3.12"
+          - os: macos-latest
+            ver: "3.11"
+          - os: macos-latest
+            ver: "3.10"
+          - os: macos-latest
+            ver: "3.9"
 
     steps:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,9 @@ jobs:
 
     - name: Install R ${{ matrix.ver }} Rlang dependencies
       run: |
+        python3 -m venv path/to/venv
+        source path/to/venv/bin/activate
+        python3 -m pip install xyz
         python3 -m pip install . 
         Rscript -e 'install.packages("devtools", repos="https://cloud.r-project.org", Ncpus=8)'
         Rscript -e 'devtools::install_deps("R", dependencies=TRUE, repos="https://cloud.r-project.org", upgrade="default")'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-13-large]
         ver: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [macos-13-large]
         ver: ['4.0']
    
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-13-large]
+        os: [ubuntu-20.04]
         ver: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        include:
+          - os: macos-latest
+            ver: "3.12"
+          - os: macos-latest
+            ver: "3.11"
+          - os: macos-latest
+            ver: "3.10"
+          - os: macos-latest
+            ver: "3.9"
 
     steps:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
@@ -49,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13-large]
+        os: [ubuntu-20.04]
         ver: ['4.0']
    
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,6 @@ jobs:
             ver: "3.11"
           - os: macos-latest
             ver: "3.10"
-          - os: macos-latest
-            ver: "3.9"
 
     steps:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
@@ -58,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [macos-latest]
         ver: ['4.0']
    
     steps:
@@ -76,7 +74,6 @@ jobs:
       run: |
         python3 -m venv path/to/venv
         source path/to/venv/bin/activate
-        python3 -m pip install xyz
         python3 -m pip install . 
         Rscript -e 'install.packages("devtools", repos="https://cloud.r-project.org", Ncpus=8)'
         Rscript -e 'devtools::install_deps("R", dependencies=TRUE, repos="https://cloud.r-project.org", upgrade="default")'


### PR DESCRIPTION
fixes specifically to tests relying on `macos-latest`

cause of issues being https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/

where the latest runner image has switched to macos 14, and arm64, bringing with it a lot of breaking changes for the CI. Most notably dropping support for older Python versions that we were testing for.