### PR TITLE
[core-change] Top level options from step decorators.

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -843,6 +843,7 @@ def version(obj):
 
 @tracing.cli_entrypoint("cli/start")
 @decorators.add_decorator_options
+@decorators.add_step_decorator_options
 @click.command(
     cls=click.CommandCollection,
     sources=[cli] + plugins.get_plugin_cli(),
@@ -1008,6 +1009,8 @@ def start(
         echo,
         deco_options,
     )
+
+    decorators._inject_step_decorator_options(ctx.obj.flow, deco_options)
 
     # In the case of run/resume, we will want to apply the TL decospecs
     # *after* the run decospecs so that they don't take precedence. In other

--- a/metaflow/parameters.py
+++ b/metaflow/parameters.py
@@ -46,6 +46,16 @@ ParameterContext = NamedTuple(
 current_flow = local()
 
 
+def _figure_step_decos_for_current_step(flow_cls):
+    deco_set = set()
+    for attr_name in dir(flow_cls):
+        attr = getattr(flow_cls, attr_name)
+        if hasattr(attr, "is_step"):
+            for deco in attr.decorators:
+                deco_set.add(deco.name)
+    return list(deco_set)
+
+
 @contextmanager
 def flow_context(flow_cls):
     """
@@ -58,6 +68,9 @@ def flow_context(flow_cls):
     current_flow.flow_cls_stack = getattr(current_flow, "flow_cls_stack", [])
     current_flow.flow_cls_stack.insert(0, flow_cls)
     current_flow.flow_cls = current_flow.flow_cls_stack[0]
+    current_flow.unique_step_decos_in_flow = _figure_step_decos_for_current_step(
+        flow_cls
+    )
     try:
         yield
     finally:

--- a/metaflow/plugins/airflow/airflow.py
+++ b/metaflow/plugins/airflow/airflow.py
@@ -542,6 +542,9 @@ class Airflow(object):
         for deco in flow_decorators(self.flow):
             top_opts_dict.update(deco.get_top_level_options())
 
+        for decorator in node.decorators:
+            top_opts_dict.update(deco.get_top_level_options())
+
         top_opts = list(dict_to_cli_options(top_opts_dict))
 
         top_level = top_opts + [

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -1454,6 +1454,9 @@ class ArgoWorkflows(object):
             for deco in flow_decorators(self.flow):
                 top_opts_dict.update(deco.get_top_level_options())
 
+            for decorator in node.decorators:
+                top_opts_dict.update(deco.get_top_level_options())
+
             top_level = list(dict_to_cli_options(top_opts_dict)) + [
                 "--quiet",
                 "--metadata=%s" % self.metadata.TYPE,

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -884,6 +884,9 @@ class StepFunctions(object):
         for deco in flow_decorators(self.flow):
             top_opts_dict.update(deco.get_top_level_options())
 
+        for decorator in node.decorators:
+            top_opts_dict.update(deco.get_top_level_options())
+
         top_opts = list(dict_to_cli_options(top_opts_dict))
 
         top_level = top_opts + [

--- a/metaflow/runner/click_api.py
+++ b/metaflow/runner/click_api.py
@@ -32,7 +32,7 @@ from metaflow._vendor.click.types import (
     UUIDParameterType,
 )
 from metaflow._vendor.typeguard import TypeCheckError, check_type
-from metaflow.decorators import add_decorator_options
+from metaflow.decorators import add_decorator_options, add_step_decorator_options
 from metaflow.exception import MetaflowException
 from metaflow.includefile import FilePathClass
 from metaflow.parameters import JSONTypeClass, flow_context
@@ -186,7 +186,7 @@ class MetaflowAPI(object):
         flow_cls = extract_flow_class_from_file(flow_file)
         flow_parameters = [p for _, p in flow_cls._get_parameters()]
         with flow_context(flow_cls) as _:
-            add_decorator_options(cli_collection)
+            add_step_decorator_options(add_decorator_options(cli_collection))
 
         class_dict = {"__module__": "metaflow", "_API_NAME": flow_file}
         command_groups = cli_collection.sources

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -1448,6 +1448,10 @@ class CLIArgs(object):
         for deco in flow_decorators(self.task.flow):
             self.top_level_options.update(deco.get_top_level_options())
 
+        # Extract the deco.get_top_level_options() equivalent for the step decorators.
+        for deco in self.task.decos:
+            self.top_level_options.update(deco.get_top_level_options())
+
         self.commands = ["step"]
         self.command_args = [self.task.step]
         self.command_options = {


### PR DESCRIPTION
- CLI options injected by step decorators in the Top level CLI
- Step decorators exposing an additional hooks in the lifecycle to accept options passed down from top level
- top level option injection is only done by step decorators that are statically set in the code