### PR TITLE
fix(kubernetes): reject empty keys in parse_kube_keyvalue_list and ad…

### DIFF
--- a/metaflow/plugins/kubernetes/kube_utils.py
+++ b/metaflow/plugins/kubernetes/kube_utils.py
@@ -96,13 +96,18 @@ def parse_kube_keyvalue_list(items: List[str], requires_both: bool = True):
         ret = {}
         for item_str in items:
             item = item_str.split("=", 1)
+            key = str(item[0])
+            if not key:
+                raise KubernetesException(
+                    "Invalid key-value item: empty key in '%s'" % item_str
+                )
             if requires_both:
                 item[1]  # raise IndexError
-            if str(item[0]) in ret:
-                raise KubernetesException("Duplicate key found: %s" % str(item[0]))
-            ret[str(item[0])] = str(item[1]) if len(item) > 1 else None
+            if key in ret:
+                raise KubernetesException("Duplicate key found: %s" % key)
+            ret[key] = str(item[1]) if len(item) > 1 else None
         return ret
     except KubernetesException as e:
         raise e
     except (AttributeError, IndexError):
-        raise KubernetesException("Unable to parse kubernetes list: %s" % items)
+        raise KubernetesException("Invalid key-value item: '%s'" % item_str)

--- a/test/unit/test_kubernetes.py
+++ b/test/unit/test_kubernetes.py
@@ -5,6 +5,7 @@ from metaflow.plugins.kubernetes.kubernetes import KubernetesException
 from metaflow.plugins.kubernetes.kube_utils import (
     validate_kube_labels,
     parse_kube_keyvalue_list,
+    KubernetesException as KubeUtilsKubernetesException,
 )
 
 
@@ -96,3 +97,15 @@ def test_kubernetes_parse_keyvalue_list(items, requires_both, expected):
 def test_kubernetes_parse_keyvalue_list(items, requires_both):
     with pytest.raises(KubernetesException):
         parse_kube_keyvalue_list(items, requires_both)
+
+
+@pytest.mark.parametrize("items", [["=value"], [""]])
+def test_parse_kube_keyvalue_list_empty_key_rejected(items):
+    """Empty keys (=value and "") raise KubernetesException"""
+    with pytest.raises(KubeUtilsKubernetesException):
+        parse_kube_keyvalue_list(items, True)
+
+
+def test_parse_kube_keyvalue_list_key_with_empty_value_accepted():
+    """key= is accepted and returns {"key": ""}"""
+    assert parse_kube_keyvalue_list(["key="], True) == {"key": ""}


### PR DESCRIPTION


## PR Type

<!-- Check one -->

- [ x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

<!-- What user-visible behavior changes? 1-2 sentences. -->
This PR fixes a bug in `parse_kube_keyvalue_list` where empty keys such as "=value" or "" were not explicitly rejected. It also improves the error message to reference the specific invalid item and adds unit tests to prevent regressions.

## Issue


<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes #2832

## Reproduction

<!-- Required for bug fixes. Required for Core Runtime changes. -->
<!-- Provide a minimal reproduction that fails before and succeeds after. -->

**Runtime:** <!-- local / kubernetes / batch / argo / etc. --> local

**Commands to run:**
```bash
# Not applicable. This is covered by unit tests.
```

**Where evidence shows up:** <!-- parent console / task logs / metadata / UI -->

<details>
<summary>Before (error / log snippet)</summary>

```
Some invalid inputs like ["=value"] or [""] were not clearly rejected at parse time and could fail later with less precise or confusing error messages.
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
Empty keys are rejected immediately with a clear error message that references the specific bad item. All unit tests pass, including new tests that cover these cases.
```

</details>

## Root Cause
After splitting on "=", the function did not validate that the key part was non empty. As a result, inputs like "=value" or "" could bypass explicit validation and either fail later or produce unclear error messages.

<!-- Required for Core Runtime. Recommended for all bug fixes. -->
<!-- Explain the causal chain: what invariant was violated, where in the code. -->
<!-- See PRs #2796, #2751, #2714 for examples of the level of detail we're looking for. -->

## Why This Fix Is Correct
The fix restores the invariant that all keys must be non empty by validating immediately after parsing each item. The change is minimal and localized, preserves existing valid behaviors such as "key=" and "key" when allowed, and improves error clarity without changing the function’s overall contract.
<!-- What invariant is restored? Why is the fix minimal? -->

## Failure Modes Considered

<!-- Required for Core Runtime (at least 2). Recommended for all bug fixes. -->
<!-- Examples: concurrency/retries, subprocess output propagation, env-var leakage, backward compat -->

1.Backward compatibility for valid inputs such as "key=" and "key" when requires_both is false
2.Duplicate key handling remains unchanged and is still validated separately

## Tests

- [ x] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ x] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

<!-- What you intentionally did not change. Helps reviewers scope their review. -->
Did not change validation rules for values

Did not change duplicate key handling logic

Did not modify any core runtime behavior or unrelated code paths

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [ ] No AI tools were used in this contribution
- [x ] AI tools were used (describe below)

<!-- If you used AI tools:
- Which tool(s)?
- What did you use them for?
- Did you review, understand, and test all generated code?
-->
Tool: ChatGPT
Used for: discussing edge cases, drafting tests, and refining error messages
All generated code was reviewed, understood, and tested locally
