### PR TITLE
feature: replace incident.io incidents with alerts for the integration.

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -2532,6 +2532,11 @@ class ArgoWorkflows(object):
                         "title": "Flow %s has failed." % self.flow.name,
                         "description": "Metaflow run %s/argo-{{workflow.name}} failed! %s"
                         % (self.flow.name, self._incident_io_ui_urls_for_run()),
+                        "metadata": {
+                            "run_status": "failed",
+                            "flow_name": self.flow.name,
+                            "run_id": "argo-{{workflow.name}}",
+                        },
                     }
                 )
             )
@@ -2560,6 +2565,11 @@ class ArgoWorkflows(object):
                         "title": "Flow %s has succeeded." % self.flow.name,
                         "description": "Metaflow run %s/argo-{{workflow.name}} succeeded!%s"
                         % (self.flow.name, self._incident_io_ui_urls_for_run()),
+                        "metadata": {
+                            "run_status": "succeeded",
+                            "flow_name": self.flow.name,
+                            "run_id": "argo-{{workflow.name}}",
+                        },
                     }
                 )
             )

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -183,14 +183,9 @@ def argo_workflows(obj, name=None):
     help="Incident.io API V2 key for workflow success/failure notifications.",
 )
 @click.option(
-    "--incident-io-success-severity-id",
+    "--incident-io-alert-source-config-id",
     default=None,
-    help="Incident.io severity id for success alerts.",
-)
-@click.option(
-    "--incident-io-error-severity-id",
-    default=None,
-    help="Incident.io severity id for error alerts.",
+    help="Incident.io Alert source config ID. Example '01GW2G3V0S59R238FAHPDS1R66'",
 )
 @click.option(
     "--enable-heartbeat-daemon/--no-enable-heartbeat-daemon",
@@ -230,8 +225,7 @@ def create(
     notify_slack_webhook_url=None,
     notify_pager_duty_integration_key=None,
     notify_incident_io_api_key=None,
-    incident_io_success_severity_id=None,
-    incident_io_error_severity_id=None,
+    incident_io_alert_source_config_id=None,
     enable_heartbeat_daemon=True,
     deployer_attribute_file=None,
     enable_error_msg_capture=False,
@@ -288,8 +282,7 @@ def create(
         notify_slack_webhook_url,
         notify_pager_duty_integration_key,
         notify_incident_io_api_key,
-        incident_io_success_severity_id,
-        incident_io_error_severity_id,
+        incident_io_alert_source_config_id,
         enable_heartbeat_daemon,
         enable_error_msg_capture,
     )
@@ -465,8 +458,7 @@ def make_flow(
     notify_slack_webhook_url,
     notify_pager_duty_integration_key,
     notify_incident_io_api_key,
-    incident_io_success_severity_id,
-    incident_io_error_severity_id,
+    incident_io_alert_source_config_id,
     enable_heartbeat_daemon,
     enable_error_msg_capture,
 ):
@@ -489,19 +481,18 @@ def make_flow(
             "https://api.slack.com/messaging/webhooks to generate a webhook url.\n"
             " For notifications through PagerDuty, generate an integration key by following the instructions at "
             "https://support.pagerduty.com/docs/services-and-integrations#create-a-generic-events-api-integration\n"
-            " For notifications through Incident.io, generate an API key with a permission to create incidents."
+            " For notifications through Incident.io, generate an alert source config."
         )
 
-    if notify_incident_io_api_key:
-        if notify_on_error and incident_io_error_severity_id is None:
-            raise MetaflowException(
-                "Incident.io error notifications require a severity id. Please set one with --incident-io-error-severity-id"
-            )
+    if (
+        (notify_on_error or notify_on_success)
+        and notify_incident_io_api_key
+        and incident_io_alert_source_config_id is None
+    ):
+        raise MetaflowException(
+            "Incident.io alerts require an alert source configuration ID. Please set one with --incident-io-alert-source-config-id"
+        )
 
-        if notify_on_success and incident_io_success_severity_id is None:
-            raise MetaflowException(
-                "Incident.io success notifications require a severity id. Please set one with --incident-io-success-severity-id"
-            )
     # Attach @kubernetes and @environment decorator to the flow to
     # ensure that the related decorator hooks are invoked.
     decorators._attach_decorators(
@@ -546,8 +537,7 @@ def make_flow(
         notify_slack_webhook_url=notify_slack_webhook_url,
         notify_pager_duty_integration_key=notify_pager_duty_integration_key,
         notify_incident_io_api_key=notify_incident_io_api_key,
-        incident_io_success_severity_id=incident_io_success_severity_id,
-        incident_io_error_severity_id=incident_io_error_severity_id,
+        incident_io_alert_source_config_id=incident_io_alert_source_config_id,
         enable_heartbeat_daemon=enable_heartbeat_daemon,
         enable_error_msg_capture=enable_error_msg_capture,
     )


### PR DESCRIPTION
switching the incident.io notification mechanism from directly creating incidents to instead creating alerts.

alerts offer a nicer flow and more customization on incident.io side. the setup is also less of a headache when deploying a flow, as users only need to create a http source endpoint for alerts, and provide the api key & source config id to Metaflow

accompanying docs changes: https://github.com/Netflix/metaflow-docs/pull/145