### PR TITLE
[refactor-jobsets] refactor to new implementation

### DIFF
--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -1,9 +1,9 @@
+import copy
 import json
 import math
 import os
 import re
 import shlex
-import copy
 import time
 from typing import Dict, List, Optional
 from uuid import uuid4
@@ -14,10 +14,11 @@ from metaflow.metaflow_config import (
     ARGO_EVENTS_EVENT,
     ARGO_EVENTS_EVENT_BUS,
     ARGO_EVENTS_EVENT_SOURCE,
-    ARGO_EVENTS_SERVICE_ACCOUNT,
     ARGO_EVENTS_INTERNAL_WEBHOOK_URL,
-    AWS_SECRETS_MANAGER_DEFAULT_REGION,
+    ARGO_EVENTS_SERVICE_ACCOUNT,
     ARGO_EVENTS_WEBHOOK_AUTH,
+    AWS_SECRETS_MANAGER_DEFAULT_REGION,
+    AZURE_KEY_VAULT_PREFIX,
     AZURE_STORAGE_BLOB_SERVICE_ENDPOINT,
     CARD_AZUREROOT,
     CARD_GSROOT,
@@ -31,18 +32,18 @@ from metaflow.metaflow_config import (
     DEFAULT_METADATA,
     DEFAULT_SECRETS_BACKEND_TYPE,
     GCP_SECRET_MANAGER_PREFIX,
-    AZURE_KEY_VAULT_PREFIX,
     KUBERNETES_FETCH_EC2_METADATA,
     KUBERNETES_LABELS,
     KUBERNETES_SANDBOX_INIT_SCRIPT,
-    S3_ENDPOINT_URL,
-    SERVICE_HEADERS,
-    SERVICE_INTERNAL_URL,
-    S3_SERVER_SIDE_ENCRYPTION,
     OTEL_ENDPOINT,
+    S3_ENDPOINT_URL,
+    S3_SERVER_SIDE_ENCRYPTION,
+    SERVICE_HEADERS,
+    KUBERNETES_SECRETS,
+    SERVICE_INTERNAL_URL,
 )
+from metaflow.unbounded_foreach import UBF_CONTROL, UBF_TASK
 from metaflow.metaflow_config_funcs import config_values
-
 from metaflow.mflog import (
     BASH_SAVE_LOGS,
     bash_capture_logs,
@@ -60,6 +61,10 @@ STDERR_FILE = "mflog_stderr"
 STDOUT_PATH = os.path.join(LOGS_DIR, STDOUT_FILE)
 STDERR_PATH = os.path.join(LOGS_DIR, STDERR_FILE)
 
+METAFLOW_PARALLEL_STEP_CLI_OPTIONS_TEMPLATE = (
+    "{METAFLOW_PARALLEL_STEP_CLI_OPTIONS_TEMPLATE}"
+)
+
 
 class KubernetesException(MetaflowException):
     headline = "Kubernetes error"
@@ -67,12 +72,6 @@ class KubernetesException(MetaflowException):
 
 class KubernetesKilledException(MetaflowException):
     headline = "Kubernetes Batch job killed"
-
-
-def _extract_labels_and_annotations_from_job_spec(job_spec):
-    annotations = job_spec.template.metadata.annotations
-    labels = job_spec.template.metadata.labels
-    return copy.copy(annotations), copy.copy(labels)
 
 
 class Kubernetes(object):
@@ -154,57 +153,286 @@ class Kubernetes(object):
             and kwargs["num_parallel"]
             and int(kwargs["num_parallel"]) > 0
         ):
-            job = self.create_job_object(**kwargs)
-            spec = job.create_job_spec()
-            # `kwargs["step_cli"]` is setting `ubf_context` as control to ALL pods.
-            # This will be modified by the KubernetesJobSet object
-            annotations, labels = _extract_labels_and_annotations_from_job_spec(spec)
-            self._job = self.create_jobset(
-                job_spec=spec,
-                run_id=kwargs["run_id"],
-                step_name=kwargs["step_name"],
-                task_id=kwargs["task_id"],
-                namespace=kwargs["namespace"],
-                env=kwargs["env"],
-                num_parallel=kwargs["num_parallel"],
-                port=kwargs["port"],
-                annotations=annotations,
-                labels=labels,
-            ).execute()
+            self._job = self.create_jobset(**kwargs).execute()
         else:
             kwargs["name_pattern"] = "t-{uid}-".format(uid=str(uuid4())[:8])
             self._job = self.create_job_object(**kwargs).create().execute()
 
     def create_jobset(
         self,
-        job_spec=None,
-        run_id=None,
-        step_name=None,
-        task_id=None,
+        flow_name,
+        run_id,
+        step_name,
+        task_id,
+        attempt,
+        user,
+        code_package_sha,
+        code_package_url,
+        code_package_ds,
+        docker_image,
+        docker_image_pull_policy,
+        step_cli=None,
+        service_account=None,
+        secrets=None,
+        node_selector=None,
         namespace=None,
+        cpu=None,
+        gpu=None,
+        gpu_vendor=None,
+        disk=None,
+        memory=None,
+        use_tmpfs=None,
+        tmpfs_tempdir=None,
+        tmpfs_size=None,
+        tmpfs_path=None,
+        run_time_limit=None,
         env=None,
-        num_parallel=None,
-        port=None,
-        annotations=None,
+        persistent_volume_claims=None,
+        tolerations=None,
         labels=None,
+        shared_memory=None,
+        port=None,
+        num_parallel=None,
     ):
-        if env is None:
-            env = {}
-
-        _prefix = str(uuid4())[:6]
-        js = KubernetesClient().jobset(
-            name="js-%s" % _prefix,
-            run_id=run_id,
-            task_id=task_id,
-            step_name=step_name,
-            namespace=namespace,
-            labels=self._get_labels(labels),
-            annotations=annotations,
-            num_parallel=num_parallel,
-            job_spec=job_spec,
-            port=port,
+        name = "js-%s" % str(uuid4())[:6]
+        jobset = (
+            KubernetesClient()
+            .jobset(
+                name=name,
+                namespace=namespace,
+                service_account=service_account,
+                node_selector=node_selector,
+                image=docker_image,
+                image_pull_policy=docker_image_pull_policy,
+                cpu=cpu,
+                memory=memory,
+                disk=disk,
+                gpu=gpu,
+                gpu_vendor=gpu_vendor,
+                timeout_in_seconds=run_time_limit,
+                # Retries are handled by Metaflow runtime
+                retries=0,
+                step_name=step_name,
+                # We set the jobset name as the subdomain.
+                # todo: [final-refactor] ask @shri what was the motive when we did initial implementation
+                subdomain=name,
+                tolerations=tolerations,
+                use_tmpfs=use_tmpfs,
+                tmpfs_tempdir=tmpfs_tempdir,
+                tmpfs_size=tmpfs_size,
+                tmpfs_path=tmpfs_path,
+                persistent_volume_claims=persistent_volume_claims,
+                shared_memory=shared_memory,
+                port=port,
+                num_parallel=num_parallel,
+            )
+            .environment_variable("METAFLOW_CODE_SHA", code_package_sha)
+            .environment_variable("METAFLOW_CODE_URL", code_package_url)
+            .environment_variable("METAFLOW_CODE_DS", code_package_ds)
+            .environment_variable("METAFLOW_USER", user)
+            .environment_variable("METAFLOW_SERVICE_URL", SERVICE_INTERNAL_URL)
+            .environment_variable(
+                "METAFLOW_SERVICE_HEADERS",
+                json.dumps(SERVICE_HEADERS),
+            )
+            .environment_variable("METAFLOW_DATASTORE_SYSROOT_S3", DATASTORE_SYSROOT_S3)
+            .environment_variable("METAFLOW_DATATOOLS_S3ROOT", DATATOOLS_S3ROOT)
+            .environment_variable("METAFLOW_DEFAULT_DATASTORE", self._datastore.TYPE)
+            .environment_variable("METAFLOW_DEFAULT_METADATA", DEFAULT_METADATA)
+            .environment_variable("METAFLOW_KUBERNETES_WORKLOAD", 1)
+            .environment_variable(
+                "METAFLOW_KUBERNETES_FETCH_EC2_METADATA", KUBERNETES_FETCH_EC2_METADATA
+            )
+            .environment_variable("METAFLOW_RUNTIME_ENVIRONMENT", "kubernetes")
+            .environment_variable(
+                "METAFLOW_DEFAULT_SECRETS_BACKEND_TYPE", DEFAULT_SECRETS_BACKEND_TYPE
+            )
+            .environment_variable("METAFLOW_CARD_S3ROOT", CARD_S3ROOT)
+            .environment_variable(
+                "METAFLOW_DEFAULT_AWS_CLIENT_PROVIDER", DEFAULT_AWS_CLIENT_PROVIDER
+            )
+            .environment_variable(
+                "METAFLOW_DEFAULT_GCP_CLIENT_PROVIDER", DEFAULT_GCP_CLIENT_PROVIDER
+            )
+            .environment_variable(
+                "METAFLOW_AWS_SECRETS_MANAGER_DEFAULT_REGION",
+                AWS_SECRETS_MANAGER_DEFAULT_REGION,
+            )
+            .environment_variable(
+                "METAFLOW_GCP_SECRET_MANAGER_PREFIX", GCP_SECRET_MANAGER_PREFIX
+            )
+            .environment_variable(
+                "METAFLOW_AZURE_KEY_VAULT_PREFIX", AZURE_KEY_VAULT_PREFIX
+            )
+            .environment_variable("METAFLOW_S3_ENDPOINT_URL", S3_ENDPOINT_URL)
+            .environment_variable(
+                "METAFLOW_AZURE_STORAGE_BLOB_SERVICE_ENDPOINT",
+                AZURE_STORAGE_BLOB_SERVICE_ENDPOINT,
+            )
+            .environment_variable(
+                "METAFLOW_DATASTORE_SYSROOT_AZURE", DATASTORE_SYSROOT_AZURE
+            )
+            .environment_variable("METAFLOW_CARD_AZUREROOT", CARD_AZUREROOT)
+            .environment_variable("METAFLOW_DATASTORE_SYSROOT_GS", DATASTORE_SYSROOT_GS)
+            .environment_variable("METAFLOW_CARD_GSROOT", CARD_GSROOT)
+            # support Metaflow sandboxes
+            .environment_variable(
+                "METAFLOW_INIT_SCRIPT", KUBERNETES_SANDBOX_INIT_SCRIPT
+            )
+            .environment_variable("METAFLOW_OTEL_ENDPOINT", OTEL_ENDPOINT)
+            # Skip setting METAFLOW_DATASTORE_SYSROOT_LOCAL because metadata sync
+            # between the local user instance and the remote Kubernetes pod
+            # assumes metadata is stored in DATASTORE_LOCAL_DIR on the Kubernetes
+            # pod; this happens when METAFLOW_DATASTORE_SYSROOT_LOCAL is NOT set (
+            # see get_datastore_root_from_config in datastore/local.py).
         )
-        return js
+
+        _labels = self._get_labels(labels)
+        for k, v in _labels.items():
+            jobset.label(k, v)
+
+        for k in list(
+            [] if not secrets else [secrets] if isinstance(secrets, str) else secrets
+        ) + KUBERNETES_SECRETS.split(","):
+            jobset.secret(k)
+
+        jobset.environment_variables_from_selectors(
+            {
+                "METAFLOW_KUBERNETES_POD_NAMESPACE": "metadata.namespace",
+                "METAFLOW_KUBERNETES_POD_NAME": "metadata.name",
+                "METAFLOW_KUBERNETES_POD_ID": "metadata.uid",
+                "METAFLOW_KUBERNETES_SERVICE_ACCOUNT_NAME": "spec.serviceAccountName",
+                "METAFLOW_KUBERNETES_NODE_IP": "status.hostIP",
+            }
+        )
+
+        # Temporary passing of *some* environment variables. Do not rely on this
+        # mechanism as it will be removed in the near future
+        for k, v in config_values():
+            if k.startswith("METAFLOW_CONDA_") or k.startswith("METAFLOW_DEBUG_"):
+                jobset.environment_variable(k, v)
+
+        if S3_SERVER_SIDE_ENCRYPTION is not None:
+            jobset.environment_variable(
+                "METAFLOW_S3_SERVER_SIDE_ENCRYPTION", S3_SERVER_SIDE_ENCRYPTION
+            )
+
+        # Set environment variables to support metaflow.integrations.ArgoEvent
+        jobset.environment_variable(
+            "METAFLOW_ARGO_EVENTS_WEBHOOK_URL", ARGO_EVENTS_INTERNAL_WEBHOOK_URL
+        )
+        jobset.environment_variable("METAFLOW_ARGO_EVENTS_EVENT", ARGO_EVENTS_EVENT)
+        jobset.environment_variable(
+            "METAFLOW_ARGO_EVENTS_EVENT_BUS", ARGO_EVENTS_EVENT_BUS
+        )
+        jobset.environment_variable(
+            "METAFLOW_ARGO_EVENTS_EVENT_SOURCE", ARGO_EVENTS_EVENT_SOURCE
+        )
+        jobset.environment_variable(
+            "METAFLOW_ARGO_EVENTS_SERVICE_ACCOUNT", ARGO_EVENTS_SERVICE_ACCOUNT
+        )
+        jobset.environment_variable(
+            "METAFLOW_ARGO_EVENTS_WEBHOOK_AUTH",
+            ARGO_EVENTS_WEBHOOK_AUTH,
+        )
+
+        ## -----Jobset specific env vars START here-----
+        jobset.environment_variable("MF_MASTER_ADDR", jobset.jobset_control_addr)
+        jobset.environment_variable("MF_MASTER_PORT", str(port))
+        jobset.environment_variable("MF_WORLD_SIZE", str(num_parallel))
+        jobset.environment_variable_from_selector(
+            "JOBSET_RESTART_ATTEMPT",
+            "metadata.annotations['jobset.sigs.k8s.io/restart-attempt']",
+        )
+        jobset.environment_variable_from_selector(
+            "METAFLOW_KUBERNETES_JOBSET_NAME",
+            "metadata.annotations['jobset.sigs.k8s.io/jobset-name']",
+        )
+        jobset.environment_variable_from_selector(
+            "MF_WORKER_REPLICA_INDEX",
+            "metadata.annotations['jobset.sigs.k8s.io/job-index']",
+        )
+        ## -----Jobset specific env vars END here-----
+
+        tmpfs_enabled = use_tmpfs or (tmpfs_size and not use_tmpfs)
+        if tmpfs_enabled and tmpfs_tempdir:
+            jobset.environment_variable("METAFLOW_TEMPDIR", tmpfs_path)
+
+        for name, value in env.items():
+            jobset.environment_variable(name, value)
+
+        annotations = {
+            "metaflow/user": user,
+            "metaflow/flow_name": flow_name,
+            "metaflow/control-task-id": task_id,
+        }
+        if current.get("project_name"):
+            annotations.update(
+                {
+                    "metaflow/project_name": current.project_name,
+                    "metaflow/branch_name": current.branch_name,
+                    "metaflow/project_flow_name": current.project_flow_name,
+                }
+            )
+
+        for name, value in annotations.items():
+            jobset.annotation(name, value)
+
+        (
+            jobset.annotation("metaflow/run_id", run_id)
+            .annotation("metaflow/step_name", step_name)
+            .annotation("metaflow/attempt", attempt)
+            .label("app.kubernetes.io/name", "metaflow-task")
+            .label("app.kubernetes.io/part-of", "metaflow")
+        )
+
+        ## ----------- control/worker specific values START here -----------
+        # We will now set the appropriate command for the control/worker job
+        _get_command = lambda index, _tskid: self._command(
+            flow_name=flow_name,
+            run_id=run_id,
+            step_name=step_name,
+            task_id=_tskid,
+            attempt=attempt,
+            code_package_url=code_package_url,
+            step_cmds=[
+                step_cli.replace(
+                    METAFLOW_PARALLEL_STEP_CLI_OPTIONS_TEMPLATE,
+                    "--ubf-context $UBF_CONTEXT --split-index %s --task-id %s"
+                    % (index, _tskid),
+                )
+            ],
+        )
+        jobset.control.replicas(1)
+        jobset.worker.replicas(num_parallel - 1)
+
+        # We set the appropriate command for the control/worker job
+        # and also set the task-id/spit-index for the control/worker job
+        # appropirately.
+        jobset.control.command(_get_command("0", str(task_id)))
+        jobset.worker.command(
+            _get_command(
+                "`expr $[MF_WORKER_REPLICA_INDEX] + 1`",
+                "-".join(
+                    [
+                        str(task_id),
+                        "worker",
+                        "$MF_WORKER_REPLICA_INDEX",
+                    ]
+                ),
+            )
+        )
+
+        jobset.control.environment_variable("UBF_CONTEXT", UBF_CONTROL)
+        jobset.worker.environment_variable("UBF_CONTEXT", UBF_TASK)
+        # Every control job requires an environment variable of MF_CONTROL_INDEX
+        # set to 0 so that we can derive the MF_PARALLEL_NODE_INDEX correctly.
+        # Since only the control job has MF_CONTROL_INDE set to 0, all worker nodes
+        # will use MF_WORKER_REPLICA_INDEX
+        jobset.control.environment_variable("MF_CONTROL_INDEX", "0")
+        ## ----------- control/worker specific values END here -----------
+
+        return jobset
 
     def create_job_object(
         self,
@@ -241,7 +469,6 @@ class Kubernetes(object):
         shared_memory=None,
         port=None,
         name_pattern=None,
-        num_parallel=None,
     ):
         if env is None:
             env = {}
@@ -282,7 +509,6 @@ class Kubernetes(object):
                 persistent_volume_claims=persistent_volume_claims,
                 shared_memory=shared_memory,
                 port=port,
-                num_parallel=num_parallel,
             )
             .environment_variable("METAFLOW_CODE_SHA", code_package_sha)
             .environment_variable("METAFLOW_CODE_URL", code_package_url)

--- a/metaflow/plugins/kubernetes/kubernetes_client.py
+++ b/metaflow/plugins/kubernetes/kubernetes_client.py
@@ -6,7 +6,6 @@ from metaflow.exception import MetaflowException
 
 from .kubernetes_job import KubernetesJob, KubernetesJobSet
 
-
 CLIENT_REFRESH_INTERVAL_SECONDS = 300
 
 

--- a/metaflow/plugins/kubernetes/kubernetes_job.py
+++ b/metaflow/plugins/kubernetes/kubernetes_job.py
@@ -1,18 +1,19 @@
+import copy
 import json
 import math
 import random
-import time
-import copy
 import sys
-from metaflow.tracing import inject_tracing_vars
+import time
+
 from metaflow.exception import MetaflowException
 from metaflow.metaflow_config import KUBERNETES_SECRETS
+from metaflow.tracing import inject_tracing_vars
 from metaflow.unbounded_foreach import UBF_CONTROL, UBF_TASK
 
 CLIENT_REFRESH_INTERVAL_SECONDS = 300
 from .kubernetes_jobsets import (
-    KubernetesJobSet,  # We need this import for Kubernetes Client.
-)
+    KubernetesJobSet,
+)  # We need this import for Kubernetes Client.
 
 
 class KubernetesJobException(MetaflowException):
