### PR TITLE
feature: enabling freethreaded python support for pypi/conda

### DIFF
--- a/metaflow/plugins/pypi/micromamba.py
+++ b/metaflow/plugins/pypi/micromamba.py
@@ -132,7 +132,11 @@ class Micromamba(object):
                 version_string = "%s==%s" % (package, version)
                 cmd.append(_double_equal_match.sub("", version_string))
             if python:
-                cmd.append("python==%s" % python)
+                if python.endswith("t"):
+                    cmd.append("python==%s" % python[:-1])
+                    cmd.append("python-freethreading")
+                else:
+                    cmd.append("python==%s" % python)
             # TODO: Ensure a human readable message is returned when the environment
             #       can't be resolved for any and all reasons.
             solved_packages = [

--- a/metaflow/plugins/pypi/pip.py
+++ b/metaflow/plugins/pypi/pip.py
@@ -83,12 +83,13 @@ class Pip(object):
             )
 
         debug.conda_exec("Solving packages for PyPI environment %s" % id_)
+        freethreaded = python.endswith("t")
         with tempfile.TemporaryDirectory() as tmp_dir:
             report = "{tmp_dir}/report.json".format(tmp_dir=tmp_dir)
             implementations, platforms, abis = zip(
                 *[
                     (tag.interpreter, tag.platform, tag.abi)
-                    for tag in pip_tags(resolved_python, platform)
+                    for tag in pip_tags(resolved_python, platform, freethreaded)
                 ]
             )
             custom_index_url, extra_index_urls = self.indices(prefix)

--- a/metaflow/plugins/pypi/utils.py
+++ b/metaflow/plugins/pypi/utils.py
@@ -68,7 +68,7 @@ def wheel_tags(wheel):
     return list(tags)
 
 
-def pip_tags(python_version, mamba_platform):
+def pip_tags(python_version, mamba_platform, freetheaded=False):
     # Returns a list of pip tags containing (implementation, platforms, abis) tuples
     # assuming a CPython implementation for Python interpreter.
 
@@ -127,6 +127,8 @@ def pip_tags(python_version, mamba_platform):
     interpreter = "cp%s" % ("".join(map(str, py_version)))
 
     abis = tags._cpython_abis(py_version)
+    if freetheaded:
+        abis = [f"{abi}t" for abi in abis]
 
     supported = []
     supported.extend(tags.cpython_tags(py_version, abis, platforms))


### PR DESCRIPTION
UX and possible corner cases still to be covered. Current approach is to have a `t` suffix in the python version to denote no GIL