### PR TITLE
Terminate early on ENOSPC

### DIFF
--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import os
 import re
@@ -135,6 +136,10 @@ class MetaflowS3AccessDenied(MetaflowException):
 
 class MetaflowS3InvalidRange(MetaflowException):
     headline = "S3 invalid range"
+
+
+class MetaflowS3InsufficientDiskSpace(MetaflowException):
+    headline = "Insufficient disk space"
 
 
 class S3Object(object):
@@ -1377,8 +1382,10 @@ class S3(object):
                 elif error_code == "NoSuchBucket":
                     raise MetaflowS3URLException("Specified S3 bucket doesn't exist.")
                 error = str(err)
+            except OSError as e:
+                if e.errno == errno.ENOSPC:
+                    raise MetaflowS3InsufficientDiskSpace(e)
             except Exception as ex:
-                # TODO specific error message for out of disk space
                 error = str(ex)
             if tmp:
                 os.unlink(tmp.name)

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -1384,7 +1384,7 @@ class S3(object):
                 error = str(err)
             except OSError as e:
                 if e.errno == errno.ENOSPC:
-                    raise MetaflowS3InsufficientDiskSpace(e)
+                    raise MetaflowS3InsufficientDiskSpace(str(e))
             except Exception as ex:
                 error = str(ex)
             if tmp:

--- a/metaflow/plugins/datatools/s3/s3op.py
+++ b/metaflow/plugins/datatools/s3/s3op.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import errno
 import json
 import time
 import math
@@ -108,6 +109,7 @@ ERROR_VERIFY_FAILED = 9
 ERROR_LOCAL_FILE_NOT_FOUND = 10
 ERROR_INVALID_RANGE = 11
 ERROR_TRANSIENT = 12
+ERROR_OUT_OF_DISK_SPACE = 13
 
 
 def format_result_line(idx, prefix, url="", local=""):
@@ -276,6 +278,15 @@ def worker(result_file_name, queue, mode, s3config):
                             os.unlink(tmp.name)
                             err = convert_to_client_error(e)
                             handle_client_error(err, idx, result_file)
+                            continue
+                        except OSError as e:
+                            tmp.close()
+                            os.unlink(tmp.name)
+                            if e.errno == errno.ENOSPC:
+                                result_file.write("%d %d\n" % (idx, -ERROR_OUT_OF_DISK_SPACE))
+                            else:
+                                result_file.write("%d %d\n" % (idx, -ERROR_TRANSIENT))
+                            result_file.flush()
                             continue
                     except (SSLError, Exception) as e:
                         tmp.close()
@@ -643,6 +654,8 @@ def exit(exit_code, url):
         msg = "Local file not found: %s" % url
     elif exit_code == ERROR_TRANSIENT:
         msg = "Transient error for url: %s" % url
+    elif exit_code == ERROR_OUT_OF_DISK_SPACE:
+        msg = "Out of disk space when downloading URL: %s" % url
     else:
         msg = "Unknown error"
     print("s3op failed:\n%s" % msg, file=sys.stderr)
@@ -1173,6 +1186,8 @@ def get(
             )
             if verify:
                 verify_info.append((url, sz))
+        elif sz == -ERROR_OUT_OF_DISK_SPACE:
+            exit(ERROR_OUT_OF_DISK_SPACE, url)
         elif sz == -ERROR_URL_ACCESS_DENIED:
             denied_url = url
             break

--- a/metaflow/plugins/datatools/s3/s3op.py
+++ b/metaflow/plugins/datatools/s3/s3op.py
@@ -283,7 +283,9 @@ def worker(result_file_name, queue, mode, s3config):
                             tmp.close()
                             os.unlink(tmp.name)
                             if e.errno == errno.ENOSPC:
-                                result_file.write("%d %d\n" % (idx, -ERROR_OUT_OF_DISK_SPACE))
+                                result_file.write(
+                                    "%d %d\n" % (idx, -ERROR_OUT_OF_DISK_SPACE)
+                                )
                             else:
                                 result_file.write("%d %d\n" % (idx, -ERROR_TRANSIENT))
                             result_file.flush()


### PR DESCRIPTION
Running out of disk space should be treated as a fatal error. It is currently treated as a transient error, leading to retries which never succeed. The task eventually dies after all the retries are exhausted.

This change makes `ENOSPC` a fatal error and we exit immediately.