### PR TITLE
fix: bootstrap pip if missing before installing remote deps

### DIFF
--- a/test/unit/test_metaflow_environment.py
+++ b/test/unit/test_metaflow_environment.py
@@ -1,0 +1,50 @@
+import unittest
+
+from metaflow.metaflow_environment import MetaflowEnvironment
+
+
+class _FakeFlow:
+    """MetaflowEnvironment.__init__ ignores its flow arg for the local TYPE."""
+
+    pass
+
+
+def _env():
+    return MetaflowEnvironment(_FakeFlow())
+
+
+class TestGetInstallDependenciesCmd(unittest.TestCase):
+    def test_s3_includes_expected_packages(self):
+        cmd = _env()._get_install_dependencies_cmd("s3")
+        self.assertIn("boto3", cmd)
+        self.assertIn("requests", cmd)
+
+    def test_azure_includes_expected_packages(self):
+        cmd = _env()._get_install_dependencies_cmd("azure")
+        for pkg in ["azure-identity", "azure-storage-blob", "requests"]:
+            self.assertIn(pkg, cmd)
+
+    def test_gs_includes_expected_packages(self):
+        cmd = _env()._get_install_dependencies_cmd("gs")
+        for pkg in ["google-cloud-storage", "google-auth", "requests"]:
+            self.assertIn(pkg, cmd)
+
+    def test_unknown_datastore_raises(self):
+        with self.assertRaises(NotImplementedError):
+            _env()._get_install_dependencies_cmd("unknown")
+
+    def test_skip_install_dependencies_guard(self):
+        cmd = _env()._get_install_dependencies_cmd("s3")
+        self.assertIn("METAFLOW_SKIP_INSTALL_DEPENDENCIES", cmd)
+        self.assertTrue(cmd.startswith("if ["))
+        self.assertTrue(cmd.rstrip().endswith("fi"))
+
+    def test_pip_check_before_install(self):
+        cmd = _env()._get_install_dependencies_cmd("s3")
+        self.assertIn("pip --version", cmd)
+        self.assertIn("ensurepip", cmd)
+        self.assertLess(cmd.find("pip --version"), cmd.find("pip install"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds an `ensurepip` fallback when [pip](cci:1://file:///home/vyagh/Work/oss/GSOC/metaflow/test/unit/test_metaflow_environment.py:41:4-45:75) is missing or unavailable in remote task environments.

Fixes #2718 

Minimal Python images (e.g. `python:3.12-slim`) often don't include [pip](cci:1://file:///home/vyagh/Work/oss/GSOC/metaflow/test/unit/test_metaflow_environment.py:41:4-45:75) by default. This causes environment hydration to fail silently or with confusing errors on Kubernetes/Batch because the bootstrap process relies on `python -m pip` to install required libraries like `boto3` and `requests`.

Since `ensurepip` is part of the python standard lib, we can use it to bootstrap [pip](cci:1://file:///home/vyagh/Work/oss/GSOC/metaflow/test/unit/test_metaflow_environment.py:41:4-45:75) when needed without requiring changes to the user's base image.

- Modified [_get_install_dependencies_cmd](cci:1://file:///home/vyagh/Work/oss/GSOC/metaflow/metaflow/metaflow_environment.py:158:4-189:87) in [metaflow_environment.py](cci:7://file:///home/vyagh/Work/oss/GSOC/metaflow/metaflow/metaflow_environment.py:0:0-0:0) to prepend a shell check for [pip](cci:1://file:///home/vyagh/Work/oss/GSOC/metaflow/test/unit/test_metaflow_environment.py:41:4-45:75).
- Added a fallback to `python -m ensurepip` if [pip](cci:1://file:///home/vyagh/Work/oss/GSOC/metaflow/test/unit/test_metaflow_environment.py:41:4-45:75) is absent.
- Added a clear error message if both [pip](cci:1://file:///home/vyagh/Work/oss/GSOC/metaflow/test/unit/test_metaflow_environment.py:41:4-45:75) and `ensurepip` are unavailable (which can happen on some minimal Debian/Ubuntu distros), pointing the user to fix their base image.
- Added unit tests in [test/unit/test_metaflow_environment.py](cci:7://file:///home/vyagh/Work/oss/GSOC/metaflow/test/unit/test_metaflow_environment.py:0:0-0:0) covering the new shell logic and datastore package lists.

### Testing
Verified with unit tests