### PR TITLE
Use mkstemp to replace deprecated mktemp

### DIFF
--- a/metaflow/_vendor/click/_termui_impl.py
+++ b/metaflow/_vendor/click/_termui_impl.py
@@ -405,7 +405,8 @@ def _tempfilepager(generator, cmd, color):
     """Page through text by invoking a program on a temporary file."""
     import tempfile
 
-    filename = tempfile.mktemp()
+    fd, filename = tempfile.mkstemp()
+    os.close(fd)
     # TODO: This never terminates if the passed generator never terminates.
     text = "".join(generator)
     if not color:


### PR DESCRIPTION
# Description
This Pull Request addresses a security concern related to the use of the [deprecated](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp) tempfile.mktemp() function, which is known to be insecure due to its susceptibility to race conditions that can lead to temporary file vulnerabilities, as described in [CWE-377](https://cwe.mitre.org/data/definitions/377.html).
# Changes Made
- Replaced tempfile.mktemp() with tempfile.mkstemp() in metaflow/_vendor/click/_termui_impl.py. tempfile.mkstemp() securely creates a temporary file by returning both a file descriptor and a path, which significantly minimizes the risk of file-based race conditions.
