### PR TITLE
fix for error capture script

### DIFF
--- a/metaflow/plugins/argo/capture_error.py
+++ b/metaflow/plugins/argo/capture_error.py
@@ -26,7 +26,7 @@ def parse_workflow_failures():
 def group_failures_by_template(failures):
     groups = {}
     for failure in failures:
-        if "finishedAt" in failure and failure["finishedAt"] is None:
+        if failure.get("finishedAt", None) is None:
             timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             failure["finishedAt"] = timestamp
         groups.setdefault(failure["templateName"], []).append(failure)


### PR DESCRIPTION
when capturing the error from argo workflows - there are situations when the template failure is due to errors which do not include the finishedAt Property. 
```[
   {
      "displayName":"hellocloudflow-8hfkz",
      "message":"",
      "templateName":"HelloCloudFlow",
      "phase":"Failed",
      "podName":"hellocloudflow-8hfkz",
      "finishedAt":"2025-10-08T22:28:10Z"
   },
   {
      "displayName":"start",
      "message":"Missing labels used as nodeSelectors",
      "templateName":"start",
      "phase":"Failed",
      "podName":"hellocloudflow-8hfkz-start-4218075540",
      "finishedAt":null
   }
]
```

In such a situation we end up with:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/metaflow/.mf_code/metaflow/plugins/argo/capture_error.py", line 69, in <module>
    first_err = determine_first_error()
                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/metaflow/.mf_code/metaflow/plugins/argo/capture_error.py", line 55, in determine_first_error
    group.sort(
  File "/metaflow/.mf_code/metaflow/plugins/argo/capture_error.py", line 56, in <lambda>
    key=lambda x: datetime.strptime(x["finishedAt"], "%Y-%m-%dT%H:%M:%SZ")
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: strptime() argument 1 must be str, not None
time="2025-10-08T14:23:18 UTC" level=info msg="sub-process exited" argo=true error="<nil>"
Error: exit status 1
```

This PR fixes that. 