### PR TITLE
Fix issue where run_command blocks when it shouldn't

### DIFF
--- a/metaflow/plugins/argo/argo_workflows_deployer_objects.py
+++ b/metaflow/plugins/argo/argo_workflows_deployer_objects.py
@@ -97,6 +97,7 @@ class ArgoWorkflowsTriggeredRun(TriggeredRun):
         )
 
         command_obj = self.deployer.spm.get(pid)
+        command_obj.sync_wait()
         return command_obj.process.returncode == 0
 
     def unsuspend(self, **kwargs) -> bool:
@@ -131,6 +132,7 @@ class ArgoWorkflowsTriggeredRun(TriggeredRun):
         )
 
         command_obj = self.deployer.spm.get(pid)
+        command_obj.sync_wait()
         return command_obj.process.returncode == 0
 
     def terminate(self, **kwargs) -> bool:
@@ -165,6 +167,7 @@ class ArgoWorkflowsTriggeredRun(TriggeredRun):
         )
 
         command_obj = self.deployer.spm.get(pid)
+        command_obj.sync_wait()
         return command_obj.process.returncode == 0
 
     @property
@@ -319,6 +322,7 @@ class ArgoWorkflowsDeployedFlow(DeployedFlow):
         )
 
         command_obj = self.deployer.spm.get(pid)
+        command_obj.sync_wait()
         return command_obj.process.returncode == 0
 
     def trigger(self, **kwargs) -> ArgoWorkflowsTriggeredRun:
@@ -361,7 +365,7 @@ class ArgoWorkflowsDeployedFlow(DeployedFlow):
             content = handle_timeout(
                 attribute_file_fd, command_obj, self.deployer.file_read_timeout
             )
-
+            command_obj.sync_wait()
             if command_obj.process.returncode == 0:
                 return ArgoWorkflowsTriggeredRun(
                     deployer=self.deployer, content=content

--- a/metaflow/plugins/aws/step_functions/step_functions_deployer_objects.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_deployer_objects.py
@@ -46,6 +46,7 @@ class StepFunctionsTriggeredRun(TriggeredRun):
         )
 
         command_obj = self.deployer.spm.get(pid)
+        command_obj.sync_wait()
         return command_obj.process.returncode == 0
 
 
@@ -174,6 +175,7 @@ class StepFunctionsDeployedFlow(DeployedFlow):
         )
 
         command_obj = self.deployer.spm.get(pid)
+        command_obj.sync_wait()
         return command_obj.process.returncode == 0
 
     def trigger(self, **kwargs) -> StepFunctionsTriggeredRun:
@@ -217,6 +219,7 @@ class StepFunctionsDeployedFlow(DeployedFlow):
                 attribute_file_fd, command_obj, self.deployer.file_read_timeout
             )
 
+            command_obj.sync_wait()
             if command_obj.process.returncode == 0:
                 return StepFunctionsTriggeredRun(
                     deployer=self.deployer, content=content

--- a/metaflow/runner/deployer.py
+++ b/metaflow/runner/deployer.py
@@ -64,7 +64,7 @@ class Deployer(metaclass=DeployerMeta):
         The directory to run the subprocess in; if not specified, the current
         directory is used.
     file_read_timeout : int, default 3600
-        The timeout until which we try to read the deployer attribute file.
+        The timeout until which we try to read the deployer attribute file (in seconds).
     **kwargs : Any
         Additional arguments that you would pass to `python myflow.py` before
         the deployment command.

--- a/metaflow/runner/deployer_impl.py
+++ b/metaflow/runner/deployer_impl.py
@@ -37,7 +37,7 @@ class DeployerImpl(object):
         The directory to run the subprocess in; if not specified, the current
         directory is used.
     file_read_timeout : int, default 3600
-        The timeout until which we try to read the deployer attribute file.
+        The timeout until which we try to read the deployer attribute file (in seconds).
     **kwargs : Any
         Additional arguments that you would pass to `python myflow.py` before
         the deployment command.
@@ -144,7 +144,7 @@ class DeployerImpl(object):
             # Additional info is used to pass additional deployer specific information.
             # It is used in non-OSS deployers (extensions).
             self.additional_info = content.get("additional_info", {})
-
+            command_obj.sync_wait()
             if command_obj.process.returncode == 0:
                 return create_class(deployer=self)
 

--- a/metaflow/runner/metaflow_runner.py
+++ b/metaflow/runner/metaflow_runner.py
@@ -221,7 +221,7 @@ class Runner(object):
         The directory to run the subprocess in; if not specified, the current
         directory is used.
     file_read_timeout : int, default 3600
-        The timeout until which we try to read the runner attribute file.
+        The timeout until which we try to read the runner attribute file (in seconds).
     **kwargs : Any
         Additional arguments that you would pass to `python myflow.py` before
         the `run` command.
@@ -326,6 +326,7 @@ class Runner(object):
                 show_output=self.show_output,
             )
             command_obj = self.spm.get(pid)
+            command_obj.sync_wait()
 
             return self.__get_executing_run(attribute_file_fd, command_obj)
 
@@ -357,6 +358,7 @@ class Runner(object):
                 show_output=self.show_output,
             )
             command_obj = self.spm.get(pid)
