### PR TITLE
feature: better bootstrap dependencies

### DIFF
--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -125,7 +125,7 @@ class MetaflowEnvironment(object):
             )
 
     def _get_install_dependencies_cmd(self, datastore_type):
-        base_cmd = "{} -m pip install".format(self._python())
+        base_cmd = "{} -m pip install -qqq".format(self._python())
 
         datastore_packages = {
             "s3": ["boto3"],

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -101,7 +101,7 @@ class MetaflowEnvironment(object):
                 "boto3.client('s3', endpoint_url=os.getenv(METAFLOW_S3_ENDPOINT_URL))"
                 ".download_file('%s', '%s', 'job.tar')\""
             ) % (
-                self._python,
+                self._python(),
                 bucket,
                 s3_object,
             )

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -152,7 +152,7 @@ class MetaflowEnvironment(object):
             base_cmd, " ".join(datastore_packages[datastore_type] + ["requests"])
         )
         # skip pip installs if we know that packages might already be available
-        return "if [ -z $SKIP_INSTALL_DEPENDENCIES ]; then {}; fi".format(cmd)
+        return "if [ -z $METAFLOW_SKIP_INSTALL_DEPENDENCIES ]; then {}; fi".format(cmd)
 
     def get_package_commands(self, code_package_url, datastore_type):
         cmds = [

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -97,13 +97,14 @@ class MetaflowEnvironment(object):
             # through pypi).
             # Instead, just use boto3 which we already have installed.
             return (
-                "%s -c \"import boto3; import os; "
+                '%s -c "import boto3; import os; '
                 "boto3.client('s3', endpoint_url=os.getenv(METAFLOW_S3_ENDPOINT_URL))"
-                ".download_file('%s', '%s', 'job.tar')\"") % (
-                    self._python,
-                    bucket,
-                    s3_object,
-                )
+                ".download_file('%s', '%s', 'job.tar')\""
+            ) % (
+                self._python,
+                bucket,
+                s3_object,
+            )
         elif datastore_type == "azure":
             from .plugins.azure.azure_utils import parse_azure_full_path
 

--- a/metaflow/plugins/aws/aws_utils.py
+++ b/metaflow/plugins/aws/aws_utils.py
@@ -4,7 +4,6 @@ import requests
 from metaflow.exception import MetaflowException
 
 
-
 def parse_s3_full_path(s3_uri):
     from urllib.parse import urlparse
 

--- a/metaflow/plugins/aws/aws_utils.py
+++ b/metaflow/plugins/aws/aws_utils.py
@@ -4,6 +4,23 @@ import requests
 from metaflow.exception import MetaflowException
 
 
+
+def parse_s3_full_path(s3_uri):
+    from urllib.parse import urlparse
+
+    #  <scheme>://<netloc>/<path>;<params>?<query>#<fragment>
+    scheme, netloc, path, _, _, _ = urlparse(s3_uri)
+    assert scheme == "s3"
+    assert netloc is not None
+
+    bucket = netloc
+    path = path.lstrip("/").rstrip("/")
+    if path == "":
+        path = None
+
+    return bucket, path
+
+
 def get_ec2_instance_metadata():
     """
     Fetches the EC2 instance metadata through AWS instance metadata service


### PR DESCRIPTION
gets rid of awscli as a dependency, opting to instead use boto3 directly with inline python to download the codepackage. Supersedes #1778 

also introduces an environment variable to allow skipping installing bootstrap dependencies completely. Motivated by #1957 

