### PR TITLE
adding startingDeadlineSeconds to 59 mins

### DIFF
--- a/metaflow/plugins/argo/argo_client.py
+++ b/metaflow/plugins/argo/argo_client.py
@@ -325,7 +325,7 @@ class ArgoClient(object):
                 "failedJobsHistoryLimit": 10000,  # default is unfortunately 1
                 "successfulJobsHistoryLimit": 10000,  # default is unfortunately 3
                 "workflowSpec": {"workflowTemplateRef": {"name": name}},
-                "startingDeadlineSeconds": 3540 # configuring this to 59 minutes so a failed trigger of cron workflow can succeed at most 59 mins after scheduled execution
+                "startingDeadlineSeconds": 3540,  # configuring this to 59 minutes so a failed trigger of cron workflow can succeed at most 59 mins after scheduled execution
             },
         }
         try:


### PR DESCRIPTION
When creating a CronWorkflow we were not adding `startingDeadlineSeconds` . Due to this if the argo controller was killed when the workflow was scheduled for execution - then the run would get skipped. 
This change will make it such that the workflow can execute upto 59 minutes after scheduled execution time  should the above mentioned failure scenario were to happen. 