### PR TITLE
feat: Support private repos for --environment=uv

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -621,6 +621,19 @@ def get_pinned_conda_libs(python_version, datastore_type):
     return pins
 
 
+###
+# UV environment
+###
+
+# Set to True to ship ~/.netrc to the remote worker so uv sync can
+# authenticate against netrc-secured private package indices.
+UV_FORWARD_NETRC = from_conf("UV_FORWARD_NETRC", False)
+
+# Comma-separated list of additional environment variable names to forward
+# to the remote worker before uv sync runs.
+# Example: METAFLOW_UV_FORWARD_ENV_VARS=MY_PYPI_TOKEN,ANOTHER_SECRET
+UV_FORWARD_ENV_VARS = from_conf("UV_FORWARD_ENV_VARS")
+
 # Check if there are extensions to Metaflow to load and override everything
 try:
     from metaflow.extension_support import get_modules

--- a/metaflow/plugins/uv/bootstrap.py
+++ b/metaflow/plugins/uv/bootstrap.py
@@ -132,9 +132,12 @@ if __name__ == "__main__":
                 """
             run_cmd(cmd)
         finally:
-            # Remove .netrc after sync to avoid credentials persisting in the task env
-            if netrc_installed and os.path.exists(netrc_dest):
-                os.remove(netrc_dest)
+            # Clean up .netrc after sync — restore original if there was one
+            if netrc_installed:
+                if netrc_had_original and os.path.exists(netrc_backup):
+                    shutil.move(netrc_backup, netrc_dest)
+                elif os.path.exists(netrc_dest):
+                    os.remove(netrc_dest)
 
     if len(sys.argv) != 2:
         print("Usage: bootstrap.py <datastore_type>")

--- a/metaflow/plugins/uv/bootstrap.py
+++ b/metaflow/plugins/uv/bootstrap.py
@@ -109,9 +109,9 @@ if __name__ == "__main__":
             "netrc", ContentType.OTHER_CONTENT
         )
         netrc_dest = os.path.expanduser("~/.netrc")
+        netrc_backup = netrc_dest + ".metaflow_bak"
         netrc_installed = False
         netrc_had_original = os.path.exists(netrc_dest)
-        netrc_backup = netrc_dest + ".metaflow_bak"
         if netrc_in_package is not None:
             if netrc_had_original:
                 shutil.copy2(netrc_dest, netrc_backup)
@@ -132,9 +132,10 @@ if __name__ == "__main__":
                 """
             run_cmd(cmd)
         finally:
-            # Clean up .netrc after sync — restore original if there was one
+            # Remove .netrc after sync to avoid credentials persisting in the task env.
+            # If a .netrc was present before we arrived, restore it from backup.
             if netrc_installed:
-                if netrc_had_original and os.path.exists(netrc_backup):
+                if netrc_had_original:
                     shutil.move(netrc_backup, netrc_dest)
                 elif os.path.exists(netrc_dest):
                     os.remove(netrc_dest)

--- a/metaflow/plugins/uv/bootstrap.py
+++ b/metaflow/plugins/uv/bootstrap.py
@@ -110,7 +110,11 @@ if __name__ == "__main__":
         )
         netrc_dest = os.path.expanduser("~/.netrc")
         netrc_installed = False
+        netrc_had_original = os.path.exists(netrc_dest)
+        netrc_backup = netrc_dest + ".metaflow_bak"
         if netrc_in_package is not None:
+            if netrc_had_original:
+                shutil.copy2(netrc_dest, netrc_backup)
             shutil.copy2(netrc_in_package, netrc_dest)
             os.chmod(netrc_dest, 0o600)
             netrc_installed = True

--- a/metaflow/plugins/uv/uv_environment.py
+++ b/metaflow/plugins/uv/uv_environment.py
@@ -85,14 +85,17 @@ class UVEnvironment(MetaflowEnvironment):
         cmds = []
 
         # Auto-forward all UV_INDEX_* vars (named-index auth tokens, URLs, etc.)
+        # Auto-forward all UV_INDEX_* vars (named-index auth tokens, URLs, etc.)
+        seen = set()
         for key, value in os.environ.items():
             if key.startswith("UV_INDEX_"):
                 cmds.append("export %s=%s" % (key, shlex.quote(value)))
+                seen.add(key)
 
         # Forward any explicitly requested extra variables
         if UV_FORWARD_ENV_VARS:
             for var_name in (v.strip() for v in UV_FORWARD_ENV_VARS.split(",")):
-                if var_name and var_name in os.environ:
+                if var_name and var_name not in seen and var_name in os.environ:
                     cmds.append(
                         "export %s=%s" % (var_name, shlex.quote(os.environ[var_name]))
                     )

