### PR TITLE
fix: detect platform/arch for uv download URL

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -494,6 +494,11 @@ CONDA_DEPENDENCY_RESOLVER = from_conf("CONDA_DEPENDENCY_RESOLVER", "conda")
 CONDA_USE_FAST_INIT = from_conf("CONDA_USE_FAST_INIT", False)
 
 ###
+# UV configuration
+###
+UV_VERSION = from_conf("UV_VERSION", "0.6.11")
+
+###
 # Escape hatch configuration
 ###
 # Print out warning if escape hatch is not used for the target packages

--- a/test/unit/test_uv_bootstrap.py
+++ b/test/unit/test_uv_bootstrap.py
@@ -1,0 +1,88 @@
+import pytest
+from unittest.mock import patch
+
+from metaflow.plugins.uv.bootstrap import (
+    _UV_BASE_URL,
+    _UV_TARGET_MAP,
+    _get_uv_download_url,
+)
+from metaflow.metaflow_config import UV_VERSION
+
+_SYS = "metaflow.plugins.uv.bootstrap.platform.system"
+_MACH = "metaflow.plugins.uv.bootstrap.platform.machine"
+
+
+@pytest.fixture
+def url():
+    def _build(version, target):
+        return f"{_UV_BASE_URL}/{version}/uv-{target}.tar.gz"
+
+    return _build
+
+
+@patch(_MACH, return_value="x86_64")
+@patch(_SYS, return_value="Linux")
+def test_linux_x86_64(_sys, _mach, url):
+    assert _get_uv_download_url() == url(UV_VERSION, "x86_64-unknown-linux-gnu")
+
+
+@patch(_MACH, return_value="aarch64")
+@patch(_SYS, return_value="Linux")
+def test_linux_aarch64(_sys, _mach, url):
+    assert _get_uv_download_url() == url(UV_VERSION, "aarch64-unknown-linux-gnu")
+
+
+@patch(_MACH, return_value="arm64")
+@patch(_SYS, return_value="Linux")
+def test_linux_arm64_alias(_sys, _mach, url):
+    assert _get_uv_download_url() == url(UV_VERSION, "aarch64-unknown-linux-gnu")
+
+
+@patch(_MACH, return_value="amd64")
+@patch(_SYS, return_value="Linux")
+def test_linux_amd64_alias(_sys, _mach, url):
+    assert _get_uv_download_url() == url(UV_VERSION, "x86_64-unknown-linux-gnu")
+
+
+@patch(_MACH, return_value="arm64")
+@patch(_SYS, return_value="Darwin")
+def test_darwin_arm64(_sys, _mach, url):
+    assert _get_uv_download_url() == url(UV_VERSION, "aarch64-apple-darwin")
+
+
+@patch(_MACH, return_value="x86_64")
+@patch(_SYS, return_value="Darwin")
+def test_darwin_x86_64(_sys, _mach, url):
+    assert _get_uv_download_url() == url(UV_VERSION, "x86_64-apple-darwin")
+
+
+@patch(_MACH, return_value="x86_64")
+@patch(_SYS, return_value="Linux")
+def test_custom_version_argument(_sys, _mach, url):
+    assert _get_uv_download_url(version="0.5.0") == url(
+        "0.5.0", "x86_64-unknown-linux-gnu"
+    )
+
+
+@patch(_MACH, return_value="riscv64")
+@patch(_SYS, return_value="Linux")
+def test_unsupported_architecture_raises(_sys, _mach):
+    with pytest.raises(RuntimeError, match="linux/riscv64"):
+        _get_uv_download_url()
+
+
+@patch(_MACH, return_value="x86_64")
+@patch(_SYS, return_value="Windows")
+def test_unsupported_os_raises(_sys, _mach):
+    with pytest.raises(RuntimeError, match="windows/x86_64"):
+        _get_uv_download_url()
+
+
+def test_target_map_completeness(url):
+    for (system, machine), target in _UV_TARGET_MAP.items():
+        with patch(_SYS, return_value=system.capitalize()):
+            with patch(_MACH, return_value=machine):
+                result = _get_uv_download_url()
+                assert target in result
+                assert result.startswith(_UV_BASE_URL)
+                assert result.endswith(".tar.gz")


### PR DESCRIPTION
### Summary
fixes the hardcoded `x86_64-unknown-linux-gnu` in the UV bootstrap download URL so it actually works on ARM instances.

closes #2642

The UV download URL was baked in as x86_64-only, so bootstrapping would silently pull the wrong binary (or fail) on aarch64 machines like Graviton or Apple Silicon running Docker. easy to miss locally since most dev machines are x86.

### Changes
- Added [_get_uv_download_url()](cci:1://file:///home/vyagh/Work/oss/GSOC/metaflow/metaflow/plugins/uv/bootstrap.py:30:0-58:5) in [metaflow/plugins/uv/bootstrap.py](cci:7://file:///home/vyagh/Work/oss/GSOC/metaflow/metaflow/plugins/uv/bootstrap.py:0:0-0:0) that uses `platform.system()` and `platform.machine()` to resolve the correct UV target triple at runtime
- Extracted `DEFAULT_UV_VERSION` as a named constant and added a `METAFLOW_UV_VERSION` env var override for pinning without code changes
- Moved URL resolution into [install_uv()](cci:1://file:///home/vyagh/Work/oss/GSOC/metaflow/metaflow/plugins/uv/bootstrap.py:78:4-121:58) (lazy) so importing the module on an unsupported platform doesn't immediately raise

Supported targets: `linux/x86_64`, `linux/aarch64`, `darwin/x86_64`, `darwin/arm64`. 
Skipped Windows per the existing pattern in the pypi bootstrap (remote compute runs linux).

### Testing
Added [test/unit/test_uv_bootstrap.py](cci:7://file:///home/vyagh/Work/oss/GSOC/metaflow/test/unit/test_uv_bootstrap.py:0:0-0:0).
12 unit tests covering all platform mappings, version override via arg and env var, and unsupported platform error paths