### PR TITLE
[Ready for Review] add attempt_ok flag so that UI will not show up unknown node

### DIFF
--- a/metaflow/clone_util.py
+++ b/metaflow/clone_util.py
@@ -66,6 +66,12 @@ def clone_task_helper(
                 type="attempt",
                 tags=metadata_tags,
             ),
+            MetaDatum(
+                field="attempt_ok",
+                value=True,  # During clone, the task is always considered successful.
+                type="internal_attempt_status",
+                tags=metadata_tags,
+            ),
         ],
     )
     output.done()

--- a/metaflow/clone_util.py
+++ b/metaflow/clone_util.py
@@ -68,7 +68,7 @@ def clone_task_helper(
             ),
             MetaDatum(
                 field="attempt_ok",
-                value=True,  # During clone, the task is always considered successful.
+                value="True",  # During clone, the task is always considered successful.
                 type="internal_attempt_status",
                 tags=metadata_tags,
             ),


### PR DESCRIPTION
This `attempt_ok` attribute is not used within metaflow runtime but is needed for UI to correctly display the status of a node. For example, in metaflow-service repo [here](https://github.com/Netflix/metaflow-service/blob/e0b149996020f1e613863015ffffee247cce49f3/services/ui_backend_service/data/db/tables/task.py#L177), if `attempt_ok` is not set, then the status become unknown.

For example, like this: 
![metaflow-unknown](https://github.com/Netflix/metaflow/assets/5545942/c14104ab-6447-4a59-bd81-e170f3d98a53)
