### PR TITLE
Add logging defaults support from Metaflow profile.

### DIFF
--- a/metaflow/cmd/configure_cmd.py
+++ b/metaflow/cmd/configure_cmd.py
@@ -537,6 +537,39 @@ def configure_aws_batch(existing_env):
             default=existing_env.get("METAFLOW_SFN_DYNAMO_DB_TABLE"),
             show_default=True,
         )
+
+    # Configure logging of AWS Batch job outputs to CloudWatch.
+    while True:
+        default_val = ",".join(existing_env.get("METAFLOW_BATCH_LOG_OPTIONS") or [])
+
+        log_options_input = click.prompt(
+            cyan("[METAFLOW_BATCH_LOG_OPTIONS]")
+            + yellow(" (optional)")
+            + " Default CloudWatch logging options for AWS Batch jobs.\n"
+            + "Example: awslogs-group:aws/batch/jobs,awslogs-stream-prefix:metaflow\n"
+            + "Enter 'none' to clear",
+            default=default_val,
+            show_default=True,
+        )
+
+        if log_options_input.lower() in ("none", ""):
+            env["METAFLOW_BATCH_LOG_OPTIONS"] = None
+            break
+
+        try:
+            log_options = [
+                opt.strip() for opt in log_options_input.split(",") if opt.strip()
+            ]
+            for opt in log_options:
+                if ":" not in opt:
+                    raise ValueError(f"Invalid log option format: {opt}")
+
+            env["METAFLOW_BATCH_LOG_OPTIONS"] = log_options
+            break
+
+        except ValueError as e:
+            echo(str(e), fg="red")
+
     return env
 
 

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -354,6 +354,9 @@ SERVICE_INTERNAL_URL = from_conf("SERVICE_INTERNAL_URL", SERVICE_URL)
 BATCH_EMIT_TAGS = from_conf("BATCH_EMIT_TAGS", False)
 # Default tags to add to AWS Batch jobs. These are in addition to the defaults set when BATCH_EMIT_TAGS is true.
 BATCH_DEFAULT_TAGS = from_conf("BATCH_DEFAULT_TAGS", {})
+# Default Cloudwatch log options for AWS Batch jobs. This should be a list of strings in the format "key:value".
+# These options will be passed as the `options` argument to the `logConfiguration` when creating AWS Batch jobs.
+BATCH_LOG_OPTIONS = from_conf("BATCH_LOG_OPTIONS", [])
 
 ###
 # AWS Step Functions configuration

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -8,7 +8,7 @@ from metaflow import util
 from metaflow import R
 from metaflow.exception import CommandException, METAFLOW_EXIT_DISALLOW_RETRY
 from metaflow.metadata_provider.util import sync_local_metadata_from_datastore
-from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
+from metaflow.metaflow_config import DATASTORE_LOCAL_DIR, BATCH_LOG_OPTIONS
 from metaflow.mflog import TASK_LOG_SOURCE
 from metaflow.unbounded_foreach import UBF_CONTROL, UBF_TASK
 from .batch import Batch, BatchKilledException
@@ -179,7 +179,7 @@ def kill(ctx, run_id, user, my_runs):
 )
 @click.option(
     "--log-options",
-    default=None,
+    default=BATCH_LOG_OPTIONS,
     type=str,
     multiple=True,
     help="Log options for the chosen log driver",

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -16,6 +16,7 @@ from metaflow.metaflow_config import (
     ECS_FARGATE_EXECUTION_ROLE,
     ECS_S3_ACCESS_IAM_ROLE,
     FEAT_ALWAYS_UPLOAD_CODE_PACKAGE,
+    BATCH_LOG_OPTIONS,
 )
 from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task
 from metaflow.sidecar import Sidecar
@@ -95,7 +96,7 @@ class BatchDecorator(StepDecorator):
         This is only relevant for Fargate compute environments
     log_driver: str, optional, default None
         The log driver to use for the Amazon ECS container.
-    log_options: List[str], optional, default None
+    log_options: List[str], optional, default METAFLOW_BATCH_LOG_OPTIONS
         List of strings containing options for the chosen log driver. The configurable values
         depend on the `log driver` chosen. Validation of these options is not supported yet.
         Example: [`awslogs-group:aws/batch/job`]
@@ -127,7 +128,7 @@ class BatchDecorator(StepDecorator):
         "tmpfs_path": "/metaflow_temp",
         "ephemeral_storage": None,
         "log_driver": None,
-        "log_options": None,
+        "log_options": BATCH_LOG_OPTIONS,
         "executable": None,
         "privileged": False,
     }

