### PR TITLE
feature: pin fast-init binary to latest

### DIFF
--- a/metaflow/plugins/pypi/bootstrap.py
+++ b/metaflow/plugins/pypi/bootstrap.py
@@ -19,7 +19,7 @@ import warnings
 
 from . import MAGIC_FILE, _datastore_packageroot
 
-FAST_INIT_BIN_URL = "https://fast-flow-init.outerbounds.sh/{platform}/fast-env-0.1.1.gz"
+FAST_INIT_BIN_URL = "https://fast-flow-init.outerbounds.sh/{platform}/latest"
 
 # Bootstraps a valid conda virtual environment composed of conda and pypi packages
 


### PR DESCRIPTION
pins fast-init binary to the `latest` alias instead of a fixed version