### PR TITLE
[parallel-fixes] core + test changes

### DIFF
--- a/metaflow/lint.py
+++ b/metaflow/lint.py
@@ -295,6 +295,19 @@ def check_parallel_step_after_next(graph):
 
 @linter.ensure_static_graph
 @linter.check
+def check_join_followed_by_parallel_step(graph):
+    msg = (
+        "An @parallel step should be followed by a join step. Step *{0}* is called "
+        "after an @parallel step but is not a join step. Please add an extra `inputs` "
+        "argument to the step."
+    )
+    for node in graph:
+        if node.parallel_step and not graph[node.out_funcs[0]].type == "join":
+            raise LintWarn(msg.format(node.out_funcs[0]))
+
+
+@linter.ensure_static_graph
+@linter.check
 def check_parallel_foreach_calls_parallel_step(graph):
     msg = (
         "Step *{0.name}* has a @parallel decorator, but is not called "

--- a/metaflow/metaflow_current.py
+++ b/metaflow/metaflow_current.py
@@ -261,14 +261,6 @@ class Current(object):
         return self._username
 
     @property
-    def parallel(self):
-        return Parallel(
-            main_ip=os.environ.get("MF_PARALLEL_MAIN_IP", "127.0.0.1"),
-            num_nodes=int(os.environ.get("MF_PARALLEL_NUM_NODES", "1")),
-            node_index=int(os.environ.get("MF_PARALLEL_NODE_INDEX", "0")),
-        )
-
-    @property
     def tags(self):
         """
         [Legacy function - do not use]


### PR DESCRIPTION
- fix tests for ubf based on new changes to core.
- [feedback] register metadata in parallel decorator
- [feedback]@parallel inject in current: - move `current.parallel` from `metaflow_current` to `parallel_decorator`
- [feedback] appropariately setting task-metadata for parallel stuff - The 'world size' metadata will be set in the @parallel decorator. - The 'node-index' metadata, however, varies depending on the type of computing environment executing the task so it will be set in the appropriate compute decorators. - One reason to specify 'node-index' within compute decorators is that the parallel implementation in the compute decorator might not directly set the required environment variables (`MF_PARALLEL_*`). Instead, these values may be established during the `task_pre_step` phase of the compute decorator using other environment variables set during the implementation. - adding some aws batch changes
- [feedback] set `is_parallel` in current to denote a step is running under an `@parallel` decorator. - users can use `if "is_parallel" in current`
- [feedback] add linter to ensure join after parallel

Re-opening #1913 