--- a/test/cmd/test_configure_log_options.py
+++ b/test/cmd/test_configure_log_options.py
@@ -1,0 +1,146 @@
+"""
+Tests for METAFLOW_BATCH_LOG_OPTIONS configuration in configure_cmd.py
+
+These tests verify the validation and parsing logic for CloudWatch logging
+options when configuring AWS Batch through the CLI.
+"""
+
+from unittest.mock import patch
+from metaflow.cmd.configure_cmd import configure_aws_batch
+
+
+MOCK_PROMPT_VALUES = [
+    "test-queue",  # METAFLOW_BATCH_JOB_QUEUE
+    "arn:aws:iam::123456789012:role/test-role",  # METAFLOW_ECS_S3_ACCESS_IAM_ROLE
+    "",  # METAFLOW_BATCH_CONTAINER_REGISTRY
+    "",  # METAFLOW_BATCH_CONTAINER_IMAGE
+]
+
+
+def test_accepts_single_key_value_pair():
+    """Test that a single log option in key:value format is accepted."""
+    # Setup: Provide a valid single key:value option
+    existing_env = {}
+
+    with patch("metaflow.cmd.configure_cmd.click.prompt") as mock_prompt, patch(
+        "metaflow.cmd.configure_cmd.click.confirm"
+    ) as mock_confirm:
+        # Mock Step Functions configuration prompt to skip it
+        mock_confirm.return_value = False
+
+        # Mock all the prompts required by configure_aws_batch
+        mock_prompt.side_effect = [
+            *MOCK_PROMPT_VALUES,
+            "awslogs-group:aws/batch/jobs",  # METAFLOW_BATCH_LOG_OPTIONS - valid format
+        ]
+
+        result = configure_aws_batch(existing_env)
+
+        # Assert: The option should be parsed and stored correctly
+        assert result["METAFLOW_BATCH_LOG_OPTIONS"] == ["awslogs-group:aws/batch/jobs"]
+
+
+def test_accepts_multiple_comma_separated_key_value_pairs():
+    """Test that multiple comma-separated log options in key:value format are accepted."""
+    # Setup: Provide multiple comma-separated key:value options
+    existing_env = {}
+
+    with patch("metaflow.cmd.configure_cmd.click.prompt") as mock_prompt, patch(
+        "metaflow.cmd.configure_cmd.click.confirm"
+    ) as mock_confirm:
+        mock_confirm.return_value = False
+
+        mock_prompt.side_effect = [
+            *MOCK_PROMPT_VALUES,
+            "awslogs-group:aws/batch/jobs,awslogs-stream-prefix:metaflow",  # Multiple valid options
+        ]
+
+        result = configure_aws_batch(existing_env)
+
+        # Assert: All options should be parsed correctly
+        assert result["METAFLOW_BATCH_LOG_OPTIONS"] == [
+            "awslogs-group:aws/batch/jobs",
+            "awslogs-stream-prefix:metaflow",
+        ]
+
+
+def test_rejects_option_without_colon_separator():
+    """Test that log options missing the colon separator are rejected with error."""
+    # Setup: Provide an invalid option without colon, then a valid one on retry
+    existing_env = {}
+
+    with patch("metaflow.cmd.configure_cmd.click.prompt") as mock_prompt, patch(
+        "metaflow.cmd.configure_cmd.click.confirm"
+    ) as mock_confirm, patch("metaflow.cmd.configure_cmd.echo") as mock_echo:
+        mock_confirm.return_value = False
+
+        mock_prompt.side_effect = [
+            *MOCK_PROMPT_VALUES,
+            "awslogs-group",  # Invalid: missing colon
+            "awslogs-group:aws/batch/jobs",  # Valid on retry
+        ]
+
+        result = configure_aws_batch(existing_env)
+
+        # Assert: Error message should be displayed for invalid format
+        error_calls = [
+            call
+            for call in mock_echo.call_args_list
+            if "Invalid log option format" in str(call)
+        ]
+        assert len(error_calls) > 0, "Expected error message for invalid format"
+
+        # Assert: Valid input on retry should be accepted
+        assert result["METAFLOW_BATCH_LOG_OPTIONS"] == ["awslogs-group:aws/batch/jobs"]
+
+
+def test_rejects_non_comma_separated_values():
+    """Test that values without colon after comma-split are rejected."""
+    # Setup: Provide comma-separated list where one value has no colon
+    # This tests that users must use commas to separate multiple options
+    existing_env = {}
+
+    with patch("metaflow.cmd.configure_cmd.click.prompt") as mock_prompt, patch(
+        "metaflow.cmd.configure_cmd.click.confirm"
+    ) as mock_confirm, patch("metaflow.cmd.configure_cmd.echo") as mock_echo:
+        mock_confirm.return_value = False
+
+        mock_prompt.side_effect = [
+            *MOCK_PROMPT_VALUES,
+            "awslogs-group:test,awslogs-prefix",  # Invalid: second value has no colon
+            "awslogs-group:test",  # Valid on retry
+        ]
+
+        result = configure_aws_batch(existing_env)
+
+        # Assert: Error should be raised for value without colon
+        error_calls = [
+            call
+            for call in mock_echo.call_args_list
+            if "Invalid log option format" in str(call) or "Invalid format" in str(call)
+        ]
+        assert len(error_calls) > 0, "Expected error message for value without colon"
+
+        # Assert: Valid input on retry should be accepted
+        assert result["METAFLOW_BATCH_LOG_OPTIONS"] == ["awslogs-group:test"]
+
+
+def test_resets_log_options():
+    """Test that log_options can be reset by passing `none`."""
+    # Setup: Provide `none` to reset log options
+    existing_env = {"METAFLOW_BATCH_LOG_OPTIONS": ["awslogs-group:old"]}
+
+    with patch("metaflow.cmd.configure_cmd.click.prompt") as mock_prompt, patch(
+        "metaflow.cmd.configure_cmd.click.confirm"
+    ) as mock_confirm, patch("metaflow.cmd.configure_cmd.echo") as mock_echo:
+        mock_confirm.return_value = False
+
+        mock_prompt.side_effect = [
+            *MOCK_PROMPT_VALUES,
+            "none",  # Reset log options to none
+        ]
+
+        result = configure_aws_batch(existing_env)
+
+        # Assert: Log options should be reset to None
+        assert result["METAFLOW_BATCH_LOG_OPTIONS"] == None


