### PR TITLE
runner fixes and enhancements

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -1,5 +1,5 @@
 import inspect
-import os
+import json
 import sys
 import traceback
 from datetime import datetime
@@ -7,6 +7,7 @@ from functools import wraps
 
 import metaflow.tracing as tracing
 from metaflow._vendor import click
+from metaflow.client.core import get_metadata
 
 from . import decorators, lint, metaflow_version, namespace, parameters, plugins
 from .cli_args import cli_args
@@ -698,15 +699,17 @@ def resume(
     runtime.print_workflow_info()
 
     runtime.persist_constants()
-    write_file(
-        runner_attribute_file,
-        "%s@%s:%s"
-        % (
-            obj.metadata.__class__.TYPE,
-            obj.metadata.__class__.INFO,
-            "/".join((obj.flow.name, runtime.run_id)),
-        ),
-    )
+
+    if runner_attribute_file:
+        with open(runner_attribute_file, "w") as f:
+            json.dump(
+                {
+                    "run_id": runtime.run_id,
+                    "flow_name": obj.flow.name,
+                    "metadata": get_metadata(),
+                },
+                f,
+            )
 
     # We may skip clone-only resume if this is not a resume leader,
     # and clone is already complete.
@@ -774,15 +777,17 @@ def run(
     obj.flow._set_constants(obj.graph, kwargs)
     runtime.print_workflow_info()
     runtime.persist_constants()
-    write_file(
-        runner_attribute_file,
-        "%s@%s:%s"
-        % (
-            obj.metadata.__class__.TYPE,
-            obj.metadata.__class__.INFO,
-            "/".join((obj.flow.name, runtime.run_id)),
-        ),
-    )
+
+    if runner_attribute_file:
+        with open(runner_attribute_file, "w") as f:
+            json.dump(
+                {
+                    "run_id": runtime.run_id,
+                    "flow_name": obj.flow.name,
+                    "metadata": get_metadata(),
+                },
+                f,
+            )
     runtime.execute()
 
 

--- a/metaflow/runner/deployer.py
+++ b/metaflow/runner/deployer.py
@@ -6,56 +6,11 @@ import importlib
 import functools
 import tempfile
 
-from subprocess import CalledProcessError
 from typing import Optional, Dict, ClassVar
 
 from metaflow.exception import MetaflowNotFound
-from metaflow.runner.subprocess_manager import CommandManager, SubprocessManager
-from metaflow.runner.utils import read_from_file_when_ready
-
-
-def handle_timeout(
-    tfp_runner_attribute, command_obj: CommandManager, file_read_timeout: int
-):
-    """
-    Handle the timeout for a running subprocess command that reads a file
-    and raises an error with appropriate logs if a TimeoutError occurs.
-
-    Parameters
-    ----------
-    tfp_runner_attribute : NamedTemporaryFile
-        Temporary file that stores runner attribute data.
-    command_obj : CommandManager
-        Command manager object that encapsulates the running command details.
-    file_read_timeout : int
-        Timeout for reading the file.
-
-    Returns
-    -------
-    str
-        Content read from the temporary file.
-
-    Raises
-    ------
-    RuntimeError
-        If a TimeoutError occurs, it raises a RuntimeError with the command's
-        stdout and stderr logs.
-    """
-    try:
-        content = read_from_file_when_ready(
-            tfp_runner_attribute.name, command_obj, timeout=file_read_timeout
-        )
-        return content
-    except (CalledProcessError, TimeoutError) as e:
-        stdout_log = open(command_obj.log_files["stdout"]).read()
-        stderr_log = open(command_obj.log_files["stderr"]).read()
-        command = " ".join(command_obj.command)
-        error_message = "Error executing: '%s':\n" % command
-        if stdout_log.strip():
-            error_message += "\nStdout:\n%s\n" % stdout_log
-        if stderr_log.strip():
-            error_message += "\nStderr:\n%s\n" % stderr_log
-        raise RuntimeError(error_message) from e
+from metaflow.runner.subprocess_manager import SubprocessManager
+from metaflow.runner.utils import handle_timeout
 
 
 def get_lower_level_group(

--- a/metaflow/runner/metaflow_runner.py
+++ b/metaflow/runner/metaflow_runner.py
@@ -4,10 +4,9 @@ import sys
 import json
 import tempfile
 
-from subprocess import CalledProcessError
 from typing import Dict, Iterator, Optional, Tuple
 
-from metaflow import Run
+from metaflow import Run, metadata
 
 from .utils import handle_timeout
 from .subprocess_manager import CommandManager, SubprocessManager
@@ -274,6 +273,11 @@ class Runner(object):
         )
         content = json.loads(content)
         pathspec = "%s/%s" % (content.get("flow_name"), content.get("run_id"))
+
+        # Set the correct metadata from the runner_attribute file corresponding to this run.
+        metadata_for_flow = content.get("metadata")
+        metadata(metadata_for_flow)
+
         run_object = Run(pathspec, _namespace_check=False)
         return ExecutingRun(self, command_obj, run_object)
 

--- a/metaflow/runner/subprocess_manager.py
+++ b/metaflow/runner/subprocess_manager.py
@@ -170,6 +170,7 @@ class CommandManager(object):
 
         self.process = None
         self.run_called: bool = False
+        self.timeout: bool = False
         self.log_files: Dict[str, str] = {}
 
         signal.signal(signal.SIGINT, self._handle_sigint)
@@ -214,6 +215,7 @@ class CommandManager(object):
                 else:
                     await asyncio.wait_for(self.emit_logs(stream), timeout)
             except asyncio.TimeoutError:
+                self.timeout = True
                 command_string = " ".join(self.command)
                 await self.kill()
                 print(

--- a/metaflow/runner/subprocess_manager.py
+++ b/metaflow/runner/subprocess_manager.py
@@ -42,6 +42,19 @@ class SubprocessManager(object):
     def __init__(self):
         self.commands: Dict[int, CommandManager] = {}
 
+        try:
+            loop = asyncio.get_running_loop()
+            loop.add_signal_handler(
+                signal.SIGINT,
+                lambda: self._handle_sigint(signum=signal.SIGINT, frame=None),
+            )
+        except RuntimeError:
+            signal.signal(signal.SIGINT, self._handle_sigint)
+
+    def _handle_sigint(self, signum, frame):
+        for each_command in self.commands.values():
+            each_command.kill(termination_timeout=2)
+
     async def __aenter__(self) -> "SubprocessManager":
         return self
 
@@ -83,6 +96,7 @@ class SubprocessManager(object):
         command_obj = CommandManager(command, env, cwd)
         pid = command_obj.run(show_output=show_output)
         self.commands[pid] = command_obj
+        command_obj.sync_wait()
         return pid
 
     async def async_run_command(
@@ -169,11 +183,11 @@ class CommandManager(object):
         self.cwd = cwd if cwd is not None else os.getcwd()
 
         self.process = None
+        self.stdout_thread = None
+        self.stderr_thread = None
         self.run_called: bool = False
         self.timeout: bool = False
         self.log_files: Dict[str, str] = {}
-
-        signal.signal(signal.SIGINT, self._handle_sigint)
 
     async def __aenter__(self) -> "CommandManager":
         return self
@@ -217,11 +231,19 @@ class CommandManager(object):
             except asyncio.TimeoutError:
                 self.timeout = True
                 command_string = " ".join(self.command)
-                await self.kill()
+                self.kill(termination_timeout=2)
                 print(
                     "Timeout: The process (PID %d; command: '%s') did not complete "
                     "within %s seconds." % (self.process.pid, command_string, timeout)
                 )
+
+    def sync_wait(self):
+        if not self.run_called:
+            raise RuntimeError("No command run yet to wait for...")
+
+        self.process.wait()
+        self.stdout_thread.join()
+        self.stderr_thread.join()
 
     def run(self, show_output: bool = False):
         """
@@ -267,22 +289,17 @@ class CommandManager(object):
 
                 self.run_called = True
 
-                stdout_thread = threading.Thread(
+                self.stdout_thread = threading.Thread(
                     target=stream_to_stdout_and_file,
                     args=(self.process.stdout, stdout_logfile),
                 )
-                stderr_thread = threading.Thread(
+                self.stderr_thread = threading.Thread(
                     target=stream_to_stdout_and_file,
                     args=(self.process.stderr, stderr_logfile),
                 )
 
-                stdout_thread.start()
-                stderr_thread.start()
-
-                self.process.wait()
-
-                stdout_thread.join()
-                stderr_thread.join()
+                self.stdout_thread.start()
+                self.stderr_thread.start()
 
                 return self.process.pid
             except Exception as e:
@@ -443,13 +460,13 @@ class CommandManager(object):
         if self.run_called:
             shutil.rmtree(self.temp_dir, ignore_errors=True)
 
-    async def kill(self, termination_timeout: float = 5):
+    def kill(self, termination_timeout: float = 2):
         """
         Kill the subprocess and its descendants.
 
         Parameters
         ----------
-        termination_timeout : float, default 5
+        termination_timeout : float, default 2
             The time to wait after sending a SIGTERM to the process and its descendants
             before sending a SIGKILL.
         """
@@ -458,9 +475,6 @@ class CommandManager(object):
             kill_process_and_descendants(self.process.pid, termination_timeout)
         else:
             print("No process to kill.")
-
-    def _handle_sigint(self, signum, frame):
-        asyncio.create_task(self.kill())
 
 
 async def main():

--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -72,3 +72,47 @@ def read_from_file_when_ready(
             time.sleep(0.1)
             content = file_pointer.read()
         return content
+
+
+def handle_timeout(
+    tfp_runner_attribute, command_obj: "CommandManager", file_read_timeout: int
+):
+    """
+    Handle the timeout for a running subprocess command that reads a file
+    and raises an error with appropriate logs if a TimeoutError occurs.
+
+    Parameters
+    ----------
+    tfp_runner_attribute : NamedTemporaryFile
+        Temporary file that stores runner attribute data.
+    command_obj : CommandManager
+        Command manager object that encapsulates the running command details.
+    file_read_timeout : int
+        Timeout for reading the file.
+
+    Returns
+    -------
+    str
+        Content read from the temporary file.
+
+    Raises
+    ------
+    RuntimeError
+        If a TimeoutError occurs, it raises a RuntimeError with the command's
+        stdout and stderr logs.
+    """
+    try:
+        content = read_from_file_when_ready(
+            tfp_runner_attribute.name, command_obj, timeout=file_read_timeout
+        )
+        return content
+    except (CalledProcessError, TimeoutError) as e:
+        stdout_log = open(command_obj.log_files["stdout"]).read()
+        stderr_log = open(command_obj.log_files["stderr"]).read()
+        command = " ".join(command_obj.command)
+        error_message = "Error executing: '%s':\n" % command
+        if stdout_log.strip():
+            error_message += "\nStdout:\n%s\n" % stdout_log
+        if stderr_log.strip():
+            error_message += "\nStderr:\n%s\n" % stderr_log
+        raise RuntimeError(error_message) from e


### PR DESCRIPTION
This PR is inspired by a few ideas from
- https://github.com/Netflix/metaflow/pull/2039 (fix for SIGINT handling)
- https://github.com/Netflix/metaflow/pull/2033 (`poll()` not available for the `Process` object created async)

It also comes with:
- storing json contents in runner attribute file
- setting status as "timeout" if it occurs