### PR TITLE
add ephemeral_storage to resources decorator

### DIFF
--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -86,7 +86,8 @@ class BatchDecorator(StepDecorator):
         Number of elastic fabric adapter network devices to attach to container
     ephemeral_storage : int, default None
         The total amount, in GiB, of ephemeral storage to set for the task, 21-200GiB.
-        This is only relevant for Fargate compute environments
+        This is only relevant for Fargate compute environments.
+        If `@resources` is also present, the maximum value from all decorators is used.
     log_driver: str, optional, default None
         The log driver to use for the Amazon ECS container.
     log_options: List[str], optional, default None

--- a/metaflow/plugins/resources_decorator.py
+++ b/metaflow/plugins/resources_decorator.py
@@ -32,6 +32,9 @@ class ResourcesDecorator(StepDecorator):
     shared_memory : int, optional, default None
         The value for the size (in MiB) of the /dev/shm volume for this step.
         This parameter maps to the `--shm-size` option in Docker.
+    ephemeral_storage : int, default None
+        The total amount, in GiB, of ephemeral storage to set for the task, 21-200GiB.
+        This is only relevant for Fargate compute environments.
     """
 
     name = "resources"
@@ -41,4 +44,5 @@ class ResourcesDecorator(StepDecorator):
         "disk": None,
         "memory": "4096",
         "shared_memory": None,
+        "ephemeral_storage": None,
     }


### PR DESCRIPTION
Add the `ephemeral_storage` parameter to the `resources` decorator. Related to this [Slack thread](https://outerbounds-community.slack.com/archives/C02116BBNTU/p1740762718179169).

It deviates from the suggestion to alias `disk` in `resources` because `disk` is in units of MiB and `ephemeral_storage` is in units of `GiB`. This means that these two would not be the same behavior.

```python
size = 50
# not equal behavior
resources(disk=size)
batch(ephemeral_storage=size)

# equal behavior
resources(ephemeral_storage=size)
batch(ephemeral_storage=size)
```