### PR DESCRIPTION
## Summary

Added support for configuring default AWS Batch CloudWatch logging options using Metaflow profiles via a new `METAFLOW_LOG_OPTIONS` configuration variable.

## Motivation

While `@batch(log_options=...)` already allows per-step configuration, there was no way to set organization-wide defaults through Metaflow profiles or environment variables. This PR fills that gap.

Fixes #471 (the part about configuring defaults via profile).

## What’s changed

* Added `METAFLOW_LOG_OPTIONS` to `metaflow_config.py` to store default CloudWatch log options.
* Updated `configure_aws_batch()` to prompt for and validate these options during setup.
* Accepts comma-separated `key:value` pairs, for example:
  `awslogs-group:aws/batch/jobs,awslogs-stream-prefix:metaflow`
* Validates that each option contains a colon.
* Supports clearing the value by entering `none` or an empty string.
* Updated `BatchDecorator` to use `METAFLOW_LOG_OPTIONS` as the default for `log_options`.

## Testing

Added `test_configure_log_options.py` with coverage for:

* Accepting a single `key:value` pair
* Accepting multiple comma-separated pairs
* Rejecting values without a colon
* Rejecting incorrectly formatted lists
* Test reseting of `METAFLOW_LOG_OPTIONS` by passing explicit `none`.


## Design notes

* Validation only checks for `key:value` format instead of enforcing specific AWS keys, to remain flexible if AWS adds new options.
* Configuration is handled through `metaflow configure aws`, consistent with other Batch-related settings.
* If `METAFLOW_LOG_OPTIONS` is unset, behavior is unchanged.