### PR TITLE
[S3] Properly handle `TimeoutException`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,4 @@ We'd love to hear from you. Join our community [Slack workspace](http://slack.ou
 ## Contributing
 We welcome contributions to Metaflow. Please see our [contribution guide](https://docs.metaflow.org/introduction/contributing-to-metaflow) for more details.
 
+

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -1385,6 +1385,9 @@ class S3(object):
             except OSError as e:
                 if e.errno == errno.ENOSPC:
                     raise MetaflowS3InsufficientDiskSpace(str(e))
+            except MetaflowException as ex:
+                # Re-raise Metaflow exceptions (including TimeoutException)
+                raise
             except Exception as ex:
                 error = str(ex)
             if tmp:


### PR DESCRIPTION
MetaflowExceptions were being treated as transient, leading to the `@timeout` decorator not terminating the flows.
Changed logic to treat all MetaflowExceptions as fatal.

Original thread: https://netflix.slack.com/archives/C02116BBNTU/p1758300976912159

Testing:

```
import os
import sys
from metaflow import FlowSpec, step, timeout
from metaflow.plugins.datatools.s3 import S3

S3ROOT = os.environ.get(
    "METAFLOW_S3_TEST_ROOT",
    "s3://netflix-dataoven-prod-users/rgruener/datatest/20220613/0/",
)


class HelloS3TimeoutFlow(FlowSpec):
    """
    Flow that tests S3 timeout behavior by downloading a large file with a timeout.
    """

    @timeout(seconds=5)  # 5-second timeout - impossible for 5GB file
    @step
    def start(self):
        """
        Download a large file (5GB) with a 5-second timeout.
        This should trigger TimeoutException before download completes.
        """
        print("Starting S3 download with 5-second timeout...")

        # Try to download the 5GB file
        large_file_url = os.path.join(S3ROOT, "5gb_file", "5gb_file")

        with S3() as s3:
            print(f"Attempting to download: {large_file_url}")
            s3_obj = s3.get(large_file_url)
            self.file_size = s3_obj.size
            print(f"Downloaded {self.file_size} bytes")

        self.next(self.end)

    @step
    def end(self):
        print("Flow completed successfully!")


if __name__ == "__main__":
    HelloS3TimeoutFlow()
```