### PR TITLE
feature: stream logs in chunks

### DIFF
--- a/metaflow/client/filecache.py
+++ b/metaflow/client/filecache.py
@@ -80,6 +80,22 @@ class FileCache(object):
         )
         return task_ds.load_logs(LOG_SOURCES, stream, attempt_override=attempt)
 
+    def logs_iterator(
+        self, ds_type, ds_root, stream, attempt, flow_name, run_id, step_name, task_id
+    ):
+        from metaflow.mflog import LOG_SOURCES
+
+        ds = self._get_flow_datastore(ds_type, ds_root, flow_name)
+
+        task_ds = ds.get_task_datastore(
+            run_id, step_name, task_id, data_metadata={"objects": {}, "info": {}}
+        )
+
+        return {
+            source: task_ds.stream_logs([source], stream, attempt_override=attempt)
+            for source in LOG_SOURCES
+        }
+
     def get_log_legacy(
         self, ds_type, location, logtype, attempt, flow_name, run_id, step_name, task_id
     ):

--- a/metaflow/datastore/datastore_storage.py
+++ b/metaflow/datastore/datastore_storage.py
@@ -271,3 +271,23 @@ class DataStoreStorage(object):
             duplicate keys.
         """
         raise NotImplementedError
+
+    def stream_bytes(self, keys, chunk_size):
+        """
+        Stream data for objects in the datastore
+
+        Useful for big files that can be read in parts.
+
+        Parameters
+        ----------
+        keys : List[str]
+            Keys to fetch
+        chunk_size : int
+            number of bytes to stream at a time.
+
+        Returns
+        -------
+        CloseAfterUse :
+            An iterator over streamed chunks of (key, file_path, metadata)
+        """
+        raise NotImplementedError


### PR DESCRIPTION
attempts to read logs with a fixed byte offset instead of all at once. Motivation is to decrease memory consumption when handling massive log files.