### PR TITLE
reducing the dep version to 4.7.0 (#47)

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -465,7 +465,7 @@ def get_pinned_conda_libs(python_version, datastore_type):
     elif datastore_type == "azure":
         pins["azure-identity"] = ">=1.10.0"
         pins["azure-storage-blob"] = ">=12.12.0"
-        pins["azure-keyvault-secrets"] = ">=4.8.0"
+        pins["azure-keyvault-secrets"] = ">=4.7.0"
     elif datastore_type == "gs":
         pins["google-cloud-storage"] = ">=2.5.0"
         pins["google-auth"] = ">=2.11.0"


### PR DESCRIPTION
## What is the change in this PR? 
* In order to support azure key vault for @secrets, we used the 4.8.0 az-keyvault-secrets library. However this conflicts with the azure-cli package which is still dependent on the 4.7.0 az-keyvault-secrets

[Darwin](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/requirements.py3.Darwin.txt#L19)
[Linux](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/requirements.py3.Linux.txt#L19)
[Windows](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/requirements.py3.windows.txt#L19)

Without this PR - installing metaflow + azure-cli will conflict with each other. The Integration of az-key-vault works as intended with 4.7.0 as well. 

Hence this PR is not going to cause any unintended consequences.