### PR TITLE
fix: bump GS datastore save_bytes timeout

### DIFF
--- a/metaflow/plugins/datastores/gs_storage.py
+++ b/metaflow/plugins/datastores/gs_storage.py
@@ -119,7 +119,9 @@ class _GSRootClient(object):
                 blob.metadata = {"metaflow-user-attributes": json.dumps(metadata)}
             from google.cloud.storage.retry import DEFAULT_RETRY
 
-            blob.upload_from_filename(tmpfile, retry=DEFAULT_RETRY)
+            blob.upload_from_filename(
+                tmpfile, retry=DEFAULT_RETRY, timeout=14400
+            )  # generous timeout for massive uploads
         except Exception as e:
             process_gs_exception(e)
 

--- a/metaflow/plugins/datastores/gs_storage.py
+++ b/metaflow/plugins/datastores/gs_storage.py
@@ -120,8 +120,8 @@ class _GSRootClient(object):
             from google.cloud.storage.retry import DEFAULT_RETRY
 
             blob.upload_from_filename(
-                tmpfile, retry=DEFAULT_RETRY, timeout=14400
-            )  # generous timeout for massive uploads
+                tmpfile, retry=DEFAULT_RETRY, timeout=(14400, 60)
+            )  # generous timeout for massive uploads. Use the same values as for Azure (connection_timeout, read_timeout)
         except Exception as e:
             process_gs_exception(e)
 

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -172,6 +172,7 @@ class CondaEnvironment(MetaflowEnvironment):
             storage.save_bytes(
                 list_of_path_and_filehandle,
                 len_hint=len(list_of_path_and_filehandle),
+                # overwrite=True
             )
             for id_, packages, _, platform in results:
                 if id_ in dirty:

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -172,7 +172,6 @@ class CondaEnvironment(MetaflowEnvironment):
             storage.save_bytes(
                 list_of_path_and_filehandle,
                 len_hint=len(list_of_path_and_filehandle),
-                # overwrite=True
             )
             for id_, packages, _, platform in results:
                 if id_ in dirty:


### PR DESCRIPTION
GS datastore uploads time out with large files due to default timeout being 60 seconds and not accounting for any activity in the connection. This PR bumps the timeout value to match that of the Azure storage implementation