### PR TITLE
Async runner improvements

### DIFF
--- a/metaflow/runner/metaflow_runner.py
+++ b/metaflow/runner/metaflow_runner.py
@@ -2,13 +2,16 @@ import importlib
 import os
 import sys
 import json
-import tempfile
 
 from typing import Dict, Iterator, Optional, Tuple
 
 from metaflow import Run
 
-from .utils import handle_timeout, async_handle_timeout
+from .utils import (
+    temporary_fifo,
+    handle_timeout,
+    async_handle_timeout,
+)
 from .subprocess_manager import CommandManager, SubprocessManager
 
 
@@ -267,10 +270,8 @@ class Runner(object):
     async def __aenter__(self) -> "Runner":
         return self
 
-    def __get_executing_run(self, tfp_runner_attribute, command_obj):
-        content = handle_timeout(
-            tfp_runner_attribute, command_obj, self.file_read_timeout
-        )
+    def __get_executing_run(self, attribute_file_fd, command_obj):
+        content = handle_timeout(attribute_file_fd, command_obj, self.file_read_timeout)
         content = json.loads(content)
         pathspec = "%s/%s" % (content.get("flow_name"), content.get("run_id"))
 
@@ -282,9 +283,9 @@ class Runner(object):
         )
         return ExecutingRun(self, command_obj, run_object)
 
-    async def __async_get_executing_run(self, tfp_runner_attribute, command_obj):
+    async def __async_get_executing_run(self, attribute_file_fd, command_obj):
         content = await async_handle_timeout(
-            tfp_runner_attribute, command_obj, self.file_read_timeout
+            attribute_file_fd, command_obj, self.file_read_timeout
         )
         content = json.loads(content)
         pathspec = "%s/%s" % (content.get("flow_name"), content.get("run_id"))
@@ -312,12 +313,9 @@ class Runner(object):
         ExecutingRun
             ExecutingRun containing the results of the run.
         """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            tfp_runner_attribute = tempfile.NamedTemporaryFile(
-                dir=temp_dir, delete=False
-            )
+        with temporary_fifo() as (attribute_file_path, attribute_file_fd):
             command = self.api(**self.top_level_kwargs).run(
-                runner_attribute_file=tfp_runner_attribute.name, **kwargs
+                runner_attribute_file=attribute_file_path, **kwargs
             )
 
             pid = self.spm.run_command(
@@ -328,7 +326,7 @@ class Runner(object):
             )
             command_obj = self.spm.get(pid)
 
-            return self.__get_executing_run(tfp_runner_attribute, command_obj)
+            return self.__get_executing_run(attribute_file_fd, command_obj)
 
     def resume(self, **kwargs):
         """
@@ -346,12 +344,9 @@ class Runner(object):
         ExecutingRun
             ExecutingRun containing the results of the resumed run.
         """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            tfp_runner_attribute = tempfile.NamedTemporaryFile(
-                dir=temp_dir, delete=False
-            )
+        with temporary_fifo() as (attribute_file_path, attribute_file_fd):
             command = self.api(**self.top_level_kwargs).resume(
-                runner_attribute_file=tfp_runner_attribute.name, **kwargs
+                runner_attribute_file=attribute_file_path, **kwargs
             )
 
             pid = self.spm.run_command(
@@ -362,7 +357,7 @@ class Runner(object):
             )
             command_obj = self.spm.get(pid)
 
-            return self.__get_executing_run(tfp_runner_attribute, command_obj)
+            return self.__get_executing_run(attribute_file_fd, command_obj)
 
     async def async_run(self, **kwargs) -> ExecutingRun:
         """
