### PR TITLE
fix: support user-defined attribute checks for pypi_base as well

### DIFF
--- a/metaflow/plugins/pypi/pypi_decorator.py
+++ b/metaflow/plugins/pypi/pypi_decorator.py
@@ -40,7 +40,12 @@ class PyPIStepDecorator(StepDecorator):
 
         # Support flow-level decorator
         if "pypi_base" in self.flow._flow_decorators:
-            super_attributes = self.flow._flow_decorators["pypi_base"][0].attributes
+            pypi_base = self.flow._flow_decorators["pypi_base"][0]
+            super_attributes = pypi_base.attributes
+            self._user_defined_attributes = {
+                **self._user_defined_attributes,
+                **pypi_base._user_defined_attributes,
+            }
             self.attributes["packages"] = {
                 **super_attributes["packages"],
                 **self.attributes["packages"],
@@ -122,6 +127,12 @@ class PyPIFlowDecorator(FlowDecorator):
 
     name = "pypi_base"
     defaults = {"packages": {}, "python": None, "disabled": None}
+
+    def __init__(self, attributes=None, statically_defined=False):
+        self._user_defined_attributes = (
+            attributes.copy() if attributes is not None else {}
+        )
+        super().__init__(attributes, statically_defined)
 
     def flow_init(
         self, flow, graph, environment, flow_datastore, metadata, logger, echo, options


### PR DESCRIPTION
examples:
this should result in a non-user-defined python version for all steps
```python
@pypi_base
class HelloFlow(FlowSpec):
...
```

and this should count as user-set for all steps
```python
@pypi_base(python="3.10")
class HelloFlow(FlowSpec):
...
```