### PR TITLE
Prevent assignment to flow-level attributes inside steps with explici…

### DIFF
--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -802,7 +802,8 @@ class TaskDataStore(object):
                     # NOTE: Destructive mutation of the flow object. We keep
                     # around artifacts called 'name' and anything starting with
                     # '_' as they are used by the Metaflow runtime.
-                    delattr(flow, var)
+                    if hasattr(flow, var):
+                        delattr(flow, var)
                 yield var, val
 
         # Save current artifacts


### PR DESCRIPTION
Problem: :

-Flow-level attributes and Parameters can currently be reassigned inside steps.
This leads to:

-Confusing artifact behavior

-Inconsistent runtime state

-Potential internal errors during datastore cleanup

Solution: :

-Convert flow-level attributes into read-only properties during step execution

-Raise a clear AttributeError if reassignment is attempted

-Add a defensive guard in datastore cleanup to prevent crashes when attributes were never created

Result: :

-Clear, explicit user-facing error

-No internal framework crash

-Stable and predictable runtime behavior