### PR TITLE
Fix mutable default arguments in card components

### DIFF
--- a/metaflow/plugins/cards/card_modules/basic.py
+++ b/metaflow/plugins/cards/card_modules/basic.py
@@ -105,16 +105,18 @@ class SubTitleComponent(MetaflowCardComponent):
 class SectionComponent(DefaultComponent):
     type = "section"
 
-    def __init__(self, title=None, subtitle=None, columns=None, contents=[]):
+    def __init__(self, title=None, subtitle=None, columns=None, contents=None):
         super().__init__(title=title, subtitle=subtitle)
         # Contents are expected to be list of dictionaries.
-        self._contents = contents
+        self._contents = contents if contents is not None else []
         self._columns = columns
 
     @classmethod
     def render_subcomponents(
-        cls, component_array, additional_allowed_types=[str, dict], allow_unknowns=False
+        cls, component_array, additional_allowed_types=None, allow_unknowns=False
     ):
+        if additional_allowed_types is None:
+            additional_allowed_types = [str, dict]
         contents = []
         for content in component_array:
             # Render objects of `MetaflowCardComponent` type
@@ -170,16 +172,16 @@ class TableComponent(DefaultComponent):
     type = "table"
 
     def __init__(
-        self, title=None, subtitle=None, headers=[], data=[[]], vertical=False
+        self, title=None, subtitle=None, headers=None, data=None, vertical=False
     ):
         super().__init__(title=title, subtitle=subtitle)
         self._headers = []
         self._data = [[]]
         self._vertical = vertical
 
-        if self._validate_header_type(headers):
+        if headers is not None and self._validate_header_type(headers):
             self._headers = headers
-        if self._validate_row_type(data):
+        if data is not None and self._validate_row_type(data):
             self._data = data
 
     @classmethod
@@ -219,9 +221,9 @@ class TableComponent(DefaultComponent):
 class DagComponent(DefaultComponent):
     type = "dag"
 
-    def __init__(self, title=None, subtitle=None, data={}):
+    def __init__(self, title=None, subtitle=None, data=None):
         super().__init__(title=title, subtitle=subtitle)
-        self._data = data
+        self._data = data if data is not None else {}
 
     def render(self):
         datadict = super().render()
@@ -290,9 +292,9 @@ class HTMLComponent(DefaultComponent):
 class PageComponent(DefaultComponent):
     type = "page"
 
-    def __init__(self, title=None, subtitle=None, contents=[]):
+    def __init__(self, title=None, subtitle=None, contents=None):
         super().__init__(title=title, subtitle=subtitle)
-        self._contents = contents
+        self._contents = contents if contents is not None else []
 
     def render(self):
         datadict = super().render()
@@ -326,9 +328,9 @@ class SerializationErrorComponent(ErrorComponent):
 class ArtifactsComponent(DefaultComponent):
     type = "artifacts"
 
-    def __init__(self, title=None, subtitle=None, data={}):
+    def __init__(self, title=None, subtitle=None, data=None):
         super().__init__(title=title, subtitle=subtitle)
-        self._data = data
+        self._data = data if data is not None else {}
 
     def render(self):
         datadict = super().render()
@@ -373,7 +375,7 @@ class TaskInfoComponent(MetaflowCardComponent):
         page_title="Task Info",
         only_repr=True,
         graph=None,
-        components=[],
+        components=None,
         runtime=False,
         flow=None,
         max_artifact_size=None,
@@ -385,7 +387,7 @@ class TaskInfoComponent(MetaflowCardComponent):
             max_artifact_size if max_artifact_size is not None else MAX_ARTIFACT_SIZE
         )
         self._graph = graph
-        self._components = components
+        self._components = components if components is not None else []
         self._page_title = page_title
         self.final_component = None
         self.page_component = None
@@ -603,10 +605,10 @@ class ErrorCard(MetaflowCard):
 
     RELOAD_POLICY = MetaflowCard.RELOAD_POLICY_ONCHANGE
 
-    def __init__(self, options={}, components=[], graph=None, **kwargs):
+    def __init__(self, options=None, components=None, graph=None, **kwargs):
         self._only_repr = True
         self._graph = None if graph is None else transform_flow_graph(graph)
