### PR TITLE
Fix an issue with using MutableFlow

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -591,9 +591,13 @@ def _init_flow_decorators(
                 )
         else:
             # Each "non-multiple" flow decorator is only allowed to have one set of options
+            # Note that there may be no deco_options if a MutableFlow config injected
+            # the decorator.
             deco_flow_init_options = {
-                option: deco_options[option.replace("-", "_")]
-                for option in deco.options
+                option: deco_options.get(
+                    option.replace("-", "_"), option_info["default"]
+                )
+                for option, option_info in deco.options.items()
             }
         for deco in decorators:
             deco.flow_init(


### PR DESCRIPTION
If you used MutableFlow to inject a flow level decorator that has TL options, Metaflow would crash.