### PR TITLE
Handle class instances in stub generator

### DIFF
--- a/metaflow/cmd/develop/stub_generator.py
+++ b/metaflow/cmd/develop/stub_generator.py
@@ -1163,25 +1163,25 @@ class StubGenerator:
             if type(default_value).__module__ == "builtins":
                 if isinstance(default_value, list):
                     elements = [exploit_default(v) for v in default_value]
-                    if any(e == '...' for e in elements):
-                        return '...'
+                    if any(e == "..." for e in elements):
+                        return "..."
                     else:
-                        return '[' + ', '.join(elements) + ']'
+                        return "[" + ", ".join(elements) + "]"
                 elif isinstance(default_value, tuple):
                     elements = [exploit_default(v) for v in default_value]
-                    if any(e == '...' for e in elements):
-                        return '...'
+                    if any(e == "..." for e in elements):
+                        return "..."
                     else:
-                        return '(' + ', '.join(elements) + ')'
+                        return "(" + ", ".join(elements) + ")"
                 elif isinstance(default_value, dict):
                     items = [
-                        exploit_default(k) + ': ' + exploit_default(v)
+                        exploit_default(k) + ": " + exploit_default(v)
                         for k, v in default_value.items()
                     ]
-                    if any('...' in item for item in items):
-                        return '...'
+                    if any("..." in item for item in items):
+                        return "..."
                     else:
-                        return '{' + ', '.join(items) + '}'
+                        return "{" + ", ".join(items) + "}"
                 elif isinstance(default_value, str):
                     return repr(default_value)  # Use repr() for proper escaping
                 elif isinstance(default_value, (int, float, bool)):
@@ -1189,7 +1189,7 @@ class StubGenerator:
                 elif default_value is None:
                     return "None"
                 else:
-                    return '...'  # For other built-in types not explicitly handled
+                    return "..."  # For other built-in types not explicitly handled
             elif inspect.isclass(default_value) or inspect.isfunction(default_value):
                 if default_value.__module__ == "builtins":
                     return default_value.__name__
@@ -1197,7 +1197,7 @@ class StubGenerator:
                     self._typing_imports.add(default_value.__module__)
                     return ".".join([default_value.__module__, default_value.__name__])
             else:
-                return '...'  # For complex objects like class instances
+                return "..."  # For complex objects like class instances
 
         buff = StringIO()
         if sign is None and func is None:

--- a/metaflow/cmd/develop/stub_generator.py
+++ b/metaflow/cmd/develop/stub_generator.py
@@ -1192,10 +1192,13 @@ class StubGenerator:
                     )
                 elif isinstance(default_value, str):
                     return "'" + default_value + "'"
+                elif isinstance(default_value, (int, float, bool)):
+                    return str(default_value)
+                elif default_value is None:
+                    return "None"
                 else:
                     return self._get_element_name_with_module(default_value)
-
-            elif str(default_value).startswith("<"):
+            elif inspect.isclass(default_value) or inspect.isfunction(default_value):
                 if default_value.__module__ == "builtins":
                     return default_value.__name__
                 else:

--- a/metaflow/cmd/develop/stub_generator.py
+++ b/metaflow/cmd/develop/stub_generator.py
@@ -92,7 +92,9 @@ def type_var_to_str(t: TypeVar) -> str:
 
 
 def new_type_to_str(t: typing.NewType) -> str:
-    return 'typing.NewType("%s", %s)' % (t.__name__, t.__supertype__.__name__)
+    name = typing.cast(str, t.__name__)
+    supertype = typing.cast(type, t.__supertype__)
+    return 'typing.NewType("%s", %s)' % (name, supertype)
 
 
 def descend_object(object: str, options: Iterable[str]):
@@ -178,7 +180,7 @@ def parse_add_to_docs(
     prop = None
     return_type = None
     property_indent = None
-    doc = []
+    doc: List[str] = []
     add_to_docs = dict()  # type: Dict[str, Union[str, Tuple[inspect.Signature, str]]]
 
     def _add():
@@ -329,7 +331,7 @@ class StubGenerator:
 
         self._reset()
 
-    def _reset(self):
+    def _reset(self) -> None:
         # "Globals" that are used throughout processing. This is not the cleanest
         # but simplifies code quite a bit.
 
@@ -350,7 +352,7 @@ class StubGenerator:
         # the "globals()"
         self._current_parent_module = None  # type: Optional[ModuleType]
 
-    def _get_module_name_alias(self, module_name):
+    def _get_module_name_alias(self, module_name: str) -> str:
         if any(
             module_name.startswith(x) for x in self._safe_modules
         ) and not module_name.startswith(self._root_module):
@@ -894,7 +896,7 @@ class StubGenerator:
             # as examples so we sort it out.
             resulting_dict = (
                 dict()
-            )  # type Dict[str, List[inspect.Signature, str, List[str]]]
+            )  # type: Dict[str, Tuple[inspect.Signature, str, List[str]]]
             for deco_name, addl_current in self._addl_current.items():
                 for name, (sign, doc) in addl_current.items():
                     r = resulting_dict.setdefault(name, [sign, doc, []])
@@ -1157,9 +1159,9 @@ class StubGenerator:
     ) -> str:
         debug.stubgen_exec("Generating function stub for %s" % name)
 
-        def exploit_default(default_value: Any) -> Optional[str]:
+        def exploit_default(default_value: Any) -> str:
             if default_value == inspect.Parameter.empty:
-                return None
+                return ""
             if type(default_value).__module__ == "builtins":
                 if isinstance(default_value, list):
                     elements = [exploit_default(v) for v in default_value]


### PR DESCRIPTION
Stub generator fails to handle something like the following where there's a class instance as a default argument: 

```
def identity(data: MDF, parameters: FunctionParameters = FunctionParameters()) -> MDF:
    return data
```

Traceback:
```
STDERR:
Traceback (most recent call last):
File "/root/metaflow/metaflow_extensions/nflx/plugins/functions/function_parameters.py", line 65, in getattr
return self[name]
File "/root/metaflow/metaflow_extensions/nflx/plugins/functions/function_parameters.py", line 61, in getitem
return self._data[name]
File "/root/metaflow/metaflow_extensions/nflx/plugins/functions/function_parameters.py", line 24, in getitem
raise KeyError(f"Artifact '{key}' not found in FunctionParameters.")
KeyError: "Artifact 'name' not found in FunctionParameters."
```