### PR TITLE
fix: shortened argo workflow name sanitising

### DIFF
--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -1369,7 +1369,7 @@ def sanitize_for_argo(text):
     Sanitizes a string so it does not contain characters that are not permitted in
     Argo Workflow resource names.
     """
-    return (
+    sanitized = (
         re.compile(r"^[^A-Za-z0-9]+")
         .sub("", text)
         .replace("_", "")
@@ -1377,6 +1377,15 @@ def sanitize_for_argo(text):
         .replace("+", "")
         .lower()
     )
+    # This is added in order to get sanitized and truncated project branch names to adhere to RFC 1123 subdomain requirements
+    # f.ex. after truncation a project flow name might be project.branch-cut-short-.flowname
+    # sanitize around the . separators by removing any non-alphanumeric characters
+    sanitized = re.compile(r"[^a-z0-9]+\.[^a-z0-9]+").sub(".", sanitized)
+
+    # sanitize the beginning and end of the string by removing any non-alphanumeric characters
+    sanitized = re.compile(r"^[^a-z0-9]").sub("", sanitized)
+    sanitized = re.compile(r"[^a-z0-9]$").sub("", sanitized)
+    return sanitized
 
 
 def remap_status(status):

--- a/test/unit/test_argo_workflows_cli.py
+++ b/test/unit/test_argo_workflows_cli.py
@@ -1,0 +1,21 @@
+import pytest
+
+from metaflow.plugins.argo.argo_workflows_cli import sanitize_for_argo
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("a-valid-name", "a-valid-name"),
+        ("removing---@+_characters@_+", "removing---characters"),
+        ("numb3rs-4r3-0k-123", "numb3rs-4r3-0k-123"),
+        ("proj3ct.br4nch.flow_name", "proj3ct.br4nch.flowname"),
+        (
+            "---1breaking1---.--2subdomain2--.-3rules3-",
+            "1breaking1.2subdomain2.3rules3",
+        ),  # should not break RFC 1123 subdomain requirements
+    ],
+)
+def test_sanitize_for_argo(name, expected):
+    sanitized = sanitize_for_argo(name)
+    assert sanitized == expected


### PR DESCRIPTION
fixes case where a truncated project flow name on argo workflows could be invalid due to subdomain sections not adhering to RFC 1123 spec, specifically beginning and ending with an alphanumeric character.

As an example, `project.branch-cut-short-.flowname` would not be a valid name.


for testing / adding to the unit tests, run them locally with
```sh
pytest test/unit -k sanitize
```