### PR TITLE
Add installed_extensions information

### DIFF
--- a/metaflow/cmd/main_cli.py
+++ b/metaflow/cmd/main_cli.py
@@ -84,12 +84,13 @@ def start(ctx):
 
     import metaflow
 
+    version = get_version()
     echo("Metaflow ", fg="magenta", bold=True, nl=False)
 
     if ctx.invoked_subcommand is None:
-        echo("(%s): " % get_version(), fg="magenta", bold=False, nl=False)
+        echo("(%s): " % version, fg="magenta", bold=False, nl=False)
     else:
-        echo("(%s)\n" % get_version(), fg="magenta", bold=False)
+        echo("(%s)\n" % version, fg="magenta", bold=False)
 
     if ctx.invoked_subcommand is None:
         echo("More data science, less engineering\n", fg="magenta")

--- a/metaflow/extension_support/__init__.py
+++ b/metaflow/extension_support/__init__.py
@@ -83,6 +83,11 @@ EXT_EXCLUDE_SUFFIXES = [".pyc"]
 # To get verbose messages, set METAFLOW_DEBUG_EXT to 1
 DEBUG_EXT = os.environ.get("METAFLOW_DEBUG_EXT", False)
 
+# This is extracted only from environment variable and here separately from
+# metaflow_config to prevent nasty circular dependencies
+EXTENSIONS_SEARCH_DIRS = os.environ.get("METAFLOW_EXTENSIONS_SEARCH_DIRS", "").split(
+    os.pathsep
+)
 
 MFExtPackage = namedtuple("MFExtPackage", "package_name tl_package config_module")
 MFExtModule = namedtuple("MFExtModule", "tl_package module")
@@ -351,9 +356,7 @@ def _get_extension_packages(ignore_info_file=False, restrict_to_directories=None
             return all_pkg, ext_to_pkg
 
     # Late import to prevent some circular nastiness
-    if restrict_to_directories is None:
-        from metaflow.metaflow_config import EXTENSIONS_SEARCH_DIRS
-
+    if restrict_to_directories is None and EXTENSIONS_SEARCH_DIRS != [""]:
         restrict_to_directories = EXTENSIONS_SEARCH_DIRS
 
     # Check if we even have extensions

--- a/metaflow/extension_support/__init__.py
+++ b/metaflow/extension_support/__init__.py
@@ -350,6 +350,12 @@ def _get_extension_packages(ignore_info_file=False, restrict_to_directories=None
                 ext_to_pkg[k] = v
             return all_pkg, ext_to_pkg
 
+    # Late import to prevent some circular nastiness
+    if restrict_to_directories is None:
+        from metaflow.metaflow_config import EXTENSIONS_SEARCH_DIRS
+
+        restrict_to_directories = EXTENSIONS_SEARCH_DIRS
+
     # Check if we even have extensions
     try:
         extensions_module = importlib.import_module(EXT_PKG)

--- a/metaflow/flowspec.py
+++ b/metaflow/flowspec.py
@@ -15,6 +15,9 @@ from .exception import (
     MissingInMergeArtifactsException,
     UnhandledInMergeArtifactsException,
 )
+
+from .extension_support import extension_info
+
 from .graph import FlowGraph
 from .unbounded_foreach import UnboundedForeachInput
 from .util import to_pod
@@ -208,6 +211,7 @@ class FlowSpec(metaclass=_FlowSpecMeta):
                 for deco in flow_decorators(self)
                 if not deco.name.startswith("_")
             ],
+            "extensions": extension_info(),
         }
         self._graph_info = graph_info
 

--- a/metaflow/metadata/metadata.py
+++ b/metaflow/metadata/metadata.py
@@ -617,8 +617,6 @@ class MetadataProvider(object):
         sys_info[identity_type] = identity_value
         if env["metaflow_version"]:
             sys_info["metaflow_version"] = env["metaflow_version"]
-        if env["installed_extensions"]:
-            sys_info["installed_extensions"] = env["installed_extensions"]
         if "metaflow_r_version" in env:
             sys_info["metaflow_r_version"] = env["metaflow_r_version"]
         if "r_version_code" in env:

