### PR TITLE
Add default IAM role setting for AWS Secrets Manager plugin

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -210,6 +210,7 @@ DATATOOLS_LOCALROOT = from_conf(
 
 # Secrets Backend - AWS Secrets Manager configuration
 AWS_SECRETS_MANAGER_DEFAULT_REGION = from_conf("AWS_SECRETS_MANAGER_DEFAULT_REGION")
+AWS_SECRETS_MANAGER_DEFAULT_ROLE = from_conf("AWS_SECRETS_MANAGER_DEFAULT_ROLE")
 
 # Secrets Backend - GCP Secrets name prefix. With this, users don't have
 # to specify the full secret name in the @secret decorator.

--- a/metaflow/plugins/aws/secrets_manager/aws_secrets_manager_secrets_provider.py
+++ b/metaflow/plugins/aws/secrets_manager/aws_secrets_manager_secrets_provider.py
@@ -4,7 +4,10 @@ from json import JSONDecodeError
 
 
 from metaflow.exception import MetaflowException
-from metaflow.metaflow_config import AWS_SECRETS_MANAGER_DEFAULT_REGION
+from metaflow.metaflow_config import (
+    AWS_SECRETS_MANAGER_DEFAULT_REGION,
+    AWS_SECRETS_MANAGER_DEFAULT_ROLE,
+)
 from metaflow.plugins.secrets import SecretsProvider
 import re
 
@@ -88,6 +91,9 @@ class AwsSecretsManagerSecretsProvider(SecretsProvider):
         # This might still be OK, if there is fallback AWS region info in environment like:
         # .aws/config or AWS_REGION env var or AWS_DEFAULT_REGION env var, etc.
         try:
+            if AWS_SECRETS_MANAGER_DEFAULT_ROLE and not role:
+                role = AWS_SECRETS_MANAGER_DEFAULT_ROLE
+
             secrets_manager_client = get_aws_client(
                 "secretsmanager",
                 client_params={"region_name": effective_aws_region},


### PR DESCRIPTION
In some cases you don't want to specify the role explicitly but have a global setting