### PR TITLE
fix: guard against missing metadata in Kubernetes decorator

### DIFF
--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -600,10 +600,10 @@ class KubernetesDecorator(StepDecorator):
             # local file system after the user code has finished execution.
             # This happens via datastore as a communication bridge.
 
-            # TODO:  There is no guarantee that task_prestep executes before
-            #        task_finished is invoked. That will result in AttributeError:
-            #        'KubernetesDecorator' object has no attribute 'metadata' error.
-            if self.metadata.TYPE == "local":
+            # TODO:  There is no guarantee that task_pre_step executes before
+            #        task_finished is invoked.
+            # For now we guard against the missing metadata object in this case.
+            if hasattr(self, "metadata") and self.metadata.TYPE == "local":
                 # Note that the datastore is *always* Amazon S3 (see
                 # runtime_task_created function).
                 sync_local_metadata_to_datastore(


### PR DESCRIPTION
fixes edge case where `@kubernetes` decorator fails to execute `task_pre_step` due to another decorator raising exceptions. guards against the missing metadata during `task_finished`

This still leaves the issue where kubernetes `task_pre_step` not executing will lead to some missing metadata as well.

relates to #2231 for a thorough fix.