@@ -382,12 +377,9 @@ class Runner(object):
         ExecutingRun
             ExecutingRun representing the run that was started.
         """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            tfp_runner_attribute = tempfile.NamedTemporaryFile(
-                dir=temp_dir, delete=False
-            )
+        with temporary_fifo() as (attribute_file_path, attribute_file_fd):
             command = self.api(**self.top_level_kwargs).run(
-                runner_attribute_file=tfp_runner_attribute.name, **kwargs
+                runner_attribute_file=attribute_file_path, **kwargs
             )
 
             pid = await self.spm.async_run_command(
@@ -397,9 +389,7 @@ class Runner(object):
             )
             command_obj = self.spm.get(pid)
 
-            return await self.__async_get_executing_run(
-                tfp_runner_attribute, command_obj
-            )
+            return await self.__async_get_executing_run(attribute_file_fd, command_obj)
 
     async def async_resume(self, **kwargs):
         """
@@ -419,12 +409,9 @@ class Runner(object):
         ExecutingRun
             ExecutingRun representing the resumed run that was started.
         """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            tfp_runner_attribute = tempfile.NamedTemporaryFile(
-                dir=temp_dir, delete=False
-            )
+        with temporary_fifo() as (attribute_file_path, attribute_file_fd):
             command = self.api(**self.top_level_kwargs).resume(
-                runner_attribute_file=tfp_runner_attribute.name, **kwargs
+                runner_attribute_file=attribute_file_path, **kwargs
             )
 
             pid = await self.spm.async_run_command(
@@ -434,9 +421,7 @@ class Runner(object):
             )
             command_obj = self.spm.get(pid)
 
-            return await self.__async_get_executing_run(
-                tfp_runner_attribute, command_obj
-            )
+            return await self.__async_get_executing_run(attribute_file_fd, command_obj)
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.spm.cleanup()

--- a/metaflow/runner/metaflow_runner.py
+++ b/metaflow/runner/metaflow_runner.py
@@ -8,7 +8,7 @@ from typing import Dict, Iterator, Optional, Tuple
 
 from metaflow import Run
 
-from .utils import handle_timeout
+from .utils import handle_timeout, async_handle_timeout
 from .subprocess_manager import CommandManager, SubprocessManager
 
 
@@ -282,6 +282,20 @@ class Runner(object):
         )
         return ExecutingRun(self, command_obj, run_object)
 
+    async def __async_get_executing_run(self, tfp_runner_attribute, command_obj):
+        content = await async_handle_timeout(
+            tfp_runner_attribute, command_obj, self.file_read_timeout
+        )
+        content = json.loads(content)
+        pathspec = "%s/%s" % (content.get("flow_name"), content.get("run_id"))
+
+        # Set the correct metadata from the runner_attribute file corresponding to this run.
+        metadata_for_flow = content.get("metadata")
+        metadata(metadata_for_flow)
+
+        run_object = Run(pathspec, _namespace_check=False)
+        return ExecutingRun(self, command_obj, run_object)
+
     def run(self, **kwargs) -> ExecutingRun:
         """
         Blocking execution of the run. This method will wait until
@@ -383,7 +397,9 @@ class Runner(object):
             )
             command_obj = self.spm.get(pid)
 
