### PR TITLE
Fix slack ui_link

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -2427,7 +2427,7 @@ class ArgoWorkflows(object):
         Use Slack's Block Kit to add general information about the environment and
         execution metadata, including a link to the UI and an optional message.
         """
-        ui_link = "%s/%s/argo-{{workflow.name}}" % (UI_URL.rstrip('/'), self.flow.name)
+        ui_link = "%s/%s/argo-{{workflow.name}}" % (UI_URL.rstrip("/"), self.flow.name)
         # fmt: off
         if getattr(current, "project_name", None):
             # Add @project metadata when available.

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -2427,7 +2427,7 @@ class ArgoWorkflows(object):
         Use Slack's Block Kit to add general information about the environment and
         execution metadata, including a link to the UI and an optional message.
         """
-        ui_link = "%s%s/argo-{{workflow.name}}" % (UI_URL, self.flow.name)
+        ui_link = "%s/%s/argo-{{workflow.name}}" % (UI_URL.rstrip('/'), self.flow.name.lstrip('/'))
         # fmt: off
         if getattr(current, "project_name", None):
             # Add @project metadata when available.

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -2427,7 +2427,7 @@ class ArgoWorkflows(object):
         Use Slack's Block Kit to add general information about the environment and
         execution metadata, including a link to the UI and an optional message.
         """
-        ui_link = "%s/%s/argo-{{workflow.name}}" % (UI_URL.rstrip('/'), self.flow.name.lstrip('/'))
+        ui_link = "%s/%s/argo-{{workflow.name}}" % (UI_URL.rstrip('/'), self.flow.name)
         # fmt: off
         if getattr(current, "project_name", None):
             # Add @project metadata when available.


### PR DESCRIPTION
The slack ui_link needs a slight bug fix. The url is missing a slash.

Why This Matters:

User Experience:
- Incorrect URLs in notifications can frustrate users and hinder workflow.
- Ensuring correct URL formatting improves reliability.

Code Maintainability:
- Proper handling of strings and URLs prevents bugs.
- Consistent practices make the code easier to understand and maintain.

Thanks y'all, and great project here!