### PR TITLE
[Ready for Review] Fix issue where resuming on successful run will fail.

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -650,7 +650,7 @@ def resume(
             )
 
     if step_to_rerun is None:
-        rerun_steps = set()
+        steps_to_rerun = set()
     else:
         # validate step name
         if step_to_rerun not in obj.graph.nodes:
@@ -660,7 +660,7 @@ def resume(
                     step_to_rerun, ",".join(list(obj.graph.nodes.keys()))
                 )
             )
-        rerun_steps = {step_to_rerun}
+        steps_to_rerun = {step_to_rerun}
 
     if run_id:
         # Run-ids that are provided by the metadata service are always integers.
@@ -688,7 +688,7 @@ def resume(
         clone_run_id=origin_run_id,
         clone_only=clone_only,
         reentrant=reentrant,
-        rerun_steps=rerun_steps,
+        steps_to_rerun=steps_to_rerun,
         max_workers=max_workers,
         max_num_splits=max_num_splits,
         max_log_size=max_log_size * 1024 * 1024,

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -650,7 +650,7 @@ def resume(
             )
 
     if step_to_rerun is None:
-        clone_steps = set()
+        rerun_steps = set()
     else:
         # validate step name
         if step_to_rerun not in obj.graph.nodes:
@@ -660,7 +660,7 @@ def resume(
                     step_to_rerun, ",".join(list(obj.graph.nodes.keys()))
                 )
             )
-        clone_steps = {step_to_rerun}
+        rerun_steps = {step_to_rerun}
 
     if run_id:
         # Run-ids that are provided by the metadata service are always integers.
@@ -688,7 +688,7 @@ def resume(
         clone_run_id=origin_run_id,
         clone_only=clone_only,
         reentrant=reentrant,
-        clone_steps=clone_steps,
+        rerun_steps=rerun_steps,
         max_workers=max_workers,
         max_num_splits=max_num_splits,
         max_log_size=max_log_size * 1024 * 1024,

--- a/metaflow/graph.py
+++ b/metaflow/graph.py
@@ -171,6 +171,8 @@ class FlowGraph(object):
         self.name = flow.__name__
         self.nodes = self._create_nodes(flow)
         self.doc = deindent_docstring(flow.__doc__)
+        # nodes sorted in topological order.
+        self.sorted_nodes = []
         self._traverse_graph()
         self._postprocess()
 
@@ -197,6 +199,7 @@ class FlowGraph(object):
 
     def _traverse_graph(self):
         def traverse(node, seen, split_parents):
+            self.sorted_nodes.append(node.name)
             if node.type in ("split", "foreach"):
                 node.split_parents = split_parents
                 split_parents = split_parents + [node.name]

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -168,6 +168,9 @@ class NativeRuntime(object):
         Any steps following steps to be rerun should also be included as
         "rerun" steps. This is to ensure that the flow is executed correctly.
         """
+
+        # sorted_nodes are in topological order already, so we only need to
+        # iterate through the nodes once to get a stable set of rerun steps.
         for step_name in self._graph.sorted_nodes:
             if step_name in self._rerun_steps:
                 out_funcs = self._graph[step_name].out_funcs or []

--- a/test/core/metaflow_test/formatter.py
+++ b/test/core/metaflow_test/formatter.py
@@ -9,6 +9,7 @@ class FlowFormatter(object):
         self.graphspec = graphspec
         self.test = test
         self.should_resume = getattr(test, "RESUME", False)
+        self.resume_step = getattr(test, "RESUME_STEP", None)
         self.should_fail = getattr(test, "SHOULD_FAIL", False)
         self.flow_name = "%sFlow" % self.test.__class__.__name__
         self.used = set()

--- a/test/core/tests/resume_succeeded_step.py
+++ b/test/core/tests/resume_succeeded_step.py
@@ -1,0 +1,39 @@
+from metaflow_test import MetaflowTest, ExpectationFailed, steps
+
+
+class ResumeSucceededStepTest(MetaflowTest):
+    """
+    Resuming from the succeeded end step should work
+    """
+
+    RESUME = True
+    # resuming on a successful step.
+    RESUME_STEP = "start"
+    PRIORITY = 3
+    PARAMETERS = {"int_param": {"default": 123}}
+
+    @steps(0, ["start"])
+    def step_start(self):
+        if is_resumed():
+            self.data = "start_r"
+        else:
+            self.data = "start"
+
+    @steps(0, ["singleton-end"], required=True)
+    def step_end(self):
+        if is_resumed():
+            self.data = "end_r"
+        else:
+            self.data = "end"
+            raise ResumeFromHere()
+
+    @steps(2, ["all"])
+    def step_all(self):
+        pass
+
+    def check_results(self, flow, checker):
+        for step in flow:
+            data_value = step.name + "_r"
+            # resumed step will rerun and hence data will have this "_r" suffix.
+            if step.name in ["end", "start"]:
+                checker.assert_artifact(step.name, "data", data_value)

--- a/test/core/tests/resume_succeeded_step.py
+++ b/test/core/tests/resume_succeeded_step.py
@@ -8,7 +8,7 @@ class ResumeSucceededStepTest(MetaflowTest):
 
     RESUME = True
     # resuming on a successful step.
-    RESUME_STEP = "start"
+    RESUME_STEP = "a"
     PRIORITY = 3
     PARAMETERS = {"int_param": {"default": 123}}
 
@@ -29,11 +29,18 @@ class ResumeSucceededStepTest(MetaflowTest):
 
     @steps(2, ["all"])
     def step_all(self):
-        pass
+        if is_resumed():
+            self.data = "test_r"
+        else:
+            self.data = "test"
 
     def check_results(self, flow, checker):
         for step in flow:
-            data_value = step.name + "_r"
+            # task copied in resume will not have artifact with "_r" suffix.
+            if step.name == "start":
+                checker.assert_artifact(step.name, "data", "start")
             # resumed step will rerun and hence data will have this "_r" suffix.
-            if step.name in ["end", "start"]:
-                checker.assert_artifact(step.name, "data", data_value)
+            elif step.name == "a":
+                checker.assert_artifact(step.name, "data", "test_r")
+            elif step.name == "end":
+                checker.assert_artifact(step.name, "data", "end_r")


### PR DESCRIPTION
when running resume with `python flow.py resume {step_name}`, user may want to rerun the "step" and continue with the execution. In current code, we will blindly copy everything as long as the step was successful.

The proposed change will look at step in topological order and skip cloning the ones on and after the specified steps (and then rerun everything if possible).