### PR TITLE
add task_failure_reason to metadata

### DIFF
--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -748,6 +748,19 @@ class NativeRuntime(object):
                 bad=True,
             )
             for worker in live_workers:
+                self._metadata.register_metadata(
+                    worker.task.run_id,
+                    worker.task.step,
+                    worker.task.task_id,
+                    [
+                        MetaDatum(
+                            field="task_fail_reason",
+                            value="killed",
+                            type="metaflow.task_fail_reason",
+                            tags=["attempt_id:{0}".format(worker.task.retries)],
+                        )
+                    ],
+                )
                 worker.kill()
         self._logger("Flushing logs...", system_msg=True, bad=True)
         # give killed workers a chance to flush their logs to datastore


### PR DESCRIPTION
Distinguish the task that failed on its own merit (the "root cause") from the tasks that were simply terminated as collateral damage.

`metaflow.task_fail_reason` is the new field and can have the following values:
- `exception` --> exception in the user's step code
- `signal_sigint` --> CTRL+C
- `signal_sigterm` --> external termination signal by K8s etc.
- `killed` --> reported by orchestrator for flagging the tasks it terminates as collateral damage.

Test Cases:
1. One task in a foreach failed due to a Python Exception. 
```
Task: 3 -> Status: False, Failure Reason: exception  <-- Root Cause
Task: 4 -> Status: False, Failure Reason: killed      <-- Collateral Damage
Task: 2 -> Status: False, Failure Reason: killed      <-- Collateral Damage
```

2. User Interruption (Ctrl+C)
All tasks that were active at the time of the interruption were correctly marked with `signal_sigint`, attributing the failure to a direct user action.

3. A task failed with an exception, and immediately after, the run was interrupted with Ctrl+C before the runtime's cleanup completed.
```
Task: 3 -> Status: False, Failure Reason: exception
Task: 4 -> Status: False, Failure Reason: signal_sigint
Task: 2 -> Status: False, Failure Reason: signal_sigint
```