### PR TITLE
Fix: allow FlowMutator and FlowDecorator to co-exist

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -495,6 +495,14 @@ def _base_flow_decorator(decofunc, *args, **kwargs):
         # The first argument is the class to be decorated.
         cls = args[0]
 
+        """
+        When stacking decorators, cls may be another FlowMutator, for example
+
+        @flow_decorator
+        @flow_mutator
+        class MyFlow(FlowSpec):
+            ...
+        """
         if isinstance(cls, (FlowMutator,)):
             cls = cls._flow_cls
 


### PR DESCRIPTION
### Context
#### Two kinds of Flow Decorators
In Metaflow we have two kinds of flow decorators: Flow Decorators and Flow Mutators:

||Flow Decorator (Decorator-Wrapper-Method) | Flow Mutator (Decorator-Class) |
|-|-|-|
| **Example** |project_decorator.ProjectDecorator| base class in metaflow/user_decorators/user_flow_decorator.py |
| **Design Pattern**|Essentially a helper wrapper method that unpacks itself, to support kwargs. A pattern similar to [this](https://www.datacamp.com/tutorial/decorators-python), section "Passing Arguments to Decorators". <br><br>Our implementation is at metaflow/decorators.py::_base_flow_decorator(). | We used a decorator-class to decorate another class.<br><br>The *decorated* class was passed in as `args[0]` in `__init__` in `FlowMutator`. See metaflow/user_decorators/user_flow_decorator.py |

#### The Issue
In the current implementation, when:
1)  A decorator-class and a decorator-wrapper-method are decorated the same class
2) The decorator-wrapper-method is on top of the decorator-class

The above implementation will fail, due to the decorat**or**-class will be treated as the decorat**ed** class, and passed in as an argument to the decorator-wrapper-method. A minimized-repro and its output is here: [gist]( https://gist.github.com/aquarin/bc8247ed1f977a7338a068f40ab1db00). In the repro's Class 4, this output line
```
decorator_helper(): cls=<__main__.MutatorLikeDecoClass object at 0x109d3a170>, args=(), kwargs={'arg1': 'mock_arg1'}
```
indicates `MutatorLikeDecoClass` is treated as a class decorat**ed** by decorator_helper, while Class4 should be decorat**ed** by decorator_helper. 


### Fix
* `_flow_cls` contains the information of the actual wrapped class.
* Verified in our own flow, which had 
```
@flow_decorator
@flow_mutator
class MyFlow
   ...
```

structure.