### PR TITLE
fix: passing kubernetes compute pool option

### DIFF
--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -158,10 +158,12 @@ class KubernetesDecorator(StepDecorator):
                 self.attributes["node_selector"].split(",")
             )
         if self.attributes["compute_pool"]:
+            if self.attributes["node_selector"] is None:
+                self.attributes["node_selector"] = {}
             self.attributes["node_selector"].update(
-                {"outerbounds.co/compute_pool": self.attributes["compute_pool"]}
+                {"outerbounds.co/compute-pool": self.attributes["compute_pool"]}
             )
-            del self.attributes["compute_pool"]
+            # del self.attributes["compute_pool"]
 
         if self.attributes["tolerations"]:
             try:
@@ -379,9 +381,13 @@ class KubernetesDecorator(StepDecorator):
             cli_args.command_args.append(self.package_sha)
             cli_args.command_args.append(self.package_url)
 
+            # skip certain keys as CLI arguments
+            _skip_keys = ["compute_pool"]
             # --namespace is used to specify Metaflow namespace (a different
             # concept from k8s namespace).
             for k, v in self.attributes.items():
+                if k in _skip_keys:
+                    continue
                 if k == "namespace":
                     cli_args.command_options["k8s_namespace"] = v
                 elif k in {"node_selector"} and v:

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -163,7 +163,6 @@ class KubernetesDecorator(StepDecorator):
             self.attributes["node_selector"].update(
                 {"outerbounds.co/compute-pool": self.attributes["compute_pool"]}
             )
-            # del self.attributes["compute_pool"]
 
         if self.attributes["tolerations"]:
             try:

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -157,8 +157,6 @@ class KubernetesDecorator(StepDecorator):
             self.attributes["node_selector"] = parse_kube_keyvalue_list(
                 self.attributes["node_selector"].split(",")
             )
-        else:
-            self.attributes["node_selector"] = {}
         if self.attributes["compute_pool"]:
             self.attributes["node_selector"].update(
                 {"outerbounds.co/compute_pool": self.attributes["compute_pool"]}


### PR DESCRIPTION
fixes issue with launching kubernetes tasks with a default node_selector. Introduced in #1952 

is the `else` block required at all? the default dict messes up with the value of node_selector being passed to the CLI, where parsing fails.

```
2024-08-19 12:06:18.037 [1450/start/4611 (pid 74904)] in kube-cli step the node_selector is: {}
2024-08-19 12:06:19.178 [1450/start/4611 (pid 74904)] Kubernetes error:
2024-08-19 12:06:19.178 [1450/start/4611 (pid 74904)] Unable to parse kubernetes list: {}
```