### PR TITLE
[argo] support for @parallel

### DIFF
--- a/metaflow/plugins/argo/jobset_input_paths.py
+++ b/metaflow/plugins/argo/jobset_input_paths.py
@@ -1,0 +1,16 @@
+import sys
+from hashlib import md5
+
+
+def generate_input_paths(run_id, step_name, task_id_entropy, num_parallel):
+    # => run_id/step/:foo,bar
+    control_id = "control-{}-0".format(task_id_entropy)
+    worker_ids = [
+        "worker-{}-{}".format(task_id_entropy, i) for i in range(int(num_parallel) - 1)
+    ]
+    ids = [control_id] + worker_ids
+    return "{}/{}/:{}".format(run_id, step_name, ",".join(ids))
+
+
+if __name__ == "__main__":
+    print(generate_input_paths(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]))

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -155,6 +155,7 @@ class Kubernetes(object):
         ):
             self._job = self.create_jobset(**kwargs).execute()
         else:
+            kwargs.pop("num_parallel", None)
             kwargs["name_pattern"] = "t-{uid}-".format(uid=str(uuid4())[:8])
             self._job = self.create_job_object(**kwargs).create().execute()
 


### PR DESCRIPTION
> supported :
- foreach + parallel
- parallel with Argo
- dynamically set worker-counts.
- should work with @timeout / @project /@card etc.
- retries working with native Argo
- fully self contained jobset with argo support - Requires Jobset v0.6.0 [kubernetes-sigs/jobset#523]

> not-supported:
- support for catch

> Notes
- not using the `{{retries}}` like we do in container templates
- Instead passing down {{retries}} as a `inputs.parameters` which will be accessible in the Jobset manifest.
- Temporary tweek to boto dep to ensure that boto install failures dont fail deployment.
- instead of relying on the kubernetes object, we freshly create a object in the ArgoContainer templates.
- Code in the same style as the kubernetes/argo integrations with explicit filling of variables and decoupled abstractions
- setting annotations explicitly as they wont be passed down from WorkflowTemplate level.
- support for jobset native success conditions (requires Jobset v0.6 on controller)
- REFACTORS THAT HAVE WENT INTO THIS COMMIT: 
- [argo][feedback] refactor dag template parameter /output setting - just move conditional block around 
- [argo][feedback] refactor references to `task_id_base` to `task_id_entropy` 
- these are set/used in the argo outputs and variable names 
- [argo][feedback] refactor references to `task-id-base` to `task-id-entropy` 
- these are uses a Argo Parameter Names. 
- [argo][feedback] refactor to match code style 
- [argo][feedback] refactor to match code style (refactor some conditionals) 
- [argo][feedback] remove k8s client and make `KubernetesArgoJobSet` directly use `kubernetes_sdk` 
- [argo][feedback] added `environment_variables_from_selectors` for code simplification -
- [argo][feedback] fix comment. - [argo][feedback] refactor condition for readabililty. 
- [argo][feedback] rollback temp boto3 installation change in metaflow env - [argo][feedback] remove rogue type hint