### PR TITLE
Stop waiting for the status file when the process finishes

### DIFF
--- a/metaflow/runner/deployer.py
+++ b/metaflow/runner/deployer.py
@@ -5,6 +5,8 @@ import time
 import importlib
 import functools
 import tempfile
+
+from subprocess import CalledProcessError
 from typing import Optional, Dict, ClassVar
 
 from metaflow.exception import MetaflowNotFound
@@ -41,10 +43,10 @@ def handle_timeout(
     """
     try:
         content = read_from_file_when_ready(
-            tfp_runner_attribute.name, timeout=file_read_timeout
+            tfp_runner_attribute.name, command_obj, timeout=file_read_timeout
         )
         return content
-    except TimeoutError as e:
+    except (CalledProcessError, TimeoutError) as e:
         stdout_log = open(command_obj.log_files["stdout"]).read()
         stderr_log = open(command_obj.log_files["stderr"]).read()
         command = " ".join(command_obj.command)

--- a/metaflow/runner/metaflow_runner.py
+++ b/metaflow/runner/metaflow_runner.py
@@ -2,6 +2,8 @@ import importlib
 import os
 import sys
 import tempfile
+
+from subprocess import CalledProcessError
 from typing import Dict, Iterator, Optional, Tuple
 
 from metaflow import Run, metadata
@@ -275,13 +277,13 @@ class Runner(object):
 
             # Set the correct metadata from the runner_attribute file corresponding to this run.
             content = read_from_file_when_ready(
-                tfp_runner_attribute.name, timeout=self.file_read_timeout
+                tfp_runner_attribute.name, command_obj, timeout=self.file_read_timeout
             )
             metadata_for_flow, pathspec = content.rsplit(":", maxsplit=1)
             metadata(metadata_for_flow)
             run_object = Run(pathspec, _namespace_check=False)
             return ExecutingRun(self, command_obj, run_object)
-        except TimeoutError as e:
+        except (CalledProcessError, TimeoutError) as e:
             stdout_log = open(command_obj.log_files["stdout"]).read()
             stderr_log = open(command_obj.log_files["stderr"]).read()
             command = " ".join(command_obj.command)

--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -48,6 +48,12 @@ def read_from_file_when_ready(
         content = file_pointer.read()
         while not content:
             if command_obj.process.poll() is not None:
+                # Check to make sure the file hasn't been read yet to avoid a race
+                # where the file is written between the end of this while loop and the
+                # poll call above.
+                content = file_pointer.read()
+                if content:
+                    break
                 raise CalledProcessError(
                     command_obj.process.returncode, command_obj.command
                 )

--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -1,7 +1,12 @@
 import os
 import ast
 import time
-from typing import Dict
+
+from subprocess import CalledProcessError
+from typing import Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .subprocess_manager import CommandManager
 
 
 def get_current_cell(ipython):
@@ -35,11 +40,17 @@ def clear_and_set_os_environ(env: Dict):
     os.environ.update(env)
 
 
-def read_from_file_when_ready(file_path: str, timeout: float = 5):
+def read_from_file_when_ready(
+    file_path: str, command_obj: "CommandManager", timeout: float = 5
+):
     start_time = time.time()
     with open(file_path, "r", encoding="utf-8") as file_pointer:
         content = file_pointer.read()
         while not content:
+            if command_obj.process.poll() is not None:
+                raise CalledProcessError(
+                    command_obj.process.returncode, command_obj.command
+                )
             if time.time() - start_time > timeout:
                 raise TimeoutError(
                     "Timeout while waiting for file content from '%s'" % file_path


### PR DESCRIPTION
This avoids waiting for a long time after a process crashes when using the Runner or Deployer