### PR TITLE
include flowdir in syspath while loading file in Runner API

### DIFF
--- a/metaflow/runner/click_api.py
+++ b/metaflow/runner/click_api.py
@@ -216,8 +216,14 @@ def extract_flow_class_from_file(flow_file: str) -> FlowSpec:
 
         return flow_cls
     finally:
-        # Remove the flow directory from sys.path
-        sys.path.remove(flow_dir)
+        # Safely remove the flow directory from sys.path if it exists
+        try:
+            # Remove the flow directory from sys.path
+            sys.path.remove(flow_dir)
+        except ValueError:
+            # The path might have been modified during module loading,
+            # so we silently ignore if flow_dir is no longer in sys.path
+            pass
 
 
 class MetaflowAPI(object):

--- a/metaflow/runner/click_api.py
+++ b/metaflow/runner/click_api.py
@@ -190,7 +190,12 @@ def extract_flow_class_from_file(flow_file: str) -> FlowSpec:
         raise FileNotFoundError("Flow file not present at '%s'" % flow_file)
 
     flow_dir = os.path.dirname(os.path.abspath(flow_file))
-    sys.path.insert(0, flow_dir)
+    path_was_added = False
+
+    # Only add to path if it's not already there
+    if flow_dir not in sys.path:
+        sys.path.insert(0, flow_dir)
+        path_was_added = True
 
     try:
         # Check if the module has already been loaded
@@ -216,14 +221,9 @@ def extract_flow_class_from_file(flow_file: str) -> FlowSpec:
 
         return flow_cls
     finally:
-        # Safely remove the flow directory from sys.path if it exists
-        try:
-            # Remove the flow directory from sys.path
+        # Only remove from path if we added it
+        if path_was_added:
             sys.path.remove(flow_dir)
-        except ValueError:
-            # The path might have been modified during module loading,
-            # so we silently ignore if flow_dir is no longer in sys.path
-            pass
 
 
 class MetaflowAPI(object):

--- a/metaflow/runner/click_api.py
+++ b/metaflow/runner/click_api.py
@@ -223,7 +223,11 @@ def extract_flow_class_from_file(flow_file: str) -> FlowSpec:
     finally:
         # Only remove from path if we added it
         if path_was_added:
-            sys.path.remove(flow_dir)
+            try:
+                sys.path.remove(flow_dir)
+            except ValueError:
+                # User's code might have removed it already
+                pass
 
 
 class MetaflowAPI(object):


### PR DESCRIPTION
Context:

The `cwd` argument of the Runner is for selecting the directory under which the `subprocess` executes in..

But, it doesn't play a role in loading of the flow file itself -- which is the first step of the lower level API to generate the command that will be executed via `subprocess`..

aka loading of file --> generate command --> run via subprocess (`cwd` is only relevant here)

Thus, in the directory structure like this:

```
├── pipelines/
│   ├── training.py
│   └── common.py
└── tests/
    └── test_sample.py
```

if `training.py` has `from common import packages`
and `test_sample.py` uses the Runner API as follows:

```
with Runner("pipelines/training.py", environment="conda").run() as running:
        return running.run.data
```

the following issue is encountered:
```
>   from common import packages
E   ModuleNotFoundError: No module named 'common'
```

This PR adds the `flow directory` into `sys.path` and also removes it later...