### PR TITLE
Allow TL flow-decorator options to be provided as part of the decorator

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -150,8 +150,8 @@ class Decorator(object):
             return
 
         # Note that by design, later values override previous ones.
-        self.attributes = unpack_delayed_evaluator(self.attributes)
-        self._user_defined_attributes.update(self.attributes.keys())
+        self.attributes, new_user_attributes = unpack_delayed_evaluator(self.attributes)
+        self._user_defined_attributes.update(new_user_attributes)
         self.attributes = resolve_delayed_evaluator(self.attributes)
 
         self._ran_init = True

--- a/metaflow/parameters.py
+++ b/metaflow/parameters.py
@@ -367,7 +367,9 @@ class Parameter(object):
         )
 
         # Resolve any value from configurations
-        self.kwargs = unpack_delayed_evaluator(self.kwargs, ignore_errors=ignore_errors)
+        self.kwargs, _ = unpack_delayed_evaluator(
+            self.kwargs, ignore_errors=ignore_errors
+        )
         # Do it one item at a time so errors are ignored at that level (as opposed to
         # at the entire kwargs level)
         self.kwargs = {

--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -561,7 +561,11 @@ class TriggerOnFinishDecorator(FlowDecorator):
                     "You cannot pass %s as both a command-line argument and an attribute "
                     "of the @trigger_on_finish decorator." % op
                 )
-        trigger_option = self.attributes.get("trigger", options["trigger"])
+        if "trigger" in self._user_defined_attributes:
+            trigger_option = self.attributes["trigger"]
+        else:
+            trigger_option = options["trigger"]
+
         self._option_values = options
         if trigger_option:
             from metaflow import Run

--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -374,7 +374,8 @@ class TriggerOnFinishDecorator(FlowDecorator):
         "flow": None,  # flow_name or project_flow_name
         "flows": [],  # flow_names or project_flow_names
         "options": {},
