### PR TITLE
Use `os.sched_getaffinity` instead of `os.cpu_count` where possible

### DIFF
--- a/metaflow/multicore_utils.py
+++ b/metaflow/multicore_utils.py
@@ -109,7 +109,7 @@ def parallel_imap_unordered(
         # Lazy import to save on startup time for metaflow as a whole
         from multiprocessing import cpu_count
 
-        max_parallel = cpu_count()
+        max_parallel = len(getattr(os, "sched_getaffinity", lambda _: [])(0)) or os.cpu_count() or 1
 
     args_iter = iter(iterable)
     pids = [_spawn(func, arg, dir) for arg in islice(args_iter, max_parallel)]


### PR DESCRIPTION
When automatically choosing the number of parallel workers, [`os.sched_getaffinity`](https://docs.python.org/3/library/os.html#os.sched_getaffinity) is a better choice than the currently used `os.cpu_count`. The former uses a process' assigned CPU count. See [this Stack Overflow answer](https://stackoverflow.com/questions/64189176/os-sched-getaffinity0-vs-os-cpu-count/64194685#64194685) for an explanation.

I changed this codebase to first check `os.sched_getaffinity` and otherwise default to `os.cpu_count` (and then default to 1; as the latter could potentially be `None`). As some form of validation, [this is something PyTorch uses as well](https://github.com/pytorch/pytorch/blob/f7bd0c6b60d91c55473e2e7101c7471eb9227a81/torch/utils/data/dataloader.py#L595C25-L595C42).

In the (rare) case that `os.sched_getaffinity` isn't defined, I make it default to `os.cpu_count`. PyTorch's code behaves differently by using the value 0. I think using 0 doesn't make sense. Still, this shouldn't happen as I was reading that [in Linux you have to assign at least one](https://linux.die.net/man/7/cpuset#:~:text=Attempted%20to%20write(2)%20a%20list%20to%20a%20cpuset.cpus%20file%20that%20did%20not%20include%20any%20online%20CPUs.).