### PR TITLE
fix python names and help params in DeployedFlow from_deployment

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -524,6 +524,7 @@ class ArgoWorkflows(object):
                 default_value = json.dumps(default_value)
 
             parameters[param.name] = dict(
+                python_var_name=var,
                 name=param.name,
                 value=default_value,
                 type=param_type,

--- a/metaflow/plugins/argo/argo_workflows_deployer_objects.py
+++ b/metaflow/plugins/argo/argo_workflows_deployer_objects.py
@@ -19,6 +19,7 @@ def generate_fake_flow_file_contents(
 ):
     params_code = ""
     for _, param_details in param_info.items():
+        param_python_var_name = param_details["python_var_name"]
         param_name = param_details["name"]
         param_type = param_details["type"]
         param_help = param_details["description"]
@@ -26,21 +27,21 @@ def generate_fake_flow_file_contents(
 
         if param_type == "JSON":
             params_code += (
-                f"    {param_name} = Parameter('{param_name}', "
-                f"type=JSONType, help='{param_help}', required={param_required})\n"
+                f"    {param_python_var_name} = Parameter('{param_name}', "
+                f"type=JSONType, help='''{param_help}''', required={param_required})\n"
             )
         elif param_type == "FilePath":
             is_text = param_details.get("is_text", True)
             encoding = param_details.get("encoding", "utf-8")
             params_code += (
-                f"    {param_name} = IncludeFile('{param_name}', "
-                f"is_text={is_text}, encoding='{encoding}', help='{param_help}', "
+                f"    {param_python_var_name} = IncludeFile('{param_name}', "
+                f"is_text={is_text}, encoding='{encoding}', help='''{param_help}''', "
                 f"required={param_required})\n"
             )
         else:
             params_code += (
-                f"    {param_name} = Parameter('{param_name}', "
-                f"type={param_type}, help='{param_help}', required={param_required})\n"
+                f"    {param_python_var_name} = Parameter('{param_name}', "
+                f"type={param_type}, help='''{param_help}''', required={param_required})\n"
             )
 
     project_decorator = f"@project(name='{project_name}')\n" if project_name else ""


### PR DESCRIPTION
example:

```
    number = Parameter(
        'input-number',
        default=3,
        help="don't input alphabets"
    )
```


fixes https://github.com/Netflix/metaflow/issues/2349