@@ -366,7 +367,6 @@ class KubernetesJob(object):
 
 
 class RunningJob(object):
-
     # State Machine implementation for the lifecycle behavior documented in
     # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
     #

--- a/metaflow/plugins/kubernetes/kubernetes_jobsets.py
+++ b/metaflow/plugins/kubernetes/kubernetes_jobsets.py
@@ -1,13 +1,16 @@
 import copy
+import json
 import math
 import random
 import time
-from metaflow.metaflow_current import current
-from metaflow.exception import MetaflowException
-from metaflow.unbounded_foreach import UBF_CONTROL, UBF_TASK
-import json
-from metaflow.metaflow_config import KUBERNETES_JOBSET_GROUP, KUBERNETES_JOBSET_VERSION
 from collections import namedtuple
+
+from metaflow.exception import MetaflowException
+from metaflow.metaflow_config import KUBERNETES_JOBSET_GROUP, KUBERNETES_JOBSET_VERSION
+from metaflow.metaflow_current import current
+from metaflow.unbounded_foreach import UBF_CONTROL, UBF_TASK
+from metaflow.tracing import inject_tracing_vars
+from metaflow.metaflow_config import KUBERNETES_SECRETS
 
 
 class KubernetesJobsetException(MetaflowException):
@@ -50,6 +53,8 @@ def k8s_retry(deadline_seconds=60, max_backoff=32):
 
     return decorator
 
