### PR TITLE
[cards] Fix config issue permanently.

### DIFF
--- a/metaflow/plugins/cards/card_decorator.py
+++ b/metaflow/plugins/cards/card_decorator.py
@@ -269,14 +269,7 @@ class CardDecorator(StepDecorator):
             self.card_creator.create(mode="render", final=True, **create_options)
             self.card_creator.create(mode="refresh", final=True, **create_options)
 
-        self._increment_completed_counter()
-        if self.task_finished_decos == self.total_decos_on_step[step_name]:
-            # Unlink the config file if it exists
-            if self._config_file_name:
-                try:
-                    os.unlink(self._config_file_name)
-                except Exception as e:
-                    pass
+        self._cleanup(step_name)
 
     @staticmethod
     def _options(mapping):
@@ -315,6 +308,9 @@ class CardDecorator(StepDecorator):
     def task_exception(
         self, exception, step_name, flow, graph, retry_count, max_user_code_retries
     ):
+        self._cleanup(step_name)
+
+    def _cleanup(self, step_name):
         self._increment_completed_counter()
         if self.task_finished_decos == self.total_decos_on_step[step_name]:
             # Unlink the config file if it exists


### PR DESCRIPTION
- Ensures configs behave consistently with cards.
Testing script to see it works : 

```python
from metaflow import FlowSpec, step, card, current, Config
from metaflow.cards import ProgressBar

def git_info(args=None):
    from subprocess import check_output, CalledProcessError

    info = {
        "commit": ["git", "rev-parse", "HEAD"],
        "branch": ["git", "rev-parse", "--abbrev-ref", "HEAD"],
        "message": ["git", "log", "-1", "--pretty=%B"],
        "remote": ["git", "config", "--get", "remote.origin.url"],
    }
    cfg = {}
    try:
        for key, cmd in info.items():
            cfg[key] = check_output(cmd, text=True).strip()
    except CalledProcessError as e:
        # Handle cases where git commands fail
        cfg["error"] = f"Git command failed: {e}"
    return cfg


class PythonCodeDemoFlow(FlowSpec):

    git_info = Config("git_info", default_value="", parser=git_info)

    @card
    @card(type="blank", id="progress_bar", customize=True)
    @step
    def start(self):
        import time
        progress = ProgressBar(max=100)

        current.card.append(progress)
        for i in range(100):
            progress.update(i)
            current.card.refresh()
            time.sleep(1)
        
        self.next(self.end)

    @step
    def end(self):
        pass

if __name__ == '__main__':
    PythonCodeDemoFlow()
```