-        self._components = components
+        self._components = components if components is not None else []
 
     def reload_content_token(self, task, data):
         """
@@ -661,18 +663,20 @@ class DefaultCardJSON(MetaflowCard):
 
     def __init__(
         self,
-        options=dict(only_repr=True),
-        components=[],
+        options=None,
+        components=None,
         graph=None,
         flow=None,
         **kwargs
     ):
+        if options is None:
+            options = {"only_repr": True}
         self._only_repr = True
         self._graph = None if graph is None else transform_flow_graph(graph)
         self._flow = flow
         if "only_repr" in options:
             self._only_repr = options["only_repr"]
-        self._components = components
+        self._components = components if components is not None else []
 
     def render(self, task):
         final_component_dict = TaskInfoComponent(
@@ -697,12 +701,14 @@ class DefaultCard(MetaflowCard):
 
     def __init__(
         self,
-        options=dict(only_repr=True),
-        components=[],
+        options=None,
+        components=None,
         graph=None,
         flow=None,
         **kwargs
     ):
+        if options is None:
+            options = {"only_repr": True}
         self._only_repr = True
         # Default max artifact size uses the global MAX_ARTIFACT_SIZE constant (200MB)
         self._max_artifact_size = MAX_ARTIFACT_SIZE
@@ -712,7 +718,7 @@ class DefaultCard(MetaflowCard):
             self._only_repr = options["only_repr"]
         if "max_artifact_size" in options:
             self._max_artifact_size = options["max_artifact_size"]
-        self._components = components
+        self._components = components if components is not None else []
 
     def render(self, task, runtime=False):
         RENDER_TEMPLATE = read_file(RENDER_TEMPLATE_PATH)
@@ -768,14 +774,16 @@ class BlankCard(MetaflowCard):
 
     type = "blank"
 
-    def __init__(self, options=dict(title=""), components=[], graph=None, **kwargs):
+    def __init__(self, options=None, components=None, graph=None, **kwargs):
+        if options is None:
+            options = {"title": ""}
         self._graph = None if graph is None else transform_flow_graph(graph)
         self._title = ""
         if "title" in options:
             self._title = options["title"]
-        self._components = components
+        self._components = components if components is not None else []
 
-    def render(self, task, components=[], runtime=False):
+    def render(self, task, components=None, runtime=False):
         RENDER_TEMPLATE = read_file(RENDER_TEMPLATE_PATH)
         JS_DATA = read_file(JS_PATH)
         CSS_DATA = read_file(CSS_PATH)

--- a/metaflow/plugins/cards/card_modules/card.py
+++ b/metaflow/plugins/cards/card_modules/card.py
@@ -67,7 +67,7 @@ class MetaflowCard(object):
     # FIXME document runtime_data
     runtime_data = None
 
-    def __init__(self, options={}, components=[], graph=None, flow=None):
+    def __init__(self, options=None, components=None, graph=None, flow=None):
         pass
 
     def _get_mustache(self):

--- a/metaflow/plugins/cards/card_modules/test_cards.py
+++ b/metaflow/plugins/cards/card_modules/test_cards.py
@@ -38,8 +38,8 @@ class TestEditableCard(MetaflowCard):
 
     ALLOW_USER_COMPONENTS = True
 
-    def __init__(self, components=[], **kwargs):
-        self._components = components
+    def __init__(self, components=None, **kwargs):
+        self._components = components if components is not None else []
 
     def render(self, task):
         return self.separator.join([str(comp) for comp in self._components])
@@ -52,8 +52,8 @@ class TestEditableCard2(MetaflowCard):
 
     ALLOW_USER_COMPONENTS = True
 
-    def __init__(self, components=[], **kwargs):
-        self._components = components
+    def __init__(self, components=None, **kwargs):
+        self._components = components if components is not None else []
 
     def render(self, task):
         return self.separator.join([str(comp) for comp in self._components])
@@ -64,8 +64,8 @@ class TestNonEditableCard(MetaflowCard):
 
     separator = "$&#!!@*"
 
-    def __init__(self, components=[], **kwargs):
-        self._components = components
+    def __init__(self, components=None, **kwargs):
+        self._components = components if components is not None else []
 
     def render(self, task):
         return self.separator.join([str(comp) for comp in self._components])
@@ -74,7 +74,9 @@ class TestNonEditableCard(MetaflowCard):
 class TestMockCard(MetaflowCard):
     type = "test_mock_card"
 
-    def __init__(self, options={"key": "dummy_key"}, **kwargs):
+    def __init__(self, options=None, **kwargs):
+        if options is None:
+            options = {"key": "dummy_key"}
         self._key = options["key"]
 
     def render(self, task):
@@ -93,8 +95,10 @@ class TestErrorCard(MetaflowCard):
 class TestTimeoutCard(MetaflowCard):
     type = "test_timeout_card"
 
-    def __init__(self, options={"timeout": 50}, **kwargs):
+    def __init__(self, options=None, **kwargs):
         super().__init__()
+        if options is None:
+            options = {"timeout": 50}
         self._timeout = 10
         if "timeout" in options:
             self._timeout = options["timeout"]
@@ -193,8 +197,8 @@ class TestRefreshComponentCard(MetaflowCard):
 
     type = "test_component_refresh_card"
 
-    def __init__(self, components=[], **kwargs):
-        self._components = components
+    def __init__(self, components=None, **kwargs):
+        self._components = components if components is not None else []
 
     def render(self, task) -> str:
         # Calling `render`/`render_runtime` wont require the `data` object

--- a/test/unit/test_card_mutable_defaults.py
+++ b/test/unit/test_card_mutable_defaults.py
@@ -1,0 +1,109 @@
+from metaflow.plugins.cards.card_modules.basic import (
+    SectionComponent,
+    PageComponent,
+    DagComponent,
+    ArtifactsComponent,
+    TableComponent,
+)
+
+
+class TestCardMutableDefaults:
+    """Verify that card components do not share mutable default arguments."""
+
+    def test_section_component_no_shared_contents(self):
+        """Two SectionComponents created without args get independent lists."""
+        a = SectionComponent()
+        b = SectionComponent()
+        assert a._contents is not b._contents
+
+    def test_page_component_no_shared_contents(self):
+        """Two PageComponents created without args get independent lists."""
+        a = PageComponent()
+        b = PageComponent()
+        assert a._contents is not b._contents
+
+    def test_dag_component_no_shared_data(self):
+        """Two DagComponents created without args get independent dicts."""
+        a = DagComponent()
+        b = DagComponent()
+        assert a._data is not b._data
+
+    def test_artifacts_component_no_shared_data(self):
+        """Two ArtifactsComponents created without args get independent dicts."""
+        a = ArtifactsComponent()
+        b = ArtifactsComponent()
+        assert a._data is not b._data
+
+    def test_table_component_no_shared_headers(self):
+        """Two TableComponents created without args get independent headers."""
+        a = TableComponent()
+        b = TableComponent()
+        assert a._headers is not b._headers
+
+    def test_table_component_no_shared_data(self):
+        """Two TableComponents created without args get independent data."""
+        a = TableComponent()
+        b = TableComponent()
+        assert a._data is not b._data
+
+    def test_explicit_contents_preserved(self):
+        """Passing explicit contents uses the provided list."""
+        custom = ["item1", "item2"]
+        comp = SectionComponent(contents=custom)
+        assert comp._contents is custom
+
+    def test_explicit_data_preserved(self):
+        """Passing explicit data uses the provided dict."""
+        custom = {"key": "value"}
+        comp = DagComponent(data=custom)
+        assert comp._data is custom
+
+    def test_table_explicit_headers_preserved(self):
+        """Passing explicit headers to TableComponent uses the provided list."""
+        custom_headers = ["col1", "col2"]
+        custom_data = [["a", "b"]]
+        comp = TableComponent(headers=custom_headers, data=custom_data)
+        assert comp._headers is custom_headers
+        assert comp._data is custom_data
+
+    def test_default_contents_is_empty_list(self):
+        """Default contents is an empty list, not None."""
+        comp = SectionComponent()
+        assert comp._contents == []
+        assert isinstance(comp._contents, list)
+
+    def test_default_data_is_empty_dict(self):
+        """Default data is an empty dict, not None."""
+        comp = DagComponent()
+        assert comp._data == {}
+        assert isinstance(comp._data, dict)
+
+    def test_table_default_headers_is_empty_list(self):
+        """Default headers is an empty list, not None."""
+        comp = TableComponent()
+        assert comp._headers == []
+        assert isinstance(comp._headers, list)
+
+    def test_mutation_does_not_leak_between_instances(self):
+        """Mutating one instance's default does not affect another."""
+        a = SectionComponent()
+        a._contents.append("leaked")
+
+        b = SectionComponent()
+        assert b._contents == []
+
+    def test_dict_mutation_does_not_leak_between_instances(self):
+        """Mutating one instance's default dict does not affect another."""
+        a = DagComponent()
+        a._data["leaked"] = True
+
+        b = DagComponent()
+        assert b._data == {}
+
+    def test_table_mutation_does_not_leak_between_instances(self):
+        """Mutating one TableComponent's default does not affect another."""
+        a = TableComponent()
+        a._headers.append("leaked")
+
+        b = TableComponent()
+        assert b._headers == []


### PR DESCRIPTION
## Summary

Card component classes use mutable default arguments (`=[]`, `={}`, `=dict(...)`) in `__init__`, a well-known Python antipattern where the default object is created once at function definition time and shared across all calls. If any caller mutates it, every subsequent caller sees the mutation.

- Replace `=[]` / `={}` / `=dict(...)` defaults with `=None` in 19 function signatures across `basic.py`, `card.py`, and `test_cards.py`
- Initialize fresh `[]` or `{}` inside each method body when `None`
- Add 15 unit tests verifying instances no longer share default state

Closes #2845

## Test plan

- [x] `pytest test/unit/test_card_mutable_defaults.py -v` — 15/15 passed
- [ ] Verify no behavioral change via existing card integration tests