### PR TITLE
add explicit cleanup() methods in Runners

### DIFF
--- a/metaflow/runner/metaflow_runner.py
+++ b/metaflow/runner/metaflow_runner.py
@@ -428,3 +428,6 @@ class Runner(object):
 
     async def __aexit__(self, exc_type, exc_value, traceback):
         self.spm.cleanup()
+
+    def cleanup(self):
+        self.spm.cleanup()

--- a/metaflow/runner/nbrun.py
+++ b/metaflow/runner/nbrun.py
@@ -97,7 +97,7 @@ class NBRunner(object):
         self.runner.show_output = True
         result = self.runner.run(**kwargs)
         self.runner.show_output = self.old_val_show_output
-        self.runner.spm.cleanup()
+        self.cleanup()
         return result.run
 
     def nbresume(self, **kwargs):
@@ -105,7 +105,7 @@ class NBRunner(object):
         self.runner.show_output = True
         result = self.runner.resume(**kwargs)
         self.runner.show_output = self.old_val_show_output
-        self.runner.spm.cleanup()
+        self.cleanup()
         return result.run
 
     def run(self, **kwargs):
@@ -131,3 +131,7 @@ class NBRunner(object):
         Asynchronously resumes the flow.
         """
         return await self.runner.async_resume(**kwargs)
+
+    def cleanup(self):
+        os.remove(self.tmp_flow_file.name)
+        self.runner.cleanup()


### PR DESCRIPTION
so user can clean up results without context managers