### PR TITLE
fix: spot interruption detection

### DIFF
--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -299,6 +299,8 @@ class BatchDecorator(StepDecorator):
             self._save_logs_sidecar.start()
 
             # Start spot termination monitor sidecar.
+            # TODO: A nicer way to pass the main process id to a Sidecar, in order to allow sidecars to send signals back to the main process.
+            os.environ["MF_MAIN_PID"] = str(os.getpid())
             current._update_env(
                 {"spot_termination_notice": "/tmp/spot_termination_notice"}
             )

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -559,6 +559,8 @@ class KubernetesDecorator(StepDecorator):
             self._save_logs_sidecar.start()
 
             # Start spot termination monitor sidecar.
+            # TODO: A nicer way to pass the main process id to a Sidecar, in order to allow sidecars to send signals back to the main process.
+            os.environ["MF_MAIN_PID"] = str(os.getpid())
             current._update_env(
                 {"spot_termination_notice": "/tmp/spot_termination_notice"}
             )

--- a/metaflow/plugins/kubernetes/spot_monitor_sidecar.py
+++ b/metaflow/plugins/kubernetes/spot_monitor_sidecar.py
@@ -21,6 +21,9 @@ class SpotTerminationMonitorSidecar(object):
         self._token = None
         self._token_expiry = 0
 
+        # Due to nesting, os.getppid is not reliable for fetching the main task pid
+        self.main_pid = int(os.getenv("MF_MAIN_PID", os.getppid()))
+
         if self._is_aws_spot_instance():
             self._process = Process(target=self._monitor_loop)
             self._process.start()
@@ -71,7 +74,7 @@ class SpotTerminationMonitorSidecar(object):
                 if response.status_code == 200:
                     termination_time = response.text
                     self._emit_termination_metadata(termination_time)
-                    os.kill(os.getppid(), signal.SIGTERM)
+                    os.kill(self.main_pid, signal.SIGTERM)
                     break
             except (requests.exceptions.RequestException, requests.exceptions.Timeout):
                 pass


### PR DESCRIPTION
fix for sending SIGTERM to the main process when a spot interruption is detected.

`os.ppid()` is not reliable inside a Sidecar due to nesting of subprocesses, so we need to instead pass the main process id via some other means. This PR does it with an environment variable.

Also noteworthy is that because tasks running on Kubernetes have `termination_grace_period_seconds=0`, this makes graceful handling of SIGTERM impossible as the pod goes down immediately upon receiving it.


Flow for testing with AWS FIS:

```python
import signal
from time import sleep
from metaflow import step, FlowSpec, retry, current, kubernetes, batch

class RetryFlow(FlowSpec):

    @kubernetes
    # @batch()
    @retry(times=3)
    @step
    def start(self):
        print("Starting 👋")
        
        def _debug_signal(*args, **kwargs):
            print("SIGTERM RECEIVED")
        
        signal.signal(signal.SIGTERM, _debug_signal)
        
        print("sleeping for 300")
        sleep(300)
        if current.retry_count<1:
            raise Exception("You shall not pass (to the next step!)")
        
        self.next(self.end)

    @step
    def end(self):
        print("Done! 🏁")

if __name__ == "__main__":
    RetryFlow()

```