### PR TITLE
added --no-dev to uv sync

### DIFF
--- a/metaflow/plugins/uv/bootstrap.py
+++ b/metaflow/plugins/uv/bootstrap.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
             [f"--no-install-package {dep}" for dep in skip_metaflow_dependencies()]
         )
         cmd = f"""set -e;
-            uv sync --frozen {skip_pkgs};
+            uv sync --frozen --no-dev {skip_pkgs};
             uv pip install {dependencies} --strict
             """
         run_cmd(cmd)


### PR DESCRIPTION
Closes https://github.com/Netflix/metaflow/issues/2693.

Line affected:
https://github.com/Netflix/metaflow/blob/0112aa39746adbb69d0206a3513c3460962dde6d/metaflow/plugins/uv/bootstrap.py#L113

Goal: syncing uv project without dev dependencies that should not be needed when running a flow.