### PR TITLE
fix: Independent decorator task exec lifecycles

### DIFF
--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -600,10 +600,9 @@ class KubernetesDecorator(StepDecorator):
             # local file system after the user code has finished execution.
             # This happens via datastore as a communication bridge.
 
-            # TODO:  There is no guarantee that task_prestep executes before
-            #        task_finished is invoked. That will result in AttributeError:
-            #        'KubernetesDecorator' object has no attribute 'metadata' error.
-            if self.metadata.TYPE == "local":
+            # TODO:  There is no guarantee that task_pre_step executes before
+            #        task_finished is invoked. This currently results in us not having access to the metadata, as it is bound in the pre_step
+            if hasattr(self, "metadata") and self.metadata.TYPE == "local":
                 # Note that the datastore is *always* Amazon S3 (see
                 # runtime_task_created function).
                 sync_local_metadata_to_datastore(

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -600,9 +600,7 @@ class KubernetesDecorator(StepDecorator):
             # local file system after the user code has finished execution.
             # This happens via datastore as a communication bridge.
 
-            # TODO:  There is no guarantee that task_pre_step executes before
-            #        task_finished is invoked. This currently results in us not having access to the metadata, as it is bound in the pre_step
-            if hasattr(self, "metadata") and self.metadata.TYPE == "local":
+            if self.metadata.TYPE == "local":
                 # Note that the datastore is *always* Amazon S3 (see
                 # runtime_task_created function).
                 sync_local_metadata_to_datastore(


### PR DESCRIPTION
Exceptions during task exec lifecycles (`task_pre_step/task_decorate/task_post_step`) in decorators can currently impact the calling of other decorator lifecycles.

Example:
```python
from metaflow import step, FlowSpec, secrets, kubernetes

class BreakSecretFlow(FlowSpec):

    @kubernetes
    @secrets(sources=["test-secret-with-no-permissions"])
    @step
    def start(self):
        print("Testing secrets..")
        self.next(self.end)

    @step
    def end(self):
        print("Done! 🏁")


if __name__ == "__main__":
    BreakSecretFlow()
```

The above flow will currently break due to 

1. `@secrets` raising an exception
2. which prevents `@kubernetes` from having `task_pre_step` called, which is supposed to bind `self.metadata`
3. The missing `self.metadata` in turn makes `task_finished` fail for `@kubernetes`.

Issues:
- the true error is masked under `@kubernetes` exceptions, making debugging nontrivial
- due to `task_pre_step` being blocked for `@kubernetes`, we end up missing metadata records (pod name etc.) which would have been recorded during this.

---
Proposal is to instead execute all the lifecycle methods independently, collecting exceptions and raising only at the end of iteration. This will ensure that decorators do not interfere with each others lifecycles via exceptions, and a decorator can more reliably perform data passing between its own lifecycle methods



Side note: The issue is dependent on decorator ordering.
```python
# This will break on the kubernetes decorator.
@kubernetes
@secrets(sources=["test-secret-with-no-permissions"])

# This will instead surface the secrets decorator exception.
@secrets(sources=["test-secret-with-no-permissions"])
@kubernetes
```