### PR TITLE
feature: Conda env extension hooks

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -503,20 +503,6 @@ def get_pinned_conda_libs(python_version, datastore_type):
     return pins
 
 
-# List of virtual environments that support @conda/@pypi
-# extensible via extensions
-def conda_supported_virtual_envs():
-    """
-    Returns a list of supported environments that @conda/@pypi use for validation.
-    """
-    # @conda uses a conda environment to create a virtual environment.
-    # The conda environment can be created through micromamba.
-
-    # To placate people who don't want to see a shred of conda in UX, we symlink
-    # --environment=pypi to --environment=conda
-    return ["conda", "pypi"]
-
-
 # Check if there are extensions to Metaflow to load and override everything
 try:
     from metaflow.extension_support import get_modules
@@ -546,15 +532,6 @@ try:
                     return d1
 
                 globals()[n] = _new_get_pinned_conda_libs
-            elif n == "conda_supported_virtual_envs":
-
-                def _new_supported_venvs(f1=globals()[n], f2=o):
-                    a1 = f1()
-                    a2 = f2()
-                    return a1 + a2
-
-                globals()[n] = _new_supported_venvs
-
             elif n == "TOGGLE_DECOSPECS":
                 if any([x.startswith("-") for x in o]):
                     raise ValueError("Removing decospecs is not currently supported")

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -503,6 +503,20 @@ def get_pinned_conda_libs(python_version, datastore_type):
     return pins
 
 
+# List of virtual environments that support @conda/@pypi
+# extensible via extensions
+def conda_supported_virtual_envs():
+    """
+    Returns a list of supported environments that @conda/@pypi use for validation.
+    """
+    # @conda uses a conda environment to create a virtual environment.
+    # The conda environment can be created through micromamba.
+
+    # To placate people who don't want to see a shred of conda in UX, we symlink
+    # --environment=pypi to --environment=conda
+    return ["conda", "pypi"]
+
+
 # Check if there are extensions to Metaflow to load and override everything
 try:
     from metaflow.extension_support import get_modules
@@ -532,6 +546,15 @@ try:
                     return d1
 
                 globals()[n] = _new_get_pinned_conda_libs
+            elif n == "conda_supported_virtual_envs":
+
+                def _new_supported_venvs(f1=globals()[n], f2=o):
+                    a1 = f1()
+                    a2 = f2()
+                    return a1 + a2
+
+                globals()[n] = _new_supported_venvs
+
             elif n == "TOGGLE_DECOSPECS":
                 if any([x.startswith("-") for x in o]):
                     raise ValueError("Removing decospecs is not currently supported")

--- a/metaflow/plugins/pypi/conda_decorator.py
+++ b/metaflow/plugins/pypi/conda_decorator.py
@@ -100,6 +100,10 @@ class CondaStepDecorator(StepDecorator):
         # --environment=pypi to --environment=conda
         _supported_virtual_envs.extend(["pypi"])
 
+        # TODO: Hardcoded for now to support Docker environment.
+        # We should introduce a more robust mechanism for appending supported environments, for example from within extensions.
+        _supported_virtual_envs.extend(["docker"])
+
         # The --environment= requirement ensures that valid virtual environments are
         # created for every step to execute it, greatly simplifying the @conda
         # implementation.
@@ -339,6 +343,10 @@ class CondaFlowDecorator(FlowDecorator):
         # To placate people who don't want to see a shred of conda in UX, we symlink
         # --environment=pypi to --environment=conda
         _supported_virtual_envs.extend(["pypi"])
+
+        # TODO: Hardcoded for now to support Docker environment.
+        # We should introduce a more robust mechanism for appending supported environments, for example from within extensions.
+        _supported_virtual_envs.extend(["docker"])
 
         # The --environment= requirement ensures that valid virtual environments are
         # created for every step to execute it, greatly simplifying the @conda

--- a/metaflow/plugins/pypi/conda_decorator.py
+++ b/metaflow/plugins/pypi/conda_decorator.py
@@ -11,7 +11,6 @@ from metaflow.extension_support import EXT_PKG
 from metaflow.metadata import MetaDatum
 from metaflow.metaflow_environment import InvalidEnvironmentException
 from metaflow.util import get_metaflow_root
-from metaflow.metaflow_config import conda_supported_virtual_envs
 
 from ... import INFO_FILE
 
@@ -95,7 +94,11 @@ class CondaStepDecorator(StepDecorator):
 
         # @conda uses a conda environment to create a virtual environment.
         # The conda environment can be created through micromamba.
-        _supported_virtual_envs = conda_supported_virtual_envs()
+        _supported_virtual_envs = ["conda"]
+
+        # To placate people who don't want to see a shred of conda in UX, we symlink
+        # --environment=pypi to --environment=conda
+        _supported_virtual_envs.extend(["pypi"])
 
         # The --environment= requirement ensures that valid virtual environments are
         # created for every step to execute it, greatly simplifying the @conda