+            command_obj.sync_wait()
 
             return self.__get_executing_run(attribute_file_fd, command_obj)
 

--- a/metaflow/runner/metaflow_runner.py
+++ b/metaflow/runner/metaflow_runner.py
@@ -272,6 +272,9 @@ class Runner(object):
 
     def __get_executing_run(self, attribute_file_fd, command_obj):
         content = handle_timeout(attribute_file_fd, command_obj, self.file_read_timeout)
+
+        command_obj.sync_wait()
+
         content = json.loads(content)
         pathspec = "%s/%s" % (content.get("flow_name"), content.get("run_id"))
 
@@ -326,7 +329,6 @@ class Runner(object):
                 show_output=self.show_output,
             )
             command_obj = self.spm.get(pid)
-            command_obj.sync_wait()
 
             return self.__get_executing_run(attribute_file_fd, command_obj)
 
@@ -358,7 +360,6 @@ class Runner(object):
                 show_output=self.show_output,
             )
             command_obj = self.spm.get(pid)
-            command_obj.sync_wait()
 
             return self.__get_executing_run(attribute_file_fd, command_obj)
 

--- a/metaflow/runner/nbdeploy.py
+++ b/metaflow/runner/nbdeploy.py
@@ -46,6 +46,8 @@ class NBDeployer(object):
     base_dir : str, optional, default None
         The directory to run the subprocess in; if not specified, the current
         working directory is used.
+    file_read_timeout : int, default 3600
+        The timeout until which we try to read the deployer attribute file (in seconds).
     **kwargs : Any
         Additional arguments that you would pass to `python myflow.py` i.e. options
         listed in `python myflow.py --help`

--- a/metaflow/runner/nbrun.py
+++ b/metaflow/runner/nbrun.py
@@ -44,7 +44,7 @@ class NBRunner(object):
         The directory to run the subprocess in; if not specified, the current
         working directory is used.
     file_read_timeout : int, default 3600
-        The timeout until which we try to read the runner attribute file.
+        The timeout until which we try to read the runner attribute file (in seconds).
     **kwargs : Any
         Additional arguments that you would pass to `python myflow.py` before
         the `run` command.

--- a/metaflow/runner/subprocess_manager.py
+++ b/metaflow/runner/subprocess_manager.py
@@ -120,6 +120,9 @@ class SubprocessManager(object):
         """
         Run a command synchronously and return its process ID.
 
+        Note: in no case does this wait for the process to *finish*. Use sync_wait()
+        to wait for the command to finish.
+
         Parameters
         ----------
         command : List[str]
@@ -145,7 +148,6 @@ class SubprocessManager(object):
         command_obj = CommandManager(command, env, cwd)
         pid = command_obj.run(show_output=show_output)
         self.commands[pid] = command_obj
-        command_obj.sync_wait()
         return pid
 
     async def async_run_command(

--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -107,33 +107,47 @@ def read_from_fifo_when_ready(
         content to the FIFO.
     """
     content = bytearray()
-
     poll = select.poll()
     poll.register(fifo_fd, select.POLLIN)
-    read_data = False
+    max_timeout = 3  # Wait for 10 * 3 = 30 ms after last write
     while True:
+        if timeout < 0:
+            raise TimeoutError("Timeout while waiting for the file content")
+
         poll_begin = time.time()
-        poll.poll(1000 * timeout)
+        # We poll for a very short time to be also able to check if the file was closed
+        # If the file is closed, we assume that we only have one writer so if we have
+        # data, we break out. This is to work around issues in macos
+        events = poll.poll(min(10, timeout * 1000))
         timeout -= time.time() - poll_begin
 
         try:
             data = os.read(fifo_fd, 8192)
-            while data:
-                read_data = True
+            if data:
                 content += data
-                data = os.read(fifo_fd, 8192)
-
-            # Read from a non-blocking closed FIFO returns an empty byte array
-            break
-
+            else:
+                if len(events):
+                    # We read an EOF -- consider the file done
+                    break
+                else:
+                    # We had no events (just a timeout) and the read didn't return
+                    # an exception so the file is still open; we continue waiting for data
+                    # Unfortunately, on MacOS, it seems that even *after* the file is
+                    # closed on the other end, we still don't get a BlockingIOError so
+                    # we hack our way and timeout if there is no write in 30ms which is
+                    # a relative eternity for file writes.
+                    if content:
+                        if max_timeout <= 0:
+                            break
+                        max_timeout -= 1
+                        continue
         except BlockingIOError:
-            if read_data:
+            has_blocking_error = True
+            if content:
+                # The file was closed
                 break
-            # FIFO is open but no data is available yet (spurious POLLIN?)
-            # so we loop around to poll again
-        finally:
-            if timeout <= 0:
-                raise TimeoutError("Timeout while waiting for the file content")
+            # else, if we have no content, we continue waiting for the file to be open
+            # and written to.
 
     if not content and check_process_exited(command_obj):
         raise CalledProcessError(command_obj.process.returncode, command_obj.command)


### PR DESCRIPTION
In cases where we need to read from a file (for the result of run_command), the current code used to make it sequential (so the timeout was actually never triggered).

This started causing problems on MacOS when writing large amounts of data (8KB FIFO)