### PR TITLE
Log input paths as an artifact

### DIFF
--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -559,6 +559,7 @@ class MetaflowTask(object):
                 self.flow._success = False
                 self.flow._task_ok = None
                 self.flow._exception = None
+                self.flow._input_paths = input_paths
                 # Note: All internal flow attributes (ie: non-user artifacts)
                 # should either be set prior to running the user code or listed in
                 # FlowSpec._EPHEMERAL to allow for proper merging/importing of


### PR DESCRIPTION
Adds `input_paths` to the `flowspec` instance so that it gets saved as an artifact. To access it one can simply do: `task["_input_paths"].data`. 