### PR TITLE
[bug fix] fix subtle bug from netflix/metaflow#2463

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -184,7 +184,7 @@ class Decorator(object):
 
             attrs[name.strip()] = val_parsed
 
-            return [], attrs
+        return [], attrs
 
     @classmethod
     def parse_decorator_spec(cls, deco_spec):


### PR DESCRIPTION
The packaging PR #2463 introduced the `extract_args_kwargs_from_decorator_spec` to parse the decospecs added from the command line. This function has a subtle bug where it returns from the for loop instead of the end of the function. 