### PR TITLE
Don't raise error if metaflow_extension's `Distribution#files` is `None`.

### DIFF
--- a/metaflow/extension_support/__init__.py
+++ b/metaflow/extension_support/__init__.py
@@ -489,6 +489,8 @@ def _get_extension_packages(ignore_info_file=False, restrict_to_directories=None
             # contributes to. This is to enable multiple namespace packages to contribute
             # to the same extension point (for example, you may have multiple packages
             # that have plugins)
+            if not dist.files:
+                _ext_debug("Invalid package seen '%s' at '%s': no file list found in metadata" % (dist_name, dist_root))
             for f in dist.files or []:
                 parts = list(f.parts)
 

--- a/metaflow/extension_support/__init__.py
+++ b/metaflow/extension_support/__init__.py
@@ -489,7 +489,7 @@ def _get_extension_packages(ignore_info_file=False, restrict_to_directories=None
             # contributes to. This is to enable multiple namespace packages to contribute
             # to the same extension point (for example, you may have multiple packages
             # that have plugins)
-            for f in dist.files:
+            for f in dist.files or []:
                 parts = list(f.parts)
 
                 if len(parts) > 1 and parts[0] == EXT_PKG:

--- a/metaflow/extension_support/__init__.py
+++ b/metaflow/extension_support/__init__.py
@@ -491,7 +491,10 @@ def _get_extension_packages(ignore_info_file=False, restrict_to_directories=None
             # that have plugins)
             if not dist.files:
                 # TODO: fallback on iterating through the package if file metadata is not included
-                _ext_debug("Invalid package seen '%s' at '%s': no file list found in metadata" % (dist_name, dist_root))
+                _ext_debug(
+                    "Invalid package seen '%s' at '%s': no file list found in metadata"
+                    % (dist_name, dist_root)
+                )
             for f in dist.files or []:
                 parts = list(f.parts)
 

--- a/metaflow/extension_support/__init__.py
+++ b/metaflow/extension_support/__init__.py
@@ -490,6 +490,7 @@ def _get_extension_packages(ignore_info_file=False, restrict_to_directories=None
             # to the same extension point (for example, you may have multiple packages
             # that have plugins)
             if not dist.files:
+                # TODO: fallback on iterating through the package if file metadata is not included
                 _ext_debug("Invalid package seen '%s' at '%s': no file list found in metadata" % (dist_name, dist_root))
             for f in dist.files or []:
                 parts = list(f.parts)


### PR DESCRIPTION
With the `metaflow-card-html` package, we're seeing the following error:

```
.../metaflow/extension_support/__init__.py", line 414, in _get_extension_packages
    for f in dist.files:
TypeError: 'NoneType' object is not iterable
```

Turns out [`Distribution.files` can return `None`](https://importlib-metadata.readthedocs.io/en/latest/api.html#importlib_metadata.Distribution.files). `metaflow-card-html` doesn't include the appropriate wheel metadata files, and, when included, hits this error.