### PR TITLE
fix: uv bootstrapping

### DIFF
--- a/metaflow/plugins/uv/bootstrap.py
+++ b/metaflow/plugins/uv/bootstrap.py
@@ -5,7 +5,7 @@ import sys
 import time
 
 from metaflow.util import which
-from metaflow.info_file import read_info_file
+from metaflow.meta_files import read_info_file
 from metaflow.metaflow_config import get_pinned_conda_libs
 from metaflow.packaging_sys import MetaflowCodeContent, ContentType
 from urllib.request import Request, urlopen


### PR DESCRIPTION
`read_info_file` was relocated in the recent release. fix import in uv bootstrap