### PR TITLE
fix: inverted condition drops container status in K8s JobSet pod status reporting

### DIFF
--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -432,8 +432,8 @@ class Kubernetes(object):
         jobset.worker.replicas(num_parallel - 1)
 
         # We set the appropriate command for the control/worker job
-        # and also set the task-id/spit-index for the control/worker job
-        # appropirately.
+        # and also set the task-id/split-index for the control/worker job
+        # appropriately.
         jobset.control.command(_get_command("0", str(task_id)))
         jobset.worker.command(
             _get_command(

--- a/metaflow/plugins/kubernetes/kubernetes_job.py
+++ b/metaflow/plugins/kubernetes/kubernetes_job.py
@@ -621,7 +621,6 @@ class RunningJob(object):
                         msg += ", Container is %s" % status["status"].lower()
                         reason = ""
                         if status.get("reason"):
-                            pass
                             reason = status["reason"]
                         if status.get("message"):
                             reason += " - %s" % status["message"]

--- a/metaflow/plugins/kubernetes/kubernetes_jobsets.py
+++ b/metaflow/plugins/kubernetes/kubernetes_jobsets.py
@@ -117,7 +117,7 @@ def _derive_pod_status_and_status_code(control_pod):
                             [v.get("reason"), v.get("message")],
                         )
                     )
-        if container_status is None:
+        if container_status:
             overall_status = "pod status: %s | container status: %s" % (
                 pod_status,
                 container_status,
@@ -130,7 +130,7 @@ def _derive_pod_status_and_status_code(control_pod):
 
 
 def _retrieve_replicated_job_statuses(jobset):
-    # We needed this abstraction because Jobsets changed thier schema
+    # We needed this abstraction because Jobsets changed their schema
     # in version v0.3.0 where `ReplicatedJobsStatus` became `replicatedJobsStatus`
     # So to handle users having an older version of jobsets, we need to account
     # for both the schemas.


### PR DESCRIPTION
## Summary

- Fix inverted condition in `_derive_pod_status_and_status_code()` (`kubernetes_jobsets.py:120`) that caused container status info (e.g., "OOMKilled: Out of memory") to be dropped when available, and literal "None" to be displayed when unavailable. The analogous code in `kubernetes_job.py:614` already uses the correct `if container_status:` pattern.
- Fix typos in comments: "thier" → "their" (`kubernetes_jobsets.py:133`), "spit-index" → "split-index" and "appropirately" → "appropriately" (`kubernetes.py:435-436`)
- Remove redundant `pass` statement before assignment (`kubernetes_job.py:624`)

## Test plan

- [x] Verified inverted condition fix matches `kubernetes_job.py:614` pattern (`if container_status:`)
- [x] Verified all modified modules import successfully
- [x] Ran existing `test/unit/test_kubernetes.py` — no new failures (1 pre-existing label validation failure on master)
- [x] Verified via grep that all typos and the inverted condition are resolved

Closes #2858