### PR TITLE
feature: add debug logging to conda_environment, micromamba and pypi

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -452,7 +452,15 @@ ESCAPE_HATCH_WARNING = from_conf("ESCAPE_HATCH_WARNING", True)
 ###
 # Debug configuration
 ###
-DEBUG_OPTIONS = ["subcommand", "sidecar", "s3client", "tracing", "stubgen", "userconf"]
+DEBUG_OPTIONS = [
+    "subcommand",
+    "sidecar",
+    "s3client",
+    "tracing",
+    "stubgen",
+    "userconf",
+    "conda",
+]
 
 for typ in DEBUG_OPTIONS:
     vars()["DEBUG_%s" % typ.upper()] = from_conf("DEBUG_%s" % typ.upper(), False)

--- a/metaflow/plugins/pypi/micromamba.py
+++ b/metaflow/plugins/pypi/micromamba.py
@@ -6,6 +6,7 @@ import subprocess
 import tempfile
 import time
 
+from metaflow.debug import debug
 from metaflow.exception import MetaflowException
 from metaflow.util import which
 
@@ -71,6 +72,7 @@ class Micromamba(object):
 
             # Install Micromamba on the fly.
             # TODO: Make this optional at some point.
+            debug.conda_exec("No Micromamba binary found. Installing micromamba")
             _install_micromamba(self._path_to_hidden_micromamba)
             self._bin = which(
                 os.path.join(self._path_to_hidden_micromamba, "bin/micromamba")
@@ -98,6 +100,7 @@ class Micromamba(object):
         #    environment
         # 4. Multiple solves can progress at the same time while relying on the same
         #    index
+        debug.conda_exec("Solving packages for conda environment %s" % id_)
         with tempfile.TemporaryDirectory() as tmp_dir:
             env = {
                 "MAMBA_ADD_PIP_AS_PYTHON_DEPENDENCY": "true",
@@ -158,6 +161,7 @@ class Micromamba(object):
         if self.path_to_environment(id_, platform):
             return
 
+        debug.conda_exec("Downloading packages for conda environment %s" % id_)
         with tempfile.TemporaryDirectory() as tmp_dir:
             env = {
                 "CONDA_SUBDIR": platform,
@@ -190,6 +194,7 @@ class Micromamba(object):
         if platform != self.platform() or self.path_to_environment(id_, platform):
             return
 
+        debug.conda_exec("Creating local Conda environment %s" % id_)
         prefix = "{env_dirs}/{keyword}/{platform}/{id}".format(
             env_dirs=self.info()["envs_dirs"][0],
             platform=platform,

--- a/metaflow/plugins/pypi/pip.py
+++ b/metaflow/plugins/pypi/pip.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from itertools import chain, product
 from urllib.parse import unquote
 
+from metaflow.debug import debug
 from metaflow.exception import MetaflowException
 
 from .micromamba import Micromamba
@@ -66,6 +67,7 @@ class Pip(object):
             msg += "for id {id}".format(id=id_)
             raise PipException(msg)
 
+        debug.conda_exec("Solving packages for PyPI environment %s" % id_)
         with tempfile.TemporaryDirectory() as tmp_dir:
             report = "{tmp_dir}/report.json".format(tmp_dir=tmp_dir)
             implementations, platforms, abis = zip(
@@ -152,6 +154,7 @@ class Pip(object):
         custom_index_url, extra_index_urls = self.indices(prefix)
 
         # build wheels if needed
+        debug.conda_exec("Building wheels for PyPI environment %s if necessary" % id_)
         with ThreadPoolExecutor() as executor:
 
             def _build(key, package):
@@ -212,6 +215,7 @@ class Pip(object):
             ]
         )
 
+        debug.conda_exec("Downloading packages for PyPI environment %s" % id_)
         cmd = [
             "download",
             "--no-deps",
@@ -251,6 +255,7 @@ class Pip(object):
         # Pip can't install packages if the underlying virtual environment doesn't
         # share the same platform
         if self.micromamba.platform() == platform:
+            debug.conda_exec("Installing packages for local PyPI environment %s" % id_)
             cmd = [
                 "install",
                 "--no-compile",


### PR DESCRIPTION
enables debugging the Conda/PyPI environment processes with the `METAFLOW_DEBUG_CONDA=1` flag


stacked on top of #2399 for easier testing.