### PR TITLE
[bug fix] fix subtle bug from netflix/metaflow#2463 (#2498)

### DIFF
--- a/metaflow/user_decorators/mutable_flow.py
+++ b/metaflow/user_decorators/mutable_flow.py
@@ -347,8 +347,10 @@ class MutableFlow:
                     "Mutable flow adding flow decorator '%s'" % deco_type
                 )
 
+            # self._flow_cls._flow_decorators is a  dictionary of form :
+            # <deco_name> : [deco_instance, deco_instance, ...]
             existing_deco = [
-                d for d in self._flow_cls._flow_decorators if d.name == flow_deco.name
+                d for d in self._flow_cls._flow_decorators if d == flow_deco.name
             ]
 
             if flow_deco.allow_multiple or not existing_deco:


### PR DESCRIPTION
When doing something like :
```
from metaflow import project

....

mymutableflow.add_decorator(
project, deco_kwargs={"name":"abc"})
```

Metaflow breaks with the error :

```
 File ".../metaflow/flowspec.py", line 312, in _process_config_decorators
    deco.pre_mutate(mutable_flow)
  File "mydeco.py", line 67, in pre_mutate
    mutable_flow.add_decorator(
  File ".../metaflow/user_decorators/mutable_flow.py", line 409, in add_decorator
    _add_flow_decorator(
  File ".../metaflow/user_decorators/mutable_flow.py", line 353, in _add_flow_decorator
      d for d in self._flow_cls._flow_decorators if d.name == flow_deco.name
                                                  ^^^^^^
AttributeError: 'str' object has no attribute 'name'
```

This is because we dont parse the _flow_cls._flow_decorators in the right way (as a dict instead of list)