### PR TITLE
Update metaflow client to accept both pathspec and _object together

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -303,7 +303,7 @@ class MetaflowObject(object):
             # distinguish between "attempt will happen" and "no such
             # attempt exists".
 
-        if pathspec:
+        if pathspec and _object is None:
             ids = pathspec.split("/")
 
             if self._NAME == "flow" and len(ids) != 1:


### PR DESCRIPTION
This allows us to access artifacts without hitting metadata service if we provide both `_object` and `pathspec` during initialization. See code sample below:

```
from metaflow import DataArtifact

artifact_object = {'flow_id': 'TestOrchestratorFlow', 'run_number': 69, 'step_name': 'run_test_batch', 'task_id': 341340224, 'name': 'batch_size', 'location': ':...', 'ds_type': 's3', 'sha': '680dfddf6636e87d2e75e6f66903e4c7dc435aec', 'type': 'metaflow.artifact', 'content_type': 'gzip+pickle-v4', 'user_name': 'ssrikanth', 'attempt_id': 0, 'tags': [], 'system_tags': [], 'ts_epoch': 1754443617295}

da = DataArtifact(_object=artifact_object, pathspec="TestOrchestratorFlow/69/run_test_batch/341340224/batch_size")
print(da.data)
```