### PR TITLE
fix: missing loglines from tailing logs with GCP

### DIFF
--- a/metaflow/plugins/azure/azure_tail.py
+++ b/metaflow/plugins/azure/azure_tail.py
@@ -70,7 +70,7 @@ class AzureTail(object):
         if data is None:
             return None
         if data:
-            buf = BytesIO(data)
+            buf = BytesIO(self._tail + data)
             self._pos += len(data)
             self._tail = b""
             return buf

--- a/metaflow/plugins/gcp/gs_tail.py
+++ b/metaflow/plugins/gcp/gs_tail.py
@@ -49,8 +49,6 @@ class GSTail(object):
             # NOTE: We must re-instantiate the whole client here due to a behavior with the GS library,
             # otherwise download_as_bytes will simply return the same content for consecutive requests with the same attributes,
             # even if the blob has grown in size.
-            # client = get_gs_storage_client()
-            # bucket = client.bucket(self.bucket_name)
             blob_client = self.bucket.blob(self.blob_name)
             return blob_client.download_as_bytes(start=self._pos)
         except NotFound:

--- a/metaflow/plugins/gcp/gs_tail.py
+++ b/metaflow/plugins/gcp/gs_tail.py
@@ -63,7 +63,7 @@ class GSTail(object):
         if data is None:
             return None
         if data:
-            buf = BytesIO(data)
+            buf = BytesIO(self._tail + data)
             self._pos += len(data)
             self._tail = b""
             return buf

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -710,12 +710,23 @@ class Kubernetes(object):
         wait_for_launch(self._job)
 
         # 2) Tail logs until the job has finished
+        self._output_final_logs = False
+
+        def _has_updates():
+            if self._job.is_running:
+                return True
+            # Make sure to output final tail for a job that has finished.
+            if not self._output_final_logs:
+                self._output_final_logs = True
+                return True
+            return False
+
         tail_logs(
             prefix=prefix(),
             stdout_tail=stdout_tail,
             stderr_tail=stderr_tail,
             echo=echo,
-            has_log_updates=lambda: self._job.is_running,
+            has_log_updates=_has_updates,
         )
         # 3) Fetch remaining logs
         #


### PR DESCRIPTION
Fixes an issue where log tailing stops working after a point on GCP, resulting in missing log output on the terminal.

The cause is with the behaviour of `google.cloud.storage` blob client, where consecutive requests with identical attributes on a single instance will not yield different responses, even if the underlying blob has advanced.

Example flow to reproduce missing log lines on GCP:

```python
from time import sleep
from metaflow import (
    FlowSpec,
    step,
    kubernetes,
)
import os

class MinimalKubeGCPLogExample(FlowSpec):
    @kubernetes
    @step
    def start(self):
        print("BUFFERED: %s" % os.getenv("PYTHONBUFFERED"))
        print("first log line so as not to have an empty file")
        for i in range(10):
            print(f"{i}\r", end="")
            sleep(1)
        print("\r\n")
        print("after progress lines")
        self.next(self.end)

    @step
    def end(self):
        pass


if __name__ == "__main__":
    MinimalKubeGCPLogExample()
```

also small fix to Azure log tailing as well.