--- a/metaflow/plugins/uv/uv_environment.py
+++ b/metaflow/plugins/uv/uv_environment.py
@@ -85,7 +85,6 @@ class UVEnvironment(MetaflowEnvironment):
         cmds = []
 
         # Auto-forward all UV_INDEX_* vars (named-index auth tokens, URLs, etc.)
-        # Auto-forward all UV_INDEX_* vars (named-index auth tokens, URLs, etc.)
         seen = set()
         for key, value in os.environ.items():
             if key.startswith("UV_INDEX_"):

--- a/test/unit/test_uv_environment.py
+++ b/test/unit/test_uv_environment.py
@@ -1,0 +1,144 @@
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+from metaflow.plugins.uv.uv_environment import UVEnvironment
+
+
+@pytest.fixture
+def uv_env(tmp_path):
+    """UVEnvironment with minimal required files present."""
+    (tmp_path / "uv.lock").touch()
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+    flow = MagicMock()
+    with patch("os.getcwd", return_value=str(tmp_path)):
+        yield UVEnvironment(flow)
+
+
+# ---------------------------------------------------------------------------
+# _get_credential_export_cmds
+# ---------------------------------------------------------------------------
+
+
+class TestGetCredentialExportCmds:
+    def test_uv_index_vars_are_forwarded(self, uv_env):
+        with patch.dict(os.environ, {"UV_INDEX_MYPYPI_PASSWORD": "secret"}, clear=True):
+            cmds = uv_env._get_credential_export_cmds()
+        assert any("UV_INDEX_MYPYPI_PASSWORD" in c for c in cmds)
+
+    def test_non_uv_index_vars_are_not_auto_forwarded(self, uv_env):
+        with patch.dict(os.environ, {"AWS_ACCESS_KEY_ID": "key"}, clear=True):
+            cmds = uv_env._get_credential_export_cmds()
+        assert not any("AWS_ACCESS_KEY_ID" in c for c in cmds)
+
+    def test_values_are_shell_escaped(self, uv_env):
+        with patch.dict(
+            os.environ, {"UV_INDEX_TOKEN": "val with spaces & special"}, clear=True
+        ):
+            cmds = uv_env._get_credential_export_cmds()
+        assert any("'val with spaces & special'" in c for c in cmds)
+
+    def test_forward_env_vars_config_forwards_named_var(self, uv_env):
+        with patch.dict(os.environ, {"MY_TOKEN": "tok123"}, clear=True):
+            with patch(
+                "metaflow.plugins.uv.uv_environment.UV_FORWARD_ENV_VARS", "MY_TOKEN"
+            ):
+                cmds = uv_env._get_credential_export_cmds()
+        assert any("MY_TOKEN" in c for c in cmds)
+
+    def test_forward_env_vars_config_skips_missing_var(self, uv_env):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "metaflow.plugins.uv.uv_environment.UV_FORWARD_ENV_VARS", "MISSING_VAR"
+            ):
+                cmds = uv_env._get_credential_export_cmds()
+        assert not any("MISSING_VAR" in c for c in cmds)
+
+    def test_forward_env_vars_config_handles_whitespace(self, uv_env):
+        with patch.dict(os.environ, {"VAR_A": "a", "VAR_B": "b"}, clear=True):
+            with patch(
+                "metaflow.plugins.uv.uv_environment.UV_FORWARD_ENV_VARS",
+                " VAR_A , VAR_B ",
+            ):
+                cmds = uv_env._get_credential_export_cmds()
+        assert any("VAR_A" in c for c in cmds)
+        assert any("VAR_B" in c for c in cmds)
+
+    def test_no_relevant_vars_returns_empty_list(self, uv_env):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "metaflow.plugins.uv.uv_environment.UV_FORWARD_ENV_VARS", None
+            ):
+                cmds = uv_env._get_credential_export_cmds()
+        assert cmds == []
+
+
+# ---------------------------------------------------------------------------
+# add_to_package — .netrc forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestAddToPackageNetrc:
+    def test_netrc_included_when_flag_set_and_file_exists(self, uv_env, tmp_path):
+        fake_netrc = tmp_path / ".netrc"
+        fake_netrc.write_text("machine example.com login user password pass")
+        with patch("metaflow.plugins.uv.uv_environment.UV_FORWARD_NETRC", True):
+            with patch("os.path.expanduser", return_value=str(fake_netrc)):
+                files = uv_env.add_to_package()
+        arcnames = [f[1] for f in files]
+        assert "netrc" in arcnames
+
+    def test_netrc_not_included_when_flag_is_false(self, uv_env):
+        with patch("metaflow.plugins.uv.uv_environment.UV_FORWARD_NETRC", False):
+            files = uv_env.add_to_package()
+        arcnames = [f[1] for f in files]
+        assert "netrc" not in arcnames
+
+    def test_missing_netrc_does_not_raise(self, uv_env):
+        with patch("metaflow.plugins.uv.uv_environment.UV_FORWARD_NETRC", True):
+            with patch("os.path.expanduser", return_value="/nonexistent/.netrc"):
+                files = uv_env.add_to_package()  # must not raise
+        arcnames = [f[1] for f in files]
+        assert "netrc" not in arcnames
+
+    def test_uv_lock_and_pyproject_always_present(self, uv_env):
+        with patch("metaflow.plugins.uv.uv_environment.UV_FORWARD_NETRC", False):
+            files = uv_env.add_to_package()
+        arcnames = [f[1] for f in files]
+        assert "uv.lock" in arcnames
+        assert "pyproject.toml" in arcnames
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_commands — ordering
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapCommands:
+    def test_export_cmds_appear_before_bootstrap_call(self, uv_env):
+        with patch.dict(os.environ, {"UV_INDEX_TOKEN": "tok"}, clear=True):
+            cmds = uv_env.bootstrap_commands("start", "s3")
+        # export must come first
+        assert cmds[0].startswith("export UV_INDEX_TOKEN=")
+        # bootstrap call must follow
+        bootstrap_idx = next(
+            i for i, c in enumerate(cmds) if "metaflow.plugins.uv.bootstrap" in c
+        )
+        assert bootstrap_idx > 0
+
+    def test_no_credential_export_cmds_when_no_uv_index_vars(self, uv_env):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "metaflow.plugins.uv.uv_environment.UV_FORWARD_ENV_VARS", None
+            ):
+                cmds = uv_env.bootstrap_commands("start", "s3")
+        # The PATH export is always present; no additional credential exports expected
+        credential_exports = [
+            c for c in cmds if c.startswith("export ") and "PATH" not in c
+        ]
+        assert credential_exports == []
+
+    def test_datastore_type_passed_to_bootstrap(self, uv_env):
+        with patch.dict(os.environ, {}, clear=True):
+            cmds = uv_env.bootstrap_commands("start", "azure")
+        assert any('"azure"' in c for c in cmds)


