### PR TITLE
Fix json decode error

### DIFF
--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -287,7 +287,6 @@ def create(
                 },
                 f,
             )
-            f.flush()
 
     obj.echo("Deploying *%s* to Argo Workflows..." % obj.flow.name, bold=True)
 
@@ -945,7 +944,6 @@ def trigger(obj, run_id_file=None, deployer_attribute_file=None, **kwargs):
                 },
                 f,
             )
-            f.flush()
 
     obj.echo(
         "Workflow *{name}* triggered on Argo Workflows "

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -191,7 +191,6 @@ def create(
                 },
                 f,
             )
-            f.flush()
 
     obj.echo(
         "Deploying *%s* to AWS Step Functions..." % obj.state_machine_name, bold=True
@@ -560,7 +559,6 @@ def trigger(obj, run_id_file=None, deployer_attribute_file=None, **kwargs):
                 },
                 f,
             )
-            f.flush()
 
     obj.echo(
         "Workflow *{name}* triggered on AWS Step Functions "


### PR DESCRIPTION
## Problem

Intermittent `JSONDecodeError` when multiple environments are resolved concurrently during deployment:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 86673 (char 86672)
```

### Root Cause

Race condition in FIFO-based IPC between deployer subprocess and parent process:

1. **Writer side**: Subprocess writes JSON to FIFO, but Python's buffered I/O may not flush immediately
2. **Reader side**: Parent process reads from FIFO in non-blocking mode
3. **Race**: When subprocess exits quickly after `close()`, reader detects process exit and breaks on empty read
4. **Problem**: OS kernel may still have buffered data in pipe that hasn't been delivered yet
5. **Result**: Truncated JSON at arbitrary positions (~86KB in the error case)

## Solution

Changed `read_from_fifo_when_ready()` to use a hybrid approach:

1. **Start in non-blocking mode** (existing behavior)
  - Use `select.poll()` to wait for data
  - Can detect subprocess failures early
  - Can timeout if subprocess hangs

2. **Switch to blocking mode** once first data arrives
  - Use `fcntl()` to remove `O_NONBLOCK` flag
  - Continue with blocking `read()` calls
  - **POSIX guarantee**: Blocking `read()` returns EOF (0 bytes) ONLY after writer closes AND all kernel pipe buffers are drained