### PR TITLE
Fix case where the decorator's init function could be called twice.

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -461,7 +461,7 @@ def start(
         )
         if all_decospecs:
             decorators._attach_decorators(ctx.obj.flow, all_decospecs)
-            decorators._init(ctx.obj.flow, only_non_static=True)
+            decorators._init(ctx.obj.flow)
             # Regenerate graph if we attached more decorators
             ctx.obj.graph = FlowGraph(ctx.obj.flow.__class__)
 

--- a/metaflow/cli_components/run_cmds.py
+++ b/metaflow/cli_components/run_cmds.py
@@ -40,7 +40,7 @@ def before_run(obj, tags, decospecs):
     )
     if all_decospecs:
         decorators._attach_decorators(obj.flow, all_decospecs)
-        decorators._init(obj.flow, only_non_static=True)
+        decorators._init(obj.flow)
         obj.graph = FlowGraph(obj.flow.__class__)
 
     obj.check(obj.graph, obj.flow, obj.environment, pylint=obj.pylint)

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -138,7 +138,7 @@ def step(
 
     if decospecs:
         decorators._attach_decorators_to_step(func, decospecs)
-        decorators._init(ctx.obj.flow, only_non_static=True)
+        decorators._init(ctx.obj.flow)
 
     step_kwargs = ctx.params
     # Remove argument `step_name` from `step_kwargs`.

--- a/metaflow/plugins/airflow/airflow_cli.py
+++ b/metaflow/plugins/airflow/airflow_cli.py
@@ -283,7 +283,7 @@ def make_flow(
 ):
     # Attach @kubernetes.
     decorators._attach_decorators(obj.flow, [KubernetesDecorator.name])
-    decorators._init(obj.flow, only_non_static=True)
+    decorators._init(obj.flow)
 
     decorators._init_step_decorators(
         obj.flow, obj.graph, obj.environment, obj.flow_datastore, obj.logger

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -470,7 +470,7 @@ def make_flow(
     decorators._attach_decorators(
         obj.flow, [KubernetesDecorator.name, EnvironmentDecorator.name]
     )
-    decorators._init(obj.flow, only_non_static=True)
+    decorators._init(obj.flow)
 
     decorators._init_step_decorators(
         obj.flow, obj.graph, obj.environment, obj.flow_datastore, obj.logger

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -326,7 +326,7 @@ def make_flow(
 
     # Attach AWS Batch decorator to the flow
     decorators._attach_decorators(obj.flow, [BatchDecorator.name])
-    decorators._init(obj.flow, only_non_static=True)
+    decorators._init(obj.flow)
     decorators._init_step_decorators(
         obj.flow, obj.graph, obj.environment, obj.flow_datastore, obj.logger
     )

--- a/metaflow/plugins/pypi/pypi_decorator.py
+++ b/metaflow/plugins/pypi/pypi_decorator.py
@@ -140,7 +140,7 @@ class PyPIFlowDecorator(FlowDecorator):
         from metaflow import decorators
 
         decorators._attach_decorators(flow, ["pypi"])
-        decorators._init(flow, only_non_static=True)
+        decorators._init(flow)
 
         # @pypi uses a conda environment to create a virtual environment.
         # The conda environment can be created through micromamba.


### PR DESCRIPTION
In some cases, specifically when using argo/airflow/sfn, the decorator's init function could be called twice which caused issues with the conda/pypi decorator.