### PR TITLE
Feat: Add the option to use shell with the metaflow python Runner

### DIFF
--- a/metaflow/runner/metaflow_runner.py
+++ b/metaflow/runner/metaflow_runner.py
@@ -218,6 +218,9 @@ class Runner(object):
         directory is used.
     file_read_timeout : int, default 3600
         The timeout until which we try to read the runner attribute file.
+    shell : bool, default False
+        If True, the runner will execute commands directly through the shell.
+        Forwarding commands to shell can provide a performance improvement.
     **kwargs : Any
         Additional arguments that you would pass to `python myflow.py` before
         the `run` command.
@@ -231,6 +234,7 @@ class Runner(object):
         env: Optional[Dict] = None,
         cwd: Optional[str] = None,
         file_read_timeout: int = 3600,
+        shell: bool = False,
         **kwargs
     ):
         # these imports are required here and not at the top
@@ -260,6 +264,8 @@ class Runner(object):
         self.spm = SubprocessManager()
         self.top_level_kwargs = kwargs
         self.api = MetaflowAPI.from_cli(self.flow_file, start)
+
+        self.shell = shell
 
     def __enter__(self) -> "Runner":
         return self
@@ -320,6 +326,7 @@ class Runner(object):
                 env=self.env_vars,
                 cwd=self.cwd,
                 show_output=self.show_output,
+                shell=self.shell,
             )
             command_obj = self.spm.get(pid)
 
@@ -354,6 +361,7 @@ class Runner(object):
                 env=self.env_vars,
                 cwd=self.cwd,
                 show_output=self.show_output,
+                shell=self.shell,
             )
             command_obj = self.spm.get(pid)
 


### PR DESCRIPTION
Hi,
Raising a pr to allow the subprocesses to be executed directly through the shell. 

Locally this had a massive performance improvement for an extreamly lightweight flow for me.
18.618823051452637
to
3.2076590061187744

I'm not 100% on where the increase comes from. I suspect this is as the shell is caching python instead of directly executing it each time.

Thank you