### PR TITLE
fix(MetaflowData): Raise AttributeError on failed `__getattr__` access

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -1027,6 +1027,8 @@ class MetaflowData(object):
         self._artifacts = dict((art.id, art) for art in artifacts)
 
     def __getattr__(self, name: str):
+        if name not in self._artifacts:
+            raise AttributeError(name)
         return self._artifacts[name].data
 
     def __contains__(self, var):


### PR DESCRIPTION
Python's custom attribute access protocol requires `AttributeError` to be raised on access failure ([docs link](https://docs.python.org/3.10/reference/datamodel.html#object.__getattr__)). The current implement propagates `KeyError` from `dict`, which breaks `hasattr()` operations on `MetaflowData`.

This PR checks for key existence and raise the correct exception in `MetaflowData.__getattr__`.

Fixes #1970.