### PR TITLE
feature: Kubernetes kill and list commands

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -53,6 +53,7 @@ from metaflow.metaflow_config import (
 from metaflow.metaflow_config_funcs import config_values
 from metaflow.mflog import BASH_SAVE_LOGS, bash_capture_logs, export_mflog_env_vars
 from metaflow.parameters import deploy_time_eval
+from metaflow.plugins.kubernetes.kube_utils import hashed_label
 from metaflow.plugins.kubernetes.kubernetes import (
     parse_kube_keyvalue_list,
     validate_kube_labels,
@@ -780,6 +781,7 @@ class ArgoWorkflows(object):
                     Metadata()
                     .label("app.kubernetes.io/name", "metaflow-task")
                     .label("app.kubernetes.io/part-of", "metaflow")
+                    .label("metaflow.org/flow-hash", hashed_label(self.flow.name))
                     .annotations(annotations)
                     .labels(self.kubernetes_labels)
                 )

--- a/metaflow/plugins/kubernetes/kube_utils.py
+++ b/metaflow/plugins/kubernetes/kube_utils.py
@@ -1,0 +1,9 @@
+from hashlib import sha256
+
+
+def hashed_label(text: str):
+    """
+    Hash a name for use as a Kubernetes label.
+    Use the maximum allowed 63 characters for the hash to minimize collisions.
+    """
+    return sha256(text.encode("utf-8")).hexdigest()[:63]

--- a/metaflow/plugins/kubernetes/kube_utils.py
+++ b/metaflow/plugins/kubernetes/kube_utils.py
@@ -1,4 +1,6 @@
 from hashlib import sha256
+from metaflow.exception import CommandException
+from metaflow.util import get_username, get_latest_run_id
 
 
 def hashed_label(text: str):
@@ -7,3 +9,26 @@ def hashed_label(text: str):
     Use the maximum allowed 63 characters for the hash to minimize collisions.
     """
     return sha256(text.encode("utf-8")).hexdigest()[:63]
+
+
+def parse_cli_options(flow_name, run_id, user, my_runs, echo):
+    if user and my_runs:
+        raise CommandException("--user and --my-runs are mutually exclusive.")
+
+    if run_id and my_runs:
+        raise CommandException("--run_id and --my-runs are mutually exclusive.")
+
+    if my_runs:
+        user = get_username()
+
+    latest_run = True
+
+    if user and not run_id:
+        latest_run = False
+
+    if not run_id and latest_run:
+        run_id = get_latest_run_id(echo, flow_name)
+        if run_id is None:
+            raise CommandException("A previous run id was not found. Specify --run-id.")
+
+    return flow_name, run_id, user

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -55,6 +55,7 @@ from metaflow.mflog import (
     tail_logs,
 )
 
+from .kube_utils import hashed_label
 from .kubernetes_client import KubernetesClient
 
 # Redirect structured logs to $PWD/.logs/
@@ -817,11 +818,3 @@ def parse_kube_keyvalue_list(items: List[str], requires_both: bool = True):
         raise e
     except (AttributeError, IndexError):
         raise KubernetesException("Unable to parse kubernetes list: %s" % items)
-
-
-def hashed_label(text: str):
-    """
-    Hash a name for use as a Kubernetes label.
-    Use the maximum allowed 63 characters for the hash to minimize collisions.
-    """
-    return sha256(text.encode("utf-8")).hexdigest()[:63]

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -1,4 +1,5 @@
 import copy
+from hashlib import sha256
 import json
 import math
 import os
@@ -400,6 +401,7 @@ class Kubernetes(object):
             .annotation("metaflow/attempt", attempt)
             .label("app.kubernetes.io/name", "metaflow-task")
             .label("app.kubernetes.io/part-of", "metaflow")
+            .label("metaflow.org/flow-hash", hashed_label(flow_name))
         )
 
         ## ----------- control/worker specific values START here -----------
@@ -659,6 +661,7 @@ class Kubernetes(object):
             .annotation("metaflow/attempt", attempt)
             .label("app.kubernetes.io/name", "metaflow-task")
             .label("app.kubernetes.io/part-of", "metaflow")
+            .label("metaflow.org/flow-hash", hashed_label(flow_name))
         )
 
         return job
@@ -814,3 +817,11 @@ def parse_kube_keyvalue_list(items: List[str], requires_both: bool = True):
         raise e
     except (AttributeError, IndexError):
         raise KubernetesException("Unable to parse kubernetes list: %s" % items)
+
+
+def hashed_label(text: str):
+    """
+    Hash a name for use as a Kubernetes label.
+    Use the maximum allowed 63 characters for the hash to minimize collisions.
+    """
+    return sha256(text.encode("utf-8")).hexdigest()[:63]

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -1,12 +1,18 @@
+import datetime
 import os
 import sys
 import time
 import traceback
 
+from metaflow.plugins.kubernetes.kubernetes_client import KubernetesClient
 import metaflow.tracing as tracing
 from metaflow import JSONTypeClass, util
 from metaflow._vendor import click
-from metaflow.exception import METAFLOW_EXIT_DISALLOW_RETRY, CommandException
+from metaflow.exception import (
+    METAFLOW_EXIT_DISALLOW_RETRY,
+    CommandException,
+    MetaflowException,
+)
 from metaflow.metadata.util import sync_local_metadata_from_datastore
 from metaflow.metaflow_config import DATASTORE_LOCAL_DIR, KUBERNETES_LABELS
 from metaflow.mflog import TASK_LOG_SOURCE
@@ -305,3 +311,123 @@ def step(
         sys.exit(METAFLOW_EXIT_DISALLOW_RETRY)
     finally:
         _sync_metadata()
+
+
+@kubernetes.command(help="List all runs of the flow on Kubernetes.")
+@click.option(
+    "--pending",
+    default=False,
+    is_flag=True,
+    help="List all pending runs of the flow on " "Kubernetes.",
+)
+@click.option(
+    "--running",
+    default=False,
+    is_flag=True,
+    help="List all running runs of the flow on " "Kubernetes.",
+)
+@click.option(
+    "--succeeded",
+    default=False,
+    is_flag=True,
+    help="List all succeeded runs of the flow on " "Kubernetes.",
+)
+@click.option(
+    "--failed",
+    default=False,
+    is_flag=True,
+    help="List all failed runs of the flow on " "Kubernetes.",
+)
+@click.option(
+    "--unknown",
+    default=False,
+    is_flag=True,
+    help="List all runs of the flow in Unknown state on "
+    "Kubernetes."
+    " (These happen when a pods status can not be obtained.)",
+)
+@click.pass_obj
+def list_runs(obj, pending, running, succeeded, failed, unknown):
+    states = []
+    if pending:
+        states.append("Pending")
+    if running:
+        states.append("Running")
+    if succeeded:
+        states.append("Succeeded")
+    if failed:
+        # group errors and failures together
+        states.append("Failed")
+        states.append("Error")
+    if unknown:
+        states.append("Unknown")
+
+    # obj.echo("flow label: %s" % flow_label)
+    kube_client = KubernetesClient()
+    executions = kube_client.list(obj.flow.name, states)
+    found = False
+    # obj.echo("%s" % executions)
+
+    def format_timestamp(timestamp=None):
+        if timestamp is None:
+            return "-"
+        return timestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
+        # return datetime.strptime(timestamp, )
+
+    def remap_status(status):
+        # remap status for the grouped cases
+        if status.failed:
+            return "Failed"
+        if status.active or not status.succeeded:
+            return "Running"
+        return "Succeeded"
+
+    for execution in executions:
+        found = True
+        obj.echo(
+            "*{id}* "
+            "startedAt: '{startedAt}' "
+            "finishedAt: '{finishedAt}' "
+            "*{status}*".format(
+                id=execution.metadata.name,
+                status=remap_status(execution.status),
+                startedAt=format_timestamp(execution.status.start_time),
+                finishedAt=format_timestamp(execution.status.completion_time),
+            )
+        )
+
+    if not found:
+        if len(states) > 0:
+            status = ""
+            for idx, state in enumerate(set(remap_status(state) for state in states)):
+                if idx == 0:
+                    pass
+                elif idx == len(states) - 1:
+                    status += " and "
+                else:
+                    status += ", "
+                status += "*%s*" % state
+            obj.echo(
+                "No %s executions for *%s* found on Kubernetes."
+                % (status, obj.flow.name)
+            )
+        else:
+            obj.echo("No executions for *%s* found on Kubernetes." % (obj.flow.name))
+
+
+@kubernetes.command(help="Terminate flow execution on Kubernetes.")
+@click.argument("run-id", required=True, type=str)
+@click.pass_obj
+def kill(obj, run_id):
+    # Trim prefix from run_id
+    name = run_id[5:]
+    obj.echo(
+        "Terminating run *{run_id}* for {flow_name} ...".format(
+            run_id=run_id, flow_name=obj.flow.name
+        ),
+        bold=True,
+    )
+
+    # terminated = ArgoWorkflows.terminate(obj.flow.name, name)
+    # if terminated:
+    #     obj.echo("\nRun terminated.")

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -389,7 +389,7 @@ def list_runs(obj, pending, running, succeeded, failed, unknown):
             "startedAt: '{startedAt}' "
             "finishedAt: '{finishedAt}' "
             "*{status}*".format(
-                id=execution.metadata.name,
+                id=execution.metadata.annotations["metaflow/run_id"],
                 status=remap_status(execution.status),
                 startedAt=format_timestamp(execution.status.start_time),
                 finishedAt=format_timestamp(execution.status.completion_time),

--- a/metaflow/plugins/kubernetes/kubernetes_cli.py
+++ b/metaflow/plugins/kubernetes/kubernetes_cli.py
@@ -345,7 +345,10 @@ def list(obj, run_id, user, my_runs):
             "Pod: *{pod_id}* "
             "Started At: {startedAt} "
             "Status: *{status}*".format(
-                run_id=pod.metadata.annotations["metaflow/run_id"],
+                run_id=pod.metadata.annotations.get(
+                    "metaflow/run_id",
+                    pod.metadata.labels.get("workflows.argoproj.io/workflow"),
+                ),
                 pod_id=pod.metadata.name,
                 startedAt=format_timestamp(pod.status.start_time),
                 status=pod.status.phase,


### PR DESCRIPTION
first draft for introducing `kubernetes list-runs` and `kubernetes kill RUN_ID` commands

list of major caveats:

***label selectors***
Due to Kubernetes being limited to label selectors for filtering resources returned by the API, we need to introduce a new label for flow objects that encodes the flow name for later retrieval. *This makes the changes not backwards compatible*.

Even with the flow hash, we still need to do some in-memory filtering of results for the `kill` command in order to only select jobs for a specific run. Introducing the run_id as a label would introduce an unnecessarily large amount of new labels

***run status***
Displaying a `status` for a run with the `list` command, or filtering by status would require introducing a client-side state machine that would need to go through all the jobs of a run in order to ascertain the current status. The main problem here is that unlike with Argo Workflows, with client-driven Kubernetes we do not have a central status location to query on the cluster side.

closes #1631 