### PR TITLE
fix: skip metaflow dependencies in uv-environment

### DIFF
--- a/metaflow/plugins/uv/uv_environment.py
+++ b/metaflow/plugins/uv/uv_environment.py
@@ -22,7 +22,7 @@ class UVEnvironment(MetaflowEnvironment):
         self.logger("Bootstrapping uv...")
 
     def executable(self, step_name, default=None):
-        return "uv run python"
+        return "uv run --no-sync python"
 
     def add_to_package(self):
         # NOTE: We treat uv.lock and pyproject.toml as regular project assets and ship these along user code as part of the code package


### PR DESCRIPTION
`uv run python` does syncing to the environment unless specifically instructed not to. this can lead to unnecessarily downloading/installing dependencies that were skipped during bootstrapping