### PR TITLE
Modify getting Metaflow version

### DIFF
--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -151,6 +151,7 @@ if sys.version_info >= (3, 7):
     from .runner.nbdeploy import NBDeployer
 
 __version_addl__ = []
+__version_override__ = None
 _ext_debug("Loading top-level modules")
 for m in _tl_modules:
     extension_module = load_module(m)
@@ -164,11 +165,15 @@ for m in _tl_modules:
         ext_version = _format_git_describe(
             _call_git_describe(cwd=os.path.dirname(extension_module.__file__))
         )
+        ext_override = None
         if ext_version is None:
-            ext_version = extension_module.__version__
-        if ext_version:
-            version_info = "%s(%s)" % (version_info, ext_version)
-        __version_addl__.append(version_info)
+            ext_version = getattr(extension_module, "__version__", "<unk>")
+            ext_override = getattr(extension_module, "__name_override__", None)
+        if ext_override:
+            __version_override__ = "%s %s" % (ext_override, ext_version)
+            __version_addl__.clear()
+        else:
+            __version_addl__.append("%s(%s)" % (version_info, ext_version))
 
 if __version_addl__:
     __version_addl__ = ";".join(__version_addl__)

--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -42,14 +42,9 @@ If you have any questions, feel free to post a bug report/question on the
 Metaflow GitHub page.
 """
 
-import importlib
+import os
 import sys
-import types
 
-from os import path
-
-CURRENT_DIRECTORY = path.dirname(path.abspath(__file__))
-INFO_FILE = path.join(path.dirname(CURRENT_DIRECTORY), "INFO")
 
 from metaflow.extension_support import (
     alias_submodules,
@@ -61,6 +56,8 @@ from metaflow.extension_support import (
     _ext_debug,
 )
 
+from metaflow.metaflow_version import call_git_describe as _call_git_describe
+from metaflow.metaflow_version import format_git_describe as _format_git_describe
 
 # We load the module overrides *first* explicitly. Non overrides can be loaded
 # in toplevel as well but these can be loaded first if needed. Note that those
@@ -164,8 +161,13 @@ for m in _tl_modules:
             alias_submodules(extension_module, tl_package, None, extra_indent=True)
         )
         version_info = getattr(extension_module, "__mf_extensions__", "<unk>")
-        if extension_module.__version__:
-            version_info = "%s(%s)" % (version_info, extension_module.__version__)
+        ext_version = _format_git_describe(
+            _call_git_describe(cwd=os.path.dirname(extension_module.__file__))
+        )
+        if ext_version is None:
+            ext_version = extension_module.__version__
+        if ext_version:
+            version_info = "%s(%s)" % (version_info, ext_version)
         __version_addl__.append(version_info)
 
 if __version_addl__:
@@ -191,6 +193,8 @@ for _n in [
     "extension_module",
     "tl_package",
     "version_info",
+    "_call_git_describe",
+    "_format_git_describe",
 ]:
     try:
         del globals()[_n]

--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -162,10 +162,10 @@ for m in _tl_modules:
             alias_submodules(extension_module, tl_package, None, extra_indent=True)
         )
         version_info = getattr(extension_module, "__mf_extensions__", "<unk>")
-        ext_version = _format_git_describe(
-            _call_git_describe(cwd=os.path.dirname(extension_module.__file__))
-        )
         ext_override = None
+        ext_version = _format_git_describe(
+            _call_git_describe(file_to_check=extension_module.__file__)
+        )
         if ext_version is None:
             ext_version = getattr(extension_module, "__version__", "<unk>")
             ext_override = getattr(extension_module, "__name_override__", None)

--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -151,7 +151,6 @@ if sys.version_info >= (3, 7):
     from .runner.nbdeploy import NBDeployer
 
 __version_addl__ = []
-__version_override__ = None
 _ext_debug("Loading top-level modules")
 for m in _tl_modules:
     extension_module = load_module(m)
@@ -162,18 +161,14 @@ for m in _tl_modules:
             alias_submodules(extension_module, tl_package, None, extra_indent=True)
         )
         version_info = getattr(extension_module, "__mf_extensions__", "<unk>")
-        ext_override = None
         ext_version = _format_git_describe(
             _call_git_describe(file_to_check=extension_module.__file__)
         )
         if ext_version is None:
             ext_version = getattr(extension_module, "__version__", "<unk>")
-            ext_override = getattr(extension_module, "__name_override__", None)
-        if ext_override:
-            __version_override__ = "%s %s" % (ext_override, ext_version)
-            __version_addl__.clear()
-        else:
-            __version_addl__.append("%s(%s)" % (version_info, ext_version))
+        if ext_version:
+            version_info = "%s(%s)" % (version_info, ext_version)
+        __version_addl__.append(version_info)
 
 if __version_addl__:
     __version_addl__ = ";".join(__version_addl__)

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -34,7 +34,7 @@ from metaflow.plugins import ENVIRONMENTS, METADATA_PROVIDERS
 from metaflow.unbounded_foreach import CONTROL_TASK_TAG
 from metaflow.util import cached_property, is_stringish, resolve_identity, to_unicode
 
-from .. import INFO_FILE
+from ..info_file import INFO_FILE
 from .filecache import FileCache
 
 try:

--- a/metaflow/cmd/main_cli.py
+++ b/metaflow/cmd/main_cli.py
@@ -84,12 +84,13 @@ def start(ctx):
 
     import metaflow
 
+    version = get_version()
     echo("Metaflow ", fg="magenta", bold=True, nl=False)
 
     if ctx.invoked_subcommand is None:
-        echo("(%s): " % get_version(), fg="magenta", bold=False, nl=False)
+        echo("(%s): " % version, fg="magenta", bold=False, nl=False)
     else:
-        echo("(%s)\n" % get_version(), fg="magenta", bold=False)
+        echo("(%s)\n" % version, fg="magenta", bold=False)
 
     if ctx.invoked_subcommand is None:
         echo("More data science, less engineering\n", fg="magenta")

--- a/metaflow/extension_support/__init__.py
+++ b/metaflow/extension_support/__init__.py
@@ -10,6 +10,7 @@ from collections import defaultdict, namedtuple
 
 from importlib.abc import MetaPathFinder, Loader
 from itertools import chain
+from pathlib import Path
 
 from metaflow.info_file import read_info_file
 
@@ -61,6 +62,9 @@ __all__ = (
     "load_module",
     "get_modules",
     "dump_module_info",
+    "get_extensions_in_dir",
+    "extension_info",
+    "update_package_info",
     "get_aliased_modules",
     "package_mfext_package",
     "package_mfext_all",
@@ -82,9 +86,14 @@ EXT_EXCLUDE_SUFFIXES = [".pyc"]
 # To get verbose messages, set METAFLOW_DEBUG_EXT to 1
 DEBUG_EXT = os.environ.get("METAFLOW_DEBUG_EXT", False)
 
+# This is extracted only from environment variable and here separately from
+# metaflow_config to prevent nasty circular dependencies
+EXTENSIONS_SEARCH_DIRS = os.environ.get("METAFLOW_EXTENSIONS_SEARCH_DIRS", "").split(
+    os.pathsep
+)
 
 MFExtPackage = namedtuple("MFExtPackage", "package_name tl_package config_module")
-MFExtModule = namedtuple("MFExtModule", "tl_package module")
+MFExtModule = namedtuple("MFExtModule", "package_name tl_package module")
 
 
 def load_module(module_name):
@@ -115,17 +124,64 @@ def get_modules(extension_point):
     return modules_to_load
 
 
-def dump_module_info():
-    _filter_files_all()
+def dump_module_info(all_packages=None, pkgs_per_extension_point=None):
+    if all_packages is None:
+        all_packages = _all_packages
+    if pkgs_per_extension_point is None:
+        pkgs_per_extension_point = _pkgs_per_extension_point
+
+    _filter_files_all(all_packages)
     sanitized_all_packages = dict()
     # Strip out root_paths (we don't need it and no need to expose user's dir structure)
-    for k, v in _all_packages.items():
+    for k, v in all_packages.items():
         sanitized_all_packages[k] = {
             "root_paths": None,
             "meta_module": v["meta_module"],
             "files": v["files"],
+            "version": v["version"],
+            "reported_version": v.get("reported_version", "<unk>"),
+            "user_visible_name": v.get("user_visible_name", "<unk>"),
         }
-    return "ext_info", [sanitized_all_packages, _pkgs_per_extension_point]
+    return "ext_info", [sanitized_all_packages, pkgs_per_extension_point]
+
+
+def get_extensions_in_dir(d):
+    if not _mfext_supported:
+        _ext_debug("Not supported for your Python version -- 3.4+ is needed")
+        return None, None
+    return _get_extension_packages(ignore_info_file=True, restrict_to_directories=[d])
+
+
+def extension_info(packages=None):
+    if packages is None:
+        packages = _all_packages
+    # Returns information about installed extensions so it it can be stored in
+    # _graph_info.
+    return {
+        "installed": {
+            k: {
+                "version": v["version"],
+                "reported_version": v.get("reported_version", "<unk>"),
+                "user_visible_name": v.get("user_visible_name", "<unk>"),
+            }
+            for k, v in packages.items()
+        },
+    }
+
+
+def update_package_info(pkg_to_update=None, package_name=None, **kwargs):
+    pkg = None
+    if pkg_to_update:
+        pkg = pkg_to_update
+    elif package_name:
+        pkg = _all_packages.get(package_name)
+    for k, v in kwargs.items():
+        if k in pkg:
+            raise ValueError(
+                "Trying to overwrite existing key '%s' for package %s" % (k, str(pkg))
+            )
+        pkg[k] = v
+    return pkg
 
 
 def get_aliased_modules():
@@ -136,8 +192,8 @@ def package_mfext_package(package_name):
     from metaflow.util import to_unicode
 
     _ext_debug("Packaging '%s'" % package_name)
-    _filter_files_package(package_name)
     pkg_info = _all_packages.get(package_name, None)
+    _filter_files_package(pkg_info)
     if pkg_info and pkg_info.get("root_paths", None):
         single_path = len(pkg_info["root_paths"]) == 1
         for p in pkg_info["root_paths"]:
@@ -298,7 +354,7 @@ def _ext_debug(*args, **kwargs):
         print(init_str, *args, **kwargs)
 
 
-def _get_extension_packages():
+def _get_extension_packages(ignore_info_file=False, restrict_to_directories=None):
     if not _mfext_supported:
         _ext_debug("Not supported for your Python version -- 3.4+ is needed")
         return {}, {}
@@ -307,7 +363,7 @@ def _get_extension_packages():
     # code package for example), we use that directly
     # Pre-compute on _extension_points
     info_content = read_info_file()
-    if info_content:
+    if not ignore_info_file and info_content:
         all_pkg, ext_to_pkg = info_content.get("ext_info", (None, None))
         if all_pkg is not None and ext_to_pkg is not None:
             _ext_debug("Loading pre-computed information from INFO file")
@@ -316,6 +372,10 @@ def _get_extension_packages():
                 v = [MFExtPackage(*d) for d in v]
                 ext_to_pkg[k] = v
             return all_pkg, ext_to_pkg
+
+    # Late import to prevent some circular nastiness
+    if restrict_to_directories is None and EXTENSIONS_SEARCH_DIRS != [""]:
+        restrict_to_directories = EXTENSIONS_SEARCH_DIRS
 
     # Check if we even have extensions
     try:
@@ -329,6 +389,11 @@ def _get_extension_packages():
                 raise
         return {}, {}
 
+    if restrict_to_directories:
+        restrict_to_directories = [
+            Path(p).resolve().as_posix() for p in restrict_to_directories
+        ]
+
     # There are two "types" of packages:
     #   - those installed on the system (distributions)
     #   - those present in the PYTHONPATH
@@ -341,8 +406,12 @@ def _get_extension_packages():
     # At this point, we look at all the paths and create a set. As we find distributions
     # that match it, we will remove from the set and then will be left with any
     # PYTHONPATH "packages"
-    all_paths = set(extensions_module.__path__)
+    all_paths = set(Path(p).resolve().as_posix() for p in extensions_module.__path__)
     _ext_debug("Found packages present at %s" % str(all_paths))
+    if restrict_to_directories:
+        _ext_debug(
+            "Processed packages will be restricted to %s" % str(restrict_to_directories)
+        )
 
     list_ext_points = [x.split(".") for x in _extension_points]
     init_ext_points = [x[0] for x in list_ext_points]
@@ -389,9 +458,20 @@ def _get_extension_packages():
             # This is not 100% accurate because it is possible that at the same
             # location there is a package and a non-package, but this is extremely
             # unlikely so we are going to ignore this case.
-            dist_root = dist.locate_file(EXT_PKG).as_posix()
+            dist_root = dist.locate_file(EXT_PKG).resolve().as_posix()
             all_paths.discard(dist_root)
-            dist_name = dist.metadata["Name"]
+            dist_name = dist.name
+            dist_version = dist.version
+            if restrict_to_directories:
+                parent_dirs = list(
+                    p.as_posix() for p in Path(dist_root).resolve().parents
+                )
+                if all(p not in parent_dirs for p in restrict_to_directories):
+                    _ext_debug(
+                        "Ignoring package at %s as it is not in the considered directories"
+                        % dist_root
+                    )
+                    continue
             if dist_name in mf_ext_packages:
                 _ext_debug(
                     "Ignoring duplicate package '%s' (duplicate paths in sys.path? (%s))"
@@ -535,6 +615,7 @@ def _get_extension_packages():
                 "root_paths": [dist_root],
                 "meta_module": meta_module,
                 "files": files_to_include,
+                "version": dist_version,
             }
     # At this point, we have all the packages that contribute to EXT_PKG,
     # we now check to see if there is an order to respect based on dependencies. We will
@@ -603,6 +684,16 @@ def _get_extension_packages():
     if len(all_paths_list) > 0:
         _ext_debug("Non installed packages present at %s" % str(all_paths))
         for package_count, package_path in enumerate(all_paths_list):
+            if restrict_to_directories:
+                parent_dirs = list(
+                    p.as_posix() for p in Path(package_path).resolve().parents
+                )
+                if all(p not in parent_dirs for p in restrict_to_directories):
+                    _ext_debug(
+                        "Ignoring non-installed package at %s as it is not in "
+                        "the considered directories" % package_path
+                    )
+                    continue
             # We give an alternate name for the visible package name. It is
             # not exposed to the end user but used to refer to the package, and it
             # doesn't provide much additional information to have the full path
@@ -738,6 +829,7 @@ def _get_extension_packages():
                 "root_paths": [package_path],
                 "meta_module": meta_module,
                 "files": files_to_include,
+                "version": "_local_",
             }
 
     # Sanity check that we only have one package per configuration file.
@@ -866,12 +958,13 @@ def _get_extension_config(distribution_name, tl_pkg, extension_point, config_mod
             _ext_debug("Package '%s' is rooted at %s" % (distribution_name, root_paths))
             _all_packages[distribution_name]["root_paths"] = root_paths
 
-        return MFExtModule(tl_package=tl_pkg, module=extension_module)
+        return MFExtModule(
+            package_name=distribution_name, tl_package=tl_pkg, module=extension_module
+        )
     return None
 
 
-def _filter_files_package(package_name):
-    pkg = _all_packages.get(package_name)
+def _filter_files_package(pkg):
     if pkg and pkg["root_paths"] and pkg["meta_module"]:
         meta_module = _attempt_load_module(pkg["meta_module"])
         if meta_module:
@@ -900,8 +993,8 @@ def _filter_files_package(package_name):
             pkg["files"] = new_files
 
 
-def _filter_files_all():
-    for p in _all_packages:
+def _filter_files_all(all_packages):
+    for p in all_packages.values():
         _filter_files_package(p)
 
 

--- a/metaflow/extension_support/__init__.py
+++ b/metaflow/extension_support/__init__.py
@@ -460,8 +460,8 @@ def _get_extension_packages(ignore_info_file=False, restrict_to_directories=None
             # unlikely so we are going to ignore this case.
             dist_root = dist.locate_file(EXT_PKG).resolve().as_posix()
             all_paths.discard(dist_root)
-            dist_name = dist.name
-            dist_version = dist.version
+            dist_name = dist.metadata["Name"]
+            dist_version = dist.metadata["Version"]
             if restrict_to_directories:
                 parent_dirs = list(
                     p.as_posix() for p in Path(dist_root).resolve().parents

--- a/metaflow/flowspec.py
+++ b/metaflow/flowspec.py
@@ -15,6 +15,9 @@ from .exception import (
     MissingInMergeArtifactsException,
     UnhandledInMergeArtifactsException,
 )
+
+from .extension_support import extension_info
+
 from .graph import FlowGraph
 from .unbounded_foreach import UnboundedForeachInput
 from .util import to_pod
@@ -208,6 +211,7 @@ class FlowSpec(metaclass=_FlowSpecMeta):
                 for deco in flow_decorators(self)
                 if not deco.name.startswith("_")
             ],
+            "extensions": extension_info(),
         }
         self._graph_info = graph_info
 

--- a/metaflow/info_file.py
+++ b/metaflow/info_file.py
@@ -1,0 +1,25 @@
+import json
+
+from os import path
+
+CURRENT_DIRECTORY = path.dirname(path.abspath(__file__))
+INFO_FILE = path.join(path.dirname(CURRENT_DIRECTORY), "INFO")
+
+_info_file_content = None
+_info_file_present = None
+
+
+def read_info_file():
+    global _info_file_content
+    global _info_file_present
+    if _info_file_present is None:
+        _info_file_present = path.exists(INFO_FILE)
+        if _info_file_present:
+            try:
+                with open(INFO_FILE, "r", encoding="utf-8") as contents:
+                    _info_file_content = json.load(contents)
+            except IOError:
+                pass
+    if _info_file_present:
+        return _info_file_content
+    return None

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -25,7 +25,6 @@ DATASTORE_LOCAL_DIR = ".metaflow"
 # Local configuration file (in .metaflow) containing overrides per-project
 LOCAL_CONFIG_FILE = "config.json"
 
-
 ###
 # Default configuration
 ###

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -9,8 +9,6 @@ from metaflow.extension_support import dump_module_info
 from metaflow.mflog import BASH_MFLOG
 from . import R
 
-version_cache = None
-
 
 class InvalidEnvironmentException(MetaflowException):
     headline = "Incompatible environment"
@@ -180,10 +178,6 @@ class MetaflowEnvironment(object):
         return cmds
 
     def get_environment_info(self, include_ext_info=False):
-        global version_cache
-        if version_cache is None:
-            version_cache = metaflow_version.get_version()
-
         # note that this dict goes into the code package
         # so variables here should be relatively stable (no
         # timestamps) so the hash won't change all the time
@@ -197,7 +191,7 @@ class MetaflowEnvironment(object):
             "use_r": R.use_r(),
             "python_version": sys.version,
             "python_version_code": "%d.%d.%d" % sys.version_info[:3],
-            "metaflow_version": version_cache,
+            "metaflow_version": metaflow_version.get_version(),
             "script": os.path.basename(os.path.abspath(sys.argv[0])),
         }
         if R.use_r():

--- a/metaflow/metaflow_version.py
+++ b/metaflow/metaflow_version.py
@@ -162,14 +162,13 @@ def get_version(public=False):
     import metaflow
 
     version_addl = metaflow.__version_addl__
-    version_override = metaflow.__version_override__
 
     version = format_git_describe(
         call_git_describe(file_to_check=metaflow.__file__), public=public
     )
 
     if version is None:
-        version = version_override or metaflow.__version__
+        version = metaflow.__version__
 
     if version_addl:
         return "+".join([version, version_addl])

--- a/metaflow/metaflow_version.py
+++ b/metaflow/metaflow_version.py
@@ -60,6 +60,8 @@ def call_git_describe(abbrev=7, cwd=None):
     """return the string output of git describe"""
     try:
         if cwd is None:
+            # NOTE: This path is currently unused -- it is here as backward compatibility
+            # as cwd was not always passed in the call to call_git_describe
             cwd = CURRENT_DIRECTORY
             # first, make sure we are actually in a Metaflow repo,
             # not some other repo
@@ -67,7 +69,6 @@ def call_git_describe(abbrev=7, cwd=None):
             reponame = (
                 check_output(arguments, cwd=cwd, stderr=DEVNULL).decode("ascii").strip()
             )
-            print("For %s got reponame: %s" % (cwd, reponame))
             if path.basename(reponame) != "metaflow":
                 return None
         # Else we assume that we are in a proper repo
@@ -94,7 +95,7 @@ def format_git_describe(git_str, public=False):
     if len(splits) == 4:
         # Formatted as <tag>-<post>-<hash>-dirty
         tag, post, h = splits[:3]
-        dirty = "-dirty"
+        dirty = splits[3]
     else:
         # Formatted as <tag>-<post>-<hash>
         tag, post, h = splits
@@ -135,10 +136,11 @@ def get_version(public=False):
     """
 
     # To get the version we do the following:
-    #  - First check if we have an INFO file with it. If so, use that as it is
+    #  - First check if we have an INFO file present. If so, use that as it is
     #    the most reliable way to get the version. In particular, when running remotely,
-    #    metaflow is installed in a directory and if any extension using distutils,
-    #    querying the version directly would fail to produce the correct result
+    #    metaflow is installed in a directory and if any extension is using distutils to
+    #    determine its version, this would return None and querying the version directly
+    #    from the extension would fail to produce the correct result
     #  - Check if we are in the GIT repository and if so, use the git describe
     #  - If we don't have an INFO file, we look at the version information that is
     #    populated by metaflow and the extensions.

--- a/metaflow/metaflow_version.py
+++ b/metaflow/metaflow_version.py
@@ -153,13 +153,14 @@ def get_version(public=False):
     import metaflow
 
     version_addl = metaflow.__version_addl__
+    version_override = metaflow.__version_override__
 
     version = format_git_describe(
         call_git_describe(cwd=path.dirname(metaflow.__file__)), public=public
     )
 
     if version is None:
-        version = metaflow.__version__
+        version = version_override or metaflow.__version__
 
     if version_addl:
         return "+".join([version, version_addl])

--- a/metaflow/package.py
+++ b/metaflow/package.py
@@ -10,7 +10,8 @@ from .extension_support import EXT_PKG, package_mfext_all
 from .metaflow_config import DEFAULT_PACKAGE_SUFFIXES
 from .exception import MetaflowException
 from .util import to_unicode
-from . import R, INFO_FILE
+from . import R
+from .info_file import INFO_FILE
 
 DEFAULT_SUFFIXES_LIST = DEFAULT_PACKAGE_SUFFIXES.split(",")
 METAFLOW_SUFFIXES_LIST = [".py", ".html", ".css", ".js"]

--- a/metaflow/plugins/pypi/conda_decorator.py
+++ b/metaflow/plugins/pypi/conda_decorator.py
@@ -12,7 +12,7 @@ from metaflow.metadata import MetaDatum
 from metaflow.metaflow_environment import InvalidEnvironmentException
 from metaflow.util import get_metaflow_root
 
-from ... import INFO_FILE
+from ...info_file import INFO_FILE
 
 
 class CondaStepDecorator(StepDecorator):


### PR DESCRIPTION
Favors reading the INFO file if present to be able to have the most accurate version of Metaflow when executing remotely (especially in the presence of extensions).

Also limit reading the INFO file to once per process (as opposed to possibly twice).

Finally, gets the version of the source of Metaflow (and not the current directory)