### PR TITLE
fix: Deployer issue

### DIFF
--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -203,7 +203,6 @@ def argo_workflows(obj, name=None):
     show_default=True,
     type=str,
     help="Write the workflow name to the file specified. Used internally for Metaflow's Deployer API.",
-    hidden=True,
 )
 @click.option(
     "--enable-error-msg-capture/--no-enable-error-msg-capture",

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -203,6 +203,7 @@ def argo_workflows(obj, name=None):
     show_default=True,
     type=str,
     help="Write the workflow name to the file specified. Used internally for Metaflow's Deployer API.",
+    hidden=True,
 )
 @click.option(
     "--enable-error-msg-capture/--no-enable-error-msg-capture",

--- a/metaflow/runner/click_api.py
+++ b/metaflow/runner/click_api.py
@@ -527,12 +527,6 @@ def extract_all_params(cmd_obj: Union[click.Command, click.Group]):
             )
             arg_parameters[each_param.name] = each_param
         elif isinstance(each_param, click.Option):
-            if each_param.hidden:
-                # Skip hidden options because users should not be setting those.
-                # These are typically internal only options (used by the Runner in part
-                # for example to pass state files or configs to pass local-config-file).
-                continue
-
             opt_params_sigs[each_param.name], annotations[each_param.name] = (
                 get_inspect_param_obj(each_param, inspect.Parameter.KEYWORD_ONLY)
             )


### PR DESCRIPTION
last release introduced an issue that broke the argo workflows/step functions deployer implementation. The cause is https://github.com/Netflix/metaflow/pull/2234/files#diff-5b4ba4c231c3ab3a8e1df579662e664605edf1b903b2299b0d75a7613ffca945R530-R535 as the Argo deployer relies on a hidden Click option to pass values.

minimal repro example:
```python
from metaflow import Deployer

if __name__=="__main__":
    deployer = Deployer(flow_file="HelloFlow.py").argo_workflows()
    deployed_flow = deployer.create()
```
will result in an error

```
ValueError: Unknown argument: 'deployer_attribute_file', possible args are: authorize, generate_new_token, given_token, tags, user_namespace, only_json, max_workers, workflow_timeout, workflow_priority, auto_emit_argo_events, notify_on_error, notify_on_success, notify_slack_webhook_url, notify_pager_duty_integration_key, notify_incident_io_api_key, incident_io_success_severity_id, incident_io_error_severity_id, enable_heartbeat_daemon, enable_error_msg_capture
```

Alternatively we could revert the skipping of hidden options introduced in #2234 