### PR TITLE
fix: S3 paths with fragments not working

### DIFF
--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -600,7 +600,7 @@ class S3(object):
         # returned are Unicode.
         key = getattr(key_value, "key", key_value)
         if self._s3root is None:
-            parsed = urlparse(to_unicode(key))
+            parsed = urlparse(to_unicode(key), allow_fragments=False)
             if parsed.scheme == "s3" and parsed.path:
                 return key
             else:
@@ -765,7 +765,7 @@ class S3(object):
         """
 
         url = self._url(key)
-        src = urlparse(url)
+        src = urlparse(url, allow_fragments=False)
 
         def _info(s3, tmp):
             resp = s3.head_object(Bucket=src.netloc, Key=src.path.lstrip('/"'))
@@ -891,7 +891,7 @@ class S3(object):
         DOWNLOAD_MAX_CHUNK = 2 * 1024 * 1024 * 1024 - 1
 
         url, r = self._url_and_range(key)
-        src = urlparse(url)
+        src = urlparse(url, allow_fragments=False)
 
         def _download(s3, tmp):
             if r:
@@ -1173,7 +1173,7 @@ class S3(object):
         blob.close = lambda: None
 
         url = self._url(key)
-        src = urlparse(url)
+        src = urlparse(url, allow_fragments=False)
         extra_args = None
         if content_type or metadata or self._encryption:
             extra_args = {}

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -600,6 +600,8 @@ class S3(object):
         # returned are Unicode.
         key = getattr(key_value, "key", key_value)
         if self._s3root is None:
+            # NOTE: S3 allows fragments as part of object names, e.g. /dataset #1/data.txt
+            # Without allow_fragments=False the parsed.path for an object name with fragments is incomplete.
             parsed = urlparse(to_unicode(key), allow_fragments=False)
             if parsed.scheme == "s3" and parsed.path:
                 return key
@@ -765,6 +767,8 @@ class S3(object):
         """
 
         url = self._url(key)
+        # NOTE: S3 allows fragments as part of object names, e.g. /dataset #1/data.txt
+        # Without allow_fragments=False the parsed src.path for an object name with fragments is incomplete.
         src = urlparse(url, allow_fragments=False)
 
         def _info(s3, tmp):
@@ -891,6 +895,8 @@ class S3(object):
         DOWNLOAD_MAX_CHUNK = 2 * 1024 * 1024 * 1024 - 1
 
         url, r = self._url_and_range(key)
+        # NOTE: S3 allows fragments as part of object names, e.g. /dataset #1/data.txt
+        # Without allow_fragments=False the parsed src.path for an object name with fragments is incomplete.
         src = urlparse(url, allow_fragments=False)
 
         def _download(s3, tmp):
@@ -1173,6 +1179,8 @@ class S3(object):
         blob.close = lambda: None
 
         url = self._url(key)
+        # NOTE: S3 allows fragments as part of object names, e.g. /dataset #1/data.txt
+        # Without allow_fragments=False the parsed src.path for an object name with fragments is incomplete.
         src = urlparse(url, allow_fragments=False)
         extra_args = None
         if content_type or metadata or self._encryption:


### PR DESCRIPTION
S3 paths with url fragments do not work with the Metaflow S3 client, but do work with boto3 directly. The cause is that any key we pass to S3 methods goes through `urlparse`, of which we only use `netloc` and `path`. Fragments get parsed into their own key in the ParseResult.