### PR TITLE
fix: Argo events project bug

### DIFF
--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -635,7 +635,7 @@ class TriggerOnFinishDecorator(FlowDecorator):
             if isinstance(trigger, dict):
                 trigger["fq_name"] = trigger.get("name")
                 trigger["project"] = trigger.get("project")
-                trigger["branch"] = trigger.get("project_branch")
+                trigger["branch"] = trigger.get("branch")
             # We also added this bc it won't be formatted yet
             if isinstance(trigger, str):
                 trigger = {"fq_name": trigger}


### PR DESCRIPTION
There is a bug specifying `project_branch` in the `@trigger_on_finish` decorators flow dictionary is ignored completely, leading to listening on events that will never be broadcast.

This PR also adds validation so we don't deploy with event names containing partial project info.

Example:
This flow incorrectly listens to the event `sa_test_project.ProjectEventsTestFlow`

```python
@trigger_on_finish(
    flow={"name": "ProjectEventsTestFlow", "project": "sa_test_project", "project_branch": "user.saikonen"}
)
class TriggerOnProjectFinish2(FlowSpec):
    pass
```