### PR TITLE
[POC][cli-options-from-step-decorators][WIP]

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -479,6 +479,7 @@ def step(
     echo("Success", fg="green", bold=True, indent=True)
 
 
+@decorators.add_step_decorator_parameters
 @parameters.add_custom_parameters(deploy_mode=False)
 @cli.command(help="Internal command to initialize a run.", hidden=True)
 @click.option(
@@ -722,6 +723,7 @@ def resume(
 
 
 @tracing.cli_entrypoint("cli/run")
+@decorators.add_step_decorator_parameters
 @parameters.add_custom_parameters(deploy_mode=True)
 @cli.command(help="Run the workflow locally.")
 @common_run_options

--- a/metaflow/parameters.py
+++ b/metaflow/parameters.py
@@ -46,6 +46,16 @@ ParameterContext = NamedTuple(
 current_flow = local()
 
 
+def _figure_step_decos_for_current_step(flow_cls):
+    deco_set = set()
+    for attr_name in dir(flow_cls):
+        attr = getattr(flow_cls, attr_name)
+        if hasattr(attr, "is_step"):
+            for deco in attr.decorators:
+                deco_set.add(deco.name)
+    return list(deco_set)
+
+
 @contextmanager
 def flow_context(flow_cls):
     """
@@ -58,6 +68,9 @@ def flow_context(flow_cls):
     current_flow.flow_cls_stack = getattr(current_flow, "flow_cls_stack", [])
     current_flow.flow_cls_stack.insert(0, flow_cls)
     current_flow.flow_cls = current_flow.flow_cls_stack[0]
+    current_flow.unique_step_decos_in_flow = _figure_step_decos_for_current_step(
+        flow_cls
+    )
     try:
         yield
     finally:

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -1448,6 +1448,9 @@ class CLIArgs(object):
         for deco in flow_decorators(self.task.flow):
             self.top_level_options.update(deco.get_top_level_options())
 
+        # TODO [CLI-OPTIONS-FROM-STEP-DECOS]:
+        # Extract the deco.get_top_level_options() equivalent for the step decorators.
+
         self.commands = ["step"]
         self.command_args = [self.task.step]
         self.command_options = {


### PR DESCRIPTION
Two parts to this whole change:
> How do step decorators inject CLI parameters
- This part is handled by piggy backing on the `flow_context` to inject the unique steps decorators in the code.
- Once the unique step decorators are available via the `current_flow` local variable, we can extract all the options a decorator class exposes and then inject them into the CLI based on the kind/type of CLI we need to inject it into.

> How are the injected parameters passed down to the decorators.
- Current TBD
- Needs more discussion to decide what needs to happen here.