### PR TITLE
Fix issue with resume combined with `@parallel`

### DIFF
--- a/metaflow/plugins/parallel_decorator.py
+++ b/metaflow/plugins/parallel_decorator.py
@@ -45,6 +45,8 @@ class ParallelDecorator(StepDecorator):
         if ubf_context == UBF_CONTROL:
             num_parallel = cli_args.task.ubf_iter.num_parallel
             cli_args.command_options["num-parallel"] = str(num_parallel)
+            if os.environ.get("METAFLOW_RUNTIME_ENVIRONMENT", "local") == "local":
+                cli_args.command_options["split_index"] = "0"
 
     def step_init(
         self, flow, graph, step_name, decorators, environment, flow_datastore, logger

--- a/metaflow/plugins/parallel_decorator.py
+++ b/metaflow/plugins/parallel_decorator.py
@@ -128,6 +128,8 @@ class ParallelDecorator(StepDecorator):
                     tags=["attempt_id:{0}".format(0)],
                 )
             ]
+            flow._control_task_is_mapper_zero = True
+
         metadata.register_metadata(run_id, step_name, task_id, task_metadata_list)
 
     def task_decorate(
@@ -223,7 +225,6 @@ def _local_multinode_control_task_step_func(
         "%s/%s/%s" % (run_id, step_name, mapper_task_id)
         for mapper_task_id in mapper_task_ids
     ]
-    flow._control_task_is_mapper_zero = True
 
     # run the step function ourselves
     os.environ["MF_PARALLEL_NODE_INDEX"] = "0"

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -413,10 +413,9 @@ class NativeRuntime(object):
                     # because the _control_task_is_mapper_zero is set in the control
                     # task *itself* and *not* in the one that is launching the UBF nest.
                     # This means that _translate_index will use None.
-
                     cloned_task_pathspec_index = re.sub(
-                        r"\[(\d+, ?)*0\]",
-                        lambda m: "[" + (m.group(1) or "") + "None]",
+                        r"(\[(?:\d+, ?)*)0\]",
+                        lambda m: (m.group(1) or "[") + "None]",
                         cloned_task_pathspec_index,
                     )
 

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -413,8 +413,15 @@ class NativeRuntime(object):
                     # because the _control_task_is_mapper_zero is set in the control
                     # task *itself* and *not* in the one that is launching the UBF nest.
                     # This means that _translate_index will use None.
+
                     cloned_task_pathspec_index = re.sub(
-                        r"\[[^]]+\]", "[None]", cloned_task_pathspec_index
+                        r"(\[\d+,\d+\])|(\[[^]]+\])",
+                        lambda m: (
+                            m.group(1).replace(",0]", ",None]")
+                            if m.group(1)
+                            else "[None]"
+                        ),
+                        cloned_task_pathspec_index,
                     )
 
                 inputs.append(

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -415,12 +415,8 @@ class NativeRuntime(object):
                     # This means that _translate_index will use None.
 
                     cloned_task_pathspec_index = re.sub(
-                        r"(\[\d+,\d+\])|(\[[^]]+\])",
-                        lambda m: (
-                            m.group(1).replace(",0]", ",None]")
-                            if m.group(1)
-                            else "[None]"
-                        ),
+                        r"\[(\d+, ?)*0\]",
+                        lambda m: "[" + (m.group(1) or "") + "None]",
                         cloned_task_pathspec_index,
                     )
 

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -49,7 +49,13 @@ PROGRESS_INTERVAL = 300  # s
 # The following is a list of the (data) artifacts used by the runtime while
 # executing a flow. These are prefetched during the resume operation by
 # leveraging the TaskDataStoreSet.
-PREFETCH_DATA_ARTIFACTS = ["_foreach_stack", "_task_ok", "_transition"]
+PREFETCH_DATA_ARTIFACTS = [
+    "_foreach_stack",
+    "_task_ok",
+    "_transition",
+    "_control_mapper_tasks",
+    "_control_task_is_mapper_zero",
+]
 RESUME_POLL_SECONDS = 60
 
 # Runtime must use logsource=RUNTIME_LOG_SOURCE for all loglines that it
@@ -269,6 +275,7 @@ class NativeRuntime(object):
         step_name,
         task_id,
         pathspec_index,
+        finished_tuple,
         ubf_context,
         generate_task_obj,
         verbose=False,
@@ -308,6 +315,9 @@ class NativeRuntime(object):
                 self._metadata,
                 origin_ds_set=self._origin_ds_set,
             )
+            task_pathspec = "{}/{}/{}".format(self._run_id, step_name, new_task_id)
+            self._finished[(step_name, finished_tuple)] = task_pathspec
+            self._is_cloned[task_pathspec] = True
         except Exception as e:
             self._logger(
                 "Cloning {}/{}/{}/{} failed with error: {}".format(
@@ -323,7 +333,8 @@ class NativeRuntime(object):
 
         inputs = []
 
-        ubf_mapper_tasks_to_clone = []
+        ubf_mapper_tasks_to_clone = set()
+        ubf_control_tasks = set()
         # We only clone ubf mapper tasks if the control task is complete.
         # Here we need to check which control tasks are complete, and then get the corresponding
         # mapper tasks.
@@ -331,13 +342,25 @@ class NativeRuntime(object):
             _, step_name, task_id = task_ds.pathspec.split("/")
             pathspec_index = task_ds.pathspec_index
             if task_ds["_task_ok"] and step_name != "_parameters":
-                # Only control task can have _control_mapper_tasks. We then store the corresponding mapepr task pathspecs.
+                # Control task and, in the case of @parallel, mapper tasks can have
+                # _control_mapper_tasks. We can strip out the control_task of the mapper
+                # task list by checking if it control_task_is_mapper_zero.
                 control_mapper_tasks = (
                     []
                     if "_control_mapper_tasks" not in task_ds
                     else task_ds["_control_mapper_tasks"]
                 )
-                ubf_mapper_tasks_to_clone.extend(control_mapper_tasks)
+                if control_mapper_tasks:
+                    if task_ds.get("_control_task_is_mapper_zero", False):
+                        # Strip out the control task of list of mapper tasks
+                        ubf_control_tasks.add(control_mapper_tasks[0])
+                        ubf_mapper_tasks_to_clone.update(control_mapper_tasks[1:])
+                    else:
+                        ubf_mapper_tasks_to_clone.update(control_mapper_tasks)
+                        # Since we only add mapper tasks here, if we are not in the list
+                        # we are a control task
+                        if task_ds.pathspec not in ubf_mapper_tasks_to_clone:
+                            ubf_control_tasks.add(task_ds.pathspec)
 
         for task_ds in self._origin_ds_set:
             _, step_name, task_id = task_ds.pathspec.split("/")
@@ -350,33 +373,42 @@ class NativeRuntime(object):
             ):
                 # "_unbounded_foreach" is a special flag to indicate that the transition is an unbounded foreach.
                 # Both parent and splitted children tasks will have this flag set. The splitted control/mapper tasks
-                # have no "foreach_param" because UBF is always followed by a join step.
+                # are not foreach types because UBF is always followed by a join step.
                 is_ubf_task = (
                     "_unbounded_foreach" in task_ds and task_ds["_unbounded_foreach"]
-                ) and (self._graph[step_name].foreach_param is None)
+                ) and (self._graph[step_name].type != "foreach")
 
-                # Only the control task has "_control_mapper_tasks" artifact.
-                is_ubf_control_task = (
-                    is_ubf_task
-                    and ("_control_mapper_tasks" in task_ds)
-                    and task_ds["_control_mapper_tasks"]
-                )
-                is_ubf_mapper_tasks = is_ubf_task and (not is_ubf_control_task)
-                if is_ubf_mapper_tasks and (
+                is_ubf_control_task = task_ds.pathspec in ubf_control_tasks
+
+                is_ubf_mapper_task = is_ubf_task and (not is_ubf_control_task)
+
+                if is_ubf_mapper_task and (
                     task_ds.pathspec not in ubf_mapper_tasks_to_clone
                 ):
-                    # Skip copying UBF mapper tasks if control tasks is incomplete.
+                    # Skip copying UBF mapper tasks if control task is incomplete.
                     continue
 
                 ubf_context = None
                 if is_ubf_task:
-                    ubf_context = "ubf_test" if is_ubf_mapper_tasks else "ubf_control"
+                    ubf_context = "ubf_test" if is_ubf_mapper_task else "ubf_control"
+
+                finished_tuple = tuple(
+                    [s._replace(value=0) for s in task_ds.get("_foreach_stack", ())]
+                )
+                if task_ds.get("_control_task_is_mapper_zero", False):
+                    # Replace None with index 0 for control task as it is part of the
+                    # UBF (as a mapper as well)
+                    finished_tuple = finished_tuple[:-1] + (
+                        finished_tuple[-1]._replace(index=0),
+                    )
+
                 inputs.append(
                     (
                         step_name,
                         task_id,
                         pathspec_index,
-                        is_ubf_mapper_tasks,
+                        finished_tuple,
+                        is_ubf_mapper_task,
                         ubf_context,
                     )
                 )
@@ -388,15 +420,17 @@ class NativeRuntime(object):
                     step_name,
                     task_id,
                     pathspec_index,
+                    finished_tuple,
                     ubf_context=ubf_context,
-                    generate_task_obj=generate_task_obj and (not is_ubf_mapper_tasks),
+                    generate_task_obj=generate_task_obj and (not is_ubf_mapper_task),
                     verbose=verbose,
                 )
                 for (
                     step_name,
                     task_id,
                     pathspec_index,
-                    is_ubf_mapper_tasks,
+                    finished_tuple,
+                    is_ubf_mapper_task,
                     ubf_context,
                 ) in inputs
             ]
