### PR TITLE
fix: R tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-20.04]
         ver: ['4.0']
    
     steps:


### PR DESCRIPTION
swap R tests to run on ubuntu due to macos-latest issues