### PR TITLE
feature: Support paginated metadata service

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -350,9 +350,10 @@ class MetaflowObject(object):
             raise MetaflowNamespaceMismatch(self._current_namespace)
 
     def _get_object(self, *path_components):
-        result = self._metaflow.metadata.get_object(
+        result_iter = self._metaflow.metadata.get_object(
             self._NAME, "self", None, self._attempt, *path_components
         )
+        result = next(result_iter, None)
         if not result:
             raise MetaflowNotFound("%s does not exist" % self)
         return result

--- a/metaflow/metadata_provider/metadata.py
+++ b/metaflow/metadata_provider/metadata.py
@@ -394,7 +394,7 @@ class MetadataProvider(object):
 
         Return
         ------
-            object or list :
+            object or iterator :
                 Depending on the call, the type of object return varies
         """
         type_order = ObjectOrder.type_to_order(obj_type)


### PR DESCRIPTION
better handling for long-running Metadata services that have accumulated a significant amount of data

depends on https://github.com/Netflix/metaflow-service/pull/457

TODO:

- [ ] feature gate to release version of Metadata service that supports pagination
- [ ] add filter support to api requests as well?