### PR TITLE
Refactor runtime DAG APIs and add methods to return task pathspecs

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -1217,31 +1217,6 @@ class Task(MetaflowObject):
             for task_pathspec in task_pathspecs:
                 yield task_pathspec
 
-    def _iter_matching_tasks(self, steps, metadata_key, metadata_pattern):
-        """
-        Yield tasks from specified steps matching a foreach path pattern.
-
-        Parameters
-        ----------
-        steps : List[str]
-            List of step names to search for tasks
-        pattern : str
-            Regex pattern to match foreach-indices metadata
-
-        Returns
-        -------
-        Iterator[Task]
-            Tasks matching the foreach path pattern
-        """
-        flow_id, run_id, _, _ = self.path_components
-
-        for step in steps:
-            task_pathspecs = self._metaflow.metadata.filter_tasks_by_metadata(
-                flow_id, run_id, step.id, metadata_key, metadata_pattern
-            )
-            for task_pathspec in task_pathspecs:
-                yield Task(pathspec=task_pathspec, _namespace_check=False)
-
     @property
     def parent_task_pathspecs(self) -> Iterator[str]:
         """

--- a/test/core/tests/runtime_dag.py
+++ b/test/core/tests/runtime_dag.py
@@ -59,7 +59,15 @@ class RuntimeDagTest(MetaflowTest):
                 for name, value in type(task1).__dict__.items()
                 if isinstance(value, property)
                 if name
-                not in ["parent_tasks", "child_tasks", "metadata", "data", "artifacts"]
+                not in [
+                    "parent_tasks",
+                    "parent_task_pathspecs",
+                    "child_tasks",
+                    "child_task_pathspecs",
+                    "metadata",
+                    "data",
+                    "artifacts",
+                ]
             ]
 
             for prop_name in properties:


### PR DESCRIPTION
Small refactor to the Runtime DAG API. Added new methods to yield task pathspecs in addition to the actual task object so that it can be used later in `spin` steps. 