### PR TITLE
Fix stubgen to add class docstrings and re-enable after version strin…

### DIFF
--- a/metaflow/cmd/develop/stubs.py
+++ b/metaflow/cmd/develop/stubs.py
@@ -170,7 +170,7 @@ def install(ctx: Any, force: bool):
                     "Metaflow stubs are already installed and valid -- use --force to reinstall"
                 )
             return
-    mf_version, _ = get_mf_version()
+    mf_version, _ = get_mf_version(True)
     with tempfile.TemporaryDirectory() as tmp_dir:
         with open(os.path.join(tmp_dir, "setup.py"), "w") as f:
             f.write(
@@ -261,10 +261,10 @@ def split_version(vers: str) -> Tuple[str, Optional[str]]:
     return vers_split[0], vers_split[1]
 
 
-def get_mf_version() -> Tuple[str, Optional[str]]:
+def get_mf_version(public: bool = False) -> Tuple[str, Optional[str]]:
     from metaflow.metaflow_version import get_version
 
-    return split_version(get_version())
+    return split_version(get_version(public))
 
 
 def get_stubs_version(stubs_root_path: Optional[str]) -> Tuple[str, Optional[str]]:

--- a/metaflow/metaflow_version.py
+++ b/metaflow/metaflow_version.py
@@ -195,11 +195,14 @@ def get_version(public=False):
         if ext_version is None:
             ext_version = getattr(extension_module, "__version__", "<unk>")
         # Update the package information about reported version for the extension
-        update_package_info(
-            package_name=pkg_name,
-            extension_name=ext_name,
-            package_version=ext_version,
-        )
+        # (only for the full info which is called at least once -- if we update more
+        # it will error out since we can only update_package_info once)
+        if not public:
+            update_package_info(
+                package_name=pkg_name,
+                extension_name=ext_name,
+                package_version=ext_version,
+            )
         ext_versions.append("%s(%s)" % (ext_name, ext_version))
 
     # We now have all the information about extensions so we can form the final string


### PR DESCRIPTION
…g change

Two changes:
  - add docstrings to the class object
  - fix issue when generating stubs when Metaflow is not a released version