### PR TITLE
Modify `_enrich_object` deployer method to set instance attributes

### DIFF
--- a/metaflow/runner/deployer.py
+++ b/metaflow/runner/deployer.py
@@ -209,7 +209,7 @@ class TriggeredRun(object):
             elif callable(v):
                 setattr(self, k, functools.partial(v, self))
             else:
-                setattr(self.__class__, k, property(fget=lambda _, v=v: v))
+                setattr(self, k, v)
 
     def wait_for_run(self, timeout=None):
         """
@@ -287,7 +287,7 @@ class DeployedFlow(object):
             elif callable(v):
                 setattr(self, k, functools.partial(v, self))
             else:
-                setattr(self.__class__, k, property(fget=lambda _, v=v: v))
+                setattr(self, k, v)
 
 
 class DeployerImpl(object):


### PR DESCRIPTION
The `_enrich_object` method currently sets attributes at a class level. 

- If we have multiple instances of a `TriggeredRun` or `DeployedFlow` in a script/notebook, then using `_enrich_object` to add/set an attribute like `url` to a `TriggeredRun` instance, would modify it for all the instances. 
- We might want a behavior where these attributes are set at an instance level, just like the methods are being set currently. 