### PR TITLE
fix: attach conda decorator in conda_base flow_init

### DIFF
--- a/metaflow/plugins/pypi/conda_decorator.py
+++ b/metaflow/plugins/pypi/conda_decorator.py
@@ -353,9 +353,8 @@ class CondaFlowDecorator(FlowDecorator):
     def flow_init(
         self, flow, graph, environment, flow_datastore, metadata, logger, echo, options
     ):
-        # NOTE: This makes sure that using conda_base marks all steps as executing with conda,
-        # without relying on --environment conda setting decospecs.
-        # Important for extensions implementing custom virtual environments
+        # NOTE: Important for extensions implementing custom virtual environments.
+        # Without this steps will not have an implicit conda step decorator on them unless the environment adds one in its decospecs.
         from metaflow import decorators
 
         decorators._attach_decorators(flow, ["conda"])

--- a/metaflow/plugins/pypi/conda_decorator.py
+++ b/metaflow/plugins/pypi/conda_decorator.py
@@ -353,6 +353,13 @@ class CondaFlowDecorator(FlowDecorator):
     def flow_init(
         self, flow, graph, environment, flow_datastore, metadata, logger, echo, options
     ):
+        # NOTE: This makes sure that using conda_base marks all steps as executing with conda,
+        # without relying on --environment conda setting decospecs.
+        # Important for extensions implementing custom virtual environments
+        from metaflow import decorators
+
+        decorators._attach_decorators(flow, ["conda"])
+
         # @conda uses a conda environment to create a virtual environment.
         # The conda environment can be created through micromamba.
         _supported_virtual_envs = ["conda"]


### PR DESCRIPTION
attach `conda` decorator to steps in the `conda_base` decorator when using it. 

This solves an issue where a virtual environment implemented in an extension does not append `conda` as part of environment decospecs, but still needs to know whether a step needs to execute on conda due to the flow decorator.

`decorators._attach_decorators` is a no-op for existing conda decorators on a step so this should not have adverse effects.