### PR TITLE
fix: Argo Workflows JSONType parameters with default values sometimes not working

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -765,9 +765,7 @@ class ArgoWorkflows(object):
                     Arguments().parameters(
                         [
                             Parameter(parameter["name"])
-                            .value(
-                                "%s" % parameter["value"]
-                            )  # double quoting the default value is required for Argo UI and cronworkflows
+                            .value(parameter["value"])
                             .description(parameter.get("description"))
                             # TODO: Better handle IncludeFile in Argo Workflows UI.
                             for parameter in self.parameters.values()

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -765,7 +765,9 @@ class ArgoWorkflows(object):
                     Arguments().parameters(
                         [
                             Parameter(parameter["name"])
-                            .value(parameter["value"])
+                            .value(
+                                "%s" % parameter["value"]
+                            )  # double quoting the default value is required for Argo UI and cronworkflows
                             .description(parameter.get("description"))
                             # TODO: Better handle IncludeFile in Argo Workflows UI.
                             for parameter in self.parameters.values()
@@ -1490,7 +1492,11 @@ class ArgoWorkflows(object):
                         # {{foo.bar['param_name']}}.
                         # https://argoproj.github.io/argo-events/tutorials/02-parameterization/
                         # http://masterminds.github.io/sprig/strings.html
-                        "--%s={{workflow.parameters.%s}}"
+                        (
+                            "--%s='{{workflow.parameters.%s}}'"
+                            if parameter["type"] == "JSON"
+                            else "--%s={{workflow.parameters.%s}}"
+                        )
                         % (parameter["name"], parameter["name"])
                         for parameter in self.parameters.values()
                     ]


### PR DESCRIPTION
due to changes in parameter quoting in the CLI, passing jsontype parameter default values has stopped working. Attempt to mend the issue with this PR

parameter default testing needs to cover:
- basic `argo-workflows trigger --param_name value` functionality
- cronworkflow parameter defaults with `@schedule`
- Argo Events payload parameter mapping