### PR TITLE
Add @local decorator to prevent steps from running remotely

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -625,6 +625,7 @@ def start(
         if all_decospecs:
             decorators._attach_decorators(ctx.obj.flow, all_decospecs)
             decorators._init(ctx.obj.flow)
+
             # Regenerate graph if we attached more decorators
             ctx.obj.flow.__class__._init_graph()
             ctx.obj.graph = ctx.obj.flow._graph

--- a/metaflow/cli_components/run_cmds.py
+++ b/metaflow/cli_components/run_cmds.py
@@ -53,8 +53,11 @@ def before_run(obj, tags, decospecs, skip_decorators=False):
         if all_decospecs:
             # These decospecs are the ones from run/resume/spin PLUS the ones from the
             # environment (for example the @conda)
-            decorators._attach_decorators(obj.flow, all_decospecs)
+            decorators._attach_decorators(
+                obj.flow, all_decospecs, respect_local_decorator=True
+            )
             decorators._init(obj.flow)
+
             # Regenerate graph if we attached more decorators
             obj.flow.__class__._init_graph()
             obj.graph = obj.flow._graph

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -30,6 +30,7 @@ from .test_unbounded_foreach_decorator import InternalTestUnboundedForeachInput
 # Add new step decorators here
 STEP_DECORATORS_DESC = [
     ("catch", ".catch_decorator.CatchDecorator"),
+    ("local", ".local_decorator.LocalDecorator"),
     ("timeout", ".timeout_decorator.TimeoutDecorator"),
     ("environment", ".environment_decorator.EnvironmentDecorator"),
     ("secrets", ".secrets.secrets_decorator.SecretsDecorator"),

--- a/metaflow/plugins/local_decorator.py
+++ b/metaflow/plugins/local_decorator.py
@@ -1,0 +1,21 @@
+from metaflow.decorators import StepDecorator
+
+
+class LocalDecorator(StepDecorator):
+    """
+    Specifies that this step should always be executed locally.
+
+    Use this decorator to exclude a step from being run remotely even
+    when the flow is invoked with a remote execution flag such as
+    `--with batch` or `--with kubernetes`.
+
+    Note that this decorator currently specifically blocks `@batch` and
+    `@kubernetes` remote execution backends.
+
+    Parameters
+    ----------
+    None
+    """
+
+    name = "local"
+    defaults = {}

--- a/test/unit/test_local_decorator.py
+++ b/test/unit/test_local_decorator.py
@@ -1,0 +1,106 @@
+from metaflow import FlowSpec, step, local
+from metaflow.decorators import _attach_decorators
+
+
+class LocalTestFlow(FlowSpec):
+    @step
+    def start(self):
+        self.next(self.process)
+
+    @local
+    @step
+    def process(self):
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+def test_local_decorator_prevents_batch():
+    """Steps marked with @local should not receive @batch when run with --with batch."""
+    # Test case for issue #350
+    flow = LocalTestFlow(use_cli=False)
+    # Simulate --with batch (respect_local_decorator=True)
+    _attach_decorators(flow, ["batch"], respect_local_decorator=True)
+
+    start_decos = [
+        d.name for d in next(s for s in flow._steps if s.__name__ == "start").decorators
+    ]
+    process_decos = [
+        d.name
+        for d in next(s for s in flow._steps if s.__name__ == "process").decorators
+    ]
+    end_decos = [
+        d.name for d in next(s for s in flow._steps if s.__name__ == "end").decorators
+    ]
+
+    assert "batch" in start_decos
+    assert "local" in process_decos
+    assert "batch" not in process_decos
+    assert "batch" in end_decos
+
+
+def test_local_decorator_prevents_kubernetes():
+    """Steps marked with @local should not receive @kubernetes when run with --with kubernetes."""
+    # Test case for issue #350
+    flow = LocalTestFlow(use_cli=False)
+    # Simulate --with kubernetes (respect_local_decorator=True)
+    _attach_decorators(flow, ["kubernetes"], respect_local_decorator=True)
+
+    process_decos = [
+        d.name
+        for d in next(s for s in flow._steps if s.__name__ == "process").decorators
+    ]
+
+    assert "kubernetes" not in process_decos
+
+
+def test_local_decorator_prevents_multiple_remote_decorators():
+    """@local should block both batch and kubernetes if both are present in --with."""
+    # Requested in PR review
+    flow = LocalTestFlow(use_cli=False)
+    # Simulate --with batch --with kubernetes (respect_local_decorator=True)
+    _attach_decorators(flow, ["batch", "kubernetes"], respect_local_decorator=True)
+
+    process_decos = [
+        d.name
+        for d in next(s for s in flow._steps if s.__name__ == "process").decorators
+    ]
+
+    assert "batch" not in process_decos
+    assert "kubernetes" not in process_decos
+
+
+def test_local_decorator_allows_non_remote_decorators():
+    """@local should only block remote execution decorators, not general-purpose ones like @retry."""
+    # Test case for issue #350
+    flow = LocalTestFlow(use_cli=False)
+    # Simulate --with retry (respect_local_decorator=True)
+    _attach_decorators(flow, ["retry"], respect_local_decorator=True)
+
+    process_decos = [
+        d.name
+        for d in next(s for s in flow._steps if s.__name__ == "process").decorators
+    ]
+
+    assert "retry" in process_decos
+
+
+def test_local_decorator_during_deployment():
+    """@local should NOT block decorators during deployment (e.g. argo create)."""
+    # Critical fix for deployment platforms as reported in greptile review
+    flow = LocalTestFlow(use_cli=False)
+    # Simulate deployment (respect_local_decorator=False, the default)
+    _attach_decorators(flow, ["kubernetes"])
+
+    process_decos = [
+        d.name
+        for d in next(s for s in flow._steps if s.__name__ == "process").decorators
+    ]
+
+    # Kubernetes SHOULD be present here even though @local is on the step
+    # because it's required for the deployment to work.
+    assert "kubernetes" in process_decos
+    assert "local" in process_decos
+


### PR DESCRIPTION
## Summary

Adds a `@local` decorator that prevents a step from being picked up by `--with batch` or `--with kubernetes`.

## Context / Motivation

When running a flow with `--with batch` or `--with kubernetes`, every step gets the remote decorator attached — even steps that must stay local, like ones reading local files or a local DB. There was no way to exclude a specific step. 
Fixes #350

## Changes Made

- Added [LocalDecorator](cci:2://file:///c:/Users/monika/OneDrive/Desktop/metaflow/metaflow/plugins/local_decorator.py:3:0-17:17) in [metaflow/plugins/local_decorator.py](cci:7://file:///c:/Users/monika/OneDrive/Desktop/metaflow/metaflow/plugins/local_decorator.py:0:0-0:0)
- Registered `local` in `STEP_DECORATORS_DESC` in [plugins/__init__.py](cci:7://file:///c:/Users/monika/OneDrive/Desktop/metaflow/metaflow/plugins/__init__.py:0:0-0:0)
- Updated [_attach_decorators()](cci:1://file:///c:/Users/monika/OneDrive/Desktop/metaflow/metaflow/decorators.py:646:0-660:51) in [decorators.py](cci:7://file:///c:/Users/monika/OneDrive/Desktop/metaflow/metaflow/decorators.py:0:0-0:0) to skip `batch` and
  `kubernetes` when a step has `@local`

## Testing

- Added [test/unit/test_local_decorator.py](cci:7://file:///c:/Users/monika/OneDrive/Desktop/metaflow/test/unit/test_local_decorator.py:0:0-0:0) with 3 tests:
  - `test_local_decorator_prevents_batch`
  - `test_local_decorator_prevents_kubernetes`
  - `test_local_decorator_allows_non_remote_decorators`

```bash
python -m pytest test/unit/test_local_decorator.py -v
# 3 passed