### PR TITLE
[OB-625] adding metaflow/cron annotation to argo workflows

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -629,6 +629,14 @@ class ArgoWorkflows(object):
             ),
         }
 
+        if self._schedule is not None:
+            # timezone is an optional field and json dumps on None will result in null
+            # hence configuring it to an empty string
+            if self._timezone is None:
+                self._timezone = ""
+            cron_info = {"schedule": self._schedule, "tz": self._timezone}
+            annotations.update({"metaflow/cron": json.dumps(cron_info)})
+
         if self.parameters:
             annotations.update({"metaflow/parameters": json.dumps(self.parameters)})
 


### PR DESCRIPTION
## What is the change in this PR? 
In order to display cron information in the deployments UI - we will add the cron information in the Workflow Template annotation. The UI can then use this information and display it.
Annotations added are:
metaflow/cron: {'schedule': <CRON>, 'tz':<timezone>}
They show up only when a @schedule decorator is used.

##How is this tested?
If timezone is defined:
![Screenshot 2024-05-21 at 12 01 08 PM](https://github.com/Netflix/metaflow/assets/144727284/1a9ff24b-d7fe-46c3-8fe2-243aca099539)


If timezone is not defined:
![Screenshot 2024-05-21 at 12 01 03 PM](https://github.com/Netflix/metaflow/assets/144727284/ae1e5b21-7a12-4ebc-84c7-5fd597af0ed9)

