### PR TITLE
wip: better pip crossplatform resolves

### DIFF
--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -55,7 +55,7 @@ class CondaEnvironment(MetaflowEnvironment):
         # Initialize necessary virtual environments for all Metaflow tasks.
         # Use Micromamba for solving conda packages and Pip for solving pypi packages.
         from .micromamba import Micromamba
-        from .pip import Pip
+        from .pip_resolver import Pip
 
         print_lock = threading.Lock()
 

--- a/metaflow/plugins/pypi/pip_patcher.py
+++ b/metaflow/plugins/pypi/pip_patcher.py
@@ -1,0 +1,15 @@
+from unittest.mock import patch
+import os
+import sys
+
+
+@patch("platform.machine", lambda: os.environ.get("PIP_PATCH_MACHINE", "x86_64"))
+@patch("platform.system", lambda: os.environ.get("PIP_PATCH_SYSTEM", "Linux"))
+def _main(args):
+    from pip import main
+
+    main(args)
+
+
+if __name__ == "__main__":
+    _main(sys.argv[1:])

--- a/metaflow/plugins/pypi/pip_patcher.py
+++ b/metaflow/plugins/pypi/pip_patcher.py
@@ -13,6 +13,7 @@ import sys
     "platform.system", lambda: os.environ.get("PIP_PATCH_SYSTEM", os.uname().sysname)
 )
 def _main(args):
+    # TODO: Pip has deprecated using script wrappers for the cli. this will break in the future, and make patching the sys internals much harder
     from pip import main
 
     exitcode = main(args)

--- a/metaflow/plugins/pypi/pip_patcher.py
+++ b/metaflow/plugins/pypi/pip_patcher.py
@@ -15,7 +15,8 @@ import sys
 def _main(args):
     from pip import main
 
-    main(args)
+    exitcode = main(args)
+    sys.exit(exitcode)
 
 
 if __name__ == "__main__":

--- a/metaflow/plugins/pypi/pip_patcher.py
+++ b/metaflow/plugins/pypi/pip_patcher.py
@@ -3,6 +3,9 @@ import os
 import sys
 
 
+# Because Pip does not offer a direct way to set target platform_system and platform_machine values for resolving packages transitive dependencies, we need to instead
+# manually patch the correct target architecture values for pip to be able to resolve the whole dependency tree successfully.
+# This is necessary for packages that have conditional dependencies dependent on machine/system, e.g. Torch
 @patch("platform.machine", lambda: os.environ.get("PIP_PATCH_MACHINE", "x86_64"))
 @patch("platform.system", lambda: os.environ.get("PIP_PATCH_SYSTEM", "Linux"))
 def _main(args):

--- a/metaflow/plugins/pypi/pip_patcher.py
+++ b/metaflow/plugins/pypi/pip_patcher.py
@@ -6,8 +6,12 @@ import sys
 # Because Pip does not offer a direct way to set target platform_system and platform_machine values for resolving packages transitive dependencies, we need to instead
 # manually patch the correct target architecture values for pip to be able to resolve the whole dependency tree successfully.
 # This is necessary for packages that have conditional dependencies dependent on machine/system, e.g. Torch
-@patch("platform.machine", lambda: os.environ.get("PIP_PATCH_MACHINE", "x86_64"))
-@patch("platform.system", lambda: os.environ.get("PIP_PATCH_SYSTEM", "Linux"))
+@patch(
+    "platform.machine", lambda: os.environ.get("PIP_PATCH_MACHINE", os.uname().machine)
+)
+@patch(
+    "platform.system", lambda: os.environ.get("PIP_PATCH_SYSTEM", os.uname().sysname)
+)
 def _main(args):
     from pip import main
 

--- a/metaflow/plugins/pypi/pip_resolver.py
+++ b/metaflow/plugins/pypi/pip_resolver.py
@@ -102,7 +102,10 @@ class Pip(object):
                 else:
                     cmd.append(f"{package}=={version}")
             try:
-                self._call(prefix, cmd)
+                env = {}
+                if platform == "linux-64":
+                    env = {"PIP_PATCH_SYSTEM": "Linux", "PIP_PATCH_MACHINE": "x86_64"}
+                self._call(prefix, cmd, env)
             except PipPackageNotFound as ex:
                 # pretty print package errors
                 raise PipException(
@@ -306,7 +309,8 @@ class Pip(object):
                         "run",
                         "--prefix",
                         prefix,
-                        "pip3",
+                        "python",
+                        os.path.join(os.path.dirname(__file__), "pip_patcher.py"),
                         "--disable-pip-version-check",
                         "--no-color",
                     ]


### PR DESCRIPTION
⚠️ Proof-of-Concept. Do not merge ⚠️ 

 for correctly resolving transient dependencies for cross-platform package resolves, where dependencies are conditional on platform/os such as

```
"nvidia-cuda-runtime-cu12 (==12.4.127) ; platform_system == \"Linux\" and platform_machine == \"x86_64\"",
```

This intends to solve an issue with packages such as the default `torch` where resolving on a mac, but deploying onto a linux-64 machine will result in a broken environment due to the conditional dependencies not getting bundled up.


Caveats:
`pip` has deprecated script wrappers and is pushing for module calls instead. This will make patching the sys values harder, and the current setup is bound to break in the future.