### PR TITLE
Fixes tolerations typehint

### DIFF
--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -96,7 +96,7 @@ class KubernetesDecorator(StepDecorator):
         the scheduled node should not have GPUs.
     gpu_vendor : str, default KUBERNETES_GPU_VENDOR
         The vendor of the GPUs to be used for this step.
-    tolerations : List[str], default []
+    tolerations : List[Dict[str,str]], default []
         The default is extracted from METAFLOW_KUBERNETES_TOLERATIONS.
         Kubernetes tolerations to use when launching pod in Kubernetes.
     labels: Dict[str, str], default: METAFLOW_KUBERNETES_LABELS


### PR DESCRIPTION
This is a very minor fix - but it confused me for a while, so for the next person poking at the code, this might be a good to sort out. The format of the tolerations is a dict with key and value strings. It is listed correctly in a comment further down in the codebase but incorrectly in the typehint. 