### PR TITLE
Fix IMDSv2 Error

### DIFF
--- a/metaflow/plugins/aws/aws_utils.py
+++ b/metaflow/plugins/aws/aws_utils.py
@@ -48,7 +48,7 @@ def get_ec2_instance_metadata():
         # Try to get an IMDSv2 token.
         token = requests.put(
             url="http://169.254.169.254/latest/api/token",
-            headers={"X-aws-ec2-metadata-token-ttl-seconds": 100},
+            headers={"X-aws-ec2-metadata-token-ttl-seconds": "100"},
             timeout=timeout,
         ).text
     except:


### PR DESCRIPTION
There is an error when trying to retrieve the IMDSv2 token because the header value is `int`. This causes all the requests to fall back to IMDSv1.