### PR TITLE
feature: conda virtual packages error messages

### DIFF
--- a/metaflow/plugins/pypi/micromamba.py
+++ b/metaflow/plugins/pypi/micromamba.py
@@ -253,7 +253,18 @@ class Micromamba(object):
             try:
                 output = json.loads(e.output)
                 err = []
+                v_pkgs = ["__cuda", "__glibc"]
                 for error in output.get("solver_problems", []):
+                    # raise a specific error message for virtual package related errors
+                    match = next((p for p in v_pkgs if p in error), None)
+                    if match is not None:
+                        raise MicromambaException(
+                            [
+                                error,
+                                "Please set the environment variable CONDA_OVERRIDE_%s to a specific version"
+                                % (match[2:].upper()),
+                            ]
+                        )
                     err.append(error)
                 raise MicromambaException(
                     msg.format(


### PR DESCRIPTION
add specific error messages with instructions for conda virtual packages

example output:

```
Micromamba ran into an error while setting up environment:
    nothing provides __glibc >=2.17,<3.0.a0 needed by pyside6-6.7.2-py310heb5a38e_0
    Please set the environment variable CONDA_OVERRIDE_GLIBC to a specific version
```