--- a/metaflow/metadata/metadata.py
+++ b/metaflow/metadata/metadata.py
@@ -617,6 +617,8 @@ class MetadataProvider(object):
         sys_info[identity_type] = identity_value
         if env["metaflow_version"]:
             sys_info["metaflow_version"] = env["metaflow_version"]
+        if env["installed_extensions"]:
+            sys_info["installed_extensions"] = env["installed_extensions"]
         if "metaflow_r_version" in env:
             sys_info["metaflow_r_version"] = env["metaflow_r_version"]
         if "r_version_code" in env:

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -25,6 +25,11 @@ DATASTORE_LOCAL_DIR = ".metaflow"
 # Local configuration file (in .metaflow) containing overrides per-project
 LOCAL_CONFIG_FILE = "config.json"
 
+###
+# Extensions
+###
+# Advanced setting -- used to restrict where Metaflow looks for extensions.
+EXTENSIONS_SEARCH_DIRS = from_conf("EXTENSIONS_SEARCH_DIRS", [])
 
 ###
 # Default configuration

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -26,12 +26,6 @@ DATASTORE_LOCAL_DIR = ".metaflow"
 LOCAL_CONFIG_FILE = "config.json"
 
 ###
-# Extensions
-###
-# Advanced setting -- used to restrict where Metaflow looks for extensions.
-EXTENSIONS_SEARCH_DIRS = from_conf("EXTENSIONS_SEARCH_DIRS", [])
-
-###
 # Default configuration
 ###
 

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -5,12 +5,9 @@ import sys
 from .util import get_username
 from . import metaflow_version
 from metaflow.exception import MetaflowException
-from metaflow.extension_support import dump_module_info, extension_info
+from metaflow.extension_support import dump_module_info
 from metaflow.mflog import BASH_MFLOG
 from . import R
-
-version_cache = None
-extension_info_cache = None
 
 
 class InvalidEnvironmentException(MetaflowException):
@@ -181,13 +178,6 @@ class MetaflowEnvironment(object):
         return cmds
 
     def get_environment_info(self, include_ext_info=False):
-        global version_cache
-        global extension_info_cache
-        if version_cache is None:
-            version_cache = metaflow_version.get_version()
-        if extension_info_cache is None:
-            extension_info_cache = extension_info()
-
         # note that this dict goes into the code package
         # so variables here should be relatively stable (no
         # timestamps) so the hash won't change all the time
@@ -201,8 +191,7 @@ class MetaflowEnvironment(object):
             "use_r": R.use_r(),
             "python_version": sys.version,
             "python_version_code": "%d.%d.%d" % sys.version_info[:3],
-            "metaflow_version": version_cache,
-            "installed_extensions": extension_info_cache,
+            "metaflow_version": metaflow_version.get_version(),
             "script": os.path.basename(os.path.abspath(sys.argv[0])),
         }
         if R.use_r():

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -5,11 +5,12 @@ import sys
 from .util import get_username
 from . import metaflow_version
 from metaflow.exception import MetaflowException
-from metaflow.extension_support import dump_module_info
+from metaflow.extension_support import dump_module_info, extension_info
 from metaflow.mflog import BASH_MFLOG
 from . import R
 
 version_cache = None
+extension_info_cache = None
 
 
 class InvalidEnvironmentException(MetaflowException):
@@ -181,8 +182,11 @@ class MetaflowEnvironment(object):
 
     def get_environment_info(self, include_ext_info=False):
         global version_cache
+        global extension_info_cache
         if version_cache is None:
             version_cache = metaflow_version.get_version()
+        if extension_info_cache is None:
+            extension_info_cache = extension_info()
 
         # note that this dict goes into the code package
         # so variables here should be relatively stable (no
@@ -198,6 +202,7 @@ class MetaflowEnvironment(object):
             "python_version": sys.version,
             "python_version_code": "%d.%d.%d" % sys.version_info[:3],
             "metaflow_version": version_cache,
+            "installed_extensions": extension_info_cache,
             "script": os.path.basename(os.path.abspath(sys.argv[0])),
         }
         if R.use_r():


### PR DESCRIPTION
This adds information to the system tags about the metaflow extensions that are installed. This makes it easier to reproduce the exact same environment. Information about whether the package information is complete or not is also included.

This PR also fixes some issues with extension loading and allows extension information to be gathered in a programatic fashion thereby enabling the discovery of extensions.