### PR TITLE
Fix issue in stubs where step decorators dont have any parameters

### DIFF
--- a/metaflow/cmd/develop/stub_generator.py
+++ b/metaflow/cmd/develop/stub_generator.py
@@ -1133,13 +1133,16 @@ class StubGenerator:
             result = result[1:]
         # Add doc to first and last overloads. Jedi uses the last one and pycharm
         # the first one. Go figure.
+        result_docstring = docs["func_doc"]
+        if docs["param_doc"]:
+            result_docstring += "\nParameters\n----------\n" + docs["param_doc"]
         result[0] = (
             result[0][0],
-            docs["func_doc"] + "\nParameters\n----------\n" + docs["param_doc"],
+            result_docstring,
         )
         result[-1] = (
             result[-1][0],
-            docs["func_doc"] + "\nParameters\n----------\n" + docs["param_doc"],
+            result_docstring,
         )
         return result
 


### PR DESCRIPTION
If we have a decorator like `@my_deco` which does not have any parameters section in the docstring, then the generated stubs are wrong since it adds an empty `Parameters` section like the one shown below:
```
@typing.overload
def my_deco(f: typing.Callable[[FlowSpecDerived, StepFlag], None]) -> typing.Callable[[FlowSpecDerived, StepFlag], None]:
    """
    My function docstring
    
    Parameters
    ----------
    """
```

This causes issues when rendering the docs using `mkdocs`. 