### PR TITLE
Fix child Flow accessor in root Metaflow class

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -2358,7 +2358,7 @@ class Metaflow(object):
         Flow
             Flow with the given name.
         """
-        return Flow(id)
+        return Flow(name)
 
 
 _CLASSES["flow"] = Flow


### PR DESCRIPTION
This PR fixes a simple bug in the object hierarchy navigation logic. Specifically, this PR ensures that one can correctly resolve a child flow by name from a root Metaflow object:

```python
from metaflow import Metaflow
mf = Metaflow()
flow = mf['HelloFlow']
```