### PR TITLE
fix: decorator attributes being modified in get_environment

### DIFF
--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -218,7 +218,7 @@ class CondaEnvironment(MetaflowEnvironment):
                 disabled = decorator.attributes["disabled"]
                 if not disabled or str(disabled).lower() == "false":
                     environment[decorator.name] = {
-                        k: decorator.attributes[k]
+                        k: copy.deepcopy(decorator.attributes[k])
                         for k in decorator.attributes
                         if k != "disabled"
                     }


### PR DESCRIPTION
use deepcopy for get_environment instead to avoid modifying deco attributes