### PR TITLE
feature: enable extending pypi/conda execution decorator support

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -257,10 +257,6 @@ class StepDecorator(Decorator):
                   pass them around with every lifecycle call.
     """
 
-    # bookkeeping for decorators that determine step execution remotely
-    step_remote_execution = False
-    target_platform = None
-
     def step_init(
         self, flow, graph, step_name, decorators, environment, flow_datastore, logger
     ):

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -257,6 +257,10 @@ class StepDecorator(Decorator):
                   pass them around with every lifecycle call.
     """
 
+    # bookkeeping for decorators that determine step execution remotely
+    step_remote_execution = False
+    target_platform = None
+
     def step_init(
         self, flow, graph, step_name, decorators, environment, flow_datastore, logger
     ):

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -133,7 +133,9 @@ class BatchDecorator(StepDecorator):
     package_url = None
     package_sha = None
     run_time_limit = None
-    step_remote_execution = True
+
+    # Conda environment support
+    support_conda = True
     target_platform = "linux-64"
 
     def __init__(self, attributes=None, statically_defined=False):

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -135,7 +135,7 @@ class BatchDecorator(StepDecorator):
     run_time_limit = None
 
     # Conda environment support
-    support_conda = True
+    supports_conda_environment = True
     target_platform = "linux-64"
 
     def __init__(self, attributes=None, statically_defined=False):

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -133,6 +133,8 @@ class BatchDecorator(StepDecorator):
     package_url = None
     package_sha = None
     run_time_limit = None
+    step_remote_execution = True
+    target_platform = "linux-64"
 
     def __init__(self, attributes=None, statically_defined=False):
         super(BatchDecorator, self).__init__(attributes, statically_defined)

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -134,7 +134,9 @@ class KubernetesDecorator(StepDecorator):
     package_url = None
     package_sha = None
     run_time_limit = None
-    step_remote_execution = True
+
+    # Conda environment support
+    support_conda = True
     target_platform = "linux-64"
 
     def __init__(self, attributes=None, statically_defined=False):

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -136,7 +136,7 @@ class KubernetesDecorator(StepDecorator):
     run_time_limit = None
 
     # Conda environment support
-    support_conda = True
+    supports_conda_environment = True
     target_platform = "linux-64"
 
     def __init__(self, attributes=None, statically_defined=False):

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -134,6 +134,8 @@ class KubernetesDecorator(StepDecorator):
     package_url = None
     package_sha = None
     run_time_limit = None
+    step_remote_execution = True
+    target_platform = "linux-64"
 
     def __init__(self, attributes=None, statically_defined=False):
         super(KubernetesDecorator, self).__init__(attributes, statically_defined)

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -272,6 +272,7 @@ class CondaEnvironment(MetaflowEnvironment):
             if getattr(decorator, "support_conda", None):
                 # TODO: Support arm architectures
                 target_platform = getattr(decorator, "target_platform", "linux-64")
+                break
 
         environment["conda"]["platforms"] = [target_platform]
         if "pypi" in environment:

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -270,7 +270,7 @@ class CondaEnvironment(MetaflowEnvironment):
         target_platform = conda_platform()
         for decorator in step.decorators:
             if getattr(
-                decorator, "supports_conda_environment", None
+                decorator, "supports_conda_environment", False
             ) or decorator.name in ["nvidia", "snowpark", "slurm"]:
                 # TODO: Support arm architectures
                 target_platform = getattr(decorator, "target_platform", "linux-64")

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -269,7 +269,9 @@ class CondaEnvironment(MetaflowEnvironment):
         # Resolve `linux-64` Conda environments if @batch or @kubernetes are in play
         target_platform = conda_platform()
         for decorator in step.decorators:
-            if getattr(decorator, "support_conda", None):
+            if getattr(
+                decorator, "supports_conda_environment", None
+            ) or decorator.name in ["nvidia", "snowpark", "slurm"]:
                 # TODO: Support arm architectures
                 target_platform = getattr(decorator, "target_platform", "linux-64")
                 break

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -269,9 +269,17 @@ class CondaEnvironment(MetaflowEnvironment):
         # Resolve `linux-64` Conda environments if @batch or @kubernetes are in play
         target_platform = conda_platform()
         for decorator in step.decorators:
+            # NOTE: Keep the list of supported decorator names for backward compatibility purposes.
+            # Older versions did not implement the 'support_conda_environment' attribute.
             if getattr(
                 decorator, "supports_conda_environment", False
-            ) or decorator.name in ["nvidia", "snowpark", "slurm"]:
+            ) or decorator.name in [
+                "batch",
+                "kubernetes",
+                "nvidia",
+                "snowpark",
+                "slurm",
+            ]:
                 # TODO: Support arm architectures
                 target_platform = getattr(decorator, "target_platform", "linux-64")
                 break

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -269,12 +269,9 @@ class CondaEnvironment(MetaflowEnvironment):
         # Resolve `linux-64` Conda environments if @batch or @kubernetes are in play
         target_platform = conda_platform()
         for decorator in step.decorators:
-            # TODO: rather than relying on decorator names, rely on attributes
-            #       to make them extensible.
-            if decorator.name in ["batch", "kubernetes", "nvidia", "snowpark", "slurm"]:
+            if decorator.step_remote_execution:
                 # TODO: Support arm architectures
-                target_platform = "linux-64"
-                break
+                target_platform = decorator.target_platform or "linux-64"
 
         environment["conda"]["platforms"] = [target_platform]
         if "pypi" in environment:

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -269,9 +269,9 @@ class CondaEnvironment(MetaflowEnvironment):
         # Resolve `linux-64` Conda environments if @batch or @kubernetes are in play
         target_platform = conda_platform()
         for decorator in step.decorators:
-            if decorator.step_remote_execution:
+            if getattr(decorator, "support_conda", None):
                 # TODO: Support arm architectures
-                target_platform = decorator.target_platform or "linux-64"
+                target_platform = getattr(decorator, "target_platform", "linux-64")
 
         environment["conda"]["platforms"] = [target_platform]
         if "pypi" in environment:


### PR DESCRIPTION
The problem is that as new execution environment decorators are being introduced, we need to constantly keep adding these to the list of supported decorators for `@pypi/@conda`.

Proposal is to instead have two flags on step decorators that keep track whether
- decorator is a conda supported execution environment
- what the target platform of said environment is

in the case of the target platform, a decorator could then implement this as a dynamic property if it can be inferred during env resolve time on a per step basis. (f.ex. for the kubernetes decorator through label selectors for `arch`)