### PR TITLE
Improve visibility of MetaflowCode object with git metadata properties

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -966,8 +966,104 @@ class MetaflowCode(object):
         """
         return self._info["script"]
 
+    @property
+    def repo_url(self) -> Optional[str]:
+        """
+        Git repository URL (HTTPS format) associated with this code package,
+        or None if the code was not in a git repository.
+
+        Returns
+        -------
+        Optional[str]
+            Repository URL or None
+        """
+        return self._info.get("repo_url")
+
+    @property
+    def git_branch(self) -> Optional[str]:
+        """
+        Git branch name at the time this code was packaged,
+        or None if the code was not in a git repository.
+
+        Returns
+        -------
+        Optional[str]
+            Branch name or None
+        """
+        return self._info.get("branch_name")
+
+    @property
+    def git_commit(self) -> Optional[str]:
+        """
+        Full git commit SHA at the time this code was packaged,
+        or None if the code was not in a git repository.
+
+        Returns
+        -------
+        Optional[str]
+            Commit SHA or None
+        """
+        return self._info.get("commit_sha")
+
+    @property
+    def is_dirty(self) -> Optional[bool]:
+        """
+        Whether the git working tree had uncommitted changes when this code
+        was packaged, or None if the code was not in a git repository.
+
+        Returns
+        -------
+        Optional[bool]
+            True if there were uncommitted changes, False if clean, None if unknown
+        """
+        return self._info.get("has_uncommitted_changes")
+
+    def describe(self) -> str:
+        """
+        Return a human-readable summary of this code package, including
+        git provenance information when available.
+
+        Returns
+        -------
+        str
+            Multi-line description of the code package
+        """
+        lines = [
+            "Code package: %s" % self.script_name,
+            "  Path: %s" % self._path,
+        ]
+        if self.git_commit:
+            lines.append("  Git commit: %s" % self.git_commit)
+        if self.git_branch:
+            lines.append("  Git branch: %s" % self.git_branch)
+        if self.repo_url:
+            lines.append("  Repository: %s" % self.repo_url)
+        if self.is_dirty is not None:
+            lines.append(
+                "  Working tree: %s"
+                % ("dirty (uncommitted changes)" if self.is_dirty else "clean")
+            )
+        if not self.git_commit and not self.git_branch:
+            lines.append("  Git info: not available (code was not in a git repository)")
+        return "\n".join(lines)
+
     def __str__(self):
-        return "<MetaflowCode: %s>" % self._info["script"]
+        dirty = ""
+        if self.is_dirty is not None:
+            dirty = " dirty" if self.is_dirty else ""
+        if self.git_commit:
+            short_sha = self.git_commit[:7]
+            branch = self.git_branch or "detached"
+            return "<MetaflowCode: %s @ %s (%s%s)>" % (
+                self.script_name,
+                short_sha,
+                branch,
+                dirty,
+            )
+        return "<MetaflowCode: %s>" % self.script_name
+
+    def __repr__(self):
+        return self.__str__()
 
 
 class DataArtifact(MetaflowObject):


### PR DESCRIPTION
## Summary

Adds convenient properties to the `MetaflowCode` client object for accessing git provenance information, addressing #1009.

## Changes

The git metadata (repo URL, branch, commit SHA, dirty status) is **already collected** by `metaflow_git.py` and stored in the code package's info dict. However, it was not easily accessible from the client API. This PR surfaces it through:

### New properties on `MetaflowCode`:
- **`repo_url`** — Git repository URL (HTTPS format)
- **`git_branch`** — Branch name at packaging time
- **`git_commit`** — Full commit SHA at packaging time
- **`is_dirty`** — Whether working tree had uncommitted changes

### New method:
- **`describe()`** — Human-readable multi-line summary with all git info

### Improved display:
- `__str__` and `__repr__` now show commit and branch inline:
  ```
  <MetaflowCode: myflow.py @ a1b2c3d (main)>
  ```

## Example usage

```python
run = Run('MyFlow/123')

# Quick glance
print(run.code)
# <MetaflowCode: myflow.py @ a1b2c3d (main)>

# Detailed info
print(run.code.describe())
# Code package: myflow.py
#   Path: s3://bucket/path
#   Git commit: a1b2c3d4e5f6...
#   Git branch: main
#   Repository: https://github.com/user/repo
#   Working tree: clean

# Programmatic access
run.code.git_commit   # 'a1b2c3d4e5f6...'
run.code.git_branch   # 'main'
run.code.is_dirty     # False
run.code.repo_url     # 'https://github.com/user/repo'
```

Closes #1009