### PR TITLE
feature: alternate approach to environment force-rebuild

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import os
 import sys
 import traceback
 from datetime import datetime
@@ -242,6 +243,14 @@ def version(obj):
     type=click.Choice(["local"] + [m.TYPE for m in ENVIRONMENTS]),
     help="Execution environment type",
 )
+@click.option(
+    "--force-rebuild-environment/--no-force-rebuild-environment",
+    is_flag=True,
+    default=False,
+    hidden=True,
+    type=bool,
+    help="Force rebuild the environment",
+)
 # See comment for --quiet
 @click.option(
     "--datastore",
@@ -300,6 +309,7 @@ def start(
     quiet=False,
     metadata=None,
     environment=None,
+    force_rebuild_environment=False,
     datastore=None,
     datastore_root=None,
     decospecs=None,
@@ -432,6 +442,9 @@ def start(
 
     ctx.obj.graph = ctx.obj.flow._graph
 
+    # carry the force rebuild as an internal env var for generic environments to use
+    if force_rebuild_environment:
+        os.environ["_MFENV_FORCE_REBUILD"] = "1"
     ctx.obj.environment = [
         e for e in ENVIRONMENTS + [MetaflowEnvironment] if e.TYPE == environment
     ][0](ctx.obj.flow)

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -244,12 +244,12 @@ def version(obj):
     help="Execution environment type",
 )
 @click.option(
-    "--force-rebuild-environment/--no-force-rebuild-environment",
+    "--force-rebuild-environments/--no-force-rebuild-environments",
     is_flag=True,
     default=False,
     hidden=True,
     type=bool,
-    help="Force rebuild the environment",
+    help="Explicitly rebuild the execution environments",
 )
 # See comment for --quiet
 @click.option(
@@ -309,7 +309,7 @@ def start(
     quiet=False,
     metadata=None,
     environment=None,
-    force_rebuild_environment=False,
+    force_rebuild_environments=False,
     datastore=None,
     datastore_root=None,
     decospecs=None,
@@ -443,8 +443,8 @@ def start(
     ctx.obj.graph = ctx.obj.flow._graph
 
     # carry the force rebuild as an internal env var for generic environments to use
-    if force_rebuild_environment:
-        os.environ["_MFENV_FORCE_REBUILD"] = "1"
+    if force_rebuild_environments:
+        os.environ["_METAFLOW_ENVIRONMENT_FORCE_REBUILD"] = "1"
     ctx.obj.environment = [
         e for e in ENVIRONMENTS + [MetaflowEnvironment] if e.TYPE == environment
     ][0](ctx.obj.flow)

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -445,7 +445,7 @@ def start(
     ctx.obj.environment = [
         e for e in ENVIRONMENTS + [MetaflowEnvironment] if e.TYPE == environment
     ][0](ctx.obj.flow)
-    # set force rebuild flag for environment
+    # set force rebuild flag for environments that support it.
     ctx.obj.environment._force_rebuild = force_rebuild_environments
     ctx.obj.environment.validate_environment(ctx.obj.logger, datastore)
 

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -442,12 +442,11 @@ def start(
 
     ctx.obj.graph = ctx.obj.flow._graph
 
-    # carry the force rebuild as an internal env var for generic environments to use
-    if force_rebuild_environments:
-        os.environ["_METAFLOW_ENVIRONMENT_FORCE_REBUILD"] = "1"
     ctx.obj.environment = [
         e for e in ENVIRONMENTS + [MetaflowEnvironment] if e.TYPE == environment
     ][0](ctx.obj.flow)
+    # set force rebuild flag for environment
+    ctx.obj.environment._force_rebuild = force_rebuild_environments
     ctx.obj.environment.validate_environment(ctx.obj.logger, datastore)
 
     ctx.obj.event_logger = LOGGING_SIDECARS[event_logger](

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -36,7 +36,9 @@ class CondaEnvironment(MetaflowEnvironment):
 
     def __init__(self, flow):
         self.flow = flow
-        self._force_rebuild = os.environ.get("_MFENV_FORCE_REBUILD", False)
+        self._force_rebuild = os.environ.get(
+            "_METAFLOW_ENVIRONMENT_FORCE_REBUILD", False
+        )
 
     def set_local_root(self, local_root):
         # TODO: Make life simple by passing echo to the constructor and getting rid of

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -33,12 +33,10 @@ class CondaEnvironmentException(MetaflowException):
 class CondaEnvironment(MetaflowEnvironment):
     TYPE = "conda"
     _filecache = None
+    _force_rebuild = False
 
     def __init__(self, flow):
         self.flow = flow
-        self._force_rebuild = os.environ.get(
-            "_METAFLOW_ENVIRONMENT_FORCE_REBUILD", False
-        )
 
     def set_local_root(self, local_root):
         # TODO: Make life simple by passing echo to the constructor and getting rid of


### PR DESCRIPTION
adds a top-level option to toggle force-rebuilding the environment

```
python HelloConda.py --environment conda --force-rebuild-environment run
```

the introduction of the new option is not mandatory. we could simply proceed with an internal envvar to enable the functionality for now. 