### PR TITLE
Use legacy bitnami repo

### DIFF
--- a/devtools/Tiltfile
+++ b/devtools/Tiltfile
@@ -185,7 +185,6 @@ if "postgresql" in enabled_components:
             'auth.password=metaflow123',
             'auth.database=metaflow',
             'image.repository=bitnamilegacy/postgresql',
-            'image.tag=15.3.0-debian-11-r7',
             'primary.persistence.enabled=false',
             'primary.resources.requests.memory=128Mi',
             'primary.resources.requests.cpu=50m',

--- a/devtools/Tiltfile
+++ b/devtools/Tiltfile
@@ -184,6 +184,8 @@ if "postgresql" in enabled_components:
             'auth.username=metaflow',
             'auth.password=metaflow123',
             'auth.database=metaflow',
+            'image.repository=bitnamilegacy/postgresql',
+            'image.tag=15.3.0-debian-11-r7',
             'primary.persistence.enabled=false',
             'primary.resources.requests.memory=128Mi',
             'primary.resources.requests.cpu=50m',


### PR DESCRIPTION
Starting August 28th, over two weeks, all existing container images, including older or versioned tags (e.g., 2.50.0, 10.6), will be migrated from the public catalog (docker.io/bitnami) to the "Bitnami Legacy" repository (docker.io/bitnamilegacy), where they will no longer receive updates.

See: https://hub.docker.com/r/bitnami/postgresql