### PR TITLE
Correct memory units from MB to MiB

### DIFF
--- a/R/R/decorators-aws.R
+++ b/R/R/decorators-aws.R
@@ -14,7 +14,7 @@
 #'
 #' @param cpu Integer number of CPUs required for this step. Defaults to `1`.
 #' @param gpu Integer number of GPUs required for this step. Defaults to `0`.
-#' @param memory Integer memory size (in MB) required for this step. Defaults to
+#' @param memory Integer memory size (in MiB) required for this step. Defaults to
 #'   `4096`.
 #' @param image Character. Specifies the image to use when launching on AWS
 #'   Batch. If not specified, an appropriate
@@ -48,9 +48,9 @@
 #' @export
 #'
 #' @examples \dontrun{
-#' # This example will generate a large random matrix which takes up roughly
-#' # 48GB of memory, and sums the entries. The `batch` decorator forces this
-#' # step to run in an environment with 60000MB of memory.
+#' # This example will generate a large random matrix that takes up roughly
+#' # 48 GiB of memory and sum the entries. The `batch` decorator forces this
+#' # step to run in an environment with 60,000 MiB of memory.
 #'
 #' start <- function(self) {
 #'   big_matrix <- matrix(rexp(80000*80000), 80000)

--- a/R/man/batch.Rd
+++ b/R/man/batch.Rd
@@ -25,7 +25,7 @@ resources(cpu = 1L, gpu = 0L, memory = 4096L, shared_memory = NULL)
 
 \item{gpu}{Integer number of GPUs required for this step. Defaults to \code{0}.}
 