@@ -640,15 +674,18 @@ class NativeRuntime(object):
                 # If the control task is cloned, all mapper tasks should have been cloned
                 # as well, so we no longer need to handle cloning of mapper tasks in runtime.
 
-                # Update _finished since these tasks were successfully
-                # run elsewhere so that join will be unblocked.
-                _, foreach_stack = task.finished_id
-                top = foreach_stack[-1]
-                bottom = list(foreach_stack[:-1])
-                for i in range(num_splits):
-                    s = tuple(bottom + [top._replace(index=i)])
-                    self._finished[(task.step, s)] = mapper_tasks[i]
-                    self._is_cloned[mapper_tasks[i]] = False
+                # Update _finished if we are not cloned. If we were cloned, we already
+                # updated _finished with the new tasks. Note that the *value* of mapper
+                # tasks is incorrect and contains the pathspec of the *cloned* run
+                # but we don't use it for anything. We could look to clean it up though
+                if not task.is_cloned:
+                    _, foreach_stack = task.finished_id
+                    top = foreach_stack[-1]
+                    bottom = list(foreach_stack[:-1])
+                    for i in range(num_splits):
+                        s = tuple(bottom + [top._replace(index=i)])
+                        self._finished[(task.step, s)] = mapper_tasks[i]
+                        self._is_cloned[mapper_tasks[i]] = False
 
             # Find and check status of control task and retrieve its pathspec
             # for retrieving unbounded foreach cardinality.