-            return self.__get_executing_run(tfp_runner_attribute, command_obj)
+            return await self.__async_get_executing_run(
+                tfp_runner_attribute, command_obj
+            )
 
     async def async_resume(self, **kwargs):
         """
@@ -418,7 +434,9 @@ class Runner(object):
             )
             command_obj = self.spm.get(pid)
 
-            return self.__get_executing_run(tfp_runner_attribute, command_obj)
+            return await self.__async_get_executing_run(
+                tfp_runner_attribute, command_obj
+            )
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.spm.cleanup()

--- a/metaflow/runner/subprocess_manager.py
+++ b/metaflow/runner/subprocess_manager.py
@@ -9,6 +9,8 @@ import tempfile
 import threading
 from typing import Callable, Dict, Iterator, List, Optional, Tuple
 
+from .utils import check_process_exited
+
 
 def kill_process_and_descendants(pid, termination_timeout):
     # TODO: there's a race condition that new descendants might
@@ -89,7 +91,7 @@ class SubprocessManager(object):
         pids = [
             str(command.process.pid)
             for command in self.commands.values()
-            if command.process
+            if command.process and not check_process_exited(command)
         ]
         await async_kill_processes_and_descendants(pids, termination_timeout=2)
 
@@ -97,7 +99,7 @@ class SubprocessManager(object):
         pids = [
             str(command.process.pid)
             for command in self.commands.values()
-            if command.process
+            if command.process and not check_process_exited(command)
         ]
         kill_processes_and_descendants(pids, termination_timeout=2)
 

--- a/metaflow/runner/subprocess_manager.py
+++ b/metaflow/runner/subprocess_manager.py
@@ -93,7 +93,8 @@ class SubprocessManager(object):
             for command in self.commands.values()
             if command.process and not check_process_exited(command)
         ]
-        await async_kill_processes_and_descendants(pids, termination_timeout=2)
+        if pids:
+            await async_kill_processes_and_descendants(pids, termination_timeout=2)
 
     def _handle_sigint(self, signum, frame):
         pids = [
@@ -101,7 +102,8 @@ class SubprocessManager(object):
             for command in self.commands.values()
             if command.process and not check_process_exited(command)
         ]
-        kill_processes_and_descendants(pids, termination_timeout=2)
+        if pids:
+            kill_processes_and_descendants(pids, termination_timeout=2)
 
     async def __aenter__(self) -> "SubprocessManager":
         return self

--- a/metaflow/runner/subprocess_manager.py
+++ b/metaflow/runner/subprocess_manager.py
@@ -32,6 +32,9 @@ def kill_process_and_descendants(pid, termination_timeout):
 
 
 def kill_processes_and_descendants(pids: List[str], termination_timeout: float):
+    # TODO: there's a race condition that new descendants might
+    # spawn b/w the invocations of 'pkill' and 'kill'.
+    # Needs to be fixed in future.
     try:
         subprocess.check_call(["pkill", "-TERM", "-P", *pids])
         subprocess.check_call(["kill", "-TERM", *pids])
@@ -50,6 +53,9 @@ def kill_processes_and_descendants(pids: List[str], termination_timeout: float):
 async def async_kill_processes_and_descendants(
     pids: List[str], termination_timeout: float
 ):
+    # TODO: there's a race condition that new descendants might
+    # spawn b/w the invocations of 'pkill' and 'kill'.
+    # Needs to be fixed in future.
     sub_term = await asyncio.create_subprocess_exec("pkill", "-TERM", "-P", *pids)
     await sub_term.wait()
 

--- a/metaflow/runner/subprocess_manager.py
+++ b/metaflow/runner/subprocess_manager.py
@@ -12,25 +12,6 @@ from typing import Callable, Dict, Iterator, List, Optional, Tuple
 from .utils import check_process_exited
 
 
-def kill_process_and_descendants(pid, termination_timeout):
-    # TODO: there's a race condition that new descendants might
-    # spawn b/w the invocations of 'pkill' and 'kill'.
-    # Needs to be fixed in future.
-    try:
-        subprocess.check_call(["pkill", "-TERM", "-P", str(pid)])
-        subprocess.check_call(["kill", "-TERM", str(pid)])
-    except subprocess.CalledProcessError:
-        pass
-
-    time.sleep(termination_timeout)
-
-    try:
-        subprocess.check_call(["pkill", "-KILL", "-P", str(pid)])
-        subprocess.check_call(["kill", "-KILL", str(pid)])
-    except subprocess.CalledProcessError:
-        pass
-
-
 def kill_processes_and_descendants(pids: List[str], termination_timeout: float):
     # TODO: there's a race condition that new descendants might
     # spawn b/w the invocations of 'pkill' and 'kill'.
@@ -528,7 +509,7 @@ class CommandManager(object):
         """
 
         if self.process is not None:
-            kill_process_and_descendants(self.process.pid, termination_timeout)
+            kill_processes_and_descendants([str(self.process.pid)], termination_timeout)
         else:
             print("No process to kill.")
 

