### PR TITLE
Revert "fix: argo events add_to_payload value casting (#2702)"

### DIFF
--- a/metaflow/plugins/argo/argo_events.py
+++ b/metaflow/plugins/argo/argo_events.py
@@ -58,7 +58,7 @@ class ArgoEvent(object):
             Value
         """
 
-        self._payload[key] = value
+        self._payload[key] = str(value)
         return self
 
     def safe_publish(self, payload=None, ignore_errors=True):


### PR DESCRIPTION
This reverts commit c035bea48a2fc1c43f80996b9c069d3556350a29.