### PR TITLE
[ubf] bug fix when using `merge_artifacts` in UBF joins

### DIFF
--- a/metaflow/flowspec.py
+++ b/metaflow/flowspec.py
@@ -28,7 +28,7 @@ except NameError:
 
 from .datastore.inputs import Inputs
 
-INTERNAL_ARTIFACTS_SET = set(["_foreach_values"])
+INTERNAL_ARTIFACTS_SET = set(["_foreach_values", "_unbounded_foreach"])
 
 
 class InvalidNextException(MetaflowException):


### PR DESCRIPTION
- When users call `self.merge_artifacts` for a join step in a UBF, the `_unbounded_foreach` internal variable gets merged too. This is because it's not included in the `INTERNAL_ARTIFACTS_SET` that exclude it in the merge_artifacts function.
- This doesn't become a problem unless users have a complex graph where there are branches and UBFs within the branches.
- but in cases where there are branches and users are calling `merge_artifacts`, then the `_unbounded_foreach` variable gets propagated to further join steps causing the code to crash in the local runtime with the join step. 
- this only affects local runtime and everything seems to work fine with remote schedulers.
- Adding this variable to the `INTERNAL_ARTIFACTS_SET` fixes the problem. 