### PR TITLE
[runtime] run heartbeats for local runtime's `run` command

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -802,20 +802,21 @@ def run(
             "msg": "Starting run",
         },
     )
-    runtime.print_workflow_info()
-    runtime.persist_constants()
+    with runtime.run_heartbeat():
+        runtime.print_workflow_info()
+        runtime.persist_constants()
 
-    if runner_attribute_file:
-        with open(runner_attribute_file, "w", encoding="utf-8") as f:
-            json.dump(
-                {
-                    "run_id": runtime.run_id,
-                    "flow_name": obj.flow.name,
-                    "metadata": obj.metadata.metadata_str(),
-                },
-                f,
-            )
-    runtime.execute()
+        if runner_attribute_file:
+            with open(runner_attribute_file, "w", encoding="utf-8") as f:
+                json.dump(
+                    {
+                        "run_id": runtime.run_id,
+                        "flow_name": obj.flow.name,
+                        "metadata": obj.metadata.metadata_str(),
+                    },
+                    f,
+                )
+        runtime.execute()
 
 
 def write_file(file_path, content):


### PR DESCRIPTION
- Ensuring parity with the `resume` command. 