### PR TITLE
fix: boto3 client configuration handling in client_params

### DIFF
--- a/metaflow/plugins/aws/aws_client.py
+++ b/metaflow/plugins/aws/aws_client.py
@@ -35,6 +35,12 @@ class Boto3ClientProvider(object):
                 "Could not import module 'boto3'. Install boto3 first."
             )
 
+        # Convert dictionary config to Config object if needed
+        if "config" in client_params and not isinstance(
+            client_params["config"], Config
+        ):
+            client_params["config"] = Config(**client_params["config"])
+
         if module == "s3" and (
             "config" not in client_params or client_params["config"].retries is None
         ):


### PR DESCRIPTION
When users set boto3 configuration options in `.metaflow/config.json` using the `DATATOOLS_CLIENT_PARAMS` key with a dictionary value like:
```
  {
    "DATATOOLS_CLIENT_PARAMS": {
      "config": {
        "retries": {
          "max_attempts": 20,
          "mode": "adaptive"
        }
      }
    }
  }
```
The code would attempt to access `.retries` on the dictionary directly, causing an `AttributeError`

Solution: Added code to convert dictionary config to proper `botocore.config.Config` objects. This ensures configurations set through metaflow configs or environment variables are properly handled.