### PR TITLE
capture 1st error in argo workflows 

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -238,6 +238,13 @@ DEFAULT_RUNTIME_LIMIT = from_conf("DEFAULT_RUNTIME_LIMIT", 5 * 24 * 60 * 60)
 ###
 UI_URL = from_conf("UI_URL")
 
+###
+# Capture error logs from argo
+###
+KUBERNETES_SANDBOX_CAPTURE_ERROR_SCRIPT = from_conf(
+    "KUBERNETES_SANDBOX_CAPTURE_ERROR_SCRIPT"
+)
+
 # Contact information displayed when running the `metaflow` command.
 # Value should be a dictionary where:
 #  - key is a string describing contact method

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -181,6 +181,12 @@ def argo_workflows(obj, name=None):
     help="Write the workflow name to the file specified. Used internally for Metaflow's Deployer API.",
     hidden=True,
 )
+@click.option(
+    "--with-capture-error-hook/--no-with-capture-error-hook",
+    default=False,
+    show_default=True,
+    help="Capture error message in an exit hook",
+)
 @click.pass_obj
 def create(
     obj,
@@ -200,6 +206,7 @@ def create(
     notify_pager_duty_integration_key=None,
     enable_heartbeat_daemon=True,
     deployer_attribute_file=None,
+    with_capture_error_hook=False,
 ):
     validate_tags(tags)
 
@@ -248,6 +255,7 @@ def create(
         notify_slack_webhook_url,
         notify_pager_duty_integration_key,
         enable_heartbeat_daemon,
+        with_capture_error_hook,
     )
 
     if only_json:
@@ -421,6 +429,7 @@ def make_flow(
     notify_slack_webhook_url,
     notify_pager_duty_integration_key,
     enable_heartbeat_daemon,
+    with_capture_error_hook,
 ):
     # TODO: Make this check less specific to Amazon S3 as we introduce
     #       support for more cloud object stores.
@@ -484,6 +493,7 @@ def make_flow(
         notify_slack_webhook_url=notify_slack_webhook_url,
         notify_pager_duty_integration_key=notify_pager_duty_integration_key,
         enable_heartbeat_daemon=enable_heartbeat_daemon,
+        with_capture_error_hook=with_capture_error_hook,
     )
 
 

--- a/metaflow/plugins/argo/capture_error.py
+++ b/metaflow/plugins/argo/capture_error.py
@@ -1,0 +1,89 @@
+import os
+import json
+from datetime import datetime
+
+###
+# Algorithm to determine 1st error:
+# ignore the failures where message = ""
+# group the failures via templateName
+# sort each group by finishedAt
+# find the group for which the last finishedAt is earliest
+# if the earliest message is "No more retries left" then get the n-1th message from that group
+# else return the last message.
+###
+
+
+def sort_tasks_by_finished_at(data: dict):
+    for key, value in data.items():
+        data[key] = sorted(
+            value,
+            key=lambda x: datetime.strptime(x["finishedAt"], "%Y-%m-%dT%H:%M:%SZ"),
+        )
+
+
+def find_key_with_smallest_largest_finished_at(data: dict) -> str:
+    smallest_largest_date = None
+    smallest_largest_key = None
+
+    for key, value in data.items():
+        largest_finished_at = datetime.strptime(
+            value[-1]["finishedAt"], "%Y-%m-%dT%H:%M:%SZ"
+        )
+        if smallest_largest_date is None or largest_finished_at < smallest_largest_date:
+            smallest_largest_date = largest_finished_at
+            smallest_largest_key = key
+
+    return smallest_largest_key
+
+
+def determine_first_error() -> str:
+    workflow_failures = os.getenv("METAFLOW_ARGO_WORKFLOW_FAILURES", "[]")
+    workflow_failures_json = json.loads(
+        json.loads(workflow_failures, strict=False), strict=False
+    )
+
+    valid_workflow_failures = []
+
+    for wf in workflow_failures_json:
+        # ignore any workflow failures whose message is empty
+        if "message" in wf and wf["message"] != "":
+            valid_workflow_failures.append(wf)
+
+    # it should never be the case that the workflow has failed but
+    # message field in every object is empty
+    if len(valid_workflow_failures) == 0:
+        return
+
+    template_dict = {}
+    # group the failures by the templateName property
+    for wf in valid_workflow_failures:
+        if wf["templateName"] not in template_dict:
+            template_dict[wf["templateName"]] = []
+        templates = template_dict[wf["templateName"]]
+        templates.append(wf)
+        template_dict[wf["templateName"]] = templates
+
+    # sort each group by finishedAt
+    sort_tasks_by_finished_at(template_dict)
+    last_finished_at_dict = {}
+    # find the group for which the last finishedAt is earliest..
+    for wf_template_name, wf in template_dict.items():
+        if wf_template_name not in last_finished_at_dict:
+            last_finished_at_dict[wf_template_name] = []
+        templates = last_finished_at_dict[wf_template_name]
+        templates.append(wf[-1])
+        last_finished_at_dict[wf_template_name] = templates
+
+    sort_tasks_by_finished_at(last_finished_at_dict)
+    candidate_template_name = find_key_with_smallest_largest_finished_at(
+        last_finished_at_dict
+    )
+
+    if template_dict[candidate_template_name][-1]["message"] == "No more retries left":
+        return template_dict[candidate_template_name][-2]["message"]
+    else:
+        return template_dict[candidate_template_name][-1]["message"]
+
+
+if __name__ == "__main__":
+    determine_first_error()

--- a/metaflow/plugins/kubernetes/kubernetes_job.py
+++ b/metaflow/plugins/kubernetes/kubernetes_job.py
@@ -257,7 +257,6 @@ class KubernetesJob(object):
                         if self._kwargs["persistent_volume_claims"] is not None
                         else []
                     ),
-                    # TODO (savin): Set termination_message_policy
                 ),
             ),
         )

--- a/metaflow/plugins/kubernetes/kubernetes_jobsets.py
+++ b/metaflow/plugins/kubernetes/kubernetes_jobsets.py
@@ -757,7 +757,6 @@ class JobSetSpec(object):
                                     is not None
                                     else []
                                 ),
-                                # TODO (savin): Set termination_message_policy
                             ),
                         ),
                     ),


### PR DESCRIPTION
This PR adds a cli option to argo workflows - when enabled - allows metaflow to capture the 1st error that has occurred during the execution of the argo workflow. 

We define 1st error as the earliest failure ( after all retries have exhausted - if configured )  that would cause the step to fail - leading to the overall failure of the workflow eventually. 

