### PR TITLE
remove old py versions for s3 tests

### DIFF
--- a/.github/workflows/metaflow.s3_tests.yml
+++ b/.github/workflows/metaflow.s3_tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        ver: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11',]
+        ver: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0


### PR DESCRIPTION
py < 3.8 is no longer available on stock GHA for MacOS