### PR TITLE
feat: Add HashiCorp Nomad plugin for Metaflow

### DIFF
--- a/docs/nomad.md
+++ b/docs/nomad.md
@@ -1,0 +1,157 @@
+# Using Metaflow with HashiCorp Nomad
+
+Metaflow allows yous to execute your workflow steps as jobs on a HashiCorp Nomad cluster. This enables scaling out your computations and managing them using Nomad's orchestration capabilities.
+
+## Prerequisites
+
+Before using the `@nomad` decorator, ensure that:
+1.  You have a running Nomad cluster accessible from where you are launching your Metaflow flows.
+2.  The `python-nomad` library is installed in your Metaflow execution environment (`pip install python-nomad`).
+3.  Your Metaflow deployment is configured with the necessary Nomad parameters (e.g., `METAFLOW_NOMAD_ADDRESS`). See [Metaflow Configuration](https://docs.metaflow.org/metaflow-on-aws/metaflow-configuration) for details on how to set these.
+
+## The `@nomad` Decorator
+
+To execute a step on Nomad, apply the `@nomad` decorator to it:
+
+```python
+from metaflow import FlowSpec, step, nomad, resources
+
+class NomadFlow(FlowSpec):
+
+    @step
+    def start(self):
+        print("Starting the flow.")
+        self.next(self.compute_on_nomad)
+
+    @nomad(cpu=2, memory=1000, disk=500) # Request 2000 MHz CPU, 1000MB RAM, 500MB Disk
+    @resources(cpu=1, memory=500) # General resource request
+    @step
+    def compute_on_nomad(self):
+        print("This step is running on Nomad!")
+        # Perform your computation here
+        self.result = sum(i*i for i in range(1000))
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print(f"Computation result: {self.result}")
+        print("Flow finished.")
+
+if __name__ == "__main__":
+    NomadFlow()
+```
+
+When both `@nomad` and `@resources` are present, the resource values specified in `@nomad` will take precedence for that specific step if they are provided. Otherwise, it falls back to `@resources`, and then to Metaflow defaults for Nomad.
+
+### Decorator Arguments
+
+The `@nomad` decorator accepts the following arguments:
+
+*   `image` (str, optional): The Docker image to use for the Nomad job. If not specified, it defaults to `METAFLOW_NOMAD_DEFAULT_IMAGE` from your Metaflow configuration, or a Python version-based image.
+*   `region` (str, optional): The Nomad region where the job should be submitted. Defaults to `METAFLOW_NOMAD_REGION`.
+*   `datacenters` (list[str], optional): A list of datacenters within the region where the job can run. Defaults to `METAFLOW_NOMAD_DEFAULT_DATACENTERS`. Example: `['dc1', 'east-2a']`.
+*   `constraints` (list[dict], optional): A list of Nomad [constraints](https://developer.hashicorp.com/nomad/docs/job-specification/constraint) to apply to the job. This allows fine-grained control over where your tasks are placed. Example: `[{"attribute": "${attr.kernel.name}", "operator": "=", "value": "linux"}]`.
+*   `cpu` (int, optional): CPU resources to request for the job, in MHz (e.g., `1000` for 1 vCPU). Overrides `@resources.cpu`.
+*   `memory` (int, optional): Memory resources to request for the job, in MB (e.g., `4096` for 4GB). Overrides `@resources.memory`.
+*   `disk` (int, optional): Disk resources to request for the job's ephemeral disk, in MB (e.g., `10240` for 10GB). Overrides `@resources.disk`.
+
+You can also specify these options on the command line for a run:
+```bash
+python your_flow.py run --with nomad:image=your/custom-image,cpu=4000
+```
+
+## Resource Management
+
+Metaflow translates the `cpu`, `memory`, and `disk` parameters into Nomad job resource stanzas.
+*   `cpu`: Maps to `Resources.CPU` in the Nomad task (MHz).
+*   `memory`: Maps to `Resources.MemoryMB` in the Nomad task (MB).
+*   `disk`: Maps to `TaskGroup.EphemeralDisk.SizeMB` in the Nomad job (MB). Ensure your Nomad client nodes are configured to allow ephemeral disk usage for tasks.
+
+If a step does not have `@nomad` specific resource values, it will use values from an `@resources` decorator if present, or fallback to defaults defined by `METAFLOW_NOMAD_CPU`, `METAFLOW_NOMAD_MEMORY`, and `METAFLOW_NOMAD_DISK` in your Metaflow configuration.
+
+## GPU Support
+
+To use GPUs with your Nomad tasks:
+1.  Ensure your Nomad cluster has nodes with GPUs and the necessary drivers installed.
+2.  Configure Nomad client nodes to advertise GPU resources. See Nomad's documentation on [Device Plugin](https://developer.hashicorp.com/nomad/docs/drivers/docker#device-plugin) for Docker tasks.
+3.  Use the `constraints` argument in the `@nomad` decorator to target GPU-enabled nodes. For example, if your GPU nodes have a specific attribute or class:
+    ```python
+    @nomad(constraints=[{"attribute": "${attr.driver.nvidia.compute.capability}", "operator": ">=", "value": "6.0"}])
+    ```
+    Or, if you are using device plugins that expose resources like `nvidia/gpu`:
+    ```python
+    # This requires changes in how Nomad plugin generates jobspec to include device requests.
+    # For now, use constraints to target nodes with GPUs.
+    # A future update might allow specifying GPU count directly if python-nomad and jobspec allow easy mapping.
+    ```
+   You might also need to ensure your Docker `image` includes the necessary CUDA libraries.
+
+## Accessing Logs
+
+Metaflow automatically captures `stdout` and `stderr` from your Nomad tasks and stores them in your configured datastore (e.g., S3). You can access these logs using the standard Metaflow `logs` command:
+```bash
+python your_flow.py logs your_run_id/step_name
+```
+For live or raw logs directly from Nomad (useful for debugging the Nomad task itself), you would typically use the Nomad CLI:
+```bash
+nomad alloc logs <allocation_id> <task_name>
+```
+The Metaflow `nomad step` execution will also attempt to print the raw stdout/stderr from the Nomad task upon completion or failure for immediate feedback.
+
+## Managing Nomad Jobs
+
+Metaflow provides CLI commands to interact with jobs launched by the `@nomad` plugin.
+
+### Listing Active Jobs
+
+To list active Nomad jobs associated with your flows:
+```bash
+python your_flow.py nomad list --help
+```
+Options:
+*   `--my-runs`: List all my unfinished tasks (based on local username).
+*   `--user TEXT`: List unfinished tasks for a specific user.
+*   `--run-id TEXT`: List unfinished tasks for a specific Metaflow run ID.
+*   `--prefix TEXT`: Filter jobs by a Nomad job name prefix.
+
+Example:
+```bash
+python your_flow.py nomad list --run-id 1678886400123456
+```
+
+### Terminating Jobs
+
+To terminate (deregister) running Nomad jobs:
+```bash
+python your_flow.py nomad kill --help
+```
+Options:
+*   `--job-id TEXT`: Specific Nomad job ID(s) to terminate. Can be used multiple times.
+*   `--my-runs`: Kill all my unfinished tasks.
+*   `--user TEXT`: Terminate unfinished tasks for the given user.
+*   `--run-id TEXT`: Terminate unfinished tasks for a specific Metaflow run ID.
+*   `--prefix TEXT`: Terminate jobs matching a Nomad job name prefix.
+*   `--purge`: Purge the job from Nomad after stopping (GCs it immediately).
+
+Example:
+```bash
+python your_flow.py nomad kill --job-id my-flow-1678886400123456-stepname-taskid-abcdef
+```
+
+## Troubleshooting
+
+*   **Job stuck in PENDING:**
+    *   Check if the requested resources (`cpu`, `memory`, `disk`) are available in your Nomad cluster.
+    *   Verify that `datacenters` and `region` specified match your Nomad setup.
+    *   Inspect `constraints` to ensure they are not preventing placement.
+    *   Use `nomad job status <job_id>` and `nomad alloc status <alloc_id>` for details.
+*   **Task Fails Immediately:**
+    *   Check the Docker `image` can be pulled by Nomad clients.
+    *   Ensure the command and arguments are correctly formed. Raw logs from `nomad alloc logs` can be helpful.
+    *   Verify that the Metaflow package (code) can be downloaded from `code_package_url` by the Nomad client node.
+*   **Authentication/Authorization Issues:**
+    *   Ensure `METAFLOW_NOMAD_ADDRESS` is correct.
+    *   If using ACLs, make sure `METAFLOW_NOMAD_TOKEN` is set and has the necessary permissions.
+    *   For mTLS, verify `METAFLOW_NOMAD_CLIENT_CERT`, `METAFLOW_NOMAD_CLIENT_KEY`, and `METAFLOW_NOMAD_CACERT` paths and contents.
+
+For further assistance, consult the Nomad documentation or reach out on the [Metaflow Slack channel](http://slack.outerbounds.co/).

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -395,6 +395,37 @@ ARGO_WORKFLOWS_ENV_VARS_TO_SKIP = from_conf("ARGO_WORKFLOWS_ENV_VARS_TO_SKIP", "
 KUBERNETES_JOBSET_GROUP = from_conf("KUBERNETES_JOBSET_GROUP", "jobset.x-k8s.io")
 KUBERNETES_JOBSET_VERSION = from_conf("KUBERNETES_JOBSET_VERSION", "v1alpha2")
 
+###
+# Nomad Configuration
+###
+# Address of the Nomad server
+NOMAD_ADDRESS = from_conf("NOMAD_ADDRESS")
+# Default Nomad region to use for jobs
+NOMAD_REGION = from_conf("NOMAD_REGION", "global")
+# Default Nomad namespace to use for jobs
+NOMAD_NAMESPACE = from_conf("NOMAD_NAMESPACE", "default")
+# Nomad ACL token for authentication
+NOMAD_TOKEN = from_conf("NOMAD_TOKEN")
+# Path to client TLS certificate for mTLS with Nomad
+NOMAD_CLIENT_CERT = from_conf("NOMAD_CLIENT_CERT")
+# Path to client TLS key for mTLS with Nomad
+NOMAD_CLIENT_KEY = from_conf("NOMAD_CLIENT_KEY")
+# Path to CA certificate for verifying Nomad server's TLS certificate
+NOMAD_CACERT = from_conf("NOMAD_CACERT")
+# Whether to verify Nomad server's TLS certificate (True/False/path_to_ca_bundle)
+NOMAD_VERIFY_TLS = from_conf("NOMAD_VERIFY_TLS", True)
+# Default Docker image for Nomad tasks if not specified in decorator
+NOMAD_DEFAULT_IMAGE = from_conf("NOMAD_DEFAULT_IMAGE", DEFAULT_CONTAINER_IMAGE)
+# Default datacenters for Nomad jobs (comma-separated string e.g., "dc1,dc2")
+NOMAD_DEFAULT_DATACENTERS = from_conf("NOMAD_DEFAULT_DATACENTERS", "dc1")
+# Default CPU request for Nomad tasks in MHz
+METAFLOW_NOMAD_CPU = from_conf("METAFLOW_NOMAD_CPU", "1000")
+# Default memory request for Nomad tasks in MB
+METAFLOW_NOMAD_MEMORY = from_conf("METAFLOW_NOMAD_MEMORY", "4096")
+# Default disk request for Nomad tasks in MB
+METAFLOW_NOMAD_DISK = from_conf("METAFLOW_NOMAD_DISK", "10240")
+
+
 ##
 # Argo Events Configuration
 ##

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -18,6 +18,7 @@ CLIS_DESC = [
     ("tag", ".tag_cli.cli"),
     ("spot-metadata", ".kubernetes.spot_metadata_cli.cli"),
     ("logs", ".logs_cli.cli"),
+    ("nomad", ".nomad.nomad_cli.cli"),
 ]
 
 # Add additional commands to the runner here
@@ -55,6 +56,7 @@ STEP_DECORATORS_DESC = [
     ("airflow_internal", ".airflow.airflow_decorator.AirflowInternalDecorator"),
     ("pypi", ".pypi.pypi_decorator.PyPIStepDecorator"),
     ("conda", ".pypi.conda_decorator.CondaStepDecorator"),
+    ("nomad", ".nomad.nomad_decorator.NomadDecorator"),
 ]
 
 # Add new flow decorators here

--- a/metaflow/plugins/nomad/__init__.py
+++ b/metaflow/plugins/nomad/__init__.py
@@ -1,0 +1,14 @@
+# This file registers the Nomad plugin with Metaflow.
+# It will be populated with the necessary imports and PLUGIN_DECORATORS, FLOW_DECORATORS, COMMANDS etc. later.
+
+PLUGINS = []
+FLOW_DECORATORS = []
+STEP_DECORATORS = []
+ENVIRONMENTS = []
+METADATA_PROVIDERS = []
+SIDECARS = {}
+LOGGING_SIDECARS = {}
+MONITOR_SIDECARS = {}
+COMMANDS = []
+
+# TODO: Populate the above lists with the Nomad plugin components.

--- a/metaflow/plugins/nomad/nomad.py
+++ b/metaflow/plugins/nomad/nomad.py
@@ -1,0 +1,718 @@
+import json
+import os
+import time
+import uuid
+
+try:
+    import nomad
+except ImportError:
+    # This is to allow metaflow to parse the decorator an CLI even if nomad is not installed.
+    # The actual client calls will fail later if nomad is not installed.
+    pass
+
+from metaflow.metaflow_config import (
+    NOMAD_ADDRESS,        # e.g., "http://localhost:4646"
+    NOMAD_REGION,         # Default Nomad region
+    NOMAD_NAMESPACE,      # Default Nomad namespace
+    NOMAD_TOKEN,          # Nomad ACL token, if any
+    NOMAD_CLIENT_CERT,    # Path to client cert
+    NOMAD_CLIENT_KEY,     # Path to client key
+    NOMAD_CACERT,         # Path to CA cert for verifying server cert
+    NOMAD_VERIFY_TLS,     # Whether to verify TLS (True/False)
+    SERVICE_INTERNAL_URL, # For metadata service
+    SERVICE_HEADERS,      # For metadata service
+    DATASTORE_SYSROOT_S3,
+    DATASTORE_SYSROOT_AZURE,
+    DATASTORE_SYSROOT_GS,
+    DEFAULT_METADATA,
+    DEFAULT_DATASTORE,
+    METAFLOW_DEFAULT_SECRETS_BACKEND_TYPE,
+    METAFLOW_CARD_S3ROOT, # Assuming cards could be supported
+    # TODO: Add any other necessary configurations from metaflow_config
+)
+from metaflow.plugins.nomad.nomad_decorator import NomadException # Re-using the exception
+from metaflow.mflog import bash_capture_logs, export_mflog_env_vars, BASH_SAVE_LOGS
+
+
+# Directory for logs within the Nomad allocation's task directory
+LOGS_DIR = "mflogs" # Changed from $PWD/.logs to avoid issues with current PWD in container
+STDOUT_FILE = "mflog_stdout"
+STDERR_FILE = "mflog_stderr"
+STDOUT_PATH = os.path.join(LOGS_DIR, STDOUT_FILE)
+STDERR_PATH = os.path.join(LOGS_DIR, STDERR_FILE)
+
+
+class NomadClient(object):
+    def __init__(
+        self,
+        nomad_address=None,
+        region=None,
+        namespace=None,
+        token=None,
+        client_cert=None,
+        client_key=None,
+        cacert=None,
+        verify_tls=None,
+        timeout=5,
+    ):
+        self.nomad_address = nomad_address or NOMAD_ADDRESS
+        self.region = region or NOMAD_REGION
+        self.namespace = namespace or NOMAD_NAMESPACE
+        self.token = token or NOMAD_TOKEN
+        self.client_cert = client_cert or NOMAD_CLIENT_CERT
+        self.client_key = client_key or NOMAD_CLIENT_KEY
+        self.cacert = cacert or NOMAD_CACERT
+        self.verify_tls = verify_tls if verify_tls is not None else NOMAD_VERIFY_TLS
+        self.timeout = timeout
+
+        if not self.nomad_address:
+            raise NomadException("Nomad address not specified. Set METAFLOW_NOMAD_ADDRESS or provide via API.")
+
+        secure = self.nomad_address.startswith("https")
+
+        cert_arg = None
+        if self.client_cert and self.client_key:
+            cert_arg = (self.client_cert, self.client_key)
+        elif self.client_cert:
+            cert_arg = self.client_cert
+
+        try:
+            self.client = nomad.Nomad(
+                host=self.nomad_address.replace("http://", "").replace("https://", ""),
+                port=4646, # Default, will be parsed from address if specified
+                secure=secure,
+                region=self.region,
+                namespace=self.namespace,
+                token=self.token,
+                timeout=self.timeout,
+                verify=self.cacert if self.cacert else self.verify_tls, # if cacert is given, requests uses it for verify
+                cert=cert_arg,
+            )
+        except NameError:
+            raise NomadException("python-nomad library is not installed. Please install it with: pip install python-nomad")
+        except Exception as e:
+            raise NomadException(f"Failed to initialize Nomad client: {e}")
+
+    def _generate_job_spec(
+        self,
+        job_name, # Typically flow_name-run_id-step_name-task_id
+        task_name, # Typically metaflow-step_name-task
+        image,
+        command_executable, # python, or from environment
+        command_args, # list of arguments for the command
+        cpu,
+        memory,
+        disk,
+        datacenters,
+        region,
+        nomad_namespace, # This is the job's namespace, distinct from client's default
+        constraints=None,
+        env_vars=None,
+        code_package_url=None,
+        # TODO: Add parameters for secrets, ports, etc.
+    ):
+        job_id = f"mf-{job_name}-{uuid.uuid4().hex[:6]}" # Ensure some uniqueness
+
+        task_resources = {
+            "CPU": int(cpu), # MHz
+            "MemoryMB": int(memory), # MB
+        }
+        if disk:
+             task_resources["DiskMB"] = int(disk) # Requires preemption_config in Nomad and host volumes
+
+        task_group = {
+            "Name": f"tg-{task_name}",
+            "Count": 1,
+            "Tasks": [{
+                "Name": task_name,
+                "Driver": "docker",
+                "Config": {
+                    "image": image,
+                    "command": command_executable,
+                    "args": command_args,
+                    # "ports": ["db"], # Example if we need port mapping
+                },
+                "Env": env_vars or {},
+                "Resources": task_resources,
+                "LogConfig": { # Basic log rotation
+                    "MaxFiles": 3,
+                    "MaxFileSizeMB": 10,
+                },
+                # "Services": [{...}] # If we need service discovery
+            }],
+            "EphemeralDisk": { # Request disk for the task group
+                "SizeMB": int(disk) if disk else 1024, # Default to 1GB if not specified
+                "Migrate": False, # Don't migrate ephemeral disk data on updates
+            },
+            # "RestartPolicy": {...} # Could configure restarts
+        }
+
+        if code_package_url:
+            task_group["Tasks"][0]["Artifacts"] = [{
+                "GetterSource": code_package_url,
+                # Download to a directory named after the task_name within the ALLOC dir
+                # The command will need to know to look for 'package.tgz' here
+                "RelativeDest": f"local/{task_name}/",
+            }]
+            # The entrypoint script will need to extract this.
+            # Example: command_args might start with a script that does:
+            # cd local/task_name && tar xzf package.tgz && cd ../.. && python original_command ...
+
+        nomad_job_spec = {
+            "Job": {
+                "ID": job_id,
+                "Name": job_name,
+                "Type": "batch", # Metaflow tasks are typically batch jobs
+                "Datacenters": datacenters,
+                "Region": region or self.region, # Job region can override client default
+                "Namespace": nomad_namespace or self.namespace, # Job namespace can override
+                "TaskGroups": [task_group],
+                # "Meta": {"metaflow_run_id": run_id, ...} # For tagging/metadata
+            }
+        }
+
+        if constraints:
+            nomad_job_spec["Job"]["Constraints"] = constraints
+
+        return nomad_job_spec
+
+    def _get_mflog_command(self, flow_name, run_id, step_name, task_id, attempt, datastore_type, user_code_command):
+        """
+        Constructs the command to be run inside the Nomad task, including mflog setup.
+        """
+        mflog_expr = export_mflog_env_vars(
+            flow_name=flow_name,
+            run_id=run_id,
+            step_name=step_name,
+            task_id=task_id,
+            retry_count=attempt,
+            datastore_type=datastore_type, # self._datastore.TYPE
+            stdout_path=STDOUT_PATH, # Relative to ALLOCDIR/task_name/mflogs/
+            stderr_path=STDERR_PATH, # Relative to ALLOCDIR/task_name/mflogs/
+            # Note: LOGS_DIR here is relative to the task's working directory,
+            # which by default is the root of the task's chroot / alloc directory.
+        )
+
+        # The user_code_command is expected to be a list: [executable, script_name, top_args..., "step", step_name, step_args...]
+        # We need to make sure it's run with bash_capture_logs
+
+        # Assuming user_code_command is a list that can be joined by spaces
+        step_expr = bash_capture_logs(" ".join(user_code_command))
+
+        # cmd_str will be executed by /bin/sh -c "cmd_str" by the docker driver by default if command is set and args is a list.
+        # We create the log dir inside the task's allocated directory.
+        # Nomad sets ALLOC_DIR and NOMAD_TASK_DIR env vars.
+        # For Docker, the default workdir is often the root of the image or /
+        # Let's assume logs are written to NOMAD_TASK_DIR / LOGS_DIR
+        # The paths in mflog_expr (STDOUT_PATH, STDERR_PATH) should be relative to where the command is run,
+        # or absolute if mflog_expr handles that.
+        # Given mflog_expr sets MF_LOG_STDOUT_PATH & STDERR_PATH, bash_capture_logs should respect them.
+
+        # Command to setup environment and run the Metaflow step
+        # The final command is executed as /bin/sh -c "<returned_command_str>"
+        # 1. Create the log directory (relative to task's working dir, often NOMAD_TASK_DIR)
+        # 2. Export mflog environment variables
+        # 3. Execute the actual step command, capturing its output
+        # 4. Persist logs using BASH_SAVE_LOGS
+        # 5. Exit with the step's exit code.
+
+        # The actual step command (python myflow.py step ...) needs to be prefixed by
+        # commands to download and extract the code package.
+        # This is handled by the `Artifacts` stanza and the entrypoint logic in `kubernetes.py`
+        # We need a similar pre-command here.
+
+        # Let's assume the command_args passed to _generate_job_spec already includes
+        # the full entrypoint logic (download, extract, then run).
+        # For now, this method just wraps the final command with mflog.
+
+        # The user_code_command is what `step_cli` (e.g. `python flow.py batch step ...`) would be.
+        # It needs to be wrapped.
+
+        # This part is tricky because the environment setup (package commands, bootstrap commands)
+        # from Kubernetes.py needs to be replicated or adapted.
+        # For now, let's assume the `command_args` for `_generate_job_spec` will handle this.
+        # This function will just focus on the mflog wrapping.
+
+        # Example from Kubernetes plugin:
+        # init_cmds = self._environment.get_package_commands(code_package_url, self._datastore.TYPE)
+        # init_expr = " && ".join(init_cmds)
+        # step_expr = bash_capture_logs(" && ".join(self._environment.bootstrap_commands(step_name, self._datastore.TYPE) + step_cmds))
+        # cmd_str = "true && mkdir -p %s && %s && %s && %s; " % (LOGS_DIR, mflog_expr, init_expr, step_expr)
+        # cmd_str += "c=$?; %s; exit $c" % BASH_SAVE_LOGS
+        # return shlex.split('bash -c "%s"' % cmd_str) -> this is for k8s spec
+        # For Nomad, the "command" is the executable, "args" is the list.
+        # The docker driver will effectively do: `Config.command Config.args[0] Config.args[1] ...`
+        # Or if command is not set, args[0] is command, args[1:] are args.
+        # If command is set and args is set, it's `command arg[0] arg[1] ...`
+        # If command is `bash` and args is `['-c', 'full_script_string']`, then bash executes the string.
+
+        # Let's assume `user_code_command` is the final python execution line.
+        # We need to build a shell script string to pass to `bash -c`.
+
+        # Placeholder for actual environment bootstrap commands
+        # These would come from `self.environment.get_package_commands` and `self.environment.bootstrap_commands`
+        # For Nomad, artifacts are downloaded to `NOMAD_ALLOC_DIR/local/<task_name>/package.tgz`
+        # So, init_expr needs to cd there, extract, then cd back or adjust paths.
+        # This logic should be part of the command_args passed to _generate_job_spec.
+        # This function is more about the mflog wrapping of the *final* command.
+
+        # This function is likely misnamed or needs to be part of a larger command construction.
+        # The command passed to Nomad's "args" should be the full Metaflow CLI invocation.
+        # The mflog setup should happen *inside* the container as part of that invocation.
+        # The `kubernetes.py` _command method constructs the bash -c string. We need similar.
+
+        # Let's assume `user_code_command` is a list like ["python", "flow.py", "step", "foo", ...]
+        # The mflog part needs to wrap this.
+        # The Kubernetes plugin does this:
+        # mflog_expr = export_mflog_env_vars(...)
+        # init_expr = "&&".join(self._environment.get_package_commands(...))
+        # step_expr = bash_capture_logs("&&".join(self._environment.bootstrap_commands(...) + step_cmds))
+        # cmd_str = "mkdir -p %s && %s && %s && %s" % (LOGS_DIR, mflog_expr, init_expr, step_expr)
+        # cmd_str += "; c=$?; %s; exit $c" % BASH_SAVE_LOGS
+        # The final command for Nomad task config: command="bash", args=["-c", cmd_str]
+
+        # This function should probably just return the `mflog_expr` and `BASH_SAVE_LOGS`
+        # and the caller (_generate_job_spec) integrates it.
+        # For now, returning as is, assuming the caller builds the bash -c string.
+        return mflog_expr, BASH_SAVE_LOGS
+
+
+    def launch_job(
+        self,
+        flow_name,
+        run_id,
+        step_name,
+        task_id,
+        attempt,
+        user, # For tagging or environment
+        code_package_sha, # For environment
+        code_package_url,
+        code_package_ds, # Datastore type for package
+        step_cli_args, # This is the full ["python", "flow.py", "step", ...]
+        docker_image,
+        datacenters, # From decorator
+        region,      # From decorator
+        nomad_namespace_job, # Job-specific namespace from decorator
+        cpu, memory, disk,
+        constraints=None,
+        environment_vars_decorator=None, # User-defined env vars from @environment
+        # TODO: Add other necessary params from Kubernetes.launch_job
+    ):
+        # 1. Construct environment variables for the Nomad task
+        env = {}
+        # Metaflow standard environment variables
+        env["METAFLOW_USER"] = user
+        env["METAFLOW_FLOW_NAME"] = flow_name
+        env["METAFLOW_RUN_ID"] = run_id
+        env["METAFLOW_STEP_NAME"] = step_name
+        env["METAFLOW_TASK_ID"] = task_id
+        env["METAFLOW_RETRY_COUNT"] = str(attempt)
+        env["METAFLOW_CODE_SHA"] = code_package_sha
+        env["METAFLOW_CODE_URL"] = code_package_url
+        env["METAFLOW_CODE_DS"] = code_package_ds
+        env["METAFLOW_SERVICE_URL"] = SERVICE_INTERNAL_URL
+        env["METAFLOW_SERVICE_HEADERS"] = json.dumps(SERVICE_HEADERS)
+        env["METAFLOW_DATASTORE_SYSROOT_S3"] = DATASTORE_SYSROOT_S3
+        env["METAFLOW_DATASTORE_SYSROOT_AZURE"] = DATASTORE_SYSROOT_AZURE
+        env["METAFLOW_DATASTORE_SYSROOT_GS"] = DATASTORE_SYSROOT_GS
+        env["METAFLOW_DEFAULT_DATASTORE"] = DEFAULT_DATASTORE
+        env["METAFLOW_DEFAULT_METADATA"] = DEFAULT_METADATA
+        env["METAFLOW_DEFAULT_SECRETS_BACKEND_TYPE"] = METAFLOW_DEFAULT_SECRETS_BACKEND_TYPE
+        env["METAFLOW_CARD_S3ROOT"] = METAFLOW_CARD_S3ROOT # If cards are used
+
+        env["METAFLOW_NOMAD_WORKLOAD"] = "1" # Marker for being inside a Nomad task
+
+        # Add user-defined environment variables from @environment decorator
+        if environment_vars_decorator:
+            env.update(environment_vars_decorator)
+
+        # Mflog variables will be set by the bash -c script using export_mflog_env_vars
+
+        # 2. Construct the command string for bash -c "..."
+        # This needs to replicate the logic in Kubernetes._command method.
+        # - Create LOGS_DIR (e.g., mflogs in NOMAD_TASK_DIR)
+        # - Setup mflog (export_mflog_env_vars)
+        # - Setup package (cd to artifact dir, extract) -> This should be part of step_cli_args or entrypoint
+        # - Bootstrap environment (bootstrap_commands) -> This should be part of step_cli_args or entrypoint
+        # - Execute step_cli_args (wrapped with bash_capture_logs)
+        # - Save logs (BASH_SAVE_LOGS)
+        # - Exit with task's exit code
+
+        # For now, let's assume step_cli_args (e.g. ["python", "flow.py", ...]) is the final command.
+        # The actual environment setup (package download/extract, bootstrap) needs to be
+        # part of an entrypoint script that Nomad's docker driver calls, or baked into the step_cli_args.
+        # Let's assume step_cli_args[0] is the executable (e.g. python) and step_cli_args[1:] are its arguments.
+
+        # Command structure:
+        # bash -c "mkdir -p mflogs && \
+        #            export MF_LOG_FOO=bar && \ (from export_mflog_env_vars)
+        #            ( (python flow.py step ...) 2> >(tee mflogs/mflog_stderr >&2) 1> >(tee mflogs/mflog_stdout) ) && \ (from bash_capture_logs)
+        #            c=$?; bash save_logs_script.sh mflogs/mflog_stdout mflogs/mflog_stderr; exit $c" (from BASH_SAVE_LOGS)
+
+        mflog_expr = export_mflog_env_vars(
+            flow_name=flow_name, run_id=run_id, step_name=step_name, task_id=task_id, retry_count=attempt,
+            datastore_type=DEFAULT_DATASTORE, # TODO: Get this from flow_datastore more reliably
+            stdout_path=STDOUT_PATH, # e.g., mflogs/mflog_stdout
+            stderr_path=STDERR_PATH  # e.g., mflogs/mflog_stderr
+        )
+
+        # Construct the Metaflow step execution command string (what the user's code will run)
+        # step_cli_args is like ['python', 'flow.py', 'batch', 'step', 'step_name', '--run-id', ...]
+        # We need to ensure this is correctly quoted if it contains spaces or special characters.
+        # For bash -c, it's safer to pass the command as a single string.
+        executable = step_cli_args[0]
+        args_string = " ".join(f"'{arg}'" for arg in step_cli_args[1:]) # Basic quoting
+        full_metaflow_cmd = f"{executable} {args_string}"
+
+        # This is where environment bootstrap (conda/pypi) and code package extraction would happen.
+        # For now, assume the docker image has python and metaflow, and code is in via Artifacts.
+        # A proper entrypoint script would handle this:
+        # 1. cd $NOMAD_ALLOC_DIR/local/$NOMAD_TASK_NAME
+        # 2. tar -xzf package.tgz (if package.tgz is the name)
+        # 3. cd back or adjust python path
+        # This entrypoint script would be the `command` in Nomad task spec.
+        # For simplicity here, we assume `full_metaflow_cmd` can run directly after mflog setup.
+
+        # We need to create the LOGS_DIR relative to NOMAD_TASK_DIR (usually the task's cwd)
+        # And BASH_SAVE_LOGS needs to know where the S3/Azure/GS datastore is for logs.
+        # The environment variables for datastore (e.g., METAFLOW_DATASTORE_SYSROOT_S3) are set in `env`.
+
+        wrapped_step_cmd = bash_capture_logs(full_metaflow_cmd)
+
+        # The command for Nomad task:
+        # Using NOMAD_TASK_DIR as the base for logs.
+        # Note: LOGS_DIR is relative path "mflogs"
+        nomad_task_command_script = f"""
+set -e
+echo "Creating logs directory: {LOGS_DIR} (relative to $PWD, which should be $NOMAD_TASK_DIR)"
+mkdir -p {LOGS_DIR}
+echo "Exporting MFLOG variables..."
+{mflog_expr}
+echo "Executing Metaflow step command..."
+{wrapped_step_cmd}
+_exit_code=$?
+echo "Saving logs..."
+{BASH_SAVE_LOGS}
+echo "Exiting with code $_exit_code"
+exit $_exit_code
+"""
+        # For Nomad, the driver usually takes `command` (executable) and `args` (list).
+        # To run a script string, we use `bash -c script_string`.
+        job_spec_command_executable = "/bin/bash"
+        job_spec_command_args = ["-c", nomad_task_command_script]
+
+        job_name_for_nomad = f"{flow_name}-{run_id}-{step_name}-{task_id}"
+        task_name_for_nomad = f"mf-task-{step_name}"
+
+        job_spec = self._generate_job_spec(
+            job_name=job_name_for_nomad,
+            task_name=task_name_for_nomad,
+            image=docker_image,
+            command_executable=job_spec_command_executable,
+            command_args=job_spec_command_args,
+            cpu=cpu, memory=memory, disk=disk,
+            datacenters=datacenters, region=region, nomad_namespace=nomad_namespace_job,
+            constraints=constraints,
+            env_vars=env,
+            code_package_url=code_package_url,
+        )
+
+        try:
+            # print("Registering Nomad job:", json.dumps(job_spec, indent=4)) # For debugging
+            # The first argument to register_job is the job ID for idempotency,
+            # but the library example uses a different string ("example") than the job_spec["Job"]["ID"].
+            # Let's use the ID from the spec for consistency if the API allows.
+            # The python-nomad docs for job.register_job(job_id, job_dict) suggest job_id is just an identifier.
+            # Let's use the generated job_id from the spec.
+            eval_info = self.client.job.register_job(job_id=job_spec["Job"]["ID"], job=job_spec)
+            # Alternative: self.client.jobs.create_job(job_spec) - Need to check which is correct
+            # The example `my_nomad.job.register_job("example", job)` suggests the first arg is a placeholder.
+            # Let's try with the actual Job ID.
+            # eval_info = self.client.jobs.create_job(job_spec) # This seems more standard for "create"
+
+            # The example `my_nomad.job.register_job("example", job)` is likely correct based on docs.
+            # The first arg is "job_id (str) – job_id." - this usually means the ID of the job to operate on.
+            # For creation, it might be used for idempotency or just be the job name.
+            # Let's try with the job_spec["Job"]["ID"].
+            # response = self.client.job.register_job(job_spec["Job"]["ID"], job_spec)
+            # The example uses "example" as the first arg, and job["Job"]["ID"] as "example" too.
+            # Let's use job_spec["Job"]["Name"] as the first argument, which is what the example implies.
+            # This first argument is the "job_id" parameter for the API endpoint, not necessarily the one in the payload.
+            # Let's assume job_spec["Job"]["ID"] is the canonical ID.
+
+            # Looking at python-nomad source:
+            # job.py -> def register_job(self, job_id, job): return self.put(job_id, json=job ...)
+            # So job_id is part of the URL. The payload is in `job`.
+            # The Job ID in the payload (`job["Job"]["ID"]`) should match the `job_id` in the URL.
+
+            response = self.client.job.register_job(job_spec["Job"]["ID"], job_spec)
+
+            if "EvalID" not in response:
+                raise NomadException(f"Failed to register Nomad job. Response: {response}")
+
+            return {
+                "job_id": job_spec["Job"]["ID"],
+                "eval_id": response["EvalID"],
+                "job_spec": job_spec # For potential later use or logging
+            }
+
+        except nomad.api.exceptions.NomadApiError as e:
+            raise NomadException(f"Nomad API error launching job: {e.nomad_resp.reason} - {e.nomad_resp.text}")
+        except Exception as e:
+            raise NomadException(f"Error launching Nomad job: {e}")
+
+    def wait_for_job_completion(self, job_id, eval_id, timeout_seconds=3600, poll_interval=10):
+        """
+        Waits for a Nomad job to complete or fail.
+        This needs to monitor allocations associated with the job evaluation.
+        Returns True if successful, False if failed or timed out.
+        """
+        start_time = time.time()
+        last_alloc_status = None
+        alloc_id_to_monitor = None
+
+        print(f"Waiting for job {job_id} (EvalID: {eval_id}) to complete...")
+
+        while time.time() - start_time < timeout_seconds:
+            try:
+                if not alloc_id_to_monitor:
+                    # First, get allocations for the evaluation
+                    # The evaluation tells us about the placement of allocations for the job.
+                    evaluation = self.client.evaluation.get_evaluation(eval_id)
+                    # evaluation might have "BlockedEval" or "FailedTgAllocs"
+                    # A successful eval should lead to allocations.
+                    # We need to find the allocation ID created by this evaluation for our job.
+
+                    # Get all allocations for the job_id
+                    job_allocs = self.client.job.get_allocations(job_id)
+                    if not job_allocs:
+                        # print(f"No allocations yet for job {job_id}. Current eval status: {evaluation.get('Status', 'N/A')}")
+                        time.sleep(poll_interval)
+                        continue
+
+                    # Find the allocation that matches our evaluation or is the latest for the job.
+                    # This logic might need refinement based on how evaluations map to allocs.
+                    # For a simple batch job, there should be one allocation.
+                    # Let's find an allocation that is not in a terminal state yet.
+                    relevant_alloc = None
+                    for alloc_summary in job_allocs:
+                        alloc_detail = self.client.allocation.get_allocation(alloc_summary["ID"])
+                        if alloc_detail["EvalID"] == eval_id: #This is the most direct link
+                            alloc_id_to_monitor = alloc_detail["ID"]
+                            break
+                        # Fallback: if no direct match, take the first non-terminal one for this job
+                        if alloc_detail["ClientStatus"] not in ["complete", "failed", "lost"]:
+                            relevant_alloc = alloc_detail
+
+                    if alloc_id_to_monitor:
+                        print(f"Monitoring allocation {alloc_id_to_monitor} for job {job_id}.")
+                    elif relevant_alloc:
+                        alloc_id_to_monitor = relevant_alloc["ID"]
+                        print(f"Monitoring allocation {alloc_id_to_monitor} (latest non-terminal) for job {job_id}.")
+                    else:
+                        # All allocations might be terminal (e.g. if job failed quickly)
+                        # Or no allocs yet tied to this eval.
+                        # print(f"Could not find a suitable allocation to monitor for job {job_id}, eval {eval_id}. Checking eval status: {evaluation.get('Status', 'N/A')}")
+                        if evaluation.get("Status") == "failed":
+                            print(f"Evaluation {eval_id} failed.")
+                            return False, None # Failed
+                        if evaluation.get("Status") == "complete" and not job_allocs : # Eval complete but no allocs
+                            print(f"Evaluation {eval_id} complete but no allocations found for job {job_id}.")
+                            # This might mean the job was valid but couldn't be placed.
+                            return False, None # Failed
+                        time.sleep(poll_interval)
+                        continue
+
+                # We have an alloc_id_to_monitor
+                alloc = self.client.allocation.get_allocation(alloc_id_to_monitor)
+                status = alloc["ClientStatus"]
+
+                if status != last_alloc_status:
+                    print(f"Allocation {alloc_id_to_monitor} status: {status}")
+                    last_alloc_status = status
+
+                if status == "complete":
+                    # Check task states within the allocation
+                    # For a single task job, if alloc is complete, task should be too.
+                    # TaskStates: {"task_name": {"State": "dead", "Failed": False, "Restarts": 0, ...}}
+                    task_state = alloc.get("TaskStates", {}).get(alloc["TaskGroup"], {}).get("State", "unknown") # This path is wrong
+                    # The task name is what we defined, e.g., "mf-task-step_name"
+                    # Let's find the task name from the job spec.
+                    # For now, assume a single task in the group.
+                    primary_task_name = None
+                    if alloc.get("Job", {}).get("TaskGroups"):
+                        primary_task_name = alloc["Job"]["TaskGroups"][0]["Tasks"][0]["Name"]
+
+                    final_task_status = "unknown"
+                    if primary_task_name and alloc.get("TaskStates", {}).get(primary_task_name):
+                        final_task_status = alloc["TaskStates"][primary_task_name]["State"]
+                        if alloc["TaskStates"][primary_task_name]["Failed"]:
+                             print(f"Allocation {alloc_id_to_monitor} complete, but task {primary_task_name} failed.")
+                             return False, alloc_id_to_monitor # Failed
+
+                    print(f"Allocation {alloc_id_to_monitor} complete. Task '{primary_task_name}' state: {final_task_status}.")
+                    return True, alloc_id_to_monitor # Success
+
+                elif status in ["failed", "lost", "cancelled", "expired"]: # Terminal failure states
+                    print(f"Allocation {alloc_id_to_monitor} ended with status: {status}.")
+                    return False, alloc_id_to_monitor # Failed
+
+            except nomad.api.exceptions.NomadApiError as e:
+                if e.nomad_resp.status_code == 404: # Allocation might not exist yet or job failed before alloc
+                    print(f"Allocation {alloc_id_to_monitor or eval_id} not found (404). Waiting...")
+                    alloc_id_to_monitor = None # Reset to re-evaluate allocations
+                else:
+                    print(f"Nomad API error while waiting for job {job_id}: {e}")
+                    # Don't exit loop immediately, maybe transient
+            except Exception as e:
+                print(f"Error waiting for job {job_id}: {e}")
+                # Don't exit loop immediately
+
+            time.sleep(poll_interval)
+
+        print(f"Timeout waiting for job {job_id} (EvalID: {eval_id}) to complete.")
+        return False, alloc_id_to_monitor # Timeout
+
+    def get_logs(self, alloc_id, task_name, log_type="stdout", tail_lines=None, follow=False):
+        """
+        Retrieves logs for a specific task in an allocation.
+        log_type can be "stdout" or "stderr".
+        If follow is True, it streams logs. Otherwise, fetches current logs.
+        tail_lines to get last N lines (if not following).
+
+        The python-nomad library's client.fs.cat or client.logs.stream might be used.
+        client.logs.stream(alloc_id, task_name, type="stdout", follow=True, offset=0, origin="end")
+        client.fs.cat(alloc_id, path_to_log_file) where path is like "alloc/logs/task_name.stdout.0"
+        """
+        if not alloc_id or not task_name:
+            raise NomadException("Allocation ID and task name are required to get logs.")
+
+        # Standard log paths in Nomad allocs:
+        # NOMAD_ALLOC_DIR/logs/<task_name>.stdout.0
+        # NOMAD_ALLOC_DIR/logs/<task_name>.stderr.0
+        # The number (0) is the restart index.
+
+        # Using client.logs.stream seems more robust than fs.cat for potentially large/rotated logs.
+        # However, mflog saves to specific files (STDOUT_PATH, STDERR_PATH) within LOGS_DIR relative to task dir.
+        # These are mflogs/mflog_stdout and mflogs/mflog_stderr
+        # So the path inside the alloc would be: alloc_dir/task_name_dir/mflogs/mflog_stdout
+        # This is complex. Let's assume for now we want the raw task stdout/stderr from Nomad.
+
+        log_file_name = f"{task_name}.{log_type}.0" # Standard Nomad log file for first run
+        # If we want the mflog captured files:
+        # mflog_filename = STDERR_FILE if log_type == "stderr" else STDOUT_FILE
+        # log_file_path_in_alloc = f"{LOGS_DIR}/{mflog_filename}"
+        # This path is relative to the task's working directory.
+        # `client.fs.cat` takes path relative to alloc root. So it would be `task_name_dir_in_alloc/LOGS_DIR/mflog_filename`
+        # This is getting complicated due to where mflog saves vs where Nomad saves raw stdout/stderr.
+
+        # For now, let's try to get Nomad's raw stdout/stderr for the task.
+        try:
+            if follow:
+                # This will yield log lines. The caller needs to handle iteration.
+                return self.client.logs.stream(
+                    alloc_id,
+                    task_name,
+                    type=log_type,
+                    follow=True,
+                    offset=0, # From start for now
+                    origin="start",
+                    plain=True # Get raw text
+                )
+            else:
+                # Fetch current logs (non-streaming)
+                # The `logs` method on the client object itself seems to be the one.
+                # client.logs(alloc_id, task_name, type, plain, offset, job_id, follow, origin)
+                log_data = self.client.logs.logs( # Confusingly named method
+                    alloc_id,
+                    task=task_name,
+                    type=log_type,
+                    plain=True,
+                    # offset=0, # Get all for now
+                    # tail is not directly supported by python-nomad's logs() call,
+                    # but origin="end" with a negative offset might work if supported by API.
+                    # For simplicity, fetch all and let caller tail if needed.
+                )
+                # log_data is a dict like {'Data': 'log content', 'File': ..., 'Offset': ...}
+                # if plain=True, it should just be the string.
+                # The documentation for python-nomad's client.logs.logs is sparse.
+                # Let's assume it returns the log string directly when plain=True.
+                if isinstance(log_data, dict) and "Data" in log_data: # Based on API spec for /client/fs/logs
+                    logs_content = log_data["Data"]
+                else: # Assuming plain=True returns string directly
+                    logs_content = log_data
+
+                if tail_lines and logs_content:
+                    return "\n".join(logs_content.splitlines()[-tail_lines:])
+                return logs_content
+
+        except nomad.api.exceptions.NomadApiError as e:
+            # If log file not found (e.g. task didn't start or write logs), it might 404.
+            if e.nomad_resp.status_code == 404:
+                return f"Log file for task {task_name} ({log_type}) not found in allocation {alloc_id}."
+            raise NomadException(f"Nomad API error getting logs for task {task_name} in alloc {alloc_id}: {e}")
+        except Exception as e:
+            raise NomadException(f"Error getting logs for task {task_name} in alloc {alloc_id}: {e}")
+
+    def stop_job(self, job_id, purge=False):
+        """ Stops (deregisters) a Nomad job. """
+        try:
+            self.client.job.deregister_job(job_id, purge=purge)
+            print(f"Successfully deregistered job {job_id}.")
+            return True
+        except nomad.api.exceptions.NomadApiError as e:
+            if e.nomad_resp.status_code == 404:
+                print(f"Job {job_id} not found, nothing to stop.")
+                return True # Idempotent
+            raise NomadException(f"Nomad API error stopping job {job_id}: {e}")
+        except Exception as e:
+            raise NomadException(f"Error stopping job {job_id}: {e}")
+
+    def list_jobs(self, prefix=None):
+        """ Lists Nomad jobs, optionally filtered by prefix. """
+        try:
+            # The library's n.jobs returns a Jobs object that can be iterated or accessed by ID.
+            # n.jobs.get_jobs(prefix=...)
+            job_list = self.client.jobs.get_jobs(prefix=prefix) # Returns a list of job summaries
+            return job_list
+        except Exception as e:
+            raise NomadException(f"Error listing Nomad jobs: {e}")
+
+# Example usage (for testing purposes, not part of the plugin runtime)
+if __name__ == "__main__":
+    # Configure these based on your Nomad setup
+    # Ensure NOMAD_ADDRESS is set in env or pass it here.
+    # client = NomadClient(nomad_address="http://localhost:4646", region="global", namespace="default")
+
+    # This main block is for quick testing, real parameters would come from Metaflow runtime.
+    print("This is a library file, not meant to be run directly for plugin operation.")
+    print("To test, you would typically call these methods from the nomad_cli.py or within a flow.")
+
+    # Example: How the CLI might use it
+    # try:
+    #     client = NomadClient() # Reads from env by default
+    #     # Test listing jobs
+    #     print("Listing jobs with prefix 'mf-':")
+    #     jobs = client.list_jobs(prefix="mf-")
+    #     for job_summary in jobs:
+    #         print(f"  ID: {job_summary['ID']}, Name: {job_summary['Name']}, Status: {job_summary['Status']}")
+    #
+    #     # Placeholder for launching a test job (requires a lot of params)
+    #     # launched_job_info = client.launch_job(...)
+    #     # if launched_job_info:
+    #     #     print(f"Launched job: {launched_job_info['job_id']}, Eval: {launched_job_info['eval_id']}")
+    #     #     success, final_alloc_id = client.wait_for_job_completion(launched_job_info['job_id'], launched_job_info['eval_id'])
+    #     #     if success:
+    #     #         print(f"Job {launched_job_info['job_id']} completed successfully on allocation {final_alloc_id}.")
+    #     #         logs = client.get_logs(final_alloc_id, "your_task_name_here", "stdout")
+    #     #         print("Logs:\n", logs)
+    #     #     else:
+    #     #         print(f"Job {launched_job_info['job_id']} failed or timed out on allocation {final_alloc_id}.")
+    #     #     client.stop_job(launched_job_info['job_id'])
+
+    # except NomadException as e:
+    #     print(f"Nomad related error: {e}")
+    # except Exception as e:
+    #     print(f"Generic error: {e}")
+
+    pass

--- a/metaflow/plugins/nomad/nomad_cli.py
+++ b/metaflow/plugins/nomad/nomad_cli.py
@@ -1,0 +1,417 @@
+import os
+import sys
+import json
+import traceback
+
+from metaflow._vendor import click
+from metaflow.exception import METAFLOW_EXIT_DISALLOW_RETRY, MetaflowException
+from metaflow.metadata_provider.util import sync_local_metadata_from_datastore
+from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
+from metaflow.mflog import TASK_LOG_SOURCE # For log saving location
+
+from .nomad import NomadClient, NomadException
+
+# Helper to parse CLI options, similar to Kubernetes CLI
+def parse_nomad_cli_options(flow_name, run_id_opt, user_opt, my_runs_opt, echo_fn):
+    if my_runs_opt:
+        if user_opt:
+            raise MetaflowException("--user is not supported with --my-runs.")
+        user = os.environ.get("METAFLOW_USER", os.environ.get("USER"))
+    elif user_opt:
+        user = user_opt
+    else:
+        user = None # Default to all users if not specified
+
+    if run_id_opt:
+        run_id = run_id_opt
+    else:
+        run_id = None
+
+    # Flow name is usually derived from the current flow context if not specified
+    # For now, assume it's available or passed if needed for filtering.
+    # The list/kill commands might need more sophisticated filtering based on Nomad job names/meta.
+    return flow_name, run_id, user
+
+
+@click.group()
+def cli():
+    pass
+
+@cli.group(help="Commands related to HashiCorp Nomad.")
+@click.pass_context
+def nomad(ctx):
+    # Make the Nomad client available to subcommands via ctx.obj if needed
+    # For now, each command will instantiate its own client.
+    pass
+
+@nomad.command(
+    help="Execute a single task on Nomad. This command is called internally by Metaflow."
+)
+@click.argument("step-name")
+@click.argument("code-package-sha")
+@click.argument("code-package-url")
+# Options from NomadDecorator - these names should match command_options in nomad_decorator.py (with '-' instead of '_')
+@click.option("--executable", help="Path to the python executable within the container.") # Added
+@click.option("--image", help="Docker image to use for the Nomad job.")
+@click.option("--region", help="Nomad region for the job.")
+@click.option("--datacenters", type=str, help="JSON string of Nomad datacenters for the job (e.g., '[\"dc1\",\"dc2\"]').")
+@click.option("--constraints", type=str, help="JSON string of Nomad constraints for the job.")
+@click.option("--cpu", help="CPU resources in MHz.")
+@click.option("--memory", help="Memory resources in MB.")
+@click.option("--disk", help="Disk resources in MB.")
+@click.option("--nomad-namespace-job", help="Nomad namespace for this specific job.") # Distinguish from client's default namespace
+# Metaflow common task options
+@click.option("--run-id", required=True, help="Current Metaflow run ID.")
+@click.option("--task-id", required=True, help="Current Metaflow task ID.")
+@click.option("--input-paths", help="Input paths for the task.") # Not directly used by Nomad client, but part of step CLI
+@click.option("--split-index", help="Split index for the task.") # Same as above
+@click.option("--clone-path", help="Clone path for the task.") # Same as above
+@click.option("--clone-run-id", help="Clone run ID for the task.") # Same as above
+@click.option("--tag", multiple=True, default=None, help="Metaflow tags for the run.")
+@click.option("--namespace", default=None, help="Metaflow namespace, not Nomad namespace.") # Metaflow's own namespace
+@click.option("--retry-count", default=0, type=int, help="Current retry count for the task.")
+@click.option("--max-user-code-retries", default=0, type=int, help="Max user code retries.")
+# TODO: Add other options if needed, e.g., from Kubernetes CLI like service_account, secrets, etc. if we support them.
+@click.pass_context
+def step(
+    ctx,
+    step_name,
+    code_package_sha,
+    code_package_url,
+    executable,
+    image,
+    region,
+    datacenters,
+    constraints,
+    cpu,
+    memory,
+    disk,
+    nomad_namespace_job,
+    run_id,
+    task_id,
+    input_paths,
+    split_index,
+    clone_path,
+    clone_run_id,
+    tag,
+    namespace, # Metaflow namespace
+    retry_count,
+    max_user_code_retries,
+    **kwargs # To catch any other options passed from decorator
+):
+    # `kwargs` will capture any other options defined in the decorator and passed via command_options
+    # These can be passed to NomadClient.launch_job if it's designed to accept them.
+
+    echo = ctx.obj.echo_always # For printing output
+
+    # Reconstruct the original step CLI arguments that the Nomad task will execute
+    # This is what the user's Python script will run inside the container.
+    # The `executable` is python, `sys.argv[0]` is the flow file name.
+    # `ctx.parent.parent.params` are top-level Metaflow args (e.g. --datastore, --metadata)
+    # `kwargs` here are the step-specific command line args from the `step` call.
+
+    # The step_cli_args should be the command that the user's code executes.
+    # It's formed from: executable, flow_file_name, top-level_metaflow_args, "step", step_name, task_args...
+    # The `nomad_decorator.runtime_step_cli` sets `cli_args.entrypoint` to be the command.
+    # And `cli_args.command_options` contains all the decorator attributes.
+    # The arguments to *this* `nomad step` command are those attributes.
+    # The command to run *inside* Nomad is the original `python flow.py step <step_name> --run-id ...`
+
+    # We need to get the flow_datastore and environment from ctx.obj
+    flow_datastore = ctx.obj.flow_datastore
+    environment = ctx.obj.environment
+    flow_name = ctx.obj.flow.name
+    user = ctx.obj.metadata.user() # Get current user from metadata
+
+    # Construct the command that the Nomad task will execute (the user's Metaflow step code)
+    # This is similar to how Kubernetes CLI constructs `step_cli`
+    # The `executable` here is the one from the *decorator's* environment.
+
+    # The `step_cli_args` passed to `NomadClient.launch_job` should be the
+    # *original* step command, not the `metaflow nomad step` command.
+    # This means we need to reconstruct it or have it passed through.
+    # The `kubernetes_cli.py` uses `ctx.obj.environment.executable(step_name, executable_option)`
+    # and then builds the full command string.
+
+    # Let's assume `executable` is the python interpreter in the container.
+    # The arguments to that python interpreter need to be assembled.
+    # This is complex because we are inside `metaflow nomad step` which is ALREADY a step execution context.
+    # The `kubernetes_cli.py` `step` command is what gets run *by* the K8s job.
+    # Our `nomad_cli.py` `step` command is the one that *launches* the Nomad job.
+
+    # The `step_cli` for `NomadClient.launch_job` should be:
+    # [executable, flow_file_name, top_level_args..., "step", step_name, original_step_args...]
+    # `original_step_args` are things like --run-id, --task-id, --input-paths etc. for the *user's* step code.
+
+    # The `executable` passed to this function is the one from `NomadDecorator.runtime_step_cli` -> `cli_args.entrypoint[0]`
+    # which is `self.environment.executable(self.step)`
+
+    original_step_task_args = {
+        "run_id": run_id,
+        "task_id": task_id,
+        "input_paths": input_paths,
+        "split_index": split_index,
+        "clone_path": clone_path,
+        "clone_run_id": clone_run_id,
+        "tag": list(tag), # Convert tuple to list
+        "namespace": namespace, # Metaflow namespace
+        "retry_count": retry_count,
+        "max_user_code_retries": max_user_code_retries,
+        # Add any other standard step arguments if needed
+    }
+    # Filter out None values, convert to CLI options
+    filtered_step_task_args = {k: v for k, v in original_step_task_args.items() if v is not None}
+    step_task_options_list = util.dict_to_cli_options(filtered_step_task_args)
+
+    # Get top-level args (like --with, --datastore)
+    # These are usually in ctx.parent.parent.params for a deeply nested command.
+    # This depends on how `metaflow nomad step` is invoked by the runtime.
+    # For now, assume they are not needed directly by the client, but by the command inside Nomad.
+    # The `kubernetes_cli.py` seems to get them from `ctx.parent.parent.params`.
+    # Let's assume `ctx.obj.top_level_options` holds these. (This needs verification)
+    top_level_options_list = []
+    if hasattr(ctx.obj, 'top_level_options'):
+        top_level_options_list = util.dict_to_cli_options(ctx.obj.top_level_options)
+
+
+    # sys.argv[0] is `metaflow` when run as `metaflow nomad step ...`
+    # We need the original flow file name. This should be part of `ctx.obj` or passed.
+    # Let's assume `ctx.obj.flow_name_path` or similar. For now, use a placeholder.
+    # This is typically `os.path.basename(sys.argv[0])` in the *user's* execution context.
+    # The Kubernetes CLI gets it from `os.path.basename(sys.argv[0])` because *it is* the user's context.
+    # Here, we are one level deeper.
+    # It's available in `ctx.obj.flow.script_name`
+    flow_script_name = os.path.basename(ctx.obj.flow.script_name)
+
+    # This is the command that will run *inside* the Nomad job container
+    cmd_to_run_in_nomad = [executable, flow_script_name]
+    cmd_to_run_in_nomad.extend(top_level_options_list) # Add top level options like --datastore
+    cmd_to_run_in_nomad.append("step")
+    cmd_to_run_in_nomad.append(step_name)
+    cmd_to_run_in_nomad.extend(step_task_options_list)
+
+    # Parse JSON string options
+    parsed_datacenters = json.loads(datacenters) if datacenters else None
+    parsed_constraints = json.loads(constraints) if constraints else None
+
+    # Environment variables for the job (from @environment decorator)
+    # This should be collected by the decorator and passed as an option.
+    # For now, assume it's empty or passed via kwargs if we add an --env option.
+    user_env_vars = {}
+    if 'env' in kwargs and kwargs['env']:
+        try:
+            user_env_vars = json.loads(kwargs['env']) if isinstance(kwargs['env'], str) else kwargs['env']
+        except json.JSONDecodeError:
+            echo("Warning: Could not parse --env JSON string.", err=True)
+
+
+    def _sync_metadata():
+        if ctx.obj.metadata.TYPE == "local":
+            sync_local_metadata_from_datastore(
+                DATASTORE_LOCAL_DIR,
+                flow_datastore.get_task_datastore(run_id, step_name, task_id)
+            )
+
+    nomad_client = None
+    try:
+        nomad_client = NomadClient(
+            # Pass relevant client config from Metaflow config if needed,
+            # or rely on env vars NOMAD_ADDR etc.
+            # region, nomad_namespace_job are for the *job*, not client config here.
+        )
+
+        launched_job_info = nomad_client.launch_job(
+            flow_name=flow_name,
+            run_id=run_id,
+            step_name=step_name,
+            task_id=task_id,
+            attempt=retry_count,
+            user=user,
+            code_package_sha=code_package_sha,
+            code_package_url=code_package_url,
+            code_package_ds=flow_datastore.TYPE,
+            step_cli_args=cmd_to_run_in_nomad, # This is the command to run inside Nomad
+            docker_image=image,
+            datacenters=parsed_datacenters,
+            region=region, # Job region
+            nomad_namespace_job=nomad_namespace_job, # Job namespace
+            cpu=cpu, memory=memory, disk=disk,
+            constraints=parsed_constraints,
+            environment_vars_decorator=user_env_vars,
+            # Pass other relevant kwargs if NomadClient.launch_job supports them
+        )
+
+        echo(f"Nomad job launched: ID {launched_job_info['job_id']}, EvalID {launched_job_info['eval_id']}", fg="green")
+
+        # Wait for completion
+        # TODO: Echo logs during wait, similar to Kubernetes CLI
+        # This requires NomadClient.wait_for_job_completion to potentially yield logs or have a callback.
+        # For now, just wait and then print final status.
+        job_succeeded, final_alloc_id = nomad_client.wait_for_job_completion(
+            launched_job_info['job_id'],
+            launched_job_info['eval_id']
+            # TODO: Add timeout from decorator if implemented
+        )
+
+        if final_alloc_id:
+            echo(f"Monitored allocation: {final_alloc_id}", fg="blue")
+            # Try to get final logs (mflog should have saved them to S3)
+            # This is more for debugging the raw output from Nomad if needed.
+            # The primary log mechanism is via BASH_SAVE_LOGS to the datastore.
+            try:
+                # The task name used in _generate_job_spec was f"mf-task-{step_name}"
+                task_name_in_nomad = f"mf-task-{step_name}"
+                stdout_logs = nomad_client.get_logs(final_alloc_id, task_name_in_nomad, "stdout")
+                stderr_logs = nomad_client.get_logs(final_alloc_id, task_name_in_nomad, "stderr")
+                if stdout_logs:
+                    echo(f"\n--- Nomad Task STDOUT (alloc: {final_alloc_id}, task: {task_name_in_nomad}) ---\n{stdout_logs}")
+                if stderr_logs:
+                    echo(f"\n--- Nomad Task STDERR (alloc: {final_alloc_id}, task: {task_name_in_nomad}) ---\n{stderr_logs}", err=True)
+            except NomadException as log_ex:
+                echo(f"Could not retrieve final raw logs from Nomad: {log_ex}", err=True)
+
+        if not job_succeeded:
+            echo(f"Nomad job {launched_job_info['job_id']} failed or timed out.", err=True, fg="red")
+            # Sync metadata before exiting on failure
+            _sync_metadata()
+            sys.exit(1) # Indicate failure
+
+        echo(f"Nomad job {launched_job_info['job_id']} completed successfully.", fg="green")
+
+    except NomadException as e:
+        echo(f"Nomad execution error: {e}", err=True, fg="red")
+        traceback.print_exc()
+        _sync_metadata() # Ensure metadata is synced on Nomad-specific errors too
+        sys.exit(METAFLOW_EXIT_DISALLOW_RETRY) # Disallow Metaflow runtime retry for Nomad infrastructure issues
+    except Exception as e:
+        echo(f"Error during Nomad step execution: {e}", err=True, fg="red")
+        traceback.print_exc()
+        _sync_metadata()
+        # For generic errors, let Metaflow decide on retries unless it's a MetaflowException
+        if isinstance(e, MetaflowException):
+            sys.exit(METAFLOW_EXIT_DISALLOW_RETRY)
+        sys.exit(1)
+    finally:
+        # This will sync metadata like logs saved to S3, task status etc.
+        _sync_metadata()
+
+
+@nomad.command(help="List running Nomad jobs for this flow or user.")
+@click.option("--my-runs", is_flag=True, help="List all my unfinished tasks.")
+@click.option("--user", help="List unfinished tasks for the given user.")
+@click.option("--run-id", help="List unfinished tasks for a specific run ID.")
+@click.option("--prefix", help="Filter jobs by a name prefix (e.g., 'mf-myflowname-').")
+@click.pass_context
+def list(ctx, my_runs, user, run_id, prefix):
+    echo = ctx.obj.echo
+    flow_name_ctx = ctx.obj.flow.name if hasattr(ctx.obj, 'flow') else None
+
+    # Use a default prefix if none is given, e.g., based on current flow
+    if not prefix and flow_name_ctx:
+        # A common job name pattern might be "mf-flowname-runid-..."
+        # Listing might need to be more flexible or rely on Nomad metadata/tags if we set them.
+        # For now, let's use a generic "mf-" prefix or allow user to specify.
+        effective_prefix = f"mf-{flow_name_ctx}-"
+        if run_id:
+            effective_prefix += f"{run_id}-"
+        # If user is specified, we can't directly filter by user via Nomad API prefix easily unless user is in job name.
+        # This might require listing more jobs and then client-side filtering if user is in job Meta.
+        echo(f"Listing jobs with effective prefix: {effective_prefix} (user filter '{user}' if any is client-side for now)")
+    else:
+        effective_prefix = prefix
+
+    try:
+        client = NomadClient()
+        jobs = client.list_jobs(prefix=effective_prefix) # Nomad API prefix filter
+
+        if not jobs:
+            echo("No matching Nomad jobs found.")
+            return
+
+        for job_summary in jobs:
+            # Client-side filter for user if applicable, assuming user is in job ID or Name or Meta.
+            # This is a basic example; real filtering might need job details if user isn't in summary.
+            # Job ID format: f"mf-{flow_name}-{run_id}-{step_name}-{task_id}-{uuid}"
+            # Job Name format: f"{flow_name}-{run_id}-{step_name}-{task_id}"
+            display_job = True
+            if user:
+                # This is a placeholder for actual user filtering logic.
+                # Nomad job summaries don't typically include user directly.
+                # We might need to embed user in job Meta or rely on naming conventions.
+                # For now, if --user is passed, we just print a note.
+                pass # echo(f"User filtering for '{user}' requires job metadata or naming convention.")
+
+            if display_job:
+                echo(
+                    f"Job ID: *{job_summary['ID']}* Name: *{job_summary['Name']}* "
+                    f"Status: *{job_summary['Status']}* Type: {job_summary['Type']} "
+                    f"SubmitTime: {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(job_summary['SubmitTime'] // 10**9))}"
+                )
+    except NomadException as e:
+        echo(f"Error listing Nomad jobs: {e}", err=True)
+    except Exception as e:
+        echo(f"Generic error listing Nomad jobs: {e}", err=True)
+        traceback.print_exc()
+
+
+@nomad.command(help="Terminate specified Nomad jobs.")
+@click.option("--my-runs", is_flag=True, help="Kill all my unfinished tasks (requires naming convention or metadata).")
+@click.option("--user", help="Terminate unfinished tasks for the given user (requires naming convention or metadata).")
+@click.option("--run-id", help="Terminate unfinished tasks for a specific run ID.")
+@click.option("--job-id", multiple=True, help="Specific Nomad job ID(s) to terminate. Can be used multiple times.")
+@click.option("--prefix", help="Terminate jobs matching a name prefix.")
+@click.option("--purge", is_flag=True, default=False, help="Purge the job from Nomad after stopping (GCs it immediately).")
+@click.pass_context
+def kill(ctx, my_runs, user, run_id, job_id, prefix, purge):
+    echo = ctx.obj.echo
+    flow_name_ctx = ctx.obj.flow.name if hasattr(ctx.obj, 'flow') else None
+
+    client = NomadClient()
+    jobs_to_kill = list(job_id) # Start with explicitly provided job IDs
+
+    if not jobs_to_kill and not prefix and not run_id and not my_runs and not user:
+        echo("No jobs specified to kill. Use --job-id, --prefix, --run-id, --my-runs, or --user.", err=True)
+        return
+
+    # Logic to find jobs based on user, run_id, prefix (similar to list, but then add to jobs_to_kill)
+    # This part needs careful implementation of job discovery.
+    # For now, if prefix or run_id is given, we list and then kill.
+
+    discovery_prefix = None
+    if prefix:
+        discovery_prefix = prefix
+    elif run_id and flow_name_ctx:
+        discovery_prefix = f"mf-{flow_name_ctx}-{run_id}-"
+    # `my_runs` and `user` based discovery is complex without metadata and is omitted for now for kill.
+
+    if discovery_prefix:
+        echo(f"Discovering jobs with prefix '{discovery_prefix}' to kill...")
+        try:
+            discovered_jobs = client.list_jobs(prefix=discovery_prefix)
+            for j_sum in discovered_jobs:
+                if j_sum['Status'] not in ['dead', 'complete']: # Only kill running/pending jobs
+                    if j_sum['ID'] not in jobs_to_kill:
+                        jobs_to_kill.append(j_sum['ID'])
+            echo(f"Found {len(discovered_jobs)} jobs with prefix, {len(jobs_to_kill)} unique jobs targeted.")
+        except NomadException as e:
+            echo(f"Error discovering jobs with prefix '{discovery_prefix}': {e}", err=True)
+            # Continue if some jobs were specified by --job-id
+
+    if not jobs_to_kill:
+        echo("No matching jobs found to kill.", err=True)
+        return
+
+    for jid in jobs_to_kill:
+        echo(f"Attempting to stop Nomad job: {jid} (Purge: {purge})")
+        try:
+            client.stop_job(jid, purge=purge)
+            echo(f"Successfully requested stop for job {jid}.", fg="green")
+        except NomadException as e:
+            echo(f"Failed to stop job {jid}: {e}", err=True, fg="red")
+        except Exception as e:
+            echo(f"Generic error stopping job {jid}: {e}", err=True, fg="red")
+            traceback.print_exc()
+
+# Need to import util for dict_to_cli_options
+from metaflow import util
+import time # for list command formatting time

--- a/metaflow/plugins/nomad/nomad_decorator.py
+++ b/metaflow/plugins/nomad/nomad_decorator.py
@@ -1,0 +1,210 @@
+import json
+import os
+import platform
+import sys
+
+from metaflow.decorators import StepDecorator
+from metaflow.exception import MetaflowException
+from metaflow.metaflow_config import (
+    NOMAD_DEFAULT_REGION,
+    NOMAD_DEFAULT_DATACENTERS,
+    NOMAD_DEFAULT_IMAGE,
+    METAFLOW_NOMAD_CPU,
+    METAFLOW_NOMAD_MEMORY,
+    METAFLOW_NOMAD_DISK,
+    # Add other Nomad-specific config variables here
+)
+from metaflow.plugins.resources_decorator import ResourcesDecorator
+# from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task # If we add timeout support
+
+# Define a new exception type for Nomad specific errors
+class NomadException(MetaflowException):
+    headline = "Nomad error"
+
+class NomadDecorator(StepDecorator):
+    """
+    Specifies that this step should execute on HashiCorp Nomad.
+
+    Parameters
+    ----------
+    region : str, optional
+        Nomad region to run the job in. Defaults to `NOMAD_DEFAULT_REGION` from Metaflow config.
+    datacenters : list[str], optional
+        List of Nomad datacenters to run the job in. Defaults to `NOMAD_DEFAULT_DATACENTERS` from Metaflow config.
+    constraints : list[dict], optional
+        Nomad constraints to apply to the job.
+        Example: `[{"attribute": "${attr.kernel.name}", "operator": "=", "value": "linux"}]`
+        See https://developer.hashicorp.com/nomad/docs/job-specification/constraint.
+    image : str, optional
+        Docker image to use for the job. Defaults to `NOMAD_DEFAULT_IMAGE` from Metaflow config or a Python version based image.
+    cpu : int, optional
+        CPU resources to request for the job (in MHz). This will override `@resources` if specified.
+    memory : int, optional
+        Memory resources to request for the job (in MB). This will override `@resources` if specified.
+    disk : int, optional
+        Disk resources to request for the job (in MB). This will override `@resources` if specified.
+    # Add other Nomad-specific parameters here, e.g., network, port_map
+    """
+    name = "nomad"
+    defaults = {
+        "region": None,
+        "datacenters": None,
+        "constraints": None,
+        "image": None,
+        "cpu": None,
+        "memory": None,
+        "disk": None,
+        # "run_time_limit": 5 * 24 * 60 * 60,  # Default 5 days, if timeout decorator is used
+    }
+
+    package_url = None
+    package_sha = None
+    run_time_limit = None # Will be set by timeout decorator logic if implemented
+
+    def init(self):
+        super(NomadDecorator, self).init()
+        # Initialize attributes from defaults or Metaflow config
+        if self.attributes["region"] is None:
+            self.attributes["region"] = NOMAD_DEFAULT_REGION
+        if self.attributes["datacenters"] is None:
+            # Ensure datacenters is a list
+            datacenters_cfg = NOMAD_DEFAULT_DATACENTERS
+            if isinstance(datacenters_cfg, str):
+                datacenters_cfg = [dc.strip() for dc in datacenters_cfg.split(',') if dc.strip()]
+            self.attributes["datacenters"] = datacenters_cfg
+
+        if self.attributes["image"] is None:
+            if NOMAD_DEFAULT_IMAGE:
+                self.attributes["image"] = NOMAD_DEFAULT_IMAGE
+            else:
+                self.attributes["image"] = "python:%s.%s-slim" % (
+                    platform.python_version_tuple()[0],
+                    platform.python_version_tuple()[1],
+                )
+
+        # Set default resource values from metaflow_config if not set by decorator
+        # These might be overridden by @resources decorator later in step_init
+        if self.attributes["cpu"] is None and METAFLOW_NOMAD_CPU:
+            self.attributes["cpu"] = METAFLOW_NOMAD_CPU
+        if self.attributes["memory"] is None and METAFLOW_NOMAD_MEMORY:
+            self.attributes["memory"] = METAFLOW_NOMAD_MEMORY
+        if self.attributes["disk"] is None and METAFLOW_NOMAD_DISK:
+            self.attributes["disk"] = METAFLOW_NOMAD_DISK
+
+
+    def step_init(self, flow, graph, step, decos, environment, flow_datastore, logger):
+        self.logger = logger
+        self.environment = environment
+        self.step = step
+        self.flow_datastore = flow_datastore
+
+        if flow_datastore.TYPE not in ("s3", "azure", "gs"):
+            raise NomadException(
+                "The *@nomad* decorator requires --datastore=s3, --datastore=azure, or --datastore=gs."
+            )
+
+        # self.run_time_limit = get_run_time_limit_for_task(decos) # If timeout decorator is used
+        # if self.run_time_limit < 60: # Or some other minimum
+        #     raise NomadException("The timeout for step *%s* should be at least 60 seconds for execution on Nomad." % step)
+
+        # Override with @resources decorator if present
+        for deco in decos:
+            if isinstance(deco, ResourcesDecorator):
+                for k, v in deco.attributes.items():
+                    if k in self.attributes and v is not None:
+                        # If @nomad also specifies cpu/memory/disk, @resources takes precedence
+                        # or we can choose to let @nomad override @resources by checking self.attributes[k] is None
+                        if self.attributes[k] is None or k not in self.defaults or self.attributes[k] == self.defaults[k]:
+                             self.attributes[k] = v
+                        else:
+                            # If both @nomad and @resources specify a resource, take the max
+                            # This behavior matches KubernetesDecorator
+                            try:
+                                self.attributes[k] = str(max(float(self.attributes[k] or 0), float(v or 0)))
+                            except ValueError:
+                                # Handle cases where conversion to float might fail (e.g. for non-numeric attributes)
+                                self.attributes[k] = v
+
+
+        # Validate resource attributes (ensure they are positive numbers if set)
+        for attr in ["cpu", "memory", "disk"]:
+            if self.attributes[attr] is not None:
+                try:
+                    val = float(self.attributes[attr])
+                    if val <= 0:
+                        raise ValueError
+                except (TypeError, ValueError):
+                    raise NomadException(
+                        "Invalid {} value *{}* for step *{}*; it should be a positive number.".format(
+                            attr, self.attributes[attr], step
+                        )
+                    )
+
+        # Validate constraints format if provided
+        if self.attributes["constraints"] is not None:
+            if not isinstance(self.attributes["constraints"], list):
+                raise NomadException("Nomad 'constraints' attribute must be a list of dicts.")
+            for constraint in self.attributes["constraints"]:
+                if not isinstance(constraint, dict):
+                    raise NomadException("Each item in Nomad 'constraints' must be a dict.")
+                # Further validation of constraint keys can be added here
+
+
+    def runtime_init(self, flow, graph, package, run_id):
+        self.flow = flow
+        self.graph = graph
+        self.package = package
+        self.run_id = run_id
+
+    def runtime_task_created(
+        self, task_datastore, task_id, split_index, input_paths, is_cloned, ubf_context
+    ):
+        if not is_cloned:
+            self._save_package_once(self.flow_datastore, self.package)
+
+    def runtime_step_cli(self, cli_args, retry_count, max_user_code_retries, ubf_context):
+        if retry_count <= max_user_code_retries:
+            cli_args.commands = ["nomad", "step"]
+            cli_args.command_args.append(self.package_sha)
+            cli_args.command_args.append(self.package_url)
+
+            # Pass all attributes of the decorator as command options
+            for k, v in self.attributes.items():
+                if v is not None:
+                    if isinstance(v, (list, dict)):
+                         cli_args.command_options[k.replace("_", "-")] = json.dumps(v)
+                    else:
+                        cli_args.command_options[k.replace("_", "-")] = v
+
+            # if self.run_time_limit: # If timeout decorator is used
+            #    cli_args.command_options["run-time-limit"] = self.run_time_limit
+
+            # Ensure the entrypoint uses the python executable from the environment
+            # This might need adjustment based on how the Nomad task driver executes the command
+            cli_args.entrypoint = [self.environment.executable(self.step)]
+
+
+    @classmethod
+    def _save_package_once(cls, flow_datastore, package):
+        if cls.package_url is None:
+            # this ensures that we upload the code package only once
+            cls.package_url, cls.package_sha = flow_datastore.save_data(
+                [package.blob], len_hint=1
+            )[0]
+
+# Placeholder for functions to be added to metaflow_config.py
+# Ensure these are actually added to the real metaflow_config.py file
+
+# NOMAD_DEFAULT_REGION = os.environ.get("METAFLOW_NOMAD_DEFAULT_REGION", "global")
+# NOMAD_DEFAULT_DATACENTERS = os.environ.get("METAFLOW_NOMAD_DEFAULT_DATACENTERS", "dc1") # Comma-separated string e.g. "dc1,dc2"
+# NOMAD_DEFAULT_IMAGE = os.environ.get("METAFLOW_NOMAD_DEFAULT_IMAGE", None)
+# METAFLOW_NOMAD_CPU = os.environ.get("METAFLOW_NOMAD_CPU", "1000") # Default CPU in MHz for Nomad tasks
+# METAFLOW_NOMAD_MEMORY = os.environ.get("METAFLOW_NOMAD_MEMORY", "4096") # Default Memory in MB for Nomad tasks
+# METAFLOW_NOMAD_DISK = os.environ.get("METAFLOW_NOMAD_DISK", "10240") # Default Disk in MB for Nomad tasks
+# To be added to metaflow_config_funcs.py in ALL_VALUE_OVERRIDES
+# ("nomad_default_region", "NOMAD_DEFAULT_REGION"),
+# ("nomad_default_datacenters", "NOMAD_DEFAULT_DATACENTERS"),
+# ("nomad_default_image", "NOMAD_DEFAULT_IMAGE"),
+# ("nomad_cpu", "METAFLOW_NOMAD_CPU"),
+# ("nomad_memory", "METAFLOW_NOMAD_MEMORY"),
+# ("nomad_disk", "METAFLOW_NOMAD_DISK"),

--- a/metaflow/tutorials/09-hello-nomad/README.md
+++ b/metaflow/tutorials/09-hello-nomad/README.md
@@ -1,0 +1,87 @@
+# Tutorial: Hello Nomad - Running Metaflow Steps on HashiCorp Nomad
+
+This tutorial demonstrates how to execute a Metaflow step on a HashiCorp Nomad cluster using the `@nomad` decorator.
+
+## Prerequisites
+
+1.  **Metaflow Installed:** Ensure Metaflow is installed.
+2.  **Nomad Cluster:** You need access to a running Nomad cluster. For local testing, you can run Nomad in development mode:
+    ```bash
+    nomad agent -dev -bind 0.0.0.0 -log-level INFO
+    ```
+    This will typically make Nomad available at `http://localhost:4646`.
+3.  **`python-nomad` Library:** The Metaflow execution environment (and the Docker image used by Nomad tasks) needs the `python-nomad` library. Install it via pip:
+    ```bash
+    pip install python-nomad
+    ```
+4.  **Docker:** Nomad's default task driver for Metaflow is Docker, so Docker must be installed and running on the Nomad client nodes where jobs will execute.
+5.  **Environment Variable (Optional but Recommended):** Set the `METAFLOW_NOMAD_ADDRESS` environment variable to your Nomad server's address:
+    ```bash
+    export METAFLOW_NOMAD_ADDRESS="http://localhost:4646"
+    ```
+    Alternatively, you can configure this in your `metaflow_config.json`.
+
+## The Flow: `hello-nomad.py`
+
+The flow `hello-nomad.py` is very simple:
+- `start`: Initiates the flow.
+- `nomad_step`: This step is decorated with `@nomad` and will be dispatched to your Nomad cluster for execution. It demonstrates requesting specific CPU, memory, and disk resources.
+- `end`: Finishes the flow after the Nomad step completes.
+
+```python
+from metaflow import FlowSpec, step, nomad, resources, current
+import os
+
+class HelloNomadFlow(FlowSpec):
+    # ... (flow code from hello-nomad.py) ...
+```
+
+## Running the Flow
+
+1.  **Navigate to the tutorial directory:**
+    ```bash
+    cd metaflow/tutorials/09-hello-nomad
+    ```
+
+2.  **Run the flow:**
+    ```bash
+    python hello-nomad.py run
+    ```
+    If you haven't set `METAFLOW_NOMAD_ADDRESS` as an environment variable, you might need to configure it, or the client might default to a pre-configured address if available.
+
+## Expected Output
+
+You should see output similar to this (details like task IDs will vary):
+
+```
+Metaflow 2.x.x executing HelloNomadFlow for user:youruser
+Workflow starting (run-id 167xxxxxxx):
+ - View this run in UI: <UI_LINK_IF_AVAILABLE>
+[167xxxxxxx][start] HelloNomadFlow starting.
+[167xxxxxxx][start] Next, we will run a step on Nomad.
+[167xxxxxxx][start] Task finished successfully.
+[167xxxxxxx][nomad_step] Task is starting on Nomad... (details about job ID, eval ID)
+[167xxxxxxx][nomad_step] Hello from a Nomad task!
+[167xxxxxxx][nomad_step] This step is running as part of flow: HelloNomadFlow
+[167xxxxxxx][nomad_step] Run ID: 167xxxxxxx, Step: nomad_step, Task ID: <task_id>
+[167xxxxxxx][nomad_step] METAFLOW_NOMAD_WORKLOAD environment variable: 1
+[167xxxxxxx][nomad_step] Successfully identified as a Nomad workload via environment variable.
+[167xxxxxxx][nomad_step] Nomad step computation complete.
+[167xxxxxxx][nomad_step] Task finished successfully.
+[167xxxxxxx][end] Back from Nomad. Message: Successfully ran a step on Nomad!
+[167xxxxxxx][end] HelloNomadFlow finished successfully!
+Done!
+```
+
+If the Nomad step is launched successfully, you will also see corresponding job and allocation activity in your Nomad UI or via the Nomad CLI (`nomad job status`, `nomad alloc status`).
+
+## Exploring Further
+
+-   Modify the `@nomad` decorator in `hello-nomad.py` to request different resources (`cpu`, `memory`, `disk`).
+-   If your Nomad cluster has specific constraints or datacenters, try using the `datacenters` and `constraints` arguments of the `@nomad` decorator.
+-   Use the `metaflow nomad list` and `metaflow nomad kill` commands (from the directory containing `hello-nomad.py`) to manage jobs launched by this flow.
+
+This tutorial provides a basic introduction. For more advanced use cases, refer to the main [Metaflow documentation on using Nomad](https://docs.metaflow.org/scaling/remote-tasks/nomad) (once available).
+```
+
+**Note:** The final link `https://docs.metaflow.org/scaling/remote-tasks/nomad` in the README is a placeholder for where the `docs/nomad.md` file (created in the previous step) would eventually be hosted.

--- a/metaflow/tutorials/09-hello-nomad/hello-nomad.py
+++ b/metaflow/tutorials/09-hello-nomad/hello-nomad.py
@@ -1,0 +1,51 @@
+from metaflow import FlowSpec, step, nomad, resources, current
+import os
+
+class HelloNomadFlow(FlowSpec):
+    """
+    A simple flow to demonstrate executing a step on HashiCorp Nomad.
+    """
+
+    @step
+    def start(self):
+        """
+        Starts the flow.
+        """
+        print("HelloNomadFlow starting.")
+        print("Next, we will run a step on Nomad.")
+        self.next(self.nomad_step)
+
+    @nomad(cpu=500, memory=256, disk=100) # Request 500 MHz CPU, 256MB RAM, 100MB Disk
+    # Example of also using @resources decorator, though @nomad can specify directly
+    @resources(memory=128) # @nomad's memory=256 will take precedence or be maxed
+    @step
+    def nomad_step(self):
+        """
+        This step is executed on Nomad.
+        """
+        print("Hello from a Nomad task!")
+        print(f"This step is running as part of flow: {current.flow_name}")
+        print(f"Run ID: {current.run_id}, Step: {current.step_name}, Task ID: {current.task_id}")
+
+        # Check for an environment variable that should be set by the Nomad plugin
+        nomad_workload_env = os.environ.get("METAFLOW_NOMAD_WORKLOAD")
+        print(f"METAFLOW_NOMAD_WORKLOAD environment variable: {nomad_workload_env}")
+        if nomad_workload_env == "1":
+            print("Successfully identified as a Nomad workload via environment variable.")
+        else:
+            print("Warning: METAFLOW_NOMAD_WORKLOAD environment variable not found or incorrect.")
+
+        self.message = "Successfully ran a step on Nomad!"
+        print("Nomad step computation complete.")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        """
+        Ends the flow.
+        """
+        print(f"Back from Nomad. Message: {self.message}")
+        print("HelloNomadFlow finished successfully!")
+
+if __name__ == "__main__":
+    HelloNomadFlow()

--- a/test/unit/test_nomad.py
+++ b/test/unit/test_nomad.py
@@ -1,0 +1,287 @@
+import pytest
+import json
+
+from metaflow.decorators import StepDecorator, flow_decorators
+from metaflow.flowspec import FlowSpec
+from metaflow.plugins.nomad.nomad_decorator import NomadDecorator, NomadException
+from metaflow.plugins.resources_decorator import ResourcesDecorator
+from metaflow.plugins.nomad.nomad import NomadClient # For testing _generate_job_spec
+
+# Mock Metaflow configurations for testing
+# These would normally come from metaflow_config.py
+MOCK_NOMAD_DEFAULT_REGION = "global-mock"
+MOCK_NOMAD_DEFAULT_DATACENTERS = ["dc1-mock"]
+MOCK_NOMAD_DEFAULT_IMAGE = "python:3.9-slim-mock"
+MOCK_METAFLOW_NOMAD_CPU = "1500"
+MOCK_METAFLOW_NOMAD_MEMORY = "3072"
+MOCK_METAFLOW_NOMAD_DISK = "5120"
+
+# Helper to create a mock flow and step context for decorator testing
+def make_mock_flow_step(decos):
+    class MockFlow(FlowSpec):
+        @classmethod
+        def get_top_level_options(cls): # Needed by environment.executable
+            return {}
+
+        _flow_decorators = flow_decorators() # Needed by environment.executable
+        script_name = "mock_flow.py" # Needed by environment.executable
+
+        @step
+        def mock_step(self):
+            pass
+
+    flow = MockFlow()
+    step = flow.mock_step
+
+    # Initialize decorators
+    # This is a simplified version of how Metaflow runtime initializes decorators
+    # environment and flow_datastore are often needed by step_init
+    from metaflow.metaflow_environment import MetaflowEnvironment
+    from metaflow.datastore.local_storage import LocalStorage
+
+    mock_logger = lambda *args, **kwargs: None # Simple mock logger
+    mock_environment = MetaflowEnvironment(flow)
+    # Mock datastore needs a sysroot
+    LocalStorage.datastore_root = "/tmp/metaflow_test_ds" # Dummy path
+    mock_flow_datastore = LocalStorage(flow.name)
+
+
+    initialized_decos = []
+    for deco_cls, attrs in decos:
+        decorator_instance = deco_cls()
+        decorator_instance.attributes = decorator_instance.defaults.copy()
+        if attrs: # Apply provided attributes
+            decorator_instance.attributes.update(attrs)
+
+        # Call init and step_init if they exist
+        if hasattr(decorator_instance, 'init'):
+             decorator_instance.init() # Call init first
+        if hasattr(decorator_instance, 'step_init'):
+            decorator_instance.step_init(
+                flow=flow,
+                graph=flow._graph, # graph might be needed
+                step=step.__name__,
+                decos=[d[0]() for d in decos], # Pass uninitialized decorator instances
+                environment=mock_environment,
+                flow_datastore=mock_flow_datastore,
+                logger=mock_logger
+            )
+        initialized_decos.append(decorator_instance)
+    return flow, step, initialized_decos
+
+
+class TestNomadDecorator:
+    @pytest.fixture(autouse=True)
+    def-monkeypatch_nomad_configs(self, monkeypatch):
+        monkeypatch.setattr("metaflow.plugins.nomad.nomad_decorator.NOMAD_DEFAULT_REGION", MOCK_NOMAD_DEFAULT_REGION)
+        monkeypatch.setattr("metaflow.plugins.nomad.nomad_decorator.NOMAD_DEFAULT_DATACENTERS", MOCK_NOMAD_DEFAULT_DATACENTERS)
+        monkeypatch.setattr("metaflow.plugins.nomad.nomad_decorator.NOMAD_DEFAULT_IMAGE", MOCK_NOMAD_DEFAULT_IMAGE)
+        monkeypatch.setattr("metaflow.plugins.nomad.nomad_decorator.METAFLOW_NOMAD_CPU", MOCK_METAFLOW_NOMAD_CPU)
+        monkeypatch.setattr("metaflow.plugins.nomad.nomad_decorator.METAFLOW_NOMAD_MEMORY", MOCK_METAFLOW_NOMAD_MEMORY)
+        monkeypatch.setattr("metaflow.plugins.nomad.nomad_decorator.METAFLOW_NOMAD_DISK", MOCK_METAFLOW_NOMAD_DISK)
+        # Mock datastore for step_init check
+        monkeypatch.setattr("metaflow.plugins.nomad.nomad_decorator.NomadException", NomadException)
+
+
+    def test_decorator_defaults(self):
+        # Test that decorator initializes with defaults from mock_config
+        _, _, decos = make_mock_flow_step([ (NomadDecorator, {}) ])
+        nomad_deco = decos[0]
+        assert nomad_deco.attributes["region"] == MOCK_NOMAD_DEFAULT_REGION
+        assert nomad_deco.attributes["datacenters"] == MOCK_NOMAD_DEFAULT_DATACENTERS
+        assert nomad_deco.attributes["image"] == MOCK_NOMAD_DEFAULT_IMAGE
+        assert nomad_deco.attributes["cpu"] == MOCK_METAFLOW_NOMAD_CPU
+        assert nomad_deco.attributes["memory"] == MOCK_METAFLOW_NOMAD_MEMORY
+        assert nomad_deco.attributes["disk"] == MOCK_METAFLOW_NOMAD_DISK
+        assert nomad_deco.attributes["constraints"] is None
+
+    def test_decorator_custom_values(self):
+        custom_attrs = {
+            "region": "us-east-1",
+            "datacenters": ["dc-custom"],
+            "image": "custom/image:latest",
+            "cpu": "2000",
+            "memory": "8192",
+            "disk": "20480",
+            "constraints": [{"attribute": "${attr.kernel.name}", "value": "linux"}]
+        }
+        _, _, decos = make_mock_flow_step([ (NomadDecorator, custom_attrs) ])
+        nomad_deco = decos[0]
+        assert nomad_deco.attributes["region"] == "us-east-1"
+        assert nomad_deco.attributes["datacenters"] == ["dc-custom"]
+        assert nomad_deco.attributes["image"] == "custom/image:latest"
+        assert nomad_deco.attributes["cpu"] == "2000"
+        assert nomad_deco.attributes["memory"] == "8192"
+        assert nomad_deco.attributes["disk"] == "20480"
+        assert nomad_deco.attributes["constraints"] == [{"attribute": "${attr.kernel.name}", "value": "linux"}]
+
+    def test_decorator_with_resources(self):
+        # @nomad takes precedence if specified, else @resources, else nomad defaults
+        nomad_attrs = {"cpu": "3000", "image": "nomad/image"} # Nomad specifies CPU
+        resources_attrs = {"cpu": "500", "memory": "1024", "disk": "1000"} # Resources specifies all
+
+        _, _, decos = make_mock_flow_step([
+            (ResourcesDecorator, resources_attrs),
+            (NomadDecorator, nomad_attrs)
+        ])
+        nomad_deco = next(d for d in decos if isinstance(d, NomadDecorator))
+
+        assert nomad_deco.attributes["image"] == "nomad/image" # From @nomad
+        assert nomad_deco.attributes["cpu"] == "3000" # From @nomad (takes precedence, or max if logic is max)
+                                                      # Current logic in decorator takes max.
+        assert nomad_deco.attributes["memory"] == "1024" # From @resources
+        assert nomad_deco.attributes["disk"] == "1000" # From @resources
+
+    def test_decorator_resources_override_nomad_defaults(self):
+        # @resources overrides @nomad's *default* values (those from METAFLOW_NOMAD_*)
+        resources_attrs = {"cpu": "600", "memory": "2048", "disk": "2000"}
+        _, _, decos = make_mock_flow_step([
+            (ResourcesDecorator, resources_attrs),
+            (NomadDecorator, {}) # Nomad decorator with no specific overrides
+        ])
+        nomad_deco = next(d for d in decos if isinstance(d, NomadDecorator))
+
+        assert nomad_deco.attributes["cpu"] == "600" # From @resources
+        assert nomad_deco.attributes["memory"] == "2048" # From @resources
+        assert nomad_deco.attributes["disk"] == "2000" # From @resources
+        assert nomad_deco.attributes["image"] == MOCK_NOMAD_DEFAULT_IMAGE # From nomad default config
+
+
+    def test_decorator_invalid_resources(self):
+        with pytest.raises(NomadException):
+            make_mock_flow_step([(NomadDecorator, {"cpu": "-100"})])
+        with pytest.raises(NomadException):
+            make_mock_flow_step([(NomadDecorator, {"memory": "0"})])
+        with pytest.raises(NomadException):
+            make_mock_flow_step([(NomadDecorator, {"disk": "abc"})])
+
+    def test_decorator_invalid_constraints_type(self):
+        with pytest.raises(NomadException):
+            make_mock_flow_step([(NomadDecorator, {"constraints": "not-a-list"})])
+        with pytest.raises(NomadException):
+            make_mock_flow_step([(NomadDecorator, {"constraints": ["not-a-dict"]})])
+
+    # TODO: Test runtime_step_cli argument formatting
+
+class TestNomadClientJobSpec:
+    @pytest.fixture
+    def nomad_client(self):
+        # Mock NomadClient to avoid actual Nomad connection for spec generation
+        # We only need to test _generate_job_spec which doesn't make API calls
+        class MockNomadLibClient: # Mock for the `nomad.Nomad()` instance
+            pass
+
+        client = NomadClient(nomad_address="http://mock-nomad:4646")
+        client.client = MockNomadLibClient() # Replace real client with mock
+        return client
+
+    def test_generate_job_spec_basic(self, nomad_client):
+        spec = nomad_client._generate_job_spec(
+            job_name="testflow-run1-step1-task1",
+            task_name="mf-task-step1",
+            image="test/image:latest",
+            command_executable="/usr/bin/python",
+            command_args=["flow.py", "step", "step1"],
+            cpu="1000", memory="512", disk="256",
+            datacenters=["dc1-test"], region="test-region", nomad_namespace="test-namespace",
+            env_vars={"MY_VAR": "value1"},
+            code_package_url="s3://bucket/path/to/package.tgz"
+        )
+        job = spec["Job"]
+        assert job["ID"].startswith("mf-testflow-run1-step1-task1-")
+        assert job["Name"] == "testflow-run1-step1-task1"
+        assert job["Type"] == "batch"
+        assert job["Datacenters"] == ["dc1-test"]
+        assert job["Region"] == "test-region"
+        assert job["Namespace"] == "test-namespace"
+
+        tg = job["TaskGroups"][0]
+        assert tg["Name"] == "tg-mf-task-step1"
+        assert tg["Count"] == 1
+        assert tg["EphemeralDisk"]["SizeMB"] == 256
+
+        task = tg["Tasks"][0]
+        assert task["Name"] == "mf-task-step1"
+        assert task["Driver"] == "docker"
+        assert task["Config"]["image"] == "test/image:latest"
+        assert task["Config"]["command"] == "/usr/bin/python"
+        assert task["Config"]["args"] == ["flow.py", "step", "step1"]
+        assert task["Env"]["MY_VAR"] == "value1"
+        assert task["Resources"]["CPU"] == 1000
+        assert task["Resources"]["MemoryMB"] == 512
+        # DiskMB at task level is not standard for Docker driver, it's at group level EphemeralDisk
+        assert "DiskMB" not in task["Resources"]
+
+        assert len(task["Artifacts"]) == 1
+        assert task["Artifacts"][0]["GetterSource"] == "s3://bucket/path/to/package.tgz"
+        assert task["Artifacts"][0]["RelativeDest"] == "local/mf-task-step1/"
+
+    def test_generate_job_spec_with_constraints(self, nomad_client):
+        constraints = [{"attribute": "${attr.kernel.name}", "operator": "=", "value": "linux"}]
+        spec = nomad_client._generate_job_spec(
+            job_name="constrained-job", task_name="mf-task-cstep",
+            image="img", command_executable="py", command_args=["f.py"],
+            cpu="100", memory="100", disk="100",
+            datacenters=["dc1"], region="reg1", nomad_namespace="ns1",
+            constraints=constraints
+        )
+        assert spec["Job"]["Constraints"] == constraints
+
+    def test_generate_job_spec_no_disk(self, nomad_client):
+        spec = nomad_client._generate_job_spec(
+            job_name="nodisk-job", task_name="mf-task-ndstep",
+            image="img", command_executable="py", command_args=["f.py"],
+            cpu="100", memory="100", disk=None, # No disk specified
+            datacenters=["dc1"], region="reg1", nomad_namespace="ns1"
+        )
+        tg = spec["Job"]["TaskGroups"][0]
+        assert tg["EphemeralDisk"]["SizeMB"] == 1024 # Default fallback
+
+    # TODO: Add more tests for _generate_job_spec, e.g. different env_vars, no code_package_url
+
+# TODO: Add tests for NomadClient API interaction methods (launch_job, wait, logs, stop, list)
+# These will require mocking the `python-nomad` library's client calls and responses.
+# Example:
+# from unittest.mock import MagicMock
+# def test_launch_job_success(nomad_client_with_mocked_api):
+#     nomad_client_with_mocked_api.client.job.register_job = MagicMock(return_value={"EvalID": "eval123"})
+#     result = nomad_client_with_mocked_api.launch_job(...)
+#     assert result["eval_id"] == "eval123"
+#     nomad_client_with_mocked_api.client.job.register_job.assert_called_once()
+
+# To run these tests:
+# Ensure metaflow is installed in editable mode or python path includes the project root.
+# `python -m pytest test/unit/test_nomad.py`
+# May need to `pip install pytest`
+# Ensure `python-nomad` is installed for `NomadClient` import, though it's mocked for spec generation.
+# The `make_mock_flow_step` might need access to `metaflow_config` for some environment/datastore setups.
+# Consider adding `from metaflow import metaflow_config` and monkeypatching its values directly
+# if the decorator/client relies on them beyond what's passed or monkeypatched at module level.
+# For `environment.executable(step_name)` to work without full flow setup, it might need more mocks.
+# `LocalDatastore.datastore_root` is set for `LocalStorage` initialization.
+# `FlowSpec._graph` is used; simple graph is fine for these unit tests.
+# `FlowSpec.script_name` is added.
+# `FlowSpec.get_top_level_options` is added.
+# `FlowSpec._flow_decorators` is added.
+
+# A fixture for a client with a fully mocked python-nomad Nomad() instance
+@pytest.fixture
+def nomad_client_with_mocked_api(monkeypatch):
+    # Mock the entire python-nomad library instance
+    mock_nomad_lib_instance = MagicMock()
+
+    # Configure return values for specific mocked calls if needed for more complex tests
+    # e.g., mock_nomad_lib_instance.job.register_job.return_value = {"EvalID": "mock-eval-id"}
+    # e.g., mock_nomad_lib_instance.allocation.get_allocation.return_value = {"ClientStatus": "complete", ...}
+
+    # Patch the nomad.Nomad class to return our mock instance
+    monkeypatch.setattr("nomad.Nomad", lambda *args, **kwargs: mock_nomad_lib_instance)
+
+    # Now, when NomadClient instantiates nomad.Nomad, it gets our MagicMock
+    client = NomadClient(nomad_address="http://mock-nomad:4646") # Address doesn't matter now
+    client.client = mock_nomad_lib_instance # Ensure it's using the top-level mock
+    return client
+
+# Need to import MagicMock for the above fixture
+from unittest.mock import MagicMock
+from metaflow import step # for @step in mock flow


### PR DESCRIPTION
This commit introduces a new Metaflow plugin to support running tasks on HashiCorp Nomad.

Key features:
- `@nomad` decorator for specifying Nomad-specific task configurations (region, datacenters, image, resources, constraints).
- `NomadClient` for interacting with the Nomad API (job submission, status checking, logging, etc.).
- CLI commands (`metaflow nomad step|list|kill`) for managing Nomad tasks.
- Configuration options for default Nomad settings.
- Unit tests for decorator logic and job specification generation.
- Basic documentation (`docs/nomad.md`) and a new tutorial (`tutorials/09-hello-nomad/`).