### PR TITLE
fix: triggers not working with argo parallel

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -3347,7 +3347,7 @@ class ArgoWorkflows(object):
                                     TriggerParameter()
                                     .src(
                                         dependency_name=event["sanitized_name"],
-                                        data_key="body.payload",
+                                        data_template="body.payload | toRawJson | squote",
                                         value=json.dumps(None),
                                     )
                                     .dest(


### PR DESCRIPTION
triggers are not working when running with argo workflows in combination with `@parallel`

problem seems to stem from argo having different quotations for parameters stemming from event payloads vs. from regular workflow submissions. this in turn breaks the pod spec in the manifest for jobsets