### PR TITLE
bug fix: unused arg for batch step --help

### DIFF
--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -211,7 +211,7 @@ def step(
     log_driver=None,
     log_options=None,
     num_parallel=None,
-    **kwargs,
+    **kwargs
 ):
     def echo(msg, stream="stderr", batch_id=None, **kwargs):
         msg = util.to_unicode(msg)

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -151,7 +151,7 @@ def kill(ctx, run_id, user, my_runs):
 @click.option("--tmpfs-size", help="tmpfs requirement for AWS Batch.")
 @click.option("--tmpfs-path", help="tmpfs requirement for AWS Batch.")
 # TODO: Maybe remove it altogether since it's not used here
-@click.option("--ubf-context", default=None, type=click.Choice([None, "ubf_control"]))
+@click.option("--ubf-context", default=None, type=click.Choice(["none", "ubf_control"]))
 @click.option("--host-volumes", multiple=True)
 @click.option("--efs-volumes", multiple=True)
 @click.option(

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -150,7 +150,7 @@ def kill(ctx, run_id, user, my_runs):
 @click.option("--tmpfs-tempdir", is_flag=True, help="tmpfs requirement for AWS Batch.")
 @click.option("--tmpfs-size", help="tmpfs requirement for AWS Batch.")
 @click.option("--tmpfs-path", help="tmpfs requirement for AWS Batch.")
-# TODO: Maybe remove it altogether since it's not used here
+# NOTE: ubf-context is not explicitly used, but @parallel decorator tries to pass this so keep it for now
 @click.option("--ubf-context", default=None, type=click.Choice(["none", "ubf_control"]))
 @click.option("--host-volumes", multiple=True)
 @click.option("--efs-volumes", multiple=True)


### PR DESCRIPTION
addresses: https://github.com/Netflix/metaflow/issues/1771

issue:

`python hello.py batch step --help` command was breaking due to wrong type for click.Choice arg.

change:

setting default arg for `ubf-context` from None to "none" in "batch step" make it compatible with [click.Choice()](https://github.com/mae5357/metaflow/blob/4e648627ea6eb6535c0e28e80ce4daf8f1839ee7/metaflow/_vendor/click/types.py#L137-L138) 

however, ubf-context is not needed for the "step" function when using aws-batch, so we can safely remove altogether.
