### PR TITLE
fix bug for fq_name

### DIFF
--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -599,7 +599,7 @@ class TriggerOnFinishDecorator(FlowDecorator):
             if isinstance(trigger, DeployTimeField):
                 trigger = deploy_time_eval(trigger)
             if isinstance(trigger, dict):
-                trigger["fq_name"] = trigger.get("name")
+                trigger["fq_name"] = trigger.get("fq_name")
                 trigger["project"] = trigger.get("project")
                 trigger["branch"] = trigger.get("project_branch")
             # We also added this bc it won't be formatted yet
@@ -607,6 +607,6 @@ class TriggerOnFinishDecorator(FlowDecorator):
                 trigger = {"fq_name": trigger}
                 trigger = self._parse_fq_name(trigger)
             self.triggers[self.triggers.index(old_trig)] = trigger
-
+    
     def get_top_level_options(self):
         return list(self._option_values.items())

--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -623,7 +623,7 @@ class TriggerOnFinishDecorator(FlowDecorator):
                             )
                     if "project_branch" in trigger:
                         if is_stringish(trigger["project_branch"]):
-                            result["branch"] = trigger["project_branch"]
+                            result["project_branch"] = trigger["project_branch"]
                         else:
                             raise MetaflowException(
                                 "The *project_branch* attribute of the *flow* is not a string"

--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -598,6 +598,10 @@ class TriggerOnFinishDecorator(FlowDecorator):
             old_trig = trigger
             if isinstance(trigger, DeployTimeField):
                 trigger = deploy_time_eval(trigger)
+                if isinstance(trigger, dict) and "fq_name" not in trigger:
+                    # When a user has a deploy time trigger on finish which returns name,
+                    # project, branch
+                    trigger["fq_name"] = trigger.get("name")
             if isinstance(trigger, dict):
                 trigger["fq_name"] = trigger.get("fq_name")
                 trigger["project"] = trigger.get("project")

--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -422,7 +422,9 @@ class TriggerOnFinishDecorator(FlowDecorator):
                         )
                 if "project_branch" in self.attributes["flow"]:
                     if is_stringish(self.attributes["flow"]["project_branch"]):
-                        result["branch"] = self.attributes["flow"]["project_branch"]
+                        result["project_branch"] = self.attributes["flow"][
+                            "project_branch"
+                        ]
                     else:
                         raise MetaflowException(
                             "The *project_branch* attribute of the *flow* is not a string"
@@ -467,6 +469,7 @@ class TriggerOnFinishDecorator(FlowDecorator):
                                 "The *name* attribute '%s' is not a valid string"
                                 % str(flow_name)
                             )
+
                         result = {"fq_name": flow_name}
                         if "project" in flow:
                             if is_stringish(flow["project"]):
@@ -478,7 +481,7 @@ class TriggerOnFinishDecorator(FlowDecorator):
                                 )
                         if "project_branch" in flow:
                             if is_stringish(flow["project_branch"]):
-                                result["branch"] = flow["project_branch"]
+                                result["project_branch"] = flow["project_branch"]
                             else:
                                 raise MetaflowException(
                                     "The *project_branch* attribute of the *flow* %s "

--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -607,6 +607,6 @@ class TriggerOnFinishDecorator(FlowDecorator):
                 trigger = {"fq_name": trigger}
                 trigger = self._parse_fq_name(trigger)
             self.triggers[self.triggers.index(old_trig)] = trigger
-    
+
     def get_top_level_options(self):
         return list(self._option_values.items())

--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -597,6 +597,7 @@ class TriggerOnFinishDecorator(FlowDecorator):
             # Entire trigger is a function (returns either string or dict)
             old_trig = trigger
             if isinstance(trigger, DeployTimeField):
+                # convert the trigger to string or dict
                 trigger = deploy_time_eval(trigger)
                 if is_stringish(trigger):
                     pass
@@ -628,6 +629,7 @@ class TriggerOnFinishDecorator(FlowDecorator):
                                 "The *project_branch* attribute of the *flow* is not a string"
                             )
                     trigger = result
+            # effect is to set all fields to None if they don't exist.
             if isinstance(trigger, dict):
                 trigger["fq_name"] = trigger.get("fq_name")
                 trigger["project"] = trigger.get("project")

--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -599,7 +599,7 @@ class TriggerOnFinishDecorator(FlowDecorator):
             if isinstance(trigger, DeployTimeField):
                 trigger = deploy_time_eval(trigger)
                 if is_stringish(trigger):
-                    trigger = {"fq_name": trigger}
+                    pass
                 elif isinstance(trigger, dict):
                     if "name" not in trigger:
                         raise MetaflowException(


### PR DESCRIPTION
The bug cause the issue when user use the @trigger_on_finish. Previously, it is not possible to deploy flows with `@trigger_on_finish` decorator whose event name was a string. 

```python
@trigger_on_finish(flow="example_flow")
class MyFlow(FlowSpec):
        ...
```

Deploying this to our internal scheduler would fail because in `flow_init` we would convert `example_flow` to a fully qualified name (`fq_name`) [here](https://github.com/Netflix/metaflow/blob/master/metaflow/plugins/events_decorator.py#L402-L406) and when parsing the triggers during graph creation, we would read the value as `name` instead of `fq_name`. This PR updates that and the logic for parsing deploy time triggers. 

The code can be further refactored for readability and @Qianh1225 will push a follow up PR for that. 