### PR TITLE
[kubernetes][parallel] hostname resolution timeout

### DIFF
--- a/metaflow/plugins/cards/card_decorator.py
+++ b/metaflow/plugins/cards/card_decorator.py
@@ -117,6 +117,7 @@ class CardDecorator(StepDecorator):
         # `'%s-%s'%(evt_name,step_name)` ensures that we capture this once per @card per @step.
         # Since there can be many steps checking if event is registered for `evt_name` will only make it check it once for all steps.
         # Hence, we have `_is_event_registered('%s-%s'%(evt_name,step_name))`
+        self._is_runtime_card = False
         evt = "%s-%s" % (evt_name, step_name)
         if not self._is_event_registered(evt):
             # We set the total count of decorators so that we can use it for

--- a/metaflow/plugins/parallel_decorator.py
+++ b/metaflow/plugins/parallel_decorator.py
@@ -13,18 +13,19 @@ class ParallelDecorator(StepDecorator):
     MF Add To Current
     -----------------
     parallel -> metaflow.metaflow_current.Parallel
+        Returns a namedtuple with relevant information about the parallel task.
 
         @@ Returns
         -------
         Parallel
             `namedtuple` with the following fields:
-                - main_ip : str
+                - main_ip (`str`)
                     The IP address of the control task.
-                - num_nodes : int
+                - num_nodes (`int`)
                     The total number of tasks created by @parallel
-                - node_index : int
+                - node_index (`int`)
                     The index of the current task in all the @parallel tasks.
-                - control_task_id : Optional[str]
+                - control_task_id (`Optional[str]`)
                     The task ID of the control task. Available to all tasks.
 
     is_parallel -> bool


### PR DESCRIPTION
In Kubernetes, jobsets ensure that all jobs within the set are scheduled together. However, while they may be scheduled concurrently, the order in which they start executing is not guaranteed. This can cause issues if a worker job starts before the control job, as the worker may fail to resolve the control job’s hostname, leading to a crash.

This update introduces a configurable `hostname_resolution_timeout`, allowing worker jobs to wait for a defined period to resolve the control job's hostname before terminating. This adds a layer of resilience, preventing crashes caused by timing issues between job start times.

One thing to note here is that if the control job finishes before the worker job starts, the worker will still wait for the `hostname_resolution_timeout`. Given that many higher-level decorators using @parallel already implement distributed barriers, this change ensures that the execution order does not jeopardize the success of the jobset.