### PR DESCRIPTION
## Summary

Closes #2695.

When `--environment=uv` is used, Metaflow ships `uv.lock` + `pyproject.toml` to remote workers and runs `uv sync --frozen`. If the lockfile references packages from **private indices** (company PyPI mirrors, GCP Artifact Registry, AWS CodeArtifact, etc.), `uv sync` fails on the remote machine because the authentication credentials present locally are never forwarded.

Three complementary mechanisms are added:

- **Auto-forward `UV_INDEX_*` env vars** — All named-index auth tokens and URLs (`UV_INDEX_<NAME>_PASSWORD`, `UV_INDEX_<NAME>_URL`, etc.) are serialised as shell `export KEY=VALUE` commands prepended to the bootstrap script, so they are present in the environment when `uv sync --frozen` runs. Values are shell-escaped with `shlex.quote` to prevent injection.

- **Optional `.netrc` forwarding** (`METAFLOW_UV_FORWARD_NETRC=True`) — Ships `~/.netrc` inside the code package. The bootstrap script restores it at `~/.netrc` with `chmod 600` before `uv sync` and removes it in a `finally` block so credentials do not persist in the task environment after sync completes.

- **Explicit extra-variable forwarding** (`METAFLOW_UV_FORWARD_ENV_VARS=VAR1,VAR2`) — Comma-separated list of any additional env var names to forward (e.g. custom registry tokens, cloud-provider secrets not covered by `UV_INDEX_*`).

## Changes

| File | Change |
|------|--------|
| `metaflow/metaflow_config.py` | Add `UV_FORWARD_NETRC` and `UV_FORWARD_ENV_VARS` config vars |
| `metaflow/plugins/uv/uv_environment.py` | Credential export commands; `.netrc` packaging; warning on missing netrc |
| `metaflow/plugins/uv/bootstrap.py` | Restore `.netrc` before `uv sync`; clean up in `finally` |
| `test/unit/test_uv_environment.py` | 14 unit tests (new file) |

## Test plan

- [x] `pytest test/unit/test_uv_environment.py -v` — 14/14 pass
- [x] Set `UV_INDEX_MYPYPI_PASSWORD=token` locally and run a flow with a private-index dependency on AWS Batch / Kubernetes — verify `uv sync` succeeds
- [x] Set `METAFLOW_UV_FORWARD_NETRC=True` with a valid `~/.netrc` — verify auth works on remote and `.netrc` is absent after task finishes