### PR TITLE
Show link to argo workflows when triggering a run

### DIFF
--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -964,7 +964,7 @@ def trigger(obj, run_id_file=None, deployer_attribute_file=None, **kwargs):
             workflow_name_to_deploy = obj._v1_workflow_name
     response = ArgoWorkflows.trigger(workflow_name_to_deploy, params)
     argo_workflow_id = response["metadata"]["name"]
-    run_id = "argo-" + argo_workflow_id
+    run_id = f"argo-{argo_workflow_id}"
 
     if run_id_file:
         with open(run_id_file, "w") as f:

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -963,7 +963,8 @@ def trigger(obj, run_id_file=None, deployer_attribute_file=None, **kwargs):
             obj.echo("re-deploy your flow in order to get rid of this message.")
             workflow_name_to_deploy = obj._v1_workflow_name
     response = ArgoWorkflows.trigger(workflow_name_to_deploy, params)
-    run_id = "argo-" + response["metadata"]["name"]
+    argo_workflow_id = response["metadata"]["name"]
+    run_id = "argo-" + argo_workflow_id
 
     if run_id_file:
         with open(run_id_file, "w") as f:
@@ -985,6 +986,23 @@ def trigger(obj, run_id_file=None, deployer_attribute_file=None, **kwargs):
         "(run-id *{run_id}*).".format(name=workflow_name_to_deploy, run_id=run_id),
         bold=True,
     )
+
+    workflow_url = (
+        "%s/workflows/%s/%s"
+        % (
+            ARGO_WORKFLOWS_UI_URL.rstrip("/"),
+            KUBERNETES_NAMESPACE,
+            argo_workflow_id,
+        )
+        if ARGO_WORKFLOWS_UI_URL
+        else None
+    )
+
+    if workflow_url:
+        obj.echo(
+            "See it in the Argo Workflows UI at %s" % workflow_url,
+            bold=True,
+        )
 
     run_url = (
         "%s/%s/%s" % (UI_URL.rstrip("/"), obj.flow.name, run_id) if UI_URL else None

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -998,17 +998,22 @@ def trigger(obj, run_id_file=None, deployer_attribute_file=None, **kwargs):
         else None
     )
 
-    if workflow_url:
-        obj.echo(
-            "See it in the Argo Workflows UI at %s" % workflow_url,
-            bold=True,
-        )
-
     run_url = (
         "%s/%s/%s" % (UI_URL.rstrip("/"), obj.flow.name, run_id) if UI_URL else None
     )
 
-    if run_url:
+    if workflow_url and run_url:
+        obj.echo(
+            "See the run in the UI at %s and in the Argo Workflows UI at %s"
+            % (run_url, workflow_url),
+            bold=True,
+        )
+    elif workflow_url:
+        obj.echo(
+            "See the run in the Argo Workflows UI at %s" % workflow_url,
+            bold=True,
+        )
+    elif run_url:
         obj.echo(
             "See the run in the UI at %s" % run_url,
             bold=True,

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -1004,7 +1004,7 @@ def trigger(obj, run_id_file=None, deployer_attribute_file=None, **kwargs):
 
     if workflow_url and run_url:
         obj.echo(
-            "See the run in the UI at %s and in the Argo Workflows UI at %s"
+            "See the run in the UI at %s\nand in the Argo Workflows UI at %s"
             % (run_url, workflow_url),
             bold=True,
         )


### PR DESCRIPTION
## PR Type

- [x] New feature

## Summary

Show the triggered workflow's URL in the Argo Workflows UI alongside the existing Metaflow UI URL when running ``argo-workflows trigger``. Either, both, or neither URL is shown depending on which of ``UI_URL`` and ``ARGO_WORKFLOWS_UI_URL`` is configured.

## Issue

No tracking issue.

## Reproduction

Trigger any deployed workflow:

```bash
python myflow.py argo-workflows trigger
```

Before this change, only the Metaflow UI URL was shown (when ``UI_URL`` was configured); ``ARGO_WORKFLOWS_UI_URL`` was unused on the trigger path even when set.

## Output examples

When both ``UI_URL`` and ``ARGO_WORKFLOWS_UI_URL`` are set:

```
Workflow *MyFlow* triggered on Argo Workflows (run-id *argo-abc123*).
See the run in the UI at https://metaflow-ui.example.com/MyFlow/argo-abc123
and in the Argo Workflows UI at https://argo.example.com/workflows/default/abc123
```

When only ``ARGO_WORKFLOWS_UI_URL`` is set:

```
See the run in the Argo Workflows UI at https://argo.example.com/workflows/default/abc123
```

When only ``UI_URL`` is set (unchanged from prior behavior):

```
See the run in the UI at https://metaflow-ui.example.com/MyFlow/argo-abc123
```

## Why This Fix Is Correct

The change is additive on the existing ``UI_URL`` output path: an Argo UI URL is shown only when ``ARGO_WORKFLOWS_UI_URL`` is set, and the existing Metaflow UI URL output is preserved unchanged when only ``UI_URL`` is set. Splitting ``argo_workflow_id`` out of ``run_id`` lets the Argo URL use the raw workflow ID (no ``argo-`` prefix), which is what the Argo UI expects.

## Failure Modes Considered

1. **Neither URL configured.** No URL line is printed; matches prior behavior.
2. **Both URLs configured.** Two URLs printed on separate lines for readability (per @savingoyal's review nit).
3. **Trailing slash on either URL.** Both code paths call ``.rstrip("/")`` before joining.

## Tests

- [x] CI passes
- Existing ``test/unit/test_argo_workflows_cli.py`` covers the trigger CLI command and continues to pass.

## Non-Goals

- This PR does not introduce URL templating for ``ARGO_WORKFLOWS_UI_URL``. The variable is still treated as a host-only base URL with ``/workflows/{namespace}/{workflow_id}`` appended. Templated URL support is a follow-up; see #2016 for the original proposal.
- No changes to ``ARGO_WORKFLOWS_UI_URL`` use elsewhere (PagerDuty notifications, ``argo-workflows create``).

## AI Tool Usage

- [x] AI tools (Claude) were used by the maintainer to draft this description and review the change. Code authored by @amerberg.