### PR TITLE
[heartbeats] Better error handling

### DIFF
--- a/metaflow/metadata_provider/heartbeat.py
+++ b/metaflow/metadata_provider/heartbeat.py
@@ -53,7 +53,7 @@ class MetadataHeartBeat(object):
                 retry_counter = 0
             except HeartBeatException as e:
                 retry_counter = retry_counter + 1
-                time.sleep(4**retry_counter)
+                time.sleep(1.5**retry_counter)
 
     def _heartbeat(self):
         if self.hb_url is not None:

--- a/metaflow/metadata_provider/heartbeat.py
+++ b/metaflow/metadata_provider/heartbeat.py
@@ -57,9 +57,23 @@ class MetadataHeartBeat(object):
 
     def _heartbeat(self):
         if self.hb_url is not None:
-            response = requests.post(
-                url=self.hb_url, data="{}", headers=self.headers.copy()
-            )
+            try:
+                response = requests.post(
+                    url=self.hb_url, data="{}", headers=self.headers.copy()
+                )
+            except requests.exceptions.ConnectionError as e:
+                raise HeartBeatException(
+                    "HeartBeat request (%s) failed" " (ConnectionError)" % (self.hb_url)
+                )
+            except requests.exceptions.Timeout as e:
+                raise HeartBeatException(
+                    "HeartBeat request (%s) failed" " (Timeout)" % (self.hb_url)
+                )
+            except requests.exceptions.RequestException as e:
+                raise HeartBeatException(
+                    "HeartBeat request (%s) failed"
+                    " (RequestException) %s" % (self.hb_url, str(e))
+                )
             # Unfortunately, response.json() returns a string that we need
             # to cast to json; however when the request encounters an error
             # the return type is a json blob :/


### PR DESCRIPTION
- Ensure better error handling so that any server related flakiness can be handled without crashing the heartbeat thread.
- If the heartbeat thread crashes because of any server issues / DNS issues / Intermittent server flakiness, it will kill the heartbeat thread causing the UI to mark the run as failed. 
- This change ensures that we don't crash the thread an makes it exponentially backoff calling the server. 