### PR TITLE
Two fixes: runner/deployer with configs and None config

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -496,7 +496,7 @@ def start(
         ctx.obj.echo,
         ctx.obj.flow_datastore,
         {
-            k: ConfigValue(v)
+            k: ConfigValue(v) if v is not None else None
             for k, v in ctx.obj.flow.__class__._flow_state.get(
                 _FlowState.CONFIGS, {}
             ).items()
@@ -524,7 +524,7 @@ def start(
             decorators._attach_decorators(ctx.obj.flow, all_decospecs)
             decorators._init(ctx.obj.flow)
             # Regenerate graph if we attached more decorators
-            ctx.obj.flow.__class__._init_attrs()
+            ctx.obj.flow.__class__._init_graph()
             ctx.obj.graph = ctx.obj.flow._graph
 
         decorators._init_step_decorators(

--- a/metaflow/cli_components/run_cmds.py
+++ b/metaflow/cli_components/run_cmds.py
@@ -45,7 +45,7 @@ def before_run(obj, tags, decospecs):
         decorators._attach_decorators(obj.flow, all_decospecs)
         decorators._init(obj.flow)
         # Regenerate graph if we attached more decorators
-        obj.flow.__class__._init_attrs()
+        obj.flow.__class__._init_graph()
         obj.graph = obj.flow._graph
 
     obj.check(obj.graph, obj.flow, obj.environment, pylint=obj.pylint)

--- a/metaflow/user_configs/config_decorators.py
+++ b/metaflow/user_configs/config_decorators.py
@@ -200,7 +200,7 @@ class MutableFlow:
         for name, value in self._flow_cls._flow_state.get(
             _FlowState.CONFIGS, {}
         ).items():
-            yield name, ConfigValue(value)
+            yield name, ConfigValue(value) if value is not None else None
 
     @property
     def parameters(self) -> Generator[Tuple[str, Any], None, None]:

--- a/metaflow/user_configs/config_options.py
+++ b/metaflow/user_configs/config_options.py
@@ -352,7 +352,9 @@ class ConfigInput:
                         return None
                     raise exc from e
                 flow_cls._flow_state[_FlowState.CONFIGS][name] = read_value
-                to_return[name] = ConfigValue(read_value)
+                to_return[name] = (
+                    ConfigValue(read_value) if read_value is not None else None
+                )
             else:
                 if self._parsers[name]:
                     read_value = self._call_parser(self._parsers[name], val)
@@ -367,7 +369,9 @@ class ConfigInput:
                         continue
                     # TODO: Support YAML
                 flow_cls._flow_state[_FlowState.CONFIGS][name] = read_value
-                to_return[name] = ConfigValue(read_value)
+                to_return[name] = (
+                    ConfigValue(read_value) if read_value is not None else None
+                )
 
         reqs = missing_configs.intersection(self._req_configs)
         for missing in reqs:


### PR DESCRIPTION
  - in some cases (if you called TWO commands like create and trigger) with a Runner/Deployer on the same flow, the flow/step mutators would be applied *twice* which could lead to weird errors (duplicate decorators)
  - using a None default for configs failed (#2449)