### PR TITLE
feat: add GPU support to metaflow-dev minikube setup

### DIFF
--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -10,6 +10,9 @@ help:
 	@echo "  down          - Stop and clean up the environment"
 	@echo "  all-up        - Start the development environment with all services"
 	@echo "  help          - Show this help message"
+	@echo ""
+	@echo "Environment variables:"
+	@echo "  MINIKUBE_ENABLE_GPU=auto|true|false  - Control GPU support (default: auto)"
 
 HELM_VERSION := v3.14.0
 MINIKUBE_VERSION := v1.32.0
@@ -31,6 +34,7 @@ MAKE_CMD := $(MAKE) -f "$(MKFILE_PATH)"
 MINIKUBE_CPUS ?= 4
 MINIKUBE_MEMORY ?= 6144
 MINIKUBE_DISK_SIZE ?= 20g
+MINIKUBE_ENABLE_GPU ?= auto
 
 ifeq ($(shell uname), Darwin)
 	minikube_os = darwin
@@ -46,6 +50,24 @@ ifeq ($(shell uname -m), x86_64)
 else
 	arch = arm64
 	tilt_arch = arm64
+endif
+
+# GPU detection for minikube
+ifeq ($(MINIKUBE_ENABLE_GPU), auto)
+	# Auto-detect GPU availability
+	ifeq ($(shell command -v nvidia-smi >/dev/null 2>&1 && echo "nvidia"), nvidia)
+		gpu_flags = --gpus all
+	else ifeq ($(shell command -v rocm-smi >/dev/null 2>&1 && echo "amd"), amd)
+		gpu_flags = --gpus all
+	else
+		gpu_flags =
+	endif
+else ifeq ($(MINIKUBE_ENABLE_GPU), true)
+	# Force enable GPU support
+	gpu_flags = --gpus all
+else
+	# Explicitly disabled
+	gpu_flags =
 endif
 
 # TODO: Move scripts to a folder
@@ -136,11 +158,13 @@ setup-minikube:
 	@echo "🔧 Setting up Minikube $(MINIKUBE_VERSION) cluster..."
 	@if ! $(MINIKUBE) status >/dev/null 2>&1; then \
 		echo "🚀 Starting new Minikube $(MINIKUBE_VERSION) cluster..."; \
+		if [ -n "$(gpu_flags)" ]; then echo "🎮 GPU support detected - enabling GPU passthrough"; else echo "💻 No GPU detected - starting without GPU support"; fi; \
 		$(MINIKUBE) start \
 			--cpus $(MINIKUBE_CPUS) \
 			--memory $(MINIKUBE_MEMORY) \
 			--disk-size $(MINIKUBE_DISK_SIZE) \
 			--driver docker \
+			$(gpu_flags) \
 		|| { echo "❌ Failed to start Minikube (check if Docker is running)"; exit 1; }; \
 		echo "🔌 Enabling metrics-server and dashboard (quietly)..."; \
 		$(MINIKUBE) addons enable metrics-server >/dev/null 2>&1; \


### PR DESCRIPTION
## Summary
- Add optional GPU support for minikube in metaflow-dev with intelligent auto-detection
- Provide manual control via `MINIKUBE_ENABLE_GPU` environment variable
- Enable GPU workloads like `@resources(gpu=1)` in local development environments

## Changes Made
- **Auto-detection logic**: Detects NVIDIA (`nvidia-smi`) and AMD (`rocm-smi`) GPUs automatically
- **Environment variable control**: `MINIKUBE_ENABLE_GPU=auto|true|false` (default: auto)
- **User feedback**: Informative messages about GPU detection status during startup
- **Help documentation**: Updated help text with environment variable usage
- **Conditional flag addition**: Adds `--gpus all` to `minikube start` only when appropriate

## Modes of Operation
1. **`auto` (default)**: Automatically detects GPU availability and enables if found
2. **`true`**: Force enables GPU support regardless of detection
3. **`false`**: Explicitly disables GPU support

## Test Plan
- ✅ Verified Makefile syntax with `make help`
- ✅ Tested dry-run with `make -n setup-minikube` (shows no GPU detected message)
- ✅ Tested forced enable with `MINIKUBE_ENABLE_GPU=true` (correctly adds `--gpus all` flag)
- ✅ Confirmed help text displays new environment variable documentation

## Example Usage
```bash
# Auto-detect GPU (default behavior)
make setup-minikube

# Force enable GPU support
MINIKUBE_ENABLE_GPU=true make setup-minikube

# Explicitly disable GPU support  
MINIKUBE_ENABLE_GPU=false make setup-minikube
```

Fixes #2606