### PR TITLE
fix: json parameters argo workflows

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -3166,7 +3166,7 @@ class ArgoWorkflows(object):
                                                             parameter_name
                                                         ]["type"]
                                                         == "JSON"
-                                                        else "| squote"
+                                                        else "| toRawJson"
                                                     ),
                                                 ),
                                                 # Unfortunately the sensor needs to

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -3173,9 +3173,20 @@ class ArgoWorkflows(object):
                                                 # record the default values for
                                                 # the parameters - there doesn't seem
                                                 # to be any way for us to skip
-                                                value=self.parameters[parameter_name][
-                                                    "value"
-                                                ],
+                                                value=(
+                                                    json.dumps(
+                                                        self.parameters[parameter_name][
+                                                            "value"
+                                                        ]
+                                                    )
+                                                    if self.parameters[parameter_name][
+                                                        "type"
+                                                    ]
+                                                    == "JSON"
+                                                    else self.parameters[
+                                                        parameter_name
+                                                    ]["value"]
+                                                ),
                                             )
                                             .dest(
                                                 # this undocumented (mis?)feature in

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -839,7 +839,7 @@ class ArgoWorkflows(object):
                         [
                             Parameter(parameter["name"])
                             .value(
-                                json.dumps(parameter["value"])
+                                "'%s'" % parameter["value"]
                                 if parameter["type"] == "JSON"
                                 else parameter["value"]
                             )


### PR DESCRIPTION
fixes #2273

One drawback of this fix is that when triggering flows through Argo UI, the JSONType parameters values will have to now have outermost quotes, essentially being string-serialized json.