### PR TITLE
fail early without needing to reduce file_read_timeout

### DIFF
--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -111,6 +111,11 @@ def read_from_fifo_when_ready(
     poll.register(fifo_fd, select.POLLIN)
     max_timeout = 3  # Wait for 10 * 3 = 30 ms after last write
     while True:
+        if check_process_exited(command_obj) and command_obj.process.returncode != 0:
+            raise CalledProcessError(
+                command_obj.process.returncode, command_obj.command
+            )
+
         if timeout < 0:
             raise TimeoutError("Timeout while waiting for the file content")
 


### PR DESCRIPTION
context:

consider the flow at `f.py`

```py
from metaflow import FlowSpec, kubernetes, step, current, project, Flow
import os, time

class HelloFlow(FlowSpec):

    @step
    def start(self):
        x.foo()
        self.next(self.end)

    @step
    def end(self):
        print('value is', self.model)

if __name__ == '__main__':
    HelloFlow()
```

and consider using it with:

```py
from metaflow import Runner

with Runner('./f.py').run() as running:
    print('done')
```

the runner gets stuck after merging of #2169

if we try the following, it exits when the timeout passes...

```py
from metaflow import Runner

with Runner('./f.py', file_read_timeout=10).run() as running:
    print('done')
```

since the default is 3600 secs, we should exit early..