### PR TITLE
[custom serializers] poc serializers implemented

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-
+import sys
 import json
 import os
 import tarfile
@@ -36,6 +36,7 @@ from metaflow.util import cached_property, is_stringish, resolve_identity, to_un
 
 from .. import INFO_FILE
 from .filecache import FileCache
+import tempfile
 
 try:
     # python2
@@ -2131,6 +2132,16 @@ class Run(MetaflowObject):
             If the name does not identify a valid Step object
         """
         return super(Run, self).__getitem__(name)
+
+    def __enter__(self):
+        self._temp_code_dir = tempfile.TemporaryDirectory("mf_code")
+        self.code.tarball.extractall(self._temp_code_dir.name)
+        sys.path.insert(0, self._temp_code_dir.name)
+        return self
+
+    def __exit__(self, type, value, traceback):
+        sys.path.remove(self._temp_code_dir.name)
+        self._temp_code_dir.cleanup()
 
     def __getstate__(self):
         return super(Run, self).__getstate__()

--- a/metaflow/datastore/serailizers.py
+++ b/metaflow/datastore/serailizers.py
@@ -1,0 +1,298 @@
+from collections import namedtuple
+from typing import Tuple, Union
+import pickle
+import io
+import os
+from .exceptions import DataException, UnpicklableArtifactException
+
+SerializationInfo = namedtuple(
+    "SerializationInfo",
+    [
+        "type",
+        "size",
+        "encode_type",
+    ],
+)
+
+
+class Serializer:
+
+    TYPE = None
+
+    ENCODING_TYPE = None
+
+    def serialize(
+        self,
+        obj,
+    ) -> Union[Tuple[bytes, SerializationInfo], None]:
+        raise NotImplementedError
+
+    def deserialize(
+        self,
+        blob,
+    ):
+        raise NotImplementedError
+
+
+def handle_import_error(method):
+    def wrapper(self, *args, **kwargs):
+        try:
+            return method(self, *args, **kwargs)
+        except ImportError:
+            return None
+
+    return wrapper
+
+
+class TensorFlowSerializer(Serializer):
+
+    _tensorflow = None
+
+    TYPE = "tensorflow"
+
+    ENCODING_TYPE = "tensorflow"
+
+    @classmethod
+    def _load_module(cls):
+        if cls._tensorflow is None:
+            # We add these lines because otherwise tensorflow pollutes the stderr
+            # with warning logs that are not necessary for the purpose of serialization.
+            os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+            import tensorflow as tf
+
+            cls._tensorflow = tf
+            del os.environ["TF_CPP_MIN_LOG_LEVEL"]
+        return cls._tensorflow
+
+    # TODO[FIXME] : Importing top level modules can be really HEAVY!.
+    # See if we can have a better way to do this (i.e.) rely on some
+    # heuritics (like via class names / module paths) to ensure that these
+    # are only loaded when needed.
+    @handle_import_error
+    def should_be_serialized(self, obj):
+        return isinstance(obj, self._load_module().keras.Model)
+
+    def serialize(self, obj) -> Union[Tuple[bytes, SerializationInfo], None]:
+        if not self.should_be_serialized(obj):
+            return None
+        tf = self._load_module()
+        buffer = io.BytesIO()
+        tf.keras.models.save_model(obj, buffer, save_format="h5")
+        return buffer.getvalue(), SerializationInfo(
+            str(type(obj)),
+            buffer.getbuffer().nbytes,
+            self.ENCODING_TYPE,
+        )
+
+    def deserialize(self, blob):
+        tf = self._load_module()
+        buffer = io.BytesIO(blob)
+        return tf.keras.models.load_model(buffer)
+
+
+class KerasSerializer(Serializer):
+
+    _keras = None
+
+    TYPE = "keras"
+
+    ENCODING_TYPE = "keras"
+
+    @classmethod
+    def _load_module(cls):
+        if cls._keras is None:
+            import keras
+
+            cls._keras = keras
+        return cls._keras
+
+    # TODO[FIXME] : Importing top level modules can be really HEAVY!.
+    # See if we can have a better way to do this (i.e.) rely on some
+    # heuritics (like via class names / module paths) to ensure that these
+    # are only loaded when needed.
+    @handle_import_error
+    def should_be_serialized(self, obj):
+        return isinstance(obj, self._load_module().Model)
+
+    def serialize(self, obj) -> Union[Tuple[bytes, SerializationInfo], None]:
+        if not self.should_be_serialized(obj):
+            return None
+        keras = self._load_module()
+        buffer = io.BytesIO()
+        keras.models.save_model(obj, buffer, save_format="h5")
+        return buffer.getvalue(), SerializationInfo(
+            str(type(obj)),
+            buffer.getbuffer().nbytes,
+            self.ENCODING_TYPE,
+        )
+
+    def deserialize(self, blob):
+        keras = self._load_module()
+        buffer = io.BytesIO(blob)
+        return keras.models.load_model(buffer)
+
+
+class XGBoostSerializer(Serializer):
+
+    _xgboost = None
+
+    TYPE = "xgboost"
+
+    ENCODING_TYPE = "xgboost"
+
+    @classmethod
+    def _load_module(cls):
+        if cls._xgboost is None:
+            import xgboost as xgb
+
+            cls._xgboost = xgb
+        return cls._xgboost
+
+    # TODO[FIXME] : Importing top level modules can be really HEAVY!.
+    # See if we can have a better way to do this (i.e.) rely on some
+    # heuritics (like via class names / module paths) to ensure that these
+    # are only loaded when needed.
+    @handle_import_error
+    def should_be_serialized(self, obj):
+        return isinstance(obj, self._load_module().XGBModel)
+
+    def serialize(self, obj) -> Union[Tuple[bytes, SerializationInfo], None]:
+        if not self.should_be_serialized(obj):
+            return None
+        xgb = self._load_module()
+        buffer = io.BytesIO()
+        obj.save_model(buffer)
+        return buffer.getvalue(), SerializationInfo(
+            str(type(obj)),
+            buffer.getbuffer().nbytes,
+            self.ENCODING_TYPE,
+        )
+
+    def deserialize(self, blob):
+        xgb = self._load_module()
+        buffer = io.BytesIO(blob)
+        model = xgb.XGBModel()
+        model.load_model(buffer)
+        return model
+
+
+class PytorchSerializer(Serializer):
+    """
+    ## Where this doesn't work:
+    - scoped `nn.Module` objects ; i.e. `nn.Module` objects that are defined within a function scope and not at the top level of the module.
+
+    ## todos:
+    - Ensure that objects are put to CPU before we run the serialization.
+      There is an off chance that torch.load may try to place them on CPUs.
+    """
+
+    _torch = None
+
+    TYPE = "pytorch"
+
+    ENCODING_TYPE = "pytorch"
+
+    @classmethod
+    def _load_module(cls):
+        if cls._torch is None:
+            import torch
+
+            cls._torch = torch
+        return cls._torch
+
+    # TODO[FIXME] : Importing top level modules can be really HEAVY!.
+    # See if we can have a better way to do this (i.e.) rely on some
+    # heuritics (like via class names / module paths) to ensure that these
+    # are only loaded when needed.
+    @handle_import_error
+    def should_be_serialized(self, obj):
+        return isinstance(obj, self._load_module().nn.Module)
+
+    def serialize(self, obj) -> Union[Tuple[bytes, SerializationInfo], None]:
+        if not self.should_be_serialized(obj):
+            return None
+        torch = self._load_module()
+        buffer = io.BytesIO()
+        torch.save(obj, buffer)
+        return buffer.getvalue(), SerializationInfo(
+            str(type(obj)),
+            buffer.getbuffer().nbytes,
+            self.ENCODING_TYPE,
+        )
+
+    def deserialize(self, blob):
+        torch = self._load_module()
+        buffer = io.BytesIO(blob)
+        return torch.load(buffer)
+
+
+SERIALIZERS = [
+    PytorchSerializer,
+    TensorFlowSerializer,
+    KerasSerializer,
+    XGBoostSerializer,
+]
+
+
+def serialize_object(name, obj, allowed_encodings, force_v4=False):
+    for s in SERIALIZERS:
+        op = s().serialize(obj)
+        if op is not None:
+            return op
+    else:
+        return _pickle_dump(name, obj, allowed_encodings, force_v4=force_v4)
+
+
+def deserialize_object(blob, encoding_type):
+    for s in SERIALIZERS:
+        if s.ENCODING_TYPE == encoding_type:
+            return s().deserialize(blob)
+    else:
+        return _pickle_loads(blob)
+
+
+def _pickle_dump(name, obj, allowed_encodings, force_v4=False):
+    do_v4 = (
+        force_v4 and force_v4
+        if isinstance(force_v4, bool)
+        else force_v4.get(name, False)
+    )
+    if do_v4:
+        encode_type = "gzip+pickle-v4"
+        if encode_type not in allowed_encodings:
+            raise DataException(
+                "Artifact *%s* requires a serialization encoding that "
+                "requires Python 3.4 or newer." % name
+            )
+        try:
+            blob = pickle.dumps(obj, protocol=4)
+        except TypeError as e:
+            raise UnpicklableArtifactException(name)
+    else:
+        try:
+            blob = pickle.dumps(obj, protocol=2)
+            encode_type = "gzip+pickle-v2"
+        except (SystemError, OverflowError):
+            encode_type = "gzip+pickle-v4"
+            if encode_type not in allowed_encodings:
+                raise DataException(
+                    "Artifact *%s* is very large (over 2GB). "
+                    "You need to use Python 3.4 or newer if you want to "
+                    "serialize large objects." % name
+                )
+            try:
+                blob = pickle.dumps(obj, protocol=4)
+            except TypeError as e:
+                raise UnpicklableArtifactException(name)
+        except TypeError as e:
+            raise UnpicklableArtifactException(name)
+
+    return blob, SerializationInfo(
+        str(type(obj)),
+        len(blob),
+        encode_type,
+    )
+
+
+def _pickle_loads(blob):
+    return pickle.loads(blob)

--- a/metaflow/extension_support/plugins.py
+++ b/metaflow/extension_support/plugins.py
@@ -189,6 +189,7 @@ _plugin_categories = {
     "cli": lambda x: list(x.commands)[0]
     if len(x.commands) == 1
     else "too many commands",
+    "serializer": lambda x: x.name,
 }
 
 

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -172,6 +172,7 @@ AWS_CLIENT_PROVIDERS = resolve_plugins("aws_client_provider")
 SECRETS_PROVIDERS = resolve_plugins("secrets_provider")
 AZURE_CLIENT_PROVIDERS = resolve_plugins("azure_client_provider")
 GCP_CLIENT_PROVIDERS = resolve_plugins("gcp_client_provider")
+SERIALIZERS = resolve_plugins("serializer")
 
 if sys.version_info >= (3, 7):
     DEPLOYER_IMPL_PROVIDERS = resolve_plugins("deployer_impl_provider")


### PR DESCRIPTION
- Under the hood serializers for Pytorch, TF, Keras, XGB
- Not the most efficient implementation
- New encoding types included for the new task datastore.
- run object context manager; This is so that we can do :

```
from metaflow import Run
run = Run("MnistTorchFlow/5132")
with run as run:
    print(run.data.model)
```