### PR TITLE
[WIP] - Support argo retry

### DIFF
--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -155,6 +155,16 @@ def step(
         ctx.obj.monitor,
         ubf_context,
     )
+
+    latest_done_attempt = task.flow_datastore.get_latest_done_attempt(
+        run_id=run_id, step_name=step_name, task_id=task_id
+    )
+    if latest_done_attempt:
+        retry_count = latest_done_attempt + 1
+    # Not sure what are the side effects to this.
+    if retry_count >= max_user_code_retries:
+        max_user_code_retries = retry_count
+
     if clone_only:
         task.clone_only(
             step_name,

--- a/metaflow/datastore/flow_datastore.py
+++ b/metaflow/datastore/flow_datastore.py
@@ -1,5 +1,6 @@
 import itertools
 import json
+from typing import Optional
 
 from .. import metaflow_config
 
@@ -66,6 +67,14 @@ class FlowDataStore(object):
     @property
     def datastore_root(self):
         return self._storage_impl.datastore_root
+
+    def get_latest_done_attempt(self, run_id, step_name, task_id) -> Optional[int]:
+        t_datastores = self.get_task_datastores(
+            pathspecs=[f"{run_id}/{step_name}/{task_id}"], include_prior=True
+        )
+        return max(
+            [t.attempt for t in t_datastores], default=None
+        )  # returns default, if this was a first attempt.
 
     def get_task_datastores(
         self,

--- a/metaflow/mflog/save_logs.py
+++ b/metaflow/mflog/save_logs.py
@@ -37,8 +37,12 @@ def save_logs():
     flow_datastore = FlowDataStore(
         flow_name, None, storage_impl=storage_impl, ds_root=ds_root
     )
+    # Use inferred attempt - to save task_stdout.log and task_stderr.log
+    latest_done_attempt = flow_datastore.get_latest_done_attempt(
+        run_id=run_id, step_name=step_name, task_id=task_id
+    )
     task_datastore = flow_datastore.get_task_datastore(
-        run_id, step_name, task_id, int(attempt), mode="w"
+        run_id, step_name, task_id, latest_done_attempt, mode="w"
     )
 
     try:


### PR DESCRIPTION
Seems like argo retry does not work as expected when a workflow is triggered using metaflow retry enabled.

```
python hello_world.py argo-workflows create
python hello_world.py argo-workflows trigger
```

### Steps to reproduce:

```python
import pandas as pd
from metaflow import (
    FlowSpec,
    Parameter,
    card,
    project,
    step,
    retry,
    environment
)

from metaflow import current

ENV_VARS = {
    "FAIL_FLOW": "YES",
}

@project(name="dummy_project")
class HelloWorld(FlowSpec):
    force_error = Parameter("force-error", type=bool, default=False)

    @card
    @step
    def start(self):
        self.next(self.print_df)

    @card
    @environment(vars=ENV_VARS)
    @step
    def print_df(self):
        import os

        if os.environ["FAIL_FLOW"] == "YES":
            raise Exception(f"Fail now, current retry count: {current.retry_count}")    
        else:
            self.new_df = pd.DataFrame(
            {
                "city": [1, 2, 3],
                "country": ["de", "de", "at"],
                "order_id": [5, 6, 7],
                "score": [0.5, 0.6, 0.7],
            }
            )
        # pass this step on retry
        print(f"count is = {current.retry_count}")
        self.next(self.end)
    
    @card  
    @step
    def end(self):
        print(f"the new df is: {self.new_df}")

if __name__ == "__main__":
    HelloWorld()

```

- Argo workflow with metaflow retry enabled and fails in all retries. Due to error induced via envar

![Image](https://github.com/user-attachments/assets/f1c117ee-0232-4176-9ca2-c20047c0a210)

- Node `print_df` passes after a fix in the backend [or updated the workflow with right env-var value], and then hit  `argo retry --node` button.

- `end` step fails with a missing artifact, `new_df` is a artifiact from the parent step, which was created when the parent node was successful on retry.

```
    print(f"the new df is: {self.new_df}")
                            ^^^^^^^^^^^
  File "/app/metaflow/metaflow/flowspec.py", line 250, in __getattr__
    raise AttributeError("Flow %s has no attribute '%s'" % (self.name, name))
AttributeError: Flow HelloWorld has no attribute 'new_df'
```
![Image](https://github.com/user-attachments/assets/4cf0b7ab-2f5c-44fe-84f8-a1dd56b415bc)


**Reason:**

The s3 artifacts in the `end` step did not contain `new_df` pointers in `data.json`, this is essentially due to the retried step `print_df` overwrote the `attempt: 0` artifacts. [Look at the timestamps]

![Image](https://github.com/user-attachments/assets/f7f607c3-ee6d-4812-a1ec-619c3eba0ce9)


## Desired Behaviour

Ideally, hitting argo retry button should create a new attempt rather than overwriting the old attempt.

[Metaflow ChatRoom Discussion](https://outerbounds-community.slack.com/archives/C020U025QJK/p1737483912784969)

## Solution Proposal

Infer the `retry_count` from flow datastore [example: s3]. The `retry_count` will be the `latest_done _attempt number + 1`
