### PR TITLE
chore: re-enable conditionals in foreach on argo workflows

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -1156,32 +1156,15 @@ class ArgoWorkflows(object):
             else:
                 # Every other node needs only input-paths
                 parameters = [
-                    (
-                        Parameter("input-paths").value(
-                            compress_list(
-                                [
-                                    "argo-{{workflow.name}}/%s/{{tasks.%s.outputs.parameters.task-id}}"
-                                    % (n, self._sanitize(n))
-                                    for n in node.in_funcs
-                                ],
-                                # NOTE: We set zlibmin to infinite because zlib compression for the Argo input-paths breaks template value substitution.
-                                zlibmin=inf,
-                            )
-                        )
-                        if not self._is_conditional_join_node(node)
-                        # The value fetching for input-paths from conditional steps has to be quite involved
-                        # in order to avoid issues with replacements due to missing step outputs.
-                        # NOTE: we differentiate the input-path expression only for conditional joins so we can still utilize the list compression,
-                        # but do not have to rework all decompress usage due to the need for a custom separator
-                        else Parameter("input-paths").value(
-                            compress_list(
-                                [
-                                    "argo-{{workflow.name}}/%s/{{=(get(tasks['%s']?.outputs?.parameters, 'task-id') ?? 'no-task')}}"
-                                    % (n, self._sanitize(n))
-                                    for n in node.in_funcs
-                                ],
-                                separator="%",  # non-default separator is required due to commas in the value expression
-                            )
+                    Parameter("input-paths").value(
+                        compress_list(
+                            [
+                                "argo-{{workflow.name}}/%s/{{tasks.%s.outputs.parameters.task-id}}"
+                                % (n, self._sanitize(n))
+                                for n in node.in_funcs
+                            ],
+                            # NOTE: We set zlibmin to infinite because zlib compression for the Argo input-paths breaks template value substitution.
+                            zlibmin=inf,
                         )
                     )
                 ]

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -1262,13 +1262,6 @@ class ArgoWorkflows(object):
                     parent_foreach,
                 )
             elif node.type == "split-switch":
-                if node.is_inside_foreach:
-                    # TODO: Fix this. The issue is with conditional branches nested inside a foreach branch. The value expression for the input-paths parameter
-                    # on Argo fails completely for the nested structure (though the identical shape outside of nesting works fine).
-                    raise MetaflowException(
-                        "*%s* is a switch step inside a foreach. Conditional steps are not supported inside a foreach on Argo Workflows yet."
-                        % node.name
-                    )
                 for n in node.out_funcs:
                     _visit(
                         self.graph[n],

--- a/metaflow/plugins/argo/conditional_input_paths.py
+++ b/metaflow/plugins/argo/conditional_input_paths.py
@@ -1,11 +1,14 @@
 from math import inf
 import sys
 from metaflow.util import decompress_list, compress_list
+import base64
 
 
 def generate_input_paths(input_paths):
     # => run_id/step/:foo,bar
-    paths = decompress_list(input_paths)
+    # input_paths are base64 encoded due to Argo shenanigans
+    decoded = base64.b64decode(input_paths).decode("utf-8")
+    paths = decompress_list(decoded)
 
     # some of the paths are going to be malformed due to never having executed per conditional.
     # strip these out of the list.

--- a/metaflow/plugins/argo/conditional_input_paths.py
+++ b/metaflow/plugins/argo/conditional_input_paths.py
@@ -4,13 +4,13 @@ from metaflow.util import decompress_list, compress_list
 
 
 def generate_input_paths(input_paths):
-    # Note the non-default separator due to difficulties setting parameter values from conditional step outputs.
-    paths = decompress_list(input_paths, separator="%")
+    # => run_id/step/:foo,bar
+    paths = decompress_list(input_paths)
 
     # some of the paths are going to be malformed due to never having executed per conditional.
     # strip these out of the list.
 
-    trimmed = [path for path in paths if not path.endswith("/no-task")]
+    trimmed = [path for path in paths if not "{{" in path]
     return compress_list(trimmed, zlibmin=inf)
 
 


### PR DESCRIPTION
draft for now, as this approach had a bunch of issues caused by the "leftover" template literals in input-paths causing havoc to argo adjacent systems.