### PR TITLE
Add contribution quality gates and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -54,7 +54,7 @@ paste here
 
 <!-- Required for Core Runtime. Recommended for all bug fixes. -->
 <!-- Explain the causal chain: what invariant was violated, where in the code. -->
-<!-- See PR #2811 for an example of the level of detail we're looking for. -->
+<!-- See PRs #2796, #2751, #2714 for examples of the level of detail we're looking for. -->
 
 ## Why This Fix Is Correct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,10 @@ PRs that don't meet these requirements may be closed without further review.
 
 Because Metaflow uses subprocesses and worker processes, printing to stderr inside a worker **does not necessarily appear where you expect** unless you explicitly propagate it. Tests must validate behavior across that boundary.
 
-**Example of a good Core Runtime PR:** [PR #2811](https://github.com/Netflix/metaflow/pull/2811) -- concrete env-var leakage mechanism identified, exact code path where the invariant fails, fix is minimal and targeted, test reproduces the real failure mode.
+**Examples of good Core Runtime PRs:**
+- [PR #2796](https://github.com/Netflix/metaflow/pull/2796) -- race condition in local storage: identifies the exact interleaving that causes `json.load()` to fail on partial writes, fix is a single atomic write helper, links to CI failure as evidence.
+- [PR #2751](https://github.com/Netflix/metaflow/pull/2751) -- symlink traversal edge case: concrete directory structure that reproduces the bug, explains the global-vs-per-branch invariant that was violated, minimal fix.
+- [PR #2714](https://github.com/Netflix/metaflow/pull/2714) -- Argo input-paths with nested conditionals: links to issue, identifies the template generation bug, scoped fix.
 
 ### Feature PRs touching Core Runtime
 
@@ -224,8 +227,8 @@ How you tested these changes:
 ```
 
 **Examples of excellent PR descriptions:**
-- [PR #2743](https://github.com/Netflix/metaflow/pull/2743): Skip Kubernetes cluster access when using `--only-json` flag
-- [PR #2744](https://github.com/Netflix/metaflow/pull/2744): Better command processing for compress state machine
+- [PR #2796](https://github.com/Netflix/metaflow/pull/2796): Fix race condition in local storage with atomic writes
+- [PR #2751](https://github.com/Netflix/metaflow/pull/2751): Fix symlink traversal edge case in packaging
 
 **Common mistakes to avoid:**
 - ❌ Empty or one-line descriptions


### PR DESCRIPTION
## Summary

Adds structured quality gates for contributions touching Core Runtime, an AI tool usage policy, and a PR template that enforces both. Motivated by a recent increase in PRs that claim manual verification but test the wrong execution boundary, and AI-generated contributions that lack understanding of Metaflow's subprocess/worker process semantics.

## Problem

We're seeing a pattern of PRs that:

1. **Test the wrong thing** -- e.g., validating stderr output in the parent process when the fix targets worker subprocess behavior. Because Metaflow executes user code in subprocesses across local/Kubernetes/Batch/Argo runtimes, something that "works" in a naive test may fail in production.
2. **Lack root-cause analysis** -- changes are proposed without explaining what invariant was violated or what failure modes were considered. This shifts the debugging burden onto maintainers.
3. **Are AI-generated without critical review** -- plausible-looking code and tests that don't actually exercise the real failure mode. The tests pass but don't validate the claim.

Maintainer time spent coaching contributors through these issues is unsustainable.

## Changes

### `CONTRIBUTING.md`

- **Core Runtime Contributions (Higher Bar)** section with:
  - Concrete file path table so contributors know exactly which files trigger the higher bar
  - Requirements: linked issue, minimal reproduction in the correct runtime, technical rationale with root cause and failure modes
  - Explanation of the subprocess boundary pitfall (the most common mistake we see)
  - Examples pointing to merged PRs from core maintainers (#2796, #2751, #2714)
  - Policy on Core Runtime feature PRs (issue-first, maintainer alignment required)

- **AI Tool Usage Policy** section:
  - Disclosure requirement (checkbox in PR template)
  - Accountability: contributor must be able to explain their code when asked
  - No ban on AI tools -- responsible use is welcome
  - Follows precedent from CPython, LLVM, and scikit-learn

- Updated PR description examples to reference merged PRs from core maintainers only

### `.github/pull_request_template.md` (new)

Structured template with sections for:
- PR type (with Core Runtime as explicit checkbox)
- Reproduction (runtime, exact commands, evidence location, before/after)
- Root cause analysis
- "Why this fix is correct"
- Failure modes considered (minimum 2 for Core Runtime)
- AI tool disclosure checkbox

## Why this approach

Other OSS projects facing the same problem (Godot, cURL, LLVM, CPython, scikit-learn) have converged on a similar pattern: **disclosure + accountability + quality gates**. The key insight is that banning AI tools doesn't work and isn't desirable -- but requiring contributors to understand and defend their code filters out low-quality submissions regardless of how they were produced.

The "Core Runtime" distinction avoids applying the higher bar to everything (docs, simple plugin changes, etc.) while protecting the areas where incorrect PRs are most costly to review and most dangerous to merge.

## Non-goals

- This does not add any automated enforcement (CI checks, bots, etc.)
- This does not change requirements for non-Core-Runtime contributions
- This does not ban AI tools

## Test plan

- [x] Verify PR template renders correctly on GitHub (will be visible on all new PRs once merged)
- [x] Verify CONTRIBUTING.md renders correctly (table formatting, links)
- [x] Use template on a few incoming PRs to validate the workflow