### PR TITLE
fix: issue with deferred micromamba installation

### DIFF
--- a/metaflow/plugins/pypi/micromamba.py
+++ b/metaflow/plugins/pypi/micromamba.py
@@ -10,6 +10,7 @@ from metaflow.exception import MetaflowException
 from metaflow.util import which
 
 from .utils import MICROMAMBA_MIRROR_URL, MICROMAMBA_URL, conda_platform
+from threading import Lock
 
 
 class MicromambaException(MetaflowException):
@@ -54,22 +55,33 @@ class Micromamba(object):
             or which(os.path.join(self._path_to_hidden_micromamba, "bin/micromamba"))
         )
 
+        # We keep a mutex as environments are resolved in parallel,
+        # which causes a race condition in case micromamba needs to be installed first.
+        self.install_mutex = Lock()
+
     @property
-    def bin(self):
+    def bin(self) -> str:
         "Defer installing Micromamba until when the binary path is actually requested"
         if self._bin is not None:
             return self._bin
-        # Install Micromamba on the fly.
-        # TODO: Make this optional at some point.
-        _install_micromamba(self._path_to_hidden_micromamba)
-        self._bin = which(
-            os.path.join(self._path_to_hidden_micromamba, "bin/micromamba")
-        )
+        with self.install_mutex:
+            # another check as micromamba might have been installed when the mutex is released.
+            if self._bin is not None:
+                return self._bin
 
-        if self._bin is None:
-            msg = "No installation for *Micromamba* found.\n"
-            msg += "Visit https://mamba.readthedocs.io/en/latest/micromamba-installation.html for installation instructions."
-            raise MetaflowException(msg)
+            # Install Micromamba on the fly.
+            # TODO: Make this optional at some point.
+            _install_micromamba(self._path_to_hidden_micromamba)
+            self._bin = which(
+                os.path.join(self._path_to_hidden_micromamba, "bin/micromamba")
+            )
+
+            if self._bin is None:
+                msg = "No installation for *Micromamba* found.\n"
+                msg += "Visit https://mamba.readthedocs.io/en/latest/micromamba-installation.html for installation instructions."
+                raise MetaflowException(msg)
+
+        return self._bin
 
     def solve(self, id_, packages, python, platform):
         # Performance enhancements


### PR DESCRIPTION
deferring micromamba binary installation in the last release (`2.13.8`) caused two issues
- when micromamba is not installed, there is a race condition due to environments being solved in parallel which can kick up multiple installs at a time
- the property was not returning the path to the binary after installation, leading to first calls failing.