@@ -329,10 +332,17 @@ class CondaFlowDecorator(FlowDecorator):
     def flow_init(
         self, flow, graph, environment, flow_datastore, metadata, logger, echo, options
     ):
+        # @conda uses a conda environment to create a virtual environment.
+        # The conda environment can be created through micromamba.
+        _supported_virtual_envs = ["conda"]
+
+        # To placate people who don't want to see a shred of conda in UX, we symlink
+        # --environment=pypi to --environment=conda
+        _supported_virtual_envs.extend(["pypi"])
+
         # The --environment= requirement ensures that valid virtual environments are
         # created for every step to execute it, greatly simplifying the @conda
         # implementation.
-        _supported_virtual_envs = conda_supported_virtual_envs()
         if environment.TYPE not in _supported_virtual_envs:
             raise InvalidEnvironmentException(
                 "@%s decorator requires %s"

--- a/metaflow/plugins/pypi/conda_decorator.py
+++ b/metaflow/plugins/pypi/conda_decorator.py
@@ -11,6 +11,7 @@ from metaflow.extension_support import EXT_PKG
 from metaflow.metadata import MetaDatum
 from metaflow.metaflow_environment import InvalidEnvironmentException
 from metaflow.util import get_metaflow_root
+from metaflow.metaflow_config import conda_supported_virtual_envs
 
 from ... import INFO_FILE
 
@@ -94,11 +95,7 @@ class CondaStepDecorator(StepDecorator):
 
         # @conda uses a conda environment to create a virtual environment.
         # The conda environment can be created through micromamba.
-        _supported_virtual_envs = ["conda"]
-
-        # To placate people who don't want to see a shred of conda in UX, we symlink
-        # --environment=pypi to --environment=conda
-        _supported_virtual_envs.extend(["pypi"])
+        _supported_virtual_envs = conda_supported_virtual_envs()
 
         # The --environment= requirement ensures that valid virtual environments are
         # created for every step to execute it, greatly simplifying the @conda
@@ -332,17 +329,10 @@ class CondaFlowDecorator(FlowDecorator):
     def flow_init(
         self, flow, graph, environment, flow_datastore, metadata, logger, echo, options
     ):
-        # @conda uses a conda environment to create a virtual environment.
-        # The conda environment can be created through micromamba.
-        _supported_virtual_envs = ["conda"]
-
-        # To placate people who don't want to see a shred of conda in UX, we symlink
-        # --environment=pypi to --environment=conda
-        _supported_virtual_envs.extend(["pypi"])
-
         # The --environment= requirement ensures that valid virtual environments are
         # created for every step to execute it, greatly simplifying the @conda
         # implementation.
+        _supported_virtual_envs = conda_supported_virtual_envs()
         if environment.TYPE not in _supported_virtual_envs:
             raise InvalidEnvironmentException(
                 "@%s decorator requires %s"

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -65,7 +65,7 @@ class CondaEnvironment(MetaflowEnvironment):
         micromamba = Micromamba()
         self.solvers = {"conda": micromamba, "pypi": Pip(micromamba)}
 
-    def init_environment(self, echo, only_steps=[]):
+    def init_environment(self, echo, only_steps=None):
         # The implementation optimizes for latency to ensure as many operations can
         # be turned into cheap no-ops as feasible. Otherwise, we focus on maintaining
         # a balance between latency and maintainability of code without re-implementing

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -65,7 +65,7 @@ class CondaEnvironment(MetaflowEnvironment):
         micromamba = Micromamba()
         self.solvers = {"conda": micromamba, "pypi": Pip(micromamba)}
 
-    def init_environment(self, echo):
+    def init_environment(self, echo, only_steps=[]):
         # The implementation optimizes for latency to ensure as many operations can
         # be turned into cheap no-ops as feasible. Otherwise, we focus on maintaining
         # a balance between latency and maintainability of code without re-implementing
@@ -77,6 +77,8 @@ class CondaEnvironment(MetaflowEnvironment):
         def environments(type_):
             seen = set()
             for step in self.flow:
+                if only_steps and step.name not in only_steps:
+                    continue
                 environment = self.get_environment(step)
                 if type_ in environment and environment["id_"] not in seen:
                     seen.add(environment["id_"])

--- a/metaflow/plugins/pypi/pypi_decorator.py
+++ b/metaflow/plugins/pypi/pypi_decorator.py
@@ -70,6 +70,10 @@ class PyPIStepDecorator(StepDecorator):
         # --environment=pypi to --environment=conda
         _supported_virtual_envs.extend(["pypi"])
 
+        # TODO: Hardcoded for now to support Docker environment.
+        # We should introduce a more robust mechanism for appending supported environments, for example from within extensions.
+        _supported_virtual_envs.extend(["docker"])
+
         # The --environment= requirement ensures that valid virtual environments are
         # created for every step to execute it, greatly simplifying the @pypi
         # implementation.
@@ -118,6 +122,10 @@ class PyPIFlowDecorator(FlowDecorator):
         # To placate people who don't want to see a shred of conda in UX, we symlink
         # --environment=pypi to --environment=conda
         _supported_virtual_envs.extend(["pypi"])
+
+        # TODO: Hardcoded for now to support Docker environment.
+        # We should introduce a more robust mechanism for appending supported environments, for example from within extensions.
+        _supported_virtual_envs.extend(["docker"])
 
         # The --environment= requirement ensures that valid virtual environments are
         # created for every step to execute it, greatly simplifying the @conda

--- a/metaflow/plugins/pypi/pypi_decorator.py
+++ b/metaflow/plugins/pypi/pypi_decorator.py
@@ -1,5 +1,6 @@
 from metaflow.decorators import FlowDecorator, StepDecorator
 from metaflow.metaflow_environment import InvalidEnvironmentException
+from metaflow.metaflow_config import conda_supported_virtual_envs
 
 
 class PyPIStepDecorator(StepDecorator):
@@ -64,11 +65,7 @@ class PyPIStepDecorator(StepDecorator):
         # one here. We can consider introducing a UX where @pypi is able to consume
         # poetry.lock files in the future.
 
-        _supported_virtual_envs = ["conda"]  # , "venv"]
-
-        # To placate people who don't want to see a shred of conda in UX, we symlink
-        # --environment=pypi to --environment=conda
-        _supported_virtual_envs.extend(["pypi"])
+        _supported_virtual_envs = conda_supported_virtual_envs()
 
         # The --environment= requirement ensures that valid virtual environments are
         # created for every step to execute it, greatly simplifying the @pypi
@@ -113,11 +110,7 @@ class PyPIFlowDecorator(FlowDecorator):
 
         # @pypi uses a conda environment to create a virtual environment.
         # The conda environment can be created through micromamba.
-        _supported_virtual_envs = ["conda"]
-
-        # To placate people who don't want to see a shred of conda in UX, we symlink
-        # --environment=pypi to --environment=conda
-        _supported_virtual_envs.extend(["pypi"])
+        _supported_virtual_envs = conda_supported_virtual_envs()
 
         # The --environment= requirement ensures that valid virtual environments are
         # created for every step to execute it, greatly simplifying the @conda

--- a/metaflow/plugins/pypi/pypi_decorator.py
+++ b/metaflow/plugins/pypi/pypi_decorator.py
@@ -1,6 +1,5 @@
 from metaflow.decorators import FlowDecorator, StepDecorator
 from metaflow.metaflow_environment import InvalidEnvironmentException
-from metaflow.metaflow_config import conda_supported_virtual_envs
 
 
 class PyPIStepDecorator(StepDecorator):
@@ -65,7 +64,11 @@ class PyPIStepDecorator(StepDecorator):
         # one here. We can consider introducing a UX where @pypi is able to consume
         # poetry.lock files in the future.
 
-        _supported_virtual_envs = conda_supported_virtual_envs()
+        _supported_virtual_envs = ["conda"]  # , "venv"]
+
+        # To placate people who don't want to see a shred of conda in UX, we symlink
+        # --environment=pypi to --environment=conda
+        _supported_virtual_envs.extend(["pypi"])
 
         # The --environment= requirement ensures that valid virtual environments are
         # created for every step to execute it, greatly simplifying the @pypi
@@ -110,7 +113,11 @@ class PyPIFlowDecorator(FlowDecorator):
 
         # @pypi uses a conda environment to create a virtual environment.
         # The conda environment can be created through micromamba.
-        _supported_virtual_envs = conda_supported_virtual_envs()
+        _supported_virtual_envs = ["conda"]
+
+        # To placate people who don't want to see a shred of conda in UX, we symlink
+        # --environment=pypi to --environment=conda
+        _supported_virtual_envs.extend(["pypi"])
 
         # The --environment= requirement ensures that valid virtual environments are
         # created for every step to execute it, greatly simplifying the @conda


### PR DESCRIPTION
We need some additional extension capabilities to be able to implement #1796 as an extension, these being:

- add 'docker' to list of supported environments for `@conda` and `@pypi`
- ability to **fallback** to the core Conda environment initialization for a subset of steps only.



Note: the changes to `conda_environment.py` would at the moment result in any plugin relying on the new `only_steps=` to break with the bleeding edge nflx-extension conda implementation