### PR TITLE
Add a flag to control escape hatch log

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -364,6 +364,12 @@ CONDA_PACKAGE_GSROOT = from_conf("CONDA_PACKAGE_GSROOT")
 CONDA_DEPENDENCY_RESOLVER = from_conf("CONDA_DEPENDENCY_RESOLVER", "conda")
 
 ###
+# Escape hatch configuration
+###
+# Print out warning if escape hatch is not used for the target packages
+ESCAPE_HATCH_WARNING = from_conf("ESCAPE_HATCH_WARN", True)
+
+###
 # Debug configuration
 ###
 DEBUG_OPTIONS = ["subcommand", "sidecar", "s3client", "tracing", "stubgen"]

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -367,7 +367,7 @@ CONDA_DEPENDENCY_RESOLVER = from_conf("CONDA_DEPENDENCY_RESOLVER", "conda")
 # Escape hatch configuration
 ###
 # Print out warning if escape hatch is not used for the target packages
-ESCAPE_HATCH_WARNING = from_conf("ESCAPE_HATCH_WARN", True)
+ESCAPE_HATCH_WARNING = from_conf("ESCAPE_HATCH_WARNING", True)
 
 ###
 # Debug configuration

--- a/metaflow/plugins/env_escape/__init__.py
+++ b/metaflow/plugins/env_escape/__init__.py
@@ -36,6 +36,7 @@ from metaflow.extension_support import get_modules
 
 from .exception_transferer import RemoteInterpreterException
 from .client_modules import create_modules
+from metaflow.metaflow_config import ESCAPE_HATCH_WARNING
 
 # Determine what is the python executable to use for the environment escape. To do this,
 # we look for ENV_ESCAPE_PY in the environment AND store it. When metaflow
@@ -146,7 +147,7 @@ def load():
             # print("Env escape using executable {python_executable}")
         else:
             # Inverse logic as above here.
-            if sys.executable != "{python_executable}":
+            if sys.executable != "{python_executable}" and ESCAPE_HATCH_WARNING:
                 # We use the package locally and warn user.
                 print("Not using environment escape for '%s' as module present" % prefix)
             # In both cases, we don't load our loader since


### PR DESCRIPTION
We print a warning if a package is supposed to be escaped but not (e.g. User include the package in conda environment). However, the log may later disturb s3op wokers since the communication between subprocesses is depend on stdout.

For example:
1. `bdp-boto` is suppposed to be escaped
2. User specify a version of `bdp-boto` in their conda environment
3. We print out "Not using environment escape for 'bdp_boto' as module present"
5. User do a `S3.put_many()`
6. The s3 option would fail since it doesn't understand the log "Not using....."
```
File "/root/metaflow/metaflow/plugins/datatools/s3/s3.py", line 1561, in _update_out_lines
>      out_lines[int(idx.decode(encoding="utf-8"))] = rest
>  ValueError: invalid literal for int() with base 10: 'Not'
```
Thus, we add a flag to control printing out these warning or not as a short term solution to the issue