### PR TITLE
[cards] bug fix with error card renders

### DIFF
--- a/metaflow/plugins/cards/card_modules/basic.py
+++ b/metaflow/plugins/cards/card_modules/basic.py
@@ -542,10 +542,23 @@ class ErrorCard(MetaflowCard):
 
     type = "error"
 
+    RELOAD_POLICY = MetaflowCard.RELOAD_POLICY_ONCHANGE
+
     def __init__(self, options={}, components=[], graph=None):
         self._only_repr = True
         self._graph = None if graph is None else transform_flow_graph(graph)
         self._components = components
+
+    def reload_content_token(self, task, data):
+        """
+        The reload token will change when the component array has changed in the Metaflow card.
+        The change in the component array is signified by the change in the component_update_ts.
+        """
+        if task.finished:
+            return "final"
+        # `component_update_ts` will never be None. It is set to a default value when the `ComponentStore` is instantiated
+        # And it is updated when components added / removed / changed from the `ComponentStore`.
+        return "runtime-%s" % (str(data["component_update_ts"]))
 
     def render(self, task, stack_trace=None):
         RENDER_TEMPLATE = read_file(RENDER_TEMPLATE_PATH)


### PR DESCRIPTION
- Error cards didn't contain a reload token replacement because of which the UI keeps trying to poll for new cards.
- This is not the best situation because the UI will keep refreshing the card constantly until the UI catches hold of the card.
- The UI changes will obviously follow for situations where a data update might be published but a card doesn't end up getting saved because of some data store issue; This PR will fix the bug and ensures that if a error card gets created instead of an expected card then the UI still gets the right reload token.