+
+CONTROL_JOB_NAME = "control"
 
 JobsetStatus = namedtuple(
     "JobsetStatus",
@@ -323,18 +328,18 @@ class RunningJobSet(object):
         with client.ApiClient() as api_client:
             api_instance = client.CustomObjectsApi(api_client)
             try:
-                jobset = api_instance.get_namespaced_custom_object(
+                obj = api_instance.get_namespaced_custom_object(
                     group=self._group,
                     version=self._version,
                     namespace=self._namespace,
-                    plural="jobsets",
+                    plural=plural,
                     name=self._name,
                 )
 
                 # Suspend the jobset and set the replica's to Zero.
                 #
-                jobset["spec"]["suspend"] = True
-                for replicated_job in jobset["spec"]["replicatedJobs"]:
+                obj["spec"]["suspend"] = True
+                for replicated_job in obj["spec"]["replicatedJobs"]:
                     replicated_job["replicas"] = 0
 
                 api_instance.replace_namespaced_custom_object(
@@ -342,8 +347,8 @@ class RunningJobSet(object):
                     version=self._version,
                     namespace=self._namespace,
                     plural=plural,
-                    name=jobset["metadata"]["name"],
-                    body=jobset,
+                    name=obj["metadata"]["name"],
+                    body=obj,
                 )
             except Exception as e:
                 raise KubernetesJobsetException(
@@ -448,203 +453,6 @@ class RunningJobSet(object):
         ).jobset_failed
 
 
-class TaskIdConstructor:
-    @classmethod
-    def jobset_worker_id(cls, control_task_id: str):
-        return "".join(
-            [control_task_id.replace("control", "worker"), "-", "$WORKER_REPLICA_INDEX"]
-        )
-
-    @classmethod
-    def join_step_task_ids(cls, num_parallel):
-        """
-        Called within the step decorator to set the `flow._control_mapper_tasks`.
-        Setting these allows the flow to know which tasks are needed in the join step.
-        We set this in the `task_pre_step` method of the decorator.
-        """
-        control_task_id = current.task_id
-        worker_task_id_base = control_task_id.replace("control", "worker")
-        mapper = lambda idx: worker_task_id_base + "-%s" % (str(idx))
-        return control_task_id, [mapper(idx) for idx in range(0, num_parallel - 1)]
-
-    @classmethod
-    def argo(cls):
-        pass
-
-
-def _jobset_specific_env_vars(client, jobset_main_addr, master_port, num_parallel):
-    return [
-        client.V1EnvVar(
-            name="MASTER_ADDR",
-            value=jobset_main_addr,
-        ),
-        client.V1EnvVar(
-            name="MASTER_PORT",
-            value=str(master_port),
-        ),
-        client.V1EnvVar(
-            name="WORLD_SIZE",
-            value=str(num_parallel),
-        ),
-    ] + [
-        client.V1EnvVar(
-            name="JOBSET_RESTART_ATTEMPT",
-            value_from=client.V1EnvVarSource(
-                field_ref=client.V1ObjectFieldSelector(
-                    field_path="metadata.annotations['jobset.sigs.k8s.io/restart-attempt']"
-                )
-            ),
-        ),
-        client.V1EnvVar(
-            name="METAFLOW_KUBERNETES_JOBSET_NAME",
-            value_from=client.V1EnvVarSource(
-                field_ref=client.V1ObjectFieldSelector(
-                    field_path="metadata.annotations['jobset.sigs.k8s.io/jobset-name']"
-                )
-            ),
-        ),
-        client.V1EnvVar(
-            name="WORKER_REPLICA_INDEX",
-            value_from=client.V1EnvVarSource(
-                field_ref=client.V1ObjectFieldSelector(
-                    field_path="metadata.annotations['jobset.sigs.k8s.io/job-index']"
-                )
-            ),
-        ),
-    ]
-
-
-def get_control_job(
-    client,
-    job_spec,
-    jobset_main_addr,
-    subdomain,
-    port=None,
-    num_parallel=None,
-    namespace=None,
-    annotations=None,
-) -> dict:
-    master_port = port
-
-    job_spec = copy.deepcopy(job_spec)
-    job_spec.parallelism = 1
-    job_spec.completions = 1
-    job_spec.template.spec.set_hostname_as_fqdn = True
-    job_spec.template.spec.subdomain = subdomain
-    job_spec.template.metadata.annotations = copy.copy(annotations)
-
-    for idx in range(len(job_spec.template.spec.containers[0].command)):
-        # CHECK FOR THE ubf_context in the command.
-        # Replace the UBF context to the one appropriately matching control/worker.
-        # Since we are passing the `step_cli` one time from the top level to one
-        # KuberentesJobSet, we need to ensure that UBF context is replaced properly
-        # in all the worker jobs.
-        if UBF_CONTROL in job_spec.template.spec.containers[0].command[idx]:
-            job_spec.template.spec.containers[0].command[idx] = (
-                job_spec.template.spec.containers[0]
-                .command[idx]
-                .replace(UBF_CONTROL, UBF_CONTROL + " " + "--split-index 0")
-            )
-
-    job_spec.template.spec.containers[0].env = (
-        job_spec.template.spec.containers[0].env
-        + _jobset_specific_env_vars(client, jobset_main_addr, master_port, num_parallel)
-        + [
-            client.V1EnvVar(
-                name="CONTROL_INDEX",
-                value=str(0),
-            )
-        ]
-    )
-
-    # Based on https://github.com/kubernetes-sigs/jobset/blob/v0.5.0/api/jobset/v1alpha2/jobset_types.go#L178
-    return dict(
-        name="control",
-        template=client.api_client.ApiClient().sanitize_for_serialization(
-            client.V1JobTemplateSpec(
-                metadata=client.V1ObjectMeta(
-                    namespace=namespace,
-                    # We don't set any annotations here
-                    # since they have been either set in the JobSpec
-                    # or on the JobSet level
-                ),
-                spec=job_spec,
-            )
-        ),
-        replicas=1,  # The control job will always have 1 replica.
-    )
-
-
-def get_worker_job(
-    client,
-    job_spec,
-    job_name,
-    jobset_main_addr,
-    subdomain,
-    control_task_id=None,
-    worker_task_id=None,
-    replicas=1,
-    port=None,
-    num_parallel=None,
-    namespace=None,
-    annotations=None,
-) -> dict:
-    master_port = port
-
-    job_spec = copy.deepcopy(job_spec)
-    job_spec.parallelism = 1
-    job_spec.completions = 1
-    job_spec.template.spec.set_hostname_as_fqdn = True
-    job_spec.template.spec.subdomain = subdomain
-    job_spec.template.metadata.annotations = copy.copy(annotations)
-
-    for idx in range(len(job_spec.template.spec.containers[0].command)):
-        if control_task_id in job_spec.template.spec.containers[0].command[idx]:
-            job_spec.template.spec.containers[0].command[idx] = (
-                job_spec.template.spec.containers[0]
-                .command[idx]
-                .replace(control_task_id, worker_task_id)
-            )
-        # CHECK FOR THE ubf_context in the command.
-        # Replace the UBF context to the one appropriately matching control/worker.
-        # Since we are passing the `step_cli` one time from the top level to one
-        # KuberentesJobSet, we need to ensure that UBF context is replaced properly
-        # in all the worker jobs.
-        if UBF_CONTROL in job_spec.template.spec.containers[0].command[idx]:
-            # Since all command will have a UBF_CONTROL, we need to replace the UBF_CONTROL
-            # with the actual UBF Context and also ensure that we are setting the correct
-            # split-index for the worker jobs.
-            split_index_str = "--split-index `expr $[WORKER_REPLICA_INDEX] + 1`"  # This set in the environment variables below
-            job_spec.template.spec.containers[0].command[idx] = (
-                job_spec.template.spec.containers[0]
-                .command[idx]
-                .replace(UBF_CONTROL, UBF_TASK + " " + split_index_str)
-            )
-
-    job_spec.template.spec.containers[0].env = job_spec.template.spec.containers[
-        0
-    ].env + _jobset_specific_env_vars(
-        client, jobset_main_addr, master_port, num_parallel
-    )
-
-    # Based on https://github.com/kubernetes-sigs/jobset/blob/v0.5.0/api/jobset/v1alpha2/jobset_types.go#L178
-    return dict(
-        name=job_name,
-        template=client.api_client.ApiClient().sanitize_for_serialization(
-            client.V1JobTemplateSpec(
-                metadata=client.V1ObjectMeta(
-                    namespace=namespace,
-                    # We don't set any annotations here
-                    # since they have been either set in the JobSpec
-                    # or on the JobSet level
-                ),
-                spec=job_spec,
-            )
-        ),
-        replicas=replicas,
-    )
-
-
 def _make_domain_name(
     jobset_name, main_job_name, main_job_index, main_pod_index, namespace
 ):
@@ -658,97 +466,413 @@ def _make_domain_name(
     )
 
 
-class KubernetesJobSet(object):
+class JobSetSpec(object):
+    def __init__(self, kubernetes_sdk, name, **kwargs):
+        self._kubernetes_sdk = kubernetes_sdk
+        self._kwargs = kwargs
+        self.name = name
+
+    def replicas(self, replicas):
+        self._kwargs["replicas"] = replicas
+        return self
+
+    def step_name(self, step_name):
+        self._kwargs["step_name"] = step_name
+        return self
+
+    def namespace(self, namespace):
+        self._kwargs["namespace"] = namespace
+        return self
+
+    def command(self, command):
+        self._kwargs["command"] = command
+        return self
+
+    def image(self, image):
+        self._kwargs["image"] = image
+        return self
+
+    def cpu(self, cpu):
+        self._kwargs["cpu"] = cpu
+        return self
+
+    def memory(self, mem):
+        self._kwargs["memory"] = mem
+        return self
+
+    def environment_variable(self, name, value):
+        # Never set to None
+        if value is None:
+            return self
+        self._kwargs["environment_variables"] = dict(
+            self._kwargs.get("environment_variables", {}), **{name: value}
+        )
+        return self
+
+    def secret(self, name):
+        if name is None:
+            return self
+        if len(self._kwargs.get("secrets", [])) == 0:
+            self._kwargs["secrets"] = []
+        self._kwargs["secrets"] = list(set(self._kwargs["secrets"] + [name]))
+
+    def environment_variable_from_selector(self, name, label_value):
+        # Never set to None
+        if label_value is None:
+            return self
+        self._kwargs["environment_variables_from_selectors"] = dict(
+            self._kwargs.get("environment_variables_from_selectors", {}),
+            **{name: label_value}
+        )
+        return self
+
+    def label(self, name, value):
+        self._kwargs["labels"] = dict(self._kwargs.get("labels", {}), **{name: value})
+        return self
+
+    def annotation(self, name, value):
+        self._kwargs["annotations"] = dict(
+            self._kwargs.get("annotations", {}), **{name: value}
+        )
+        return self
+
+    def dump(self):
+        client = self._kubernetes_sdk
+        use_tmpfs = self._kwargs["use_tmpfs"]
+        tmpfs_size = self._kwargs["tmpfs_size"]
+        tmpfs_enabled = use_tmpfs or (tmpfs_size and not use_tmpfs)
+        shared_memory = (
+            int(self._kwargs["shared_memory"])
+            if self._kwargs["shared_memory"]
+            else None
+        )
+
+        return dict(
+            name=self.name,
+            template=client.api_client.ApiClient().sanitize_for_serialization(
+                client.V1JobTemplateSpec(
+                    metadata=client.V1ObjectMeta(
+                        namespace=self._kwargs["namespace"],
+                        # We don't set any annotations here
+                        # since they have been either set in the JobSpec
+                        # or on the JobSet level
+                    ),
+                    spec=client.V1JobSpec(
+                        # Retries are handled by Metaflow when it is responsible for
+                        # executing the flow. The responsibility is moved to Kubernetes
+                        # when Argo Workflows is responsible for the execution.
+                        backoff_limit=self._kwargs.get("retries", 0),
+                        completions=1,
+                        parallelism=1,
+                        ttl_seconds_after_finished=7
+                        * 60
+                        * 60  # Remove job after a week. TODO: Make this configurable
+                        * 24,
+                        template=client.V1PodTemplateSpec(
+                            metadata=client.V1ObjectMeta(
+                                annotations=self._kwargs.get("annotations", {}),
+                                labels=self._kwargs.get("labels", {}),
+                                namespace=self._kwargs["namespace"],
+                            ),
+                            spec=client.V1PodSpec(
+                                ##  --- jobset require podspec deets start----
+                                subdomain=self._kwargs["subdomain"],
+                                set_hostname_as_fqdn=True,
+                                ##  --- jobset require podspec deets end ----
+                                # Timeout is set on the pod and not the job (important!)
+                                active_deadline_seconds=self._kwargs[
+                                    "timeout_in_seconds"
+                                ],
+                                # TODO (savin): Enable affinities for GPU scheduling.
+                                # affinity=?,
+                                containers=[
+                                    client.V1Container(
+                                        command=self._kwargs["command"],
+                                        ports=[]
+                                        if self._kwargs["port"] is None
+                                        else [
+                                            client.V1ContainerPort(
+                                                container_port=int(self._kwargs["port"])
+                                            )
+                                        ],
+                                        env=[
+                                            client.V1EnvVar(name=k, value=str(v))
+                                            for k, v in self._kwargs.get(
+                                                "environment_variables", {}
+                                            ).items()
+                                        ]
+                                        # And some downward API magic. Add (key, value)
+                                        # pairs below to make pod metadata available
+                                        # within Kubernetes container.
+                                        + [
+                                            client.V1EnvVar(
+                                                name=k,
+                                                value_from=client.V1EnvVarSource(
+                                                    field_ref=client.V1ObjectFieldSelector(
+                                                        field_path=str(v)
+                                                    )
+                                                ),
+                                            )
+                                            for k, v in self._kwargs.get(
+                                                "environment_variables_from_selectors",
+                                                {},
+                                            ).items()
+                                        ]
+                                        + [
+                                            client.V1EnvVar(name=k, value=str(v))
+                                            for k, v in inject_tracing_vars({}).items()
+                                        ],
+                                        env_from=[
+                                            client.V1EnvFromSource(
+                                                secret_ref=client.V1SecretEnvSource(
+                                                    name=str(k),
+                                                    # optional=True
+                                                )
+                                            )
+                                            for k in list(
+                                                self._kwargs.get("secrets", [])
+                                            )
+                                            if k
+                                        ],
+                                        image=self._kwargs["image"],
+                                        image_pull_policy=self._kwargs[
+                                            "image_pull_policy"
+                                        ],
+                                        name=self._kwargs["step_name"].replace(
+                                            "_", "-"
+                                        ),
+                                        resources=client.V1ResourceRequirements(
+                                            requests={
+                                                "cpu": str(self._kwargs["cpu"]),
+                                                "memory": "%sM"
+                                                % str(self._kwargs["memory"]),
+                                                "ephemeral-storage": "%sM"
+                                                % str(self._kwargs["disk"]),
+                                            },
+                                            limits={
+                                                "%s.com/gpu".lower()
+                                                % self._kwargs["gpu_vendor"]: str(
+                                                    self._kwargs["gpu"]
+                                                )
+                                                for k in [0]
+                                                # Don't set GPU limits if gpu isn't specified.
+                                                if self._kwargs["gpu"] is not None
+                                            },
+                                        ),
+                                        volume_mounts=(
+                                            [
+                                                client.V1VolumeMount(
+                                                    mount_path=self._kwargs.get(
+                                                        "tmpfs_path"
+                                                    ),
+                                                    name="tmpfs-ephemeral-volume",
+                                                )
+                                            ]
+                                            if tmpfs_enabled
+                                            else []
+                                        )
+                                        + (
+                                            [
+                                                client.V1VolumeMount(
+                                                    mount_path="/dev/shm", name="dhsm"
+                                                )
+                                            ]
+                                            if shared_memory
+                                            else []
+                                        )
+                                        + (
+                                            [
+                                                client.V1VolumeMount(
+                                                    mount_path=path, name=claim
+                                                )
+                                                for claim, path in self._kwargs[
+                                                    "persistent_volume_claims"
+                                                ].items()
+                                            ]
+                                            if self._kwargs["persistent_volume_claims"]
+                                            is not None
+                                            else []
+                                        ),
+                                    )
+                                ],
+                                node_selector=self._kwargs.get("node_selector"),
+                                # TODO (savin): Support image_pull_secrets
+                                # image_pull_secrets=?,
+                                # TODO (savin): Support preemption policies
+                                # preemption_policy=?,
+                                #
+                                # A Container in a Pod may fail for a number of
+                                # reasons, such as because the process in it exited
+                                # with a non-zero exit code, or the Container was
+                                # killed due to OOM etc. If this happens, fail the pod
+                                # and let Metaflow handle the retries.
+                                restart_policy="Never",
+                                service_account_name=self._kwargs["service_account"],
+                                # Terminate the container immediately on SIGTERM
+                                termination_grace_period_seconds=0,
+                                tolerations=[
+                                    client.V1Toleration(**toleration)
+                                    for toleration in self._kwargs.get("tolerations")
+                                    or []
+                                ],
+                                volumes=(
+                                    [
+                                        client.V1Volume(
+                                            name="tmpfs-ephemeral-volume",
+                                            empty_dir=client.V1EmptyDirVolumeSource(
+                                                medium="Memory",
+                                                # Add default unit as ours differs from Kubernetes default.
+                                                size_limit="{}Mi".format(tmpfs_size),
+                                            ),
+                                        )
+                                    ]
+                                    if tmpfs_enabled
+                                    else []
+                                )
+                                + (
+                                    [
+                                        client.V1Volume(
+                                            name="dhsm",
+                                            empty_dir=client.V1EmptyDirVolumeSource(
+                                                medium="Memory",
+                                                size_limit="{}Mi".format(shared_memory),
+                                            ),
+                                        )
+                                    ]
+                                    if shared_memory
+                                    else []
+                                )
+                                + (
+                                    [
+                                        client.V1Volume(
+                                            name=claim,
+                                            persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(
+                                                claim_name=claim
+                                            ),
+                                        )
+                                        for claim in self._kwargs[
+                                            "persistent_volume_claims"
+                                        ].keys()
+                                    ]
+                                    if self._kwargs["persistent_volume_claims"]
+                                    is not None
+                                    else []
+                                ),
+                                # TODO (savin): Set termination_message_policy
+                            ),
+                        ),
+                    ),
+                )
+            ),
+            replicas=self._kwargs["replicas"],
+        )
+
+
+class KubernetesJobSet(object):  # todo : [final-refactor] : fix-me
     def __init__(
         self,
         client,
         name=None,
-        job_spec=None,
         namespace=None,
         num_parallel=None,
-        annotations=None,
-        labels=None,
-        port=None,
-        task_id=None,
+        # explcitly declaring num_parallel because we need to ensure that
+        # num_parallel is an INTEGER and this abstraction is called by the
+        # local runtime abstraction of kubernetes.
+        # Argo will call another abstraction that will allow setting a lot of these
+        # values from the top level argo code.
         **kwargs
     ):
         self._client = client
-        self._kwargs = kwargs
+        self._annotations = {}
+        self._labels = {}
         self._group = KUBERNETES_JOBSET_GROUP
         self._version = KUBERNETES_JOBSET_VERSION
+        self._namespace = namespace
         self.name = name
 
-        main_job_name = "control"
-        main_job_index = 0
-        main_pod_index = 0
-        subdomain = self.name
-        num_parallel = int(1 if not num_parallel else num_parallel)
-        self._namespace = namespace
-        jobset_main_addr = _make_domain_name(
-            self.name,
-            main_job_name,
-            main_job_index,
-            main_pod_index,
-            self._namespace,
+        self._jobset_control_addr = _make_domain_name(
+            name,
+            CONTROL_JOB_NAME,
+            0,
+            0,
+            namespace,
         )
 
-        annotations = {} if not annotations else annotations
-        labels = {} if not labels else labels
-
-        if "metaflow/task_id" in annotations:
-            del annotations["metaflow/task_id"]
-
-        control_job = get_control_job(
-            client=self._client.get(),
-            job_spec=job_spec,
-            jobset_main_addr=jobset_main_addr,
-            subdomain=subdomain,
-            port=port,
-            num_parallel=num_parallel,
-            namespace=namespace,
-            annotations=annotations,
+        self._control_spec = JobSetSpec(
+            client.get(), name=CONTROL_JOB_NAME, namespace=namespace, **kwargs
         )
-        worker_task_id = TaskIdConstructor.jobset_worker_id(task_id)
-        worker_job = get_worker_job(
-            client=self._client.get(),
-            job_spec=job_spec,
-            job_name="worker",
-            jobset_main_addr=jobset_main_addr,
-            subdomain=subdomain,
-            control_task_id=task_id,
-            worker_task_id=worker_task_id,
-            replicas=num_parallel - 1,
-            port=port,
-            num_parallel=num_parallel,
-            namespace=namespace,
-            annotations=annotations,
+        self._worker_spec = JobSetSpec(
+            client.get(), name="worker", namespace=namespace, **kwargs
         )
-        worker_jobs = [worker_job]
-        # Based on https://github.com/kubernetes-sigs/jobset/blob/v0.5.0/api/jobset/v1alpha2/jobset_types.go#L163
-        _kclient = client.get()
-        self._jobset = dict(
+        assert (
+            type(num_parallel) == int
+        ), "num_parallel must be an integer"  # todo: [final-refactor] : fix-me
+
+    @property
+    def jobset_control_addr(self):
+        return self._jobset_control_addr
+
+    @property
+    def worker(self):
+        return self._worker_spec
+
+    @property
+    def control(self):
+        return self._control_spec
+
+    def environment_variable_from_selector(self, name, label_value):
+        self.worker.environment_variable_from_selector(name, label_value)
+        self.control.environment_variable_from_selector(name, label_value)
+        return self
+
+    def environment_variables_from_selectors(self, env_dict):
+        for name, label_value in env_dict.items():
+            self.worker.environment_variable_from_selector(name, label_value)
+            self.control.environment_variable_from_selector(name, label_value)
+        return self
+
+    def environment_variable(self, name, value):
+        self.worker.environment_variable(name, value)
+        self.control.environment_variable(name, value)
+        return self
+
+    def label(self, name, value):
+        self.worker.label(name, value)
+        self.control.label(name, value)
+        self._labels = dict(self._labels, **{name: value})
+        return self
+
+    def annotation(self, name, value):
+        self.worker.annotation(name, value)
+        self.control.annotation(name, value)
+        self._annotations = dict(self._annotations, **{name: value})
+        return self
+
+    def secret(self, name):
+        self.worker.secret(name)
+        self.control.secret(name)
+        return self
+
+    def dump(self):
+        client = self._client.get()
+        return dict(
             apiVersion=self._group + "/" + self._version,
             kind="JobSet",
-            metadata=_kclient.api_client.ApiClient().sanitize_for_serialization(
-                _kclient.V1ObjectMeta(
-                    name=self.name, labels=labels, annotations=annotations
+            metadata=client.api_client.ApiClient().sanitize_for_serialization(
+                client.V1ObjectMeta(
+                    name=self.name,
+                    labels=self._labels,
+                    annotations=self._annotations,
                 )
             ),
             spec=dict(
-                replicatedJobs=[control_job] + worker_jobs,
+                replicatedJobs=[self.control.dump(), self.worker.dump()],
                 suspend=False,
                 startupPolicy=None,
                 successPolicy=None,
                 # The Failure Policy helps setting the number of retries for the jobset.
-                # It cannot accept a value of 0 for maxRestarts.
-                # So the attempt needs to be smartly set.
-                # If there is no retry decorator then we not set maxRestarts and instead we will
-                # set the attempt statically to 0. Otherwise we will make the job pickup the attempt
-                # from the `V1EnvVarSource.value_from.V1ObjectFieldSelector.field_path` = "metadata.annotations['jobset.sigs.k8s.io/restart-attempt']"
-                # failurePolicy={
-                #     "maxRestarts" : 1
-                # },
-                # The can be set for ArgoWorkflows
+                # but we don't rely on it and instead rely on either the local scheduler
+                # or the Argo Workflows to handle retries.
                 failurePolicy=None,
                 network=None,
             ),
@@ -767,7 +891,7 @@ class KubernetesJobSet(object):
                     version=self._version,
                     namespace=self._namespace,
                     plural="jobsets",
-                    body=self._jobset,
+                    body=self.dump(),
                 )
             except Exception as e:
                 raise KubernetesJobsetException(


### PR DESCRIPTION
- Some changes stemming from Netflix/metaflow#1854
- reorder imports
- changes to env var prefixes + id generation
- Abstraction over Jobset Spec
- Create general abstraction and copy style of how we create jobspec for native k8s jobs.
- simplified the implementation.
- similar pattern/trend to follow for argo
- remove older implementation
- @parallel metadata from k8s decorator - added attempt to MetaDatum tags - We didn't have this earlier