-\item{memory}{Integer memory size (in MB) required for this step. Defaults to
+\item{memory}{Integer memory size (in MiB) required for this step. Defaults to
 \code{4096}.}
 
 \item{image}{Character. Specifies the image to use when launching on AWS
@@ -78,9 +78,9 @@ from all decorators is used.
 }
 \examples{
 \dontrun{
-# This example will generate a large random matrix which takes up roughly
-# 48GB of memory, and sums the entries. The `batch` decorator forces this
-# step to run in an environment with 60000MB of memory.
+# This example will generate a large random matrix that takes up roughly
+# 48 GiB of memory and sum the entries. The `batch` decorator forces this
+# step to run in an environment with 60,000 MiB of memory.
 
 start <- function(self) {
   big_matrix <- matrix(rexp(80000*80000), 80000)

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -3145,7 +3145,7 @@ class ArgoWorkflows(object):
                     resources=kubernetes_sdk.V1ResourceRequirements(
                         requests={
                             "cpu": str(kube_defaults["cpu"]),
-                            "memory": "%sM" % str(kube_defaults["memory"]),
+                            "memory": "%sMi" % str(kube_defaults["memory"]),
                         }
                     ),
                 ).to_dict()

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -43,7 +43,7 @@ class BatchDecorator(StepDecorator):
         Number of GPUs required for this step. If `@resources` is
         also present, the maximum value from all decorators is used.
     memory : int, default 4096
-        Memory size (in MB) required for this step. If
+        Memory size (in MiB) required for this step. If
         `@resources` is also present, the maximum value from all decorators is
         used.
     image : str, optional, default None

--- a/metaflow/plugins/kubernetes/kube_utils.py
+++ b/metaflow/plugins/kubernetes/kube_utils.py
@@ -43,8 +43,8 @@ def qos_requests_and_limits(qos: str, cpu: int, memory: int, storage: int):
         # Guaranteed - has both cpu/memory limits. requests not required, as these will be inferred.
         qos_limits = {
             "cpu": str(cpu),
-            "memory": "%sM" % str(memory),
-            "ephemeral-storage": "%sM" % str(storage),
+            "memory": "%sMi" % str(memory),
+            "ephemeral-storage": "%sMi" % str(storage),
         }
         # NOTE: Even though Kubernetes will produce matching requests for the specified limits, this happens late in the lifecycle.
         # We specify them explicitly here to make some K8S tooling happy, in case they rely on .resources.requests being present at time of submitting the job.
@@ -53,8 +53,8 @@ def qos_requests_and_limits(qos: str, cpu: int, memory: int, storage: int):
         # Burstable - not Guaranteed, and has a memory/cpu limit or request
         qos_requests = {
             "cpu": str(cpu),
-            "memory": "%sM" % str(memory),
-            "ephemeral-storage": "%sM" % str(storage),
+            "memory": "%sMi" % str(memory),
+            "ephemeral-storage": "%sMi" % str(storage),
         }
     # TODO: Add support for BestEffort once there is a use case for it.
     # BestEffort - no limit or requests for cpu/memory

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -61,11 +61,11 @@ class KubernetesDecorator(StepDecorator):
         Number of CPUs required for this step. If `@resources` is
         also present, the maximum value from all decorators is used.
     memory : int, default 4096
-        Memory size (in MB) required for this step. If
+        Memory size (in MiB) required for this step. If
         `@resources` is also present, the maximum value from all decorators is
         used.
     disk : int, default 10240
-        Disk size (in MB) required for this step. If
+        Disk size (in MiB) required for this step. If
         `@resources` is also present, the maximum value from all decorators is
         used.
     image : str, optional, default None

--- a/metaflow/plugins/resources_decorator.py
+++ b/metaflow/plugins/resources_decorator.py
@@ -26,9 +26,9 @@ class ResourcesDecorator(StepDecorator):
     gpu : int, optional, default None
         Number of GPUs required for this step.
     disk : int, optional, default None
-        Disk size (in MB) required for this step. Only applies on Kubernetes.
+        Disk size (in MiB) required for this step. Only applies on Kubernetes.
     memory : int, default 4096
-        Memory size (in MB) required for this step.
+        Memory size (in MiB) required for this step.
     shared_memory : int, optional, default None
         The value for the size (in MiB) of the /dev/shm volume for this step.
         This parameter maps to the `--shm-size` option in Docker.

--- a/test/ux/core/test_argo_compilation.py
+++ b/test/ux/core/test_argo_compilation.py
@@ -134,7 +134,7 @@ def test_late_attached_kubernetes_mutator_is_reflected_in_argo_template(
     ]
 
     assert start_resources["requests"]["cpu"] == "2"
-    assert start_resources["requests"]["memory"] == "8192M"
+    assert start_resources["requests"]["memory"] == "8192Mi"
 
     assert end_resources["requests"]["cpu"] == "1"
-    assert end_resources["requests"]["memory"] == "4096M"
+    assert end_resources["requests"]["memory"] == "4096Mi"


### PR DESCRIPTION
The docs currently suggest that the [`@batch`](https://docs.metaflow.org/api/step-decorators/batch) and [`@resources`](https://docs.metaflow.org/api/step-decorators/resources) memory units are MB, but I suspect they may be MiB.

For AWS Batch computes, I believe these parameters are passed directly to `ResourceRequirement`, like so:
```
      "ResourceRequirements": [
        {
          "Value": "1",
          "Type": "VCPU"
        },
        {
          "Value": "4096",
          "Type": "MEMORY"
        }
      ],
```
and the `ResourceRequirement` [docs](https://docs.aws.amazon.com/batch/latest/APIReference/API_ResourceRequirement.html) indicate memory values are in MiB.

Furthermore, the default of 4096 makes sense to me if the units are MiB, since 4096 MiB = 4 GiB. If MB, it's hard to interpret.

This PR originally proposed changes to four of seven instances of "(in MB)".

In response to reviewer feedback, it also:
- Includes the remaining three, Kubernetes-specific, instances of "(in MB)".
- Changes the Kubernetes memory units and disk units, and the Argo memory units, to `Mi`, for consistency. These are behavior changes.
