### PR TITLE
ping r version to 4.4.1 to fix test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        ver: ['4.4']
+        ver: ['4.4.1']
 
     steps:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0


### PR DESCRIPTION
R test failure is blocking release pipeline. The tests passed with 4.4.1 and failed for 4.4.2, pin R version as a temp fix to unblock tests