### PR TITLE
reset AWS_SHARED_CREDENTIALS_FILE as AWS_CONFIG_FILE includes creds

### DIFF
--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -260,6 +260,7 @@ shell: setup-tilt
 			env METAFLOW_HOME="$(DEVTOOLS_DIR)" \
 				METAFLOW_PROFILE=local \
 				AWS_CONFIG_FILE="$(DEVTOOLS_DIR)/aws_config" \
+				AWS_SHARED_CREDENTIALS_FILE= \
 				"$$user_shell" -i; \
 		else \
 			env METAFLOW_HOME="$(DEVTOOLS_DIR)" \
@@ -301,6 +302,7 @@ create-dev-shell: setup-tilt
 		echo "    env METAFLOW_HOME=\"$(DEVTOOLS_DIR)\" \\" >> $$SHELL_PATH && \
 		echo "        METAFLOW_PROFILE=local \\" >> $$SHELL_PATH && \
 		echo "        AWS_CONFIG_FILE=\"$(DEVTOOLS_DIR)/aws_config\" \\" >> $$SHELL_PATH && \
+		echo "        AWS_SHARED_CREDENTIALS_FILE= \\" >> $$SHELL_PATH && \
 		echo "        \"\$$user_shell\" -i" >> $$SHELL_PATH && \
 		echo "else" >> $$SHELL_PATH && \
 		echo "    env METAFLOW_HOME=\"$(DEVTOOLS_DIR)\" \\" >> $$SHELL_PATH && \


### PR DESCRIPTION
The dev stack's `aws_config` currently includes config (endpoint URL) and the credentials as well, and setting the `AWS_CONFIG_FILE` env var to point to that file, which works fine IF the user doesn't have a credentials file -- as per the related AWS docs at https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html?shortFooter=true#cli-configure-files-where:

> You can keep all of your profile settings in a single file as the AWS CLI can read credentials from the config file. If there are credentials in both files for a profile sharing the same name, the keys in the credentials file take precedence. We suggest keeping credentials in the credentials files.

This PR resets the credentials file reference by setting `AWS_SHARED_CREDENTIALS_FILE` to blank.

More details at https://outerbounds-community.slack.com/archives/C02116BBNTU/p1743773858828969