### PR TITLE
Fix/aws secrets manager through container

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -206,6 +206,7 @@ class Batch(object):
         ephemeral_storage=None,
         log_driver=None,
         log_options=None,
+        container_secrets=None,
     ):
         job_name = self._job_name(
             attrs.get("metaflow.user"),
@@ -262,6 +263,7 @@ class Batch(object):
                 ephemeral_storage=ephemeral_storage,
                 log_driver=log_driver,
                 log_options=log_options,
+                container_secrets=container_secrets,
             )
             .task_id(attrs.get("metaflow.task_id"))
             .environment_variable("AWS_DEFAULT_REGION", self._client.region())
@@ -380,6 +382,7 @@ class Batch(object):
         ephemeral_storage=None,
         log_driver=None,
         log_options=None,
+        container_secrets=None,
     ):
         if queue is None:
             queue = next(self._client.active_job_queues(), None)
@@ -421,6 +424,7 @@ class Batch(object):
             ephemeral_storage=ephemeral_storage,
             log_driver=log_driver,
             log_options=log_options,
+            container_secrets=container_secrets,
         )
         self.num_parallel = num_parallel
         self.job = job.execute()

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -294,7 +294,7 @@ def step(
                     value_from = s.get("value_from")
                     if isinstance(name, str) and isinstance(value_from, str):
                         container_secrets.append(
-                            {"name": name, "valueFrom": value_from}
+                            {"name": name, "value_from": value_from}
                         )
         except Exception:
             # best-effort only; ignore malformed entries silently to avoid breaking launches

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -162,6 +162,7 @@ class BatchJob(object):
         ephemeral_storage,
         log_driver,
         log_options,
+        container_secrets=None,
     ):
         # identify platform from any compute environment associated with the
         # queue
@@ -198,6 +199,19 @@ class BatchJob(object):
             # ECS tasks.
             "propagateTags": True,
         }
+
+        # Inject ECS secrets for container-start environment variables, if provided.
+        if container_secrets:
+            norm = []
+            for item in container_secrets:
+                if not isinstance(item, dict):
+                    continue
+                name = item.get("name")
+                value_from = item.get("value_from") or item.get("valueFrom")
+                if isinstance(name, str) and isinstance(value_from, str):
+                    norm.append({"name": name, "valueFrom": value_from})
+            if norm:
+                job_definition["containerProperties"]["secrets"] = norm
 
         log_options_dict = {}
         if log_options:
@@ -480,6 +494,7 @@ class BatchJob(object):
         ephemeral_storage,
         log_driver,
         log_options,
+        container_secrets=None,
     ):
         self.payload["jobDefinition"] = self._register_job_definition(
             image,
@@ -502,6 +517,7 @@ class BatchJob(object):
             ephemeral_storage,
             log_driver,
             log_options,
+            container_secrets,
         )
         return self
 

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -207,7 +207,7 @@ class BatchJob(object):
                 if not isinstance(item, dict):
                     continue
                 name = item.get("name")
-                value_from = item.get("value_from") or item.get("valueFrom")
+                value_from = item.get("value_from")
                 if isinstance(name, str) and isinstance(value_from, str):
                     norm.append({"name": name, "valueFrom": value_from})
             if norm:

--- a/metaflow/plugins/secrets/secrets_decorator.py
+++ b/metaflow/plugins/secrets/secrets_decorator.py
@@ -82,12 +82,8 @@ class SecretsDecorator(StepDecorator):
             elif isinstance(secret_spec_str_or_dict, dict):
                 # If the dict is an ECS-style container-start secret spec, skip runtime fetching.
                 # These entries will be wired into the AWS Batch job definition as ECS secrets.
-                if (
-                    "name" in secret_spec_str_or_dict
-                    and (
-                        "value_from" in secret_spec_str_or_dict
-                        or "valueFrom" in secret_spec_str_or_dict
-                    )
+                if "name" in secret_spec_str_or_dict and (
+                    "value_from" in secret_spec_str_or_dict
                 ):
                     continue
                 secret_specs.append(

--- a/metaflow/plugins/secrets/secrets_decorator.py
+++ b/metaflow/plugins/secrets/secrets_decorator.py
@@ -80,6 +80,16 @@ class SecretsDecorator(StepDecorator):
                     SecretSpec.secret_spec_from_str(secret_spec_str_or_dict, role=role)
                 )
             elif isinstance(secret_spec_str_or_dict, dict):
+                # If the dict is an ECS-style container-start secret spec, skip runtime fetching.
+                # These entries will be wired into the AWS Batch job definition as ECS secrets.
+                if (
+                    "name" in secret_spec_str_or_dict
+                    and (
+                        "value_from" in secret_spec_str_or_dict
+                        or "valueFrom" in secret_spec_str_or_dict
+                    )
+                ):
+                    continue
                 secret_specs.append(
                     SecretSpec.secret_spec_from_dict(secret_spec_str_or_dict, role=role)
                 )


### PR DESCRIPTION
Right now, the secrets decorator injects the secrets into an AWS Batch job after the container has been set up. However, there may be times when secrets are necessary at the container setup entrypoint. This PR allows a user to specify a name and secrets ARN so that these can be passed into the job configuration at construction time, so that the right fields can be set like in [the AWS documentation.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/secrets-envvar-secrets-manager.html)