### PR TITLE
[CLI] Handle truthy values

### DIFF
--- a/metaflow/runner/click_api.py
+++ b/metaflow/runner/click_api.py
@@ -140,9 +140,9 @@ def _method_sanity_check(
         elif supplied_k in possible_opt_params:
             if possible_opt_params[supplied_k].is_bool_flag:
                 # it is a boolean flag..
-                if supplied_v == True:
+                if supplied_v:
                     cli_name = possible_opt_params[supplied_k].opts[0].strip("-")
-                elif supplied_v == False:
+                else:
                     if possible_opt_params[supplied_k].secondary_opts:
                         cli_name = (
                             possible_opt_params[supplied_k].secondary_opts[0].strip("-")


### PR DESCRIPTION
https://github.com/Netflix/metaflow/blob/master/metaflow/runner/click_api.py#L141-L152 is only checking for True/False and doesn't set `cli_name` for other truthy/falsy values