### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/full-stack-test.yml
+++ b/.github/workflows/full-stack-test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Metaflow
         run: |

--- a/.github/workflows/metaflow.s3_tests.minio.yml
+++ b/.github/workflows/metaflow.s3_tests.minio.yml
@@ -23,12 +23,12 @@ jobs:
         ver: ['3.8', '3.9', '3.10', '3.11', '3.12']
     
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       with:
         ref: refs/pull/${{ github.event.pull_request.number }}/merge
         submodules: recursive
     - name: Set up Python
-      uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: ${{ matrix.ver }}
     - name: Install Python ${{ matrix.ver }} dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,9 @@ jobs:
       # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
     - name: Set up Python 3.x
-      uses: actions/setup-python@152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20 # v1.2.3
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: '3.x'
     - name: Install Python 3.x dependencies

--- a/.github/workflows/test-card-build.yml
+++ b/.github/workflows/test-card-build.yml
@@ -14,9 +14,9 @@ jobs:
       run:
         working-directory: ./metaflow/plugins/cards/ui
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
       - run: npm ci

--- a/.github/workflows/test-stubs.yml
+++ b/.github/workflows/test-stubs.yml
@@ -32,10 +32,10 @@ jobs:
             ver: "3.10"
 
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
     - name: Set up Python
-      uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: ${{ matrix.ver }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-    - uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   Python:
@@ -39,10 +39,10 @@ jobs:
             ver: "3.10"
 
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
     - name: Set up Python
-      uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: ${{ matrix.ver }}
       env:
@@ -66,7 +66,7 @@ jobs:
         ver: ['4.4.1']
 
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
     - name: Set up ${{ matrix.ver }}
       uses: r-lib/actions/setup-r@33f03a860e4659235eb60a4d87ebc0b2ea65f722 # v2.4.0
       with:


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`ee0669b`](https://github.com/actions/checkout/commit/ee0669bd1cc54295c223e0bb666b733df41de1c5), [`v3`](https://github.com/actions/checkout/releases/tag/v3), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`8e8c483`](https://github.com/actions/checkout/commit/8e8c483db84b4bee98b60c0593521ed34d9990e8) | [Release](https://github.com/actions/checkout/releases/tag/v6) | codeql.yml, full-stack-test.yml, metaflow.s3_tests.minio.yml, publish.yml, test-card-build.yml, test-stubs.yml, test.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | test-card-build.yml |
| `actions/setup-python` | [`152ba7c`](https://github.com/actions/setup-python/commit/152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20), [`75f3110`](https://github.com/actions/setup-python/commit/75f3110429a8c05be0e1bf360334e4cced2b63fa) | [`a309ff8`](https://github.com/actions/setup-python/commit/a309ff8b426b58ec0e2a45f0f869d46889d02405) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | metaflow.s3_tests.minio.yml, publish.yml, test-stubs.yml, test.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
