### PR TITLE
fix: argo events add_to_payload value casting

### DIFF
--- a/metaflow/plugins/argo/argo_events.py
+++ b/metaflow/plugins/argo/argo_events.py
@@ -58,7 +58,7 @@ class ArgoEvent(object):
             Value
         """
 
-        self._payload[key] = str(value)
+        self._payload[key] = value
         return self
 
     def safe_publish(self, payload=None, ignore_errors=True):


### PR DESCRIPTION
`add_to_payload` was unnecessarily casting the added value to a str