### PR TITLE
Refactor system event logger and monitor, add new metrics

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -699,6 +699,15 @@ def resume(
     runtime.print_workflow_info()
 
     runtime.persist_constants()
+    _system_logger.log_event(
+        level="info",
+        module="metaflow.resume",
+        name="graph_info",
+        payload={
+            "run_id": str(runtime.run_id),
+            "msg": str(obj.flow._graph_info),
+        },
+    )
 
     if runner_attribute_file:
         with open(runner_attribute_file, "w") as f:
@@ -775,6 +784,15 @@ def run(
     write_file(run_id_file, runtime.run_id)
 
     obj.flow._set_constants(obj.graph, kwargs)
+    _system_logger.log_event(
+        level="info",
+        module="metaflow.run",
+        name="graph_info",
+        payload={
+            "run_id": str(runtime.run_id),
+            "msg": str(obj.flow._graph_info),
+        },
+    )
     runtime.print_workflow_info()
     runtime.persist_constants()
 

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -716,6 +716,15 @@ def resume(
     if runtime.should_skip_clone_only_execution():
         return
 
+    _system_logger.log_event(
+        level="info",
+        module="metaflow.resume",
+        name="start",
+        payload={
+            "run_id": str(runtime.run_id),
+        },
+    )
+
     with runtime.run_heartbeat():
         if clone_only:
             runtime.clone_original_run()
@@ -778,7 +787,7 @@ def run(
     _system_logger.log_event(
         level="info",
         module="metaflow.run",
-        name="graph_info",
+        name="start",
         payload={
             "run_id": str(runtime.run_id),
             "msg": str(obj.flow._graph_info),

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -716,12 +716,17 @@ def resume(
     if runtime.should_skip_clone_only_execution():
         return
 
+    current._update_env(
+        {
+            "run_id": runtime.run_id,
+        }
+    )
     _system_logger.log_event(
         level="info",
         module="metaflow.resume",
         name="start",
         payload={
-            "run_id": str(runtime.run_id),
+            "msg": "Resuming run",
         },
     )
 
@@ -784,13 +789,17 @@ def run(
     write_file(run_id_file, runtime.run_id)
 
     obj.flow._set_constants(obj.graph, kwargs)
+    current._update_env(
+        {
+            "run_id": runtime.run_id,
+        }
+    )
     _system_logger.log_event(
         level="info",
         module="metaflow.run",
         name="start",
         payload={
-            "run_id": str(runtime.run_id),
-            "msg": str(obj.flow._graph_info),
+            "msg": "Starting run",
         },
     )
     runtime.print_workflow_info()

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -699,15 +699,6 @@ def resume(
     runtime.print_workflow_info()
 
     runtime.persist_constants()
-    _system_logger.log_event(
-        level="info",
-        module="metaflow.resume",
-        name="graph_info",
-        payload={
-            "run_id": str(runtime.run_id),
-            "msg": str(obj.flow._graph_info),
-        },
-    )
 
     if runner_attribute_file:
         with open(runner_attribute_file, "w") as f:

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -16,7 +16,6 @@ from io import BytesIO
 from functools import partial
 from concurrent import futures
 
-from metaflow.system import _system_logger
 from metaflow.datastore.exceptions import DataException
 from contextlib import contextmanager
 
@@ -88,15 +87,6 @@ class NativeRuntime(object):
         else:
             self._run_id = run_id
             metadata.register_run_id(run_id)
-
-        _system_logger.log_event(
-            level="info",
-            module="metaflow.runtime",
-            name="start",
-            payload={
-                "run_id": str(self._run_id),
-            },
-        )
 
         self._flow = flow
         self._graph = graph
@@ -524,15 +514,6 @@ class NativeRuntime(object):
             raise MetaflowInternalError(
                 "The *end* step was not successful by the end of flow."
             )
-
-        _system_logger.log_event(
-            level="info",
-            module="metaflow.runtime",
-            name="end",
-            payload={
-                "run_id": str(self._run_id),
-            },
-        )
 
     def _killall(self):
         # If we are here, all children have received a signal and are shutting down.

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -525,6 +525,15 @@ class NativeRuntime(object):
                 "The *end* step was not successful by the end of flow."
             )
 
+        _system_logger.log_event(
+            level="info",
+            module="metaflow.runtime",
+            name="end",
+            payload={
+                "run_id": str(self._run_id),
+            },
+        )
+
     def _killall(self):
         # If we are here, all children have received a signal and are shutting down.
         # We want to give them an opportunity to do so and then kill

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -16,6 +16,7 @@ from io import BytesIO
 from functools import partial
 from concurrent import futures
 
+from metaflow.system import _system_logger
 from metaflow.datastore.exceptions import DataException
 from contextlib import contextmanager
 
@@ -87,6 +88,15 @@ class NativeRuntime(object):
         else:
             self._run_id = run_id
             metadata.register_run_id(run_id)
+
+        _system_logger.log_event(
+            level="info",
+            module="metaflow.runtime",
+            name="start",
+            payload={
+                "run_id": str(self._run_id),
+            },
+        )
 
         self._flow = flow
         self._graph = graph

--- a/metaflow/system/system_logger.py
+++ b/metaflow/system/system_logger.py
@@ -56,7 +56,7 @@ class SystemLogger(object):
             "false",
             "",
         ):
-            print("system monitor: %s" % msg, file=sys.stderr)
+            print("system logger: %s" % msg, file=sys.stderr)
 
     def log_event(
         self, level: str, module: str, name: str, payload: Optional[Any] = None

--- a/metaflow/system/system_logger.py
+++ b/metaflow/system/system_logger.py
@@ -7,25 +7,10 @@ class SystemLogger(object):
     def __init__(self):
         self._logger = None
         self._flow_name = None
-        self._context = {}
-        self._is_context_updated = False
 
     def __del__(self):
         if self._flow_name == "not_a_real_flow":
             self.logger.terminate()
-
-    def update_context(self, context: Dict[str, Any]):
-        """
-        Update the global context maintained by the system logger.
-
-        Parameters
-        ----------
-        context : Dict[str, Any]
-            A dictionary containing the context to update.
-
-        """
-        self._is_context_updated = True
-        self._context.update(context)
 
     def init_system_logger(
         self, flow_name: str, logger: "metaflow.event_logger.NullEventLogger"
@@ -96,8 +81,5 @@ class SystemLogger(object):
                 "module": module,
                 "name": name,
                 "payload": payload if payload is not None else {},
-                "context": self._context,
-                "is_context_updated": self._is_context_updated,
             }
         )
-        self._is_context_updated = False

--- a/metaflow/system/system_monitor.py
+++ b/metaflow/system/system_monitor.py
@@ -15,29 +15,6 @@ class SystemMonitor(object):
         if self._flow_name == "not_a_real_flow":
             self.monitor.terminate()
 
-    def update_context(self, context: Dict[str, Any]):
-        """
-        Update the global context maintained by the system monitor.
-
-        Parameters
-        ----------
-        context : Dict[str, Any]
-            A dictionary containing the context to update.
-
-        """
-        from metaflow.sidecar import Message, MessageTypes
-
-        self._context.update(context)
-        self.monitor.send(
-            Message(
-                MessageTypes.MUST_SEND,
-                {
-                    "is_context_updated": True,
-                    **self._context,
-                },
-            )
-        )
-
     def init_system_monitor(
         self, flow_name: str, monitor: "metaflow.monitor.NullMonitor"
     ):

--- a/metaflow/system/system_monitor.py
+++ b/metaflow/system/system_monitor.py
@@ -9,7 +9,6 @@ class SystemMonitor(object):
     def __init__(self):
         self._monitor = None
         self._flow_name = None
-        self._context = {}
 
     def __del__(self):
         if self._flow_name == "not_a_real_flow":

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -544,9 +544,6 @@ class MetaflowTask(object):
             "project_flow_name": current.get("project_flow_name"),
             "trace_id": trace_id or None,
         }
-
-        _system_logger.update_context(task_payload)
-        _system_monitor.update_context(task_payload)
         start = time.time()
         self.metadata.start_task_heartbeat(self.flow.name, run_id, step_name, task_id)
         with self.monitor.measure("metaflow.task.duration"):
@@ -591,7 +588,8 @@ class MetaflowTask(object):
                         {
                             "parameter_names": self._init_parameters(
                                 inputs[0], passdown=True
-                            )
+                            ),
+                            "graph_info": self.flow._graph_info,
                         }
                     )
                 else:
@@ -615,7 +613,8 @@ class MetaflowTask(object):
                             {
                                 "parameter_names": self._init_parameters(
                                     inputs[0], passdown=False
-                                )
+                                ),
+                                "graph_info": self.flow._graph_info,
                             }
                         )
 

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -306,8 +306,6 @@ class MetaflowTask(object):
             "origin_run_id": origin_run_id,
             "origin_task_id": origin_task_id,
         }
-        _system_logger.update_context(task_payload)
-        _system_monitor.update_context(task_payload)
 
         msg = "Cloning task from {}/{}/{}/{} to {}/{}/{}/{}".format(
             self.flow.name,


### PR DESCRIPTION
This PR removes the notion of a separate global context from `system_monitor` and `system_logger`. User's can now implement their event loggers and monitors to make use of the current singleton instead. 

Additionally, it adds the `graph_info` object to the current singleton, but it is not directly exposed to the end user. 