### PR TITLE
Add complete Colima support for metaflow-dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ stubs/version.py
 
 # devtools
 .devtools
+
+# Colima environment files
+.env.colima
+activate-colima.sh

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ For more details on Metaflow’s features and best practices, check out:
 
 If you need help, don’t hesitate to reach out on our [Slack community](http://slack.outerbounds.co/)!
 
+### Docker Runtime
+
+Metaflow development requires Docker. You can use either:
+- **Docker Desktop** (default)
+- **[Colima](docs/colima.md)** (open-source alternative for macOS)
+
+Check your Docker setup with: `make check-docker`
 
 ### Deploying infrastructure for Metaflow in your cloud
 <img src="./docs/multicloud.png" width="800px">

--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -67,17 +67,55 @@ install-helm:
 	fi
 
 check-docker:
-	@if ! command -v docker >/dev/null 2>&1; then \
-		echo "❌ Docker is not installed. Please install Docker first: https://docs.docker.com/get-docker/"; \
+	@echo "Checking Docker runtime..."
+	@if command -v docker >/dev/null 2>&1; then \
+		if docker info >/dev/null 2>&1; then \
+			if colima status 2>&1 | grep -q "is running"; then \
+				echo "✓ Using Colima as Docker runtime"; \
+				$(MAKE) configure-colima; \
+			elif docker context ls | grep -q "desktop-linux"; then \
+				echo "✓ Using Docker Desktop"; \
+			else \
+				echo "✓ Using generic Docker runtime"; \
+			fi; \
+		else \
+			if command -v colima >/dev/null 2>&1; then \
+				echo "❌ Docker daemon not running. Colima is installed but not started."; \
+				echo "   Run: colima start"; \
+			else \
+				echo "❌ Docker daemon not running."; \
+				echo "   Please start Docker Desktop or install and start Colima:"; \
+				echo "   brew install colima && colima start"; \
+			fi; \
+			exit 1; \
+		fi; \
+	else \
+		echo "❌ Docker CLI not found. Please install Docker or Colima."; \
 		exit 1; \
 	fi
-	@echo "🔍 Checking Docker daemon..."
-	@if [ "$(shell uname)" = "Darwin" ]; then \
-		open -a Docker || (echo "❌ Please start Docker Desktop" && exit 1); \
-	else \
-                docker info >/dev/null 2>&1 || (echo "❌ Docker daemon is not running." && exit 1); \
+
+configure-colima:
+	@if [ ! -f .env.colima ]; then \
+		echo "export DOCKER_HOST=\"unix://\$${HOME}/.colima/default/docker.sock\"" > .env.colima; \
+		echo "export DOCKER_BUILDKIT=1" >> .env.colima; \
+		echo "export COMPOSE_DOCKER_CLI_BUILD=1" >> .env.colima; \
 	fi
-	@echo "✅ Docker is running"
+	@if DOCKER_HOST="unix://\$${HOME}/.colima/default/docker.sock" docker version >/dev/null 2>&1; then \
+		echo "✓ Docker commands routing through Colima successfully"; \
+	else \
+		echo "❌ Failed to connect to Docker through Colima"; \
+		exit 1; \
+	fi
+
+-include .env.colima
+
+ifdef DOCKER_HOST
+    DOCKER_CMD := DOCKER_HOST=$(DOCKER_HOST) docker
+    DOCKER_COMPOSE_CMD := DOCKER_HOST=$(DOCKER_HOST) docker-compose
+else
+    DOCKER_CMD := docker
+    DOCKER_COMPOSE_CMD := docker-compose
+endif
 
 install-brew:
 	@if [ "$(shell uname)" = "Darwin" ] && ! command -v brew >/dev/null 2>&1; then \

--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -107,6 +107,13 @@ configure-colima:
 		exit 1; \
 	fi
 
+# Export for sub-makes
+ifdef DOCKER_HOST
+export DOCKER_HOST
+export DOCKER_BUILDKIT
+export COMPOSE_DOCKER_CLI_BUILD
+endif
+
 -include .env.colima
 
 ifdef DOCKER_HOST

--- a/devtools/setup-colima.sh
+++ b/devtools/setup-colima.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# setup-colima.sh - Complete Colima setup for Metaflow development
+
+set -e
+
+COLIMA_PROFILE="${COLIMA_PROFILE:-default}"
+COLIMA_CPUS="${COLIMA_CPUS:-4}"
+COLIMA_MEMORY="${COLIMA_MEMORY:-8}"
+COLIMA_DISK="${COLIMA_DISK:-60}"
+
+echo "Setting up Colima for Metaflow development..."
+
+# Check if Colima is installed
+if ! command -v colima &> /dev/null; then
+    echo "❌ Colima not found. Installing via Homebrew..."
+    brew install colima
+fi
+
+# Check if Docker CLI is installed
+if ! command -v docker &> /dev/null; then
+    echo "❌ Docker CLI not found. Installing..."
+    brew install docker
+fi
+
+# Check if Docker Compose is installed
+if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/null; then
+    echo "⚠️  Docker Compose not found. Installing..."
+    brew install docker-compose
+fi
+
+# Stop existing Colima instance if running
+if colima status &> /dev/null; then
+    echo "Stopping existing Colima instance..."
+    colima stop
+fi
+
+# Start Colima with appropriate resources for Metaflow
+echo "Starting Colima with optimized settings for Metaflow..."
+echo "  CPUs: ${COLIMA_CPUS}"
+echo "  Memory: ${COLIMA_MEMORY}GB"
+echo "  Disk: ${COLIMA_DISK}GB"
+
+colima start \
+    --cpu "${COLIMA_CPUS}" \
+    --memory "${COLIMA_MEMORY}" \
+    --disk "${COLIMA_DISK}" \
+    --vm-type vz \
+    --network-address
+
+# Wait for Colima to be ready
+echo "Waiting for Colima to be ready..."
+for i in {1..30}; do
+    if docker version &> /dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+# Set up Docker context
+echo "Configuring Docker context..."
+docker context use colima 2>/dev/null || {
+    echo "Creating colima context..."
+    docker context create colima \
+        --description "Colima Docker Desktop replacement" \
+        --docker "host=unix://${HOME}/.colima/${COLIMA_PROFILE}/docker.sock"
+    docker context use colima
+}
+
+# Create environment file
+echo "Creating environment configuration..."
+cat > .env.colima <<EOF
+# Colima configuration for Metaflow
+export DOCKER_HOST="unix://\${HOME}/.colima/${COLIMA_PROFILE}/docker.sock"
+export DOCKER_BUILDKIT=1
+export COMPOSE_DOCKER_CLI_BUILD=1
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+EOF
+
+# Create a helper script
+cat > activate-colima.sh <<'EOF'
+#!/bin/bash
+# Source this file to activate Colima environment
+# Usage: source activate-colima.sh
+
+if [ -f .env.colima ]; then
+    source .env.colima
+    echo "✓ Colima environment activated"
+    echo "  DOCKER_HOST=${DOCKER_HOST}"
+else
+    echo "❌ .env.colima not found. Run setup-colima.sh first."
+fi
+EOF
+chmod +x activate-colima.sh
+
+# Test the setup
+echo "Testing Docker connectivity..."
+if docker run --rm hello-world &> /dev/null; then
+    echo "✓ Docker is working correctly through Colima"
+else
+    echo "❌ Docker test failed"
+    exit 1
+fi
+
+echo ""
+echo "✅ Colima setup complete!"
+echo ""
+echo "To use Colima in your current shell, run:"
+echo "  source activate-colima.sh"

--- a/devtools/setup-colima.sh
+++ b/devtools/setup-colima.sh
@@ -40,11 +40,18 @@ echo "  CPUs: ${COLIMA_CPUS}"
 echo "  Memory: ${COLIMA_MEMORY}GB"
 echo "  Disk: ${COLIMA_DISK}GB"
 
+# Detect macOS version for vm-type
+if [[ $(uname) == "Darwin" ]] && [[ $(sw_vers -productVersion | cut -d. -f1) -ge 13 ]]; then
+    VM_TYPE="--vm-type vz"
+else
+    VM_TYPE=""
+fi
+
 colima start \
     --cpu "${COLIMA_CPUS}" \
     --memory "${COLIMA_MEMORY}" \
     --disk "${COLIMA_DISK}" \
-    --vm-type vz \
+    ${VM_TYPE} \
     --network-address
 
 # Wait for Colima to be ready

--- a/docs/colima.md
+++ b/docs/colima.md
@@ -1,0 +1,65 @@
+# Using Colima with Metaflow Development
+
+Colima is an open-source alternative to Docker Desktop for macOS.
+
+## Installation
+
+```bash
+brew install colima docker docker-compose
+```
+
+## Quick Setup
+
+Run the setup script:
+```bash
+./devtools/setup-colima.sh
+```
+
+Then activate Colima in your shell:
+```bash
+source activate-colima.sh
+```
+
+## Manual Setup
+
+If you prefer to set up manually:
+
+```bash
+# Start Colima
+colima start --cpu 4 --memory 8 --disk 60
+
+# Use Colima context
+docker context use colima
+
+# Set environment variables
+export DOCKER_HOST="unix://${HOME}/.colima/default/docker.sock"
+```
+
+## Verify Setup
+
+```bash
+make check-docker
+```
+
+You should see: "✓ Using Colima as Docker runtime"
+
+## Switching Between Docker Desktop and Colima
+
+To use Colima:
+```bash
+docker context use colima
+source activate-colima.sh
+```
+
+To use Docker Desktop:
+```bash
+docker context use desktop-linux
+unset DOCKER_HOST
+```
+
+## Troubleshooting
+
+If Docker commands fail:
+1. Check Colima is running: `colima status`
+2. Start if needed: `colima start`
+3. Re-run setup: `./devtools/setup-colima.sh`


### PR DESCRIPTION
## Description

This PR adds complete support for Colima as an alternative to Docker Desktop for running `metaflow-dev` on macOS.

## Problem

The current `check-docker` target in devtools/Makefile uses `open -a Docker` which only works with Docker Desktop. This prevents users who use Colima (or other Docker alternatives) from using `metaflow-dev`.

## Solution

Implemented full Colima integration including:
1. **Detection and Configuration**: Automatically detects and configures Colima runtime
2. **Context Management**: Properly switches Docker context to use Colima  
3. **Environment Setup**: Configures required environment variables (DOCKER_HOST, etc.)
4. **Setup Automation**: Includes setup script for easy Colima installation
5. **Documentation**: Comprehensive guide for using Colima with Metaflow

## Changes

- Modified `devtools/Makefile` to support multiple Docker runtimes
- Added `devtools/setup-colima.sh` for automated Colima setup
- Added `docs/colima.md` with usage documentation  
- Updated README.md to mention Colima support
- Maintains full backward compatibility with Docker Desktop

## Testing

Tested on macOS with:
- ✅ Colima - full functionality verified
- ✅ Docker Desktop - backward compatibility maintained
- ✅ Switching between runtimes
- ✅ Docker Compose operations
- ✅ Environment variable exports for sub-processes
- ✅ macOS version compatibility (pre and post Ventura)

## Related Issues

This is a complete implementation following feedback from #2520 

Fixes #2362 