--- a/test/core/graphs/parallel.json
+++ b/test/core/graphs/parallel.json
@@ -1,7 +1,7 @@
 {
     "name": "small-parallel",
     "graph": {
-        "start": {"linear": "parallel_split"},
+        "start": {"linear": "parallel_split", "quals": ["start"]},
         "parallel_split": {
             "num_parallel": 4,
             "parallel": "parallel_inner",

--- a/test/core/tests/resume_ubf_basic_foreach.py
+++ b/test/core/tests/resume_ubf_basic_foreach.py
@@ -1,0 +1,58 @@
+from metaflow_test import MetaflowTest, ExpectationFailed, steps, tag
+
+
+class BasicUnboundedForeachResumeTest(MetaflowTest):
+    RESUME = True
+    PRIORITY = 1
+
+    @steps(0, ["start"])
+    def step_start(self):
+        self.data = "start"
+        self.after = False
+
+    @steps(0, ["foreach-split-small"], required=True)
+    def split(self):
+        self.my_index = None
+        from metaflow.plugins import InternalTestUnboundedForeachInput
+
+        self.arr = InternalTestUnboundedForeachInput(range(2))
+
+    @tag("unbounded_test_foreach_internal")
+    @steps(0, ["foreach-inner-small"], required=True)
+    def inner(self):
+        # index must stay constant over multiple steps inside foreach
+        if self.my_index is None:
+            self.my_index = self.index
+        assert_equals(self.my_index, self.index)
+        assert_equals(self.input, self.arr[self.index])
+        self.my_input = self.input
+
+    @steps(0, ["foreach-join-small"], required=True)
+    def join(self, inputs):
+        if is_resumed():
+            self.data = "resume"
+            self.after = True
+            got = sorted([inp.my_input for inp in inputs])
+            assert_equals(list(range(2)), got)
+        else:
+            self.data = "run"
+            raise ResumeFromHere()
+
+    @steps(2, ["all"])
+    def step_all(self):
+        if self.after:
+            assert_equals("resume", self.data)
+        else:
+            assert_equals("start", self.data)
+
+    def check_results(self, flow, checker):
+        run = checker.get_run()
+        if type(checker).__name__ == "CliCheck":
+            # CliCheck doesn't support enlisting of tasks.
+            assert run is None
+        else:
+            assert run is not None
+            tasks = run["foreach_inner"].tasks()
+            task_list = list(tasks)
+            assert_equals(3, len(task_list))
+            assert_equals(1, len(list(run["foreach_inner"].control_tasks())))

--- a/test/core/tests/resume_ubf_foreach_join.py
+++ b/test/core/tests/resume_ubf_foreach_join.py
@@ -1,0 +1,52 @@
+from metaflow_test import MetaflowTest, ExpectationFailed, steps, tag
+
+
+class ResumeUBFJoinTest(MetaflowTest):
+    """
+    Resuming from a foreach join should work.
+    Check that data changes in all downstream steps after resume.
+    """
+
+    RESUME = True
+    PRIORITY = 3
+
+    @steps(0, ["start"])
+    def step_start(self):
+        self.data = "start"
+        self.after = False
+
+    @steps(0, ["parallel-split"], required=True)
+    def split(self):
+        self.my_node_index = None
+
+    @steps(0, ["parallel-step"], required=True)
+    def inner(self):
+        from metaflow import current
+
+        assert_equals(4, current.parallel.num_nodes)
+        self.my_node_index = current.parallel.node_index
+        assert_equals(self.my_node_index, self.input)
+
+    @steps(0, ["join"], required=True)
+    def join(self, inputs):
+        if is_resumed():
+            self.data = "resume"
+            got = sorted([inp.my_node_index for inp in inputs])
+            assert_equals(list(range(4)), got)
+            self.after = True
+        else:
+            self.data = "run"
+            raise ResumeFromHere()
+
+    @steps(2, ["all"])
+    def step_all(self):
+        if self.after:
+            assert_equals("resume", self.data)
+        else:
+            assert_equals("start", self.data)
+
+    def check_results(self, flow, checker):
+        from itertools import product
+
+        checker.assert_artifact("start", "data", "start")
+        checker.assert_artifact("end", "data", "resume")


### PR DESCRIPTION
`@parallel` uses the control task as a mapper task. This was not a situation the resume functionality for UBF handled well.

In the process, also cleared up some other bugs that could have cropped up later.

This should replace #2159.