-    } + {k: v["default"] for k, v in options.items()}
+        **{k: v["default"] for k, v in options.items()},
+    }
 
     def flow_init(
         self,

--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -542,29 +542,34 @@ class TriggerOnFinishDecorator(FlowDecorator):
 
         # Handle scenario for local testing using --trigger.
 
-        # This is overkill since default is None for all options but adding this code
-        # to make it safe if other non None-default options are added in the future.
-        for op in options:
-            if (
-                op in self._user_defined_attributes
-                and options[op] != self.defaults[op]
-                and self.attributes[op] != options[op]
-            ):
-                # Exception if:
-                #  - the user provides a value in the attributes field
-                #  - AND the user provided a value in the command line (non default)
-                #  - AND the values are different
-                # Note that this won't raise an error if the user provided the default
-                # value in the command line and provided one in attribute but although
-                # slightly inconsistent, it is not incorrect.
-                raise MetaflowException(
-                    "You cannot pass %s as both a command-line argument and an attribute "
-                    "of the @trigger_on_finish decorator." % op
-                )
-        if "trigger" in self._user_defined_attributes:
-            trigger_option = self.attributes["trigger"]
-        else:
-            trigger_option = options["trigger"]
+        # Re-enable this code if you want to support passing trigger directly in the
+        # decorator in a way similar to how production and branch are passed in the
+        # project decorator.
+
+        # # This is overkill since default is None for all options but adding this code
+        # # to make it safe if other non None-default options are added in the future.
+        # for op in options:
+        #     if (
+        #         op in self._user_defined_attributes
+        #         and options[op] != self.defaults[op]
+        #         and self.attributes[op] != options[op]
+        #     ):
+        #         # Exception if:
+        #         #  - the user provides a value in the attributes field
+        #         #  - AND the user provided a value in the command line (non default)
+        #         #  - AND the values are different
+        #         # Note that this won't raise an error if the user provided the default
+        #         # value in the command line and provided one in attribute but although
+        #         # slightly inconsistent, it is not incorrect.
+        #         raise MetaflowException(
+        #             "You cannot pass %s as both a command-line argument and an attribute "
+        #             "of the @trigger_on_finish decorator." % op
+        #         )
+
+        # if "trigger" in self._user_defined_attributes:
+        #    trigger_option = self.attributes["trigger"]
+        # else:
+        trigger_option = options["trigger"]
 
         self._option_values = options
         if trigger_option:

--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -374,7 +374,9 @@ class TriggerOnFinishDecorator(FlowDecorator):
         "flow": None,  # flow_name or project_flow_name
         "flows": [],  # flow_names or project_flow_names
         "options": {},
-        **{k: v["default"] for k, v in options.items()},
+        # Re-enable if you want to support TL options directly in the decorator like
+        # for @project decorator
+        #    **{k: v["default"] for k, v in options.items()},
     }
 
     def flow_init(

--- a/metaflow/plugins/project_decorator.py
+++ b/metaflow/plugins/project_decorator.py
@@ -72,7 +72,6 @@ class ProjectDecorator(FlowDecorator):
     """
 
     name = "project"
-    defaults = {"name": None}
 
     options = {
         "production": dict(
@@ -91,19 +90,40 @@ class ProjectDecorator(FlowDecorator):
         ),
     }
 
+    defaults = {"name": None} + {k: v["default"] for k, v in options.items()}
+
     def flow_init(
         self, flow, graph, environment, flow_datastore, metadata, logger, echo, options
     ):
         self._option_values = options
         project_name = self.attributes.get("name")
+        for op in options:
+            if (
+                op in self.attributes
+                and options[op] != self.defaults[op]
+                and self.attributes[op] != options[op]
+            ):
+                # Exception if:
+                #  - the user provides a value in the attributes field
+                #  - AND the user provided a value in the command line (non default)
+                #  - AND the values are different
+                # Note that this won't raise an error if the user provided the default
+                # value in the command line and provided one in attribute but although
+                # slightly inconsistent, it is not incorrect.
+                raise MetaflowException(
+                    "You cannot pass %s as both a command-line argument and an attribute "
+                    "of the @project decorator." % op
+                )
+        project_branch = self.attributes.get("branch", options["branch"])
+        project_production = self.attributes.get("production", options["production"])
         project_flow_name, branch_name = format_name(
             flow.name,
             project_name,
-            options["production"],
-            options["branch"],
+            project_production,
+            project_branch,
             get_username(),
         )
-        is_user_branch = options["branch"] is None and not options["production"]
+        is_user_branch = project_branch is None and not project_production
         echo(
             "Project: *%s*, Branch: *%s*" % (project_name, branch_name),
             fg="magenta",
@@ -114,7 +134,7 @@ class ProjectDecorator(FlowDecorator):
                 "project_name": project_name,
                 "branch_name": branch_name,
                 "is_user_branch": is_user_branch,
-                "is_production": options["production"],
+                "is_production": project_production,
                 "project_flow_name": project_flow_name,
             }
         )

--- a/metaflow/plugins/project_decorator.py
+++ b/metaflow/plugins/project_decorator.py
@@ -90,7 +90,7 @@ class ProjectDecorator(FlowDecorator):
         ),
     }
 
-    defaults = {"name": None} + {k: v["default"] for k, v in options.items()}
+    defaults = {"name": None, **{k: v["default"] for k, v in options.items()}}
 
     def flow_init(
         self, flow, graph, environment, flow_datastore, metadata, logger, echo, options
@@ -99,7 +99,7 @@ class ProjectDecorator(FlowDecorator):
         project_name = self.attributes.get("name")
         for op in options:
             if (
-                op in self.attributes
+                op in self._user_defined_attributes
                 and options[op] != self.defaults[op]
                 and self.attributes[op] != options[op]
             ):

--- a/metaflow/plugins/project_decorator.py
+++ b/metaflow/plugins/project_decorator.py
@@ -114,8 +114,16 @@ class ProjectDecorator(FlowDecorator):
                     "You cannot pass %s as both a command-line argument and an attribute "
                     "of the @project decorator." % op
                 )
-        project_branch = self.attributes.get("branch", options["branch"])
-        project_production = self.attributes.get("production", options["production"])
+        if "branch" in self._user_defined_attributes:
+            project_branch = self.attributes["branch"]
+        else:
+            project_branch = options["branch"]
+
+        if "production" in self._user_defined_attributes:
+            project_production = self.attributes["production"]
+        else:
+            project_production = options["production"]
+
         project_flow_name, branch_name = format_name(
             flow.name,
             project_name,

--- a/metaflow/user_configs/config_parameters.py
+++ b/metaflow/user_configs/config_parameters.py
@@ -3,7 +3,7 @@ import json
 import os
 import re
 
-from typing import Any, Callable, Dict, Optional, TYPE_CHECKING, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 
 from ..exception import MetaflowException
@@ -406,17 +406,20 @@ def resolve_delayed_evaluator(v: Any, ignore_errors: bool = False) -> Any:
 
 def unpack_delayed_evaluator(
     to_unpack: Dict[str, Any], ignore_errors: bool = False
-) -> Dict[str, Any]:
+) -> Tuple[Dict[str, Any], List[str]]:
     result = {}
+    new_keys = []
     for k, v in to_unpack.items():
         if not isinstance(k, str) or not k.startswith(UNPACK_KEY):
             result[k] = v
         else:
             # k.startswith(UNPACK_KEY)
             try:
-                result.update(resolve_delayed_evaluator(v))
+                new_vals = resolve_delayed_evaluator(v)
+                new_keys.extend(new_vals.keys())
+                result.update(new_vals)
             except Exception as e:
                 if ignore_errors:
                     continue
                 raise e
-    return result
+    return result, new_keys


### PR DESCRIPTION

This would allow for a more flexible use of configs as you can now provide those options directly from a config file.

This impacts the only two decorators that have this: project and trigger_on_finish