### PR TITLE
fix: add S3_ENDPOINT_URL to the required env list in argo templates

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -2255,7 +2255,6 @@ class ArgoWorkflows(object):
                         "METAFLOW_SERVICE_URL": SERVICE_INTERNAL_URL,
                         "METAFLOW_SERVICE_HEADERS": json.dumps(SERVICE_HEADERS),
                         "METAFLOW_USER": "argo-workflows",
-                        "METAFLOW_S3_ENDPOINT_URL": S3_ENDPOINT_URL,
                         "METAFLOW_DATASTORE_SYSROOT_S3": DATASTORE_SYSROOT_S3,
                         "METAFLOW_DATATOOLS_S3ROOT": DATATOOLS_S3ROOT,
                         "METAFLOW_DEFAULT_DATASTORE": self.flow_datastore.TYPE,


### PR DESCRIPTION
adds `S3_ENDPOINT_URL` to argo lifecycle hook templates that had it missing.

closes #2738 