### PR TITLE
fix: argo params issue with char encodings

### DIFF
--- a/metaflow/plugins/argo/param_val.py
+++ b/metaflow/plugins/argo/param_val.py
@@ -3,17 +3,8 @@ import base64
 import json
 
 
-def parse_parameter_value(base64_value, param_type):
+def parse_parameter_value(base64_value):
     val = base64.b64decode(base64_value).decode("utf-8")
-
-    # Keep the value as-is in case of stringified json.
-    if param_type == "JSON":
-        try:
-            # see if param is proper jsonstring
-            return json.loads(val)
-        except json.decoder.JSONDecodeError:
-            # remove outer quotes which conflict with jsonstr
-            return val.strip("'")
 
     try:
         return json.loads(val)
@@ -25,9 +16,4 @@ def parse_parameter_value(base64_value, param_type):
 if __name__ == "__main__":
     base64_val = sys.argv[1]
 
-    try:
-        param_type = sys.argv[2]
-    except IndexError:
-        param_type = "str"
-
-    print(parse_parameter_value(base64_val, param_type))
+    print(parse_parameter_value(base64_val))


### PR DESCRIPTION
introduce a script for parsing param values from a base64 encoding instead of passing raw values to the command line, in order to get around some encoding issues

other JSONType parameter fixes
- support both json-strings and proper objects as parameter default values
- support json-stringified values in argo event payloads
- unify param serialisation between cron and manual triggers