### PR TITLE
fix: R test dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Install R ${{ matrix.ver }} system dependencies
       if: matrix.os == 'ubuntu-22.04'
-      run: sudo apt-get update; sudo apt-get install -y libcurl4-openssl-dev qpdf libgit2-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev
+      run: sudo apt-get update; sudo apt-get install -y libcurl4-openssl-dev qpdf libgit2-dev libharfbuzz-dev libfribidi-dev libwebp-dev
 
     - name: Install R ${{ matrix.ver }} Rlang dependencies
       run: |


### PR DESCRIPTION
building test dependency `ragg` started failing with their latest release `1.5.0` when `1.4.0` was working.

Adding the missing system dependency for `libwebp-dev` to make the build pass for now.