### PR TITLE
Add local configuration option

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -15,6 +15,17 @@ if sys.platform == "darwin":
 ## value, either set `METAFLOW_DEFAULT_DATASTORE` in your configuration file or set
 ## an environment variable called `METAFLOW_DEFAULT_DATASTORE`
 
+##
+# Constants (NOTE: these need to live before any from_conf)
+##
+
+# Path to the local directory to store artifacts for 'local' datastore.
+DATASTORE_LOCAL_DIR = ".metaflow"
+
+# Local configuration file (in .metaflow) containing overrides per-project
+LOCAL_CONFIG_FILE = "config.json"
+
+
 ###
 # Default configuration
 ###
@@ -39,8 +50,6 @@ USER = from_conf("USER")
 ###
 # Datastore configuration
 ###
-# Path to the local directory to store artifacts for 'local' datastore.
-DATASTORE_LOCAL_DIR = ".metaflow"
 DATASTORE_SYSROOT_LOCAL = from_conf("DATASTORE_SYSROOT_LOCAL")
 # S3 bucket and prefix to store artifacts for 's3' datastore.
 DATASTORE_SYSROOT_S3 = from_conf("DATASTORE_SYSROOT_S3")

--- a/metaflow/metaflow_config_funcs.py
+++ b/metaflow/metaflow_config_funcs.py
@@ -32,8 +32,37 @@ def init_config():
     return config
 
 
+def init_local_config():
+    # This function is heavily inspired from LocalStorage.get_datastore_root_from_config
+    # but simplifies certain things and also does not depend on DATASTORE_SYSROOT_LOCAL.
+    #
+    # In other words, since this config is meant to be local to a directory, it does not
+    # check in DATASTORE_SYSROOT_LOCAL but only up the current getcwd() path. This also
+    # prevents nasty circular dependencies :)
+
+    from metaflow.metaflow_config import DATASTORE_LOCAL_DIR, LOCAL_CONFIG_FILE
+
+    current_path = os.getcwd()
+    check_dir = os.path.join(current_path, DATASTORE_LOCAL_DIR)
+    check_dir = os.path.realpath(check_dir)
+    while not os.path.isdir(check_dir):
+        new_path = os.path.dirname(current_path)
+        if new_path == current_path:  # No longer making upward progress
+            return {}
+        current_path = new_path
+        check_dir = os.path.join(current_path, DATASTORE_LOCAL_DIR)
+    path_to_config = os.path.join(check_dir, LOCAL_CONFIG_FILE)
+    # We found a directory to look for the config file in
+    if os.path.exists(path_to_config):
+        with open(path_to_config, encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
 # Initialize defaults required to setup environment variables.
 METAFLOW_CONFIG = init_config()
+
+METAFLOW_LOCAL_CONFIG = init_local_config()
 
 _all_configs = {}
 
@@ -51,7 +80,13 @@ def config_values(include=0):
 
 def from_conf(name, default=None, validate_fn=None):
     """
-    First try to pull value from environment, then from metaflow config JSON
+    Pull value from the environment or configuration.
+    Order is:
+    1. Environment (use any environment variable explicitly set by user)
+    2. Local config (use any value set in the local config file -- so stuff in
+       .metaflow/project.json for example)
+    3. Global config (use any value set in the global config file)
+    4. Default
 
     Prior to a value being returned, we will validate using validate_fn (if provided).
     Only non-None values are validated.
@@ -61,7 +96,10 @@ def from_conf(name, default=None, validate_fn=None):
     """
     is_default = True
     env_name = "METAFLOW_%s" % name
-    value = os.environ.get(env_name, METAFLOW_CONFIG.get(env_name, default))
+    value = os.environ.get(
+        env_name,
+        METAFLOW_LOCAL_CONFIG.get(env_name, METAFLOW_CONFIG.get(env_name, default)),
+    )
     if validate_fn and value is not None:
         validate_fn(env_name, value)
     if default is not None:

--- a/metaflow/metaflow_config_funcs.py
+++ b/metaflow/metaflow_config_funcs.py
@@ -60,9 +60,12 @@ def init_local_config():
 
 
 # Initialize defaults required to setup environment variables.
-METAFLOW_CONFIG = init_config()
+# (initialized lazily in from_conf since init_local_config requires
+# some configuration values
 
-METAFLOW_LOCAL_CONFIG = init_local_config()
+METAFLOW_CONFIG = None
+
+METAFLOW_LOCAL_CONFIG = None
 
 _all_configs = {}
 
@@ -94,6 +97,12 @@ def from_conf(name, default=None, validate_fn=None):
     validate_fn should accept (name, value).
     If the value validates, return None, else raise an MetaflowException.
     """
+    global METAFLOW_CONFIG, METAFLOW_LOCAL_CONFIG
+
+    if METAFLOW_CONFIG is None:
+        METAFLOW_CONFIG = init_config()
+        METAFLOW_LOCAL_CONFIG = init_local_config()
+
     is_default = True
     env_name = "METAFLOW_%s" % name
     value = os.environ.get(


### PR DESCRIPTION
This allows a per-project (directory) override of configuration values.

This is similar to using profiles but allows for finer grained overrides and will be particularly useful with default decorators.