--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -81,14 +81,23 @@ async def async_read_from_file_when_ready(
     command_obj: "metaflow.runner.subprocess_manager.CommandManager",
     timeout: float = 5,
 ):
-    await asyncio.wait_for(command_obj.process.wait(), timeout)
-
+    start_time = time.time()
     with open(file_path, "r", encoding="utf-8") as file_pointer:
         content = file_pointer.read()
-        if not content:
-            raise CalledProcessError(
-                command_obj.process.returncode, command_obj.command
-            )
+        while not content:
+            if check_process_status(command_obj):
+                content = file_pointer.read()
+                if content:
+                    break
+                raise CalledProcessError(
+                    command_obj.process.returncode, command_obj.command
+                )
+            if time.time() - start_time > timeout:
+                raise TimeoutError(
+                    "Timeout while waiting for file content from '%s'" % file_path
+                )
+            await asyncio.sleep(0.1)
+            content = file_pointer.read()
         return content
 
 

--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -39,9 +39,9 @@ def format_flowfile(cell):
     return "\n".join(lines)
 
 
-def check_process_status(
+def check_process_exited(
     command_obj: "metaflow.runner.subprocess_manager.CommandManager",
-):
+) -> bool:
     if isinstance(command_obj.process, asyncio.subprocess.Process):
         return command_obj.process.returncode is not None
     else:
@@ -57,7 +57,7 @@ def read_from_file_when_ready(
     with open(file_path, "r", encoding="utf-8") as file_pointer:
         content = file_pointer.read()
         while not content:
-            if check_process_status(command_obj):
+            if check_process_exited(command_obj):
                 # Check to make sure the file hasn't been read yet to avoid a race
                 # where the file is written between the end of this while loop and the
                 # poll call above.
@@ -85,7 +85,7 @@ async def async_read_from_file_when_ready(
     with open(file_path, "r", encoding="utf-8") as file_pointer:
         content = file_pointer.read()
         while not content:
-            if check_process_status(command_obj):
+            if check_process_exited(command_obj):
                 content = file_pointer.read()
                 if content:
                     break

--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -76,6 +76,35 @@ def read_from_file_when_ready(
         return content
 
 
+async def async_read_from_file_when_ready(
+    file_path: str,
+    command_obj: "metaflow.runner.subprocess_manager.CommandManager",
+    timeout: float = 5,
+):
+    await asyncio.wait_for(command_obj.process.wait(), timeout)
+
+    with open(file_path, "r", encoding="utf-8") as file_pointer:
+        content = file_pointer.read()
+        if not content:
+            raise CalledProcessError(
+                command_obj.process.returncode, command_obj.command
+            )
+        return content
+
+
+def handle_process_error(
+    command_obj: "metaflow.runner.subprocess_manager.CommandManager",
+):
+    stdout_log = open(command_obj.log_files["stdout"], encoding="utf-8").read()
+    stderr_log = open(command_obj.log_files["stderr"], encoding="utf-8").read()
+    command = " ".join(command_obj.command)
+    error_message = "Error executing: '%s':\n" % command
+    if stdout_log.strip():
+        error_message += "\nStdout:\n%s\n" % stdout_log
+    if stderr_log.strip():
+        error_message += "\nStderr:\n%s\n" % stderr_log
+
+
 def handle_timeout(
     tfp_runner_attribute: "tempfile._TemporaryFileWrapper[str]",
     command_obj: "metaflow.runner.subprocess_manager.CommandManager",
@@ -111,15 +140,46 @@ def handle_timeout(
         )
         return content
     except (CalledProcessError, TimeoutError) as e:
-        stdout_log = open(command_obj.log_files["stdout"], encoding="utf-8").read()
-        stderr_log = open(command_obj.log_files["stderr"], encoding="utf-8").read()
-        command = " ".join(command_obj.command)
-        error_message = "Error executing: '%s':\n" % command
-        if stdout_log.strip():
-            error_message += "\nStdout:\n%s\n" % stdout_log
-        if stderr_log.strip():
-            error_message += "\nStderr:\n%s\n" % stderr_log
-        raise RuntimeError(error_message) from e
+        handle_process_error(command_obj)
+        raise RuntimeError from e
+
+
+async def async_handle_timeout(
+    tfp_runner_attribute: "tempfile._TemporaryFileWrapper[str]",
+    command_obj: "metaflow.runner.subprocess_manager.CommandManager",
+    file_read_timeout: int,
+):
+    """
+    Handle the timeout for a running subprocess command that reads a file
+    and raises an error with appropriate logs if a TimeoutError occurs.
+
+    Parameters
+    ----------
+    tfp_runner_attribute : NamedTemporaryFile
+        Temporary file that stores runner attribute data.
+    command_obj : CommandManager
+        Command manager object that encapsulates the running command details.
+    file_read_timeout : int
+        Timeout for reading the file.
+
+    Returns
+    -------
+    str
+        Content read from the temporary file.
+
+    Raises
+    ------
+    RuntimeError
+        If a TimeoutError occurs, it raises a RuntimeError with the command's
+        stdout and stderr logs.
+    """
+    try:
+        return await async_read_from_file_when_ready(
+            tfp_runner_attribute.name, command_obj, timeout=file_read_timeout
+        )
+    except (CalledProcessError, TimeoutError) as e:
+        handle_process_error(command_obj)
+        raise RuntimeError from e
 
 
 def get_lower_level_group(

--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -2,7 +2,9 @@ import os
 import ast
 import time
 import asyncio
-
+import tempfile
+import select
+from contextlib import contextmanager
 from subprocess import CalledProcessError
 from typing import Any, Dict, TYPE_CHECKING
 
@@ -48,57 +50,130 @@ def check_process_exited(
         return command_obj.process.poll() is not None
 
 
-def read_from_file_when_ready(
-    file_path: str,
-    command_obj: "metaflow.runner.subprocess_manager.CommandManager",
-    timeout: float = 5,
-):
-    start_time = time.time()
-    with open(file_path, "r", encoding="utf-8") as file_pointer:
-        content = file_pointer.read()
-        while not content:
-            if check_process_exited(command_obj):
-                # Check to make sure the file hasn't been read yet to avoid a race
-                # where the file is written between the end of this while loop and the
-                # poll call above.
-                content = file_pointer.read()
-                if content:
-                    break
-                raise CalledProcessError(
-                    command_obj.process.returncode, command_obj.command
-                )
-            if time.time() - start_time > timeout:
-                raise TimeoutError(
-                    "Timeout while waiting for file content from '%s'" % file_path
-                )
-            time.sleep(0.1)
-            content = file_pointer.read()
-        return content
+@contextmanager
+def temporary_fifo() -> (str, int):
+    """
+    Create and open the read side of a temporary FIFO in a non-blocking mode.
+
+    Returns
+    -------
+    str
+        Path to the temporary FIFO.
+    int
+        File descriptor of the temporary FIFO.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        path = os.path.join(temp_dir, "fifo")
+        os.mkfifo(path)
+        # Blocks until the write side is opened unless in non-blocking mode
+        fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+        try:
+            yield path, fd
+        finally:
+            os.close(fd)
 
 
-async def async_read_from_file_when_ready(
-    file_path: str,
+def read_from_fifo_when_ready(
+    fifo_fd: int,
     command_obj: "metaflow.runner.subprocess_manager.CommandManager",
-    timeout: float = 5,
-):
-    start_time = time.time()
-    with open(file_path, "r", encoding="utf-8") as file_pointer:
-        content = file_pointer.read()
-        while not content:
-            if check_process_exited(command_obj):
-                content = file_pointer.read()
-                if content:
-                    break
-                raise CalledProcessError(
-                    command_obj.process.returncode, command_obj.command
-                )
-            if time.time() - start_time > timeout:
-                raise TimeoutError(
-                    "Timeout while waiting for file content from '%s'" % file_path
-                )
-            await asyncio.sleep(0.1)
-            content = file_pointer.read()
-        return content
+    encoding: str = "utf-8",
+    timeout: int = 3600,
+) -> str:
+    """
+    Read the content from the FIFO file descriptor when it is ready.
+
+    Parameters
+    ----------
+    fifo_fd : int
+        File descriptor of the FIFO.
+    command_obj : CommandManager
+        Command manager object that handles the write side of the FIFO.
+    encoding : str, optional
+        Encoding to use while reading the file, by default "utf-8".
+    timeout : int, optional
+        Timeout for reading the file in milliseconds, by default 3600.
+
+    Returns
+    -------
+    str
+        Content read from the FIFO.
+
+    Raises
+    ------
+    TimeoutError
+        If no event occurs on the FIFO within the timeout.
+    CalledProcessError
+        If the process managed by `command_obj` has exited without writing any
+        content to the FIFO.
+    """
+    content = bytearray()
+
+    poll = select.poll()
+    poll.register(fifo_fd, select.POLLIN)
+
+    while True:
+        poll_begin = time.time()
+        poll.poll(timeout)
+        timeout -= 1000 * (time.time() - poll_begin)
+
+        if timeout <= 0:
+            raise TimeoutError("Timeout while waiting for the file content")
+
+        try:
+            data = os.read(fifo_fd, 128)
+            while data:
+                content += data
+                data = os.read(fifo_fd, 128)
+
+            # Read from a non-blocking closed FIFO returns an empty byte array
+            break
+
+        except BlockingIOError:
+            # FIFO is open but no data is available yet
+            continue
+
+    if not content and check_process_exited(command_obj):
+        raise CalledProcessError(command_obj.process.returncode, command_obj.command)
+
+    return content.decode(encoding)
+
+
+async def async_read_from_fifo_when_ready(
+    fifo_fd: int,
+    command_obj: "metaflow.runner.subprocess_manager.CommandManager",
+    encoding: str = "utf-8",
+    timeout: int = 3600,
+) -> str:
+    """
+    Read the content from the FIFO file descriptor when it is ready.
+
+    Parameters
+    ----------
+    fifo_fd : int
+        File descriptor of the FIFO.
+    command_obj : CommandManager
+        Command manager object that handles the write side of the FIFO.
+    encoding : str, optional
+        Encoding to use while reading the file, by default "utf-8".
+    timeout : int, optional
+        Timeout for reading the file in milliseconds, by default 3600.
+
+    Returns
+    -------
+    str
+        Content read from the FIFO.
+
+    Raises
+    ------
+    TimeoutError
+        If no event occurs on the FIFO within the timeout.
+    CalledProcessError
+        If the process managed by `command_obj` has exited without writing any
+        content to the FIFO.
+    """
+    return await asyncio.to_thread(
+        read_from_fifo_when_ready, fifo_fd, command_obj, encoding, timeout
+    )
 
 
 def make_process_error_message(
@@ -116,7 +191,7 @@ def make_process_error_message(
 
 
 def handle_timeout(
-    tfp_runner_attribute: "tempfile._TemporaryFileWrapper[str]",
+    attribute_file_fd: int,
     command_obj: "metaflow.runner.subprocess_manager.CommandManager",
     file_read_timeout: int,
 ):
@@ -126,8 +201,8 @@ def handle_timeout(
 
     Parameters
     ----------
-    tfp_runner_attribute : NamedTemporaryFile
-        Temporary file that stores runner attribute data.
+    attribute_file_fd : int
+        File descriptor belonging to the FIFO containing the attribute data.
     command_obj : CommandManager
         Command manager object that encapsulates the running command details.
     file_read_timeout : int
@@ -145,16 +220,15 @@ def handle_timeout(
         stdout and stderr logs.
     """
     try:
-        content = read_from_file_when_ready(
-            tfp_runner_attribute.name, command_obj, timeout=file_read_timeout
+        return read_from_fifo_when_ready(
+            attribute_file_fd, command_obj=command_obj, timeout=file_read_timeout
         )
-        return content
     except (CalledProcessError, TimeoutError) as e:
         raise RuntimeError(make_process_error_message(command_obj)) from e
 
 
 async def async_handle_timeout(
-    tfp_runner_attribute: "tempfile._TemporaryFileWrapper[str]",
+    attribute_file_fd: "int",
     command_obj: "metaflow.runner.subprocess_manager.CommandManager",
     file_read_timeout: int,
 ):
@@ -164,8 +238,8 @@ async def async_handle_timeout(
 
     Parameters
     ----------
-    tfp_runner_attribute : NamedTemporaryFile
-        Temporary file that stores runner attribute data.
+    attribute_file_fd : int
+        File descriptor belonging to the FIFO containing the attribute data.
     command_obj : CommandManager
         Command manager object that encapsulates the running command details.
     file_read_timeout : int
@@ -183,8 +257,8 @@ async def async_handle_timeout(
         stdout and stderr logs.
     """
     try:
-        return await async_read_from_file_when_ready(
-            tfp_runner_attribute.name, command_obj, timeout=file_read_timeout
+        return await async_read_from_fifo_when_ready(
+            attribute_file_fd, command_obj=command_obj, timeout=file_read_timeout
         )
     except (CalledProcessError, TimeoutError) as e:
         raise RuntimeError(make_process_error_message(command_obj)) from e

--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -92,7 +92,7 @@ async def async_read_from_file_when_ready(
         return content
 
 
-def handle_process_error(
+def make_process_error_message(
     command_obj: "metaflow.runner.subprocess_manager.CommandManager",
 ):
     stdout_log = open(command_obj.log_files["stdout"], encoding="utf-8").read()
@@ -103,6 +103,7 @@ def handle_process_error(
         error_message += "\nStdout:\n%s\n" % stdout_log
     if stderr_log.strip():
         error_message += "\nStderr:\n%s\n" % stderr_log
+    return error_message
 
 
 def handle_timeout(
@@ -140,8 +141,7 @@ def handle_timeout(
         )
         return content
     except (CalledProcessError, TimeoutError) as e:
-        handle_process_error(command_obj)
-        raise RuntimeError from e
+        raise RuntimeError(make_process_error_message(command_obj)) from e
 
 
 async def async_handle_timeout(
@@ -178,8 +178,7 @@ async def async_handle_timeout(
             tfp_runner_attribute.name, command_obj, timeout=file_read_timeout
         )
     except (CalledProcessError, TimeoutError) as e:
-        handle_process_error(command_obj)
-        raise RuntimeError from e
+        raise RuntimeError(make_process_error_message(command_obj)) from e
 
 
 def get_lower_level_group(

--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -6,7 +6,7 @@ import tempfile
 import select
 from contextlib import contextmanager
 from subprocess import CalledProcessError
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, Dict, TYPE_CHECKING, ContextManager
 
 if TYPE_CHECKING:
     import tempfile
@@ -51,7 +51,7 @@ def check_process_exited(
 
 
 @contextmanager
-def temporary_fifo() -> (str, int):
+def temporary_fifo() -> ContextManager[tuple[str, int]]:
     """
     Create and open the read side of a temporary FIFO in a non-blocking mode.
 


### PR DESCRIPTION
Follow-up to https://github.com/Netflix/metaflow/pull/2053

Added an async implementation of Runner's signal handling, as discussed here https://github.com/Netflix/metaflow/pull/2053#discussion_r1771641866.

Added an async implementation of Runner's `__get_executing_run`, which is used in `async_run` and `async_resume`, the current implementation relies on `time.sleep`, which blocks other coroutines from running (modified code from my previous PR https://github.com/Netflix/metaflow/pull/2033).