### PR TITLE
Add enum type support for Parameter

### DIFF
--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -101,7 +101,7 @@ from .metaflow_current import current
 # Flow spec
 from .flowspec import FlowSpec
 
-from .parameters import Parameter, JSONTypeClass, JSONType
+from .parameters import Parameter, JSONTypeClass, JSONType, EnumTypeClass
 
 from .user_configs.config_parameters import Config, ConfigValue, config_expr
 from .user_decorators.user_step_decorator import (

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -10,6 +10,7 @@ from math import inf
 from typing import List
 
 from metaflow import JSONType, current
+from metaflow.parameters import EnumTypeClass
 from metaflow.decorators import flow_decorators
 from metaflow.exception import MetaflowException
 from metaflow.graph import FlowGraph
@@ -582,6 +583,10 @@ class ArgoWorkflows(object):
             extra_attrs = {}
             if param.kwargs.get("type") == JSONType:
                 param_type = str(param.kwargs.get("type").name)
+            elif isinstance(param.kwargs.get("type"), EnumTypeClass):
+                param_type = str(param.kwargs.get("type").name)
+                extra_attrs["enum"] = list(param.kwargs.get("type").choices)
+                extra_attrs["case_sensitive"] = param.kwargs.get("type").case_sensitive
             elif isinstance(param.kwargs.get("type"), FilePathClass):
                 param_type = str(param.kwargs.get("type").name)
                 extra_attrs["is_text"] = getattr(

--- a/metaflow/runner/click_api.py
+++ b/metaflow/runner/click_api.py
@@ -46,7 +46,7 @@ from metaflow.exception import MetaflowException
 from metaflow.flowspec import FlowStateItems
 from metaflow.includefile import FilePathClass
 from metaflow.metaflow_config import CLICK_API_PROCESS_CONFIG
-from metaflow.parameters import JSONTypeClass, flow_context
+from metaflow.parameters import JSONTypeClass, EnumTypeClass, flow_context
 from metaflow.user_configs.config_options import (
     ConfigValue,
     ConvertDictOrStr,
@@ -72,6 +72,7 @@ click_to_python_types = {
     Choice: str,
     File: str,
     JSONTypeClass: JSON,
+    EnumTypeClass: str,
     FilePathClass: str,
     LocalFileInput: str,
     MultipleTuple: TTuple[str, Union[JSON, ConfigValue]],

--- a/metaflow/runner/deployer.py
+++ b/metaflow/runner/deployer.py
@@ -34,6 +34,14 @@ def generate_fake_flow_file_contents(
                 f"is_text={is_text}, encoding='{encoding}', help='''{param_help}''', "
                 f"required={param_required})\n"
             )
+        elif param_type == "Enum":
+            enum_values = param_details.get("enum", [])
+            case_sensitive = param_details.get("case_sensitive", True)
+            params_code += (
+                f"    {param_python_var_name} = Parameter('{param_name}', "
+                f"type='enum', values={enum_values!r}, case_sensitive={case_sensitive}, "
+                f"help='''{param_help}''', required={param_required})\n"
+            )
         else:
             params_code += (
                 f"    {param_python_var_name} = Parameter('{param_name}', "

--- a/test/unit/test_enum_parameter.py
+++ b/test/unit/test_enum_parameter.py
@@ -1,0 +1,137 @@
+import pytest
+
+from metaflow import EnumTypeClass, Parameter
+from metaflow.exception import MetaflowException
+from metaflow.parameters import flow_context
+from metaflow._vendor import click
+
+
+def _make_flow(*params):
+    """Return a minimal fake flow class containing the given parameters."""
+
+    attrs = {"_get_parameters": classmethod(lambda cls: [(p.name, p) for p in params])}
+    for p in params:
+        attrs[p.name] = p
+    return type("FakeFlow", (), attrs)
+
+
+def _init(param):
+    flow_cls = _make_flow(param)
+    with flow_context(flow_cls):
+        param.init()
+    return param
+
+
+class TestEnumTypeClass:
+    def test_repr_and_str(self):
+        t = EnumTypeClass(["traffic", "labeling"])
+        assert repr(t) == "Enum[traffic|labeling]"
+        assert str(t) == "Enum[traffic|labeling]"
+
+    def test_choices_stored(self):
+        choices = ["a", "b", "c"]
+        t = EnumTypeClass(choices)
+        assert list(t.choices) == choices
+
+    def test_convert_valid_value(self):
+        t = EnumTypeClass(["traffic", "labeling"])
+        assert t.convert("traffic", None, None) == "traffic"
+        assert t.convert("labeling", None, None) == "labeling"
+
+    def test_convert_invalid_value_raises(self):
+        t = EnumTypeClass(["traffic", "labeling"])
+        with pytest.raises(Exception):
+            t.convert("invalid", None, None)
+
+    def test_convert_case_sensitive_by_default(self):
+        t = EnumTypeClass(["Traffic"])
+        with pytest.raises(Exception):
+            t.convert("traffic", None, None)
+
+    def test_convert_case_insensitive_matches_original_casing(self):
+        t = EnumTypeClass(["Traffic", "Labeling"], case_sensitive=False)
+        assert t.convert("traffic", None, None) == "Traffic"
+        assert t.convert("LABELING", None, None) == "Labeling"
+
+    def test_metavar_format(self):
+        t = EnumTypeClass(["a", "b"])
+        assert t.get_metavar(None) == "[a|b]"
+
+    def test_name_attribute(self):
+        assert EnumTypeClass(["x"]).name == "Enum"
+
+
+class TestEnumParameter:
+    def test_basic_enum_parameter(self):
+        p = _init(
+            Parameter(
+                "action",
+                type="enum",
+                values=["traffic", "labeling"],
+                default="traffic",
+            )
+        )
+        assert isinstance(p.kwargs["type"], EnumTypeClass)
+        assert list(p.kwargs["type"].choices) == ["traffic", "labeling"]
+
+    def test_default_value_preserved(self):
+        p = _init(
+            Parameter("mode", type="enum", values=["fast", "slow"], default="fast")
+        )
+        assert p.kwargs["default"] == "fast"
+
+    def test_values_not_leaked_to_click_kwargs(self):
+        p = _init(Parameter("x", type="enum", values=["a", "b"]))
+        assert "values" not in p.kwargs
+
+    def test_case_sensitive_not_leaked_to_click_kwargs(self):
+        p = _init(Parameter("x", type="enum", values=["a", "b"], case_sensitive=False))
+        assert "case_sensitive" not in p.kwargs
+
+    def test_case_insensitive_parameter(self):
+        p = _init(
+            Parameter(
+                "env",
+                type="enum",
+                values=["Prod", "Dev"],
+                case_sensitive=False,
+            )
+        )
+        enum_type = p.kwargs["type"]
+        assert enum_type.convert("prod", None, None) == "Prod"
+
+    def test_values_are_stringified(self):
+        p = _init(Parameter("level", type="enum", values=[1, 2, 3]))
+        assert list(p.kwargs["type"].choices) == ["1", "2", "3"]
+
+    def test_enum_type_is_not_string_type(self):
+        p = _init(Parameter("x", type="enum", values=["a", "b"]))
+        assert not p.is_string_type
+
+    def test_direct_enum_type_class_instantiation(self):
+        p = _init(Parameter("x", type=EnumTypeClass(["yes", "no"]), default="yes"))
+        assert isinstance(p.kwargs["type"], EnumTypeClass)
+        assert list(p.kwargs["type"].choices) == ["yes", "no"]
+
+    def test_option_kwargs_contains_enum_type(self):
+        p = _init(Parameter("action", type="enum", values=["a", "b"]))
+        kwargs = p.option_kwargs(deploy_mode=False)
+        assert isinstance(kwargs["type"], EnumTypeClass)
+
+
+class TestEnumParameterErrors:
+    def test_missing_values_raises(self):
+        with pytest.raises(MetaflowException, match="values"):
+            _init(Parameter("x", type="enum"))
+
+    def test_empty_values_list_raises(self):
+        with pytest.raises(MetaflowException, match="values"):
+            _init(Parameter("x", type="enum", values=[]))
+
+    def test_values_without_enum_type_raises(self):
+        with pytest.raises(MetaflowException, match="values"):
+            _init(Parameter("x", values=["a", "b"]))
+
+    def test_separator_with_enum_raises(self):
+        with pytest.raises(MetaflowException, match="[Ss]eparator"):
+            _init(Parameter("x", type="enum", values=["a", "b"], separator=","))


### PR DESCRIPTION
Users can now declare Parameters with a fixed set of valid string values using `type="enum"` and `values=[...]`. Metaflow validates the supplied value at the CLI level automatically via click.Choice, removing the need for manual validation inside the flow.

## PR Type

<!-- Check one -->

- [ ] Bug fix
- [x] New feature
- [x] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Adds `type="enum"` support to `Parameter`, allowing users to declare a fixed set of valid string choices. Metaflow automatically validates the value at the CLI level and displays valid choices in the `--help` output.

## Issue

<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes #2117 

## Reproduction

<!-- Required for bug fixes. Required for Core Runtime changes. -->
<!-- Provide a minimal reproduction that fails before and succeeds after. -->

**Runtime:** local

**Commands to run:**
```bash
# flow.py
from metaflow import FlowSpec, step, Parameter

class EnumFlow(FlowSpec):
    action = Parameter("action", type="enum", values=["traffic", "labeling"], default="traffic")

    @step
    def start(self):
        print(f"Action is {self.action}")
        self.next(self.end)

    @step
    def end(self):
        pass

if __name__ == '__main__':
    EnumFlow()
```

Run with: `python flow.py run --action invalid`

**Where evidence shows up:** parent console 

<details>
<summary>Before</summary>

  ```python
  # Without enum support, users had to use a plain string Parameter
  action = Parameter(
      "action",
      help="Supported values are 'traffic' and 'labeling'.",
      default="traffic",
  )
  ```
  
 ```
  $ python flow.py run --action invalid
  # No CLI error — invalid value silently accepted, flow executes
  Action is invalid
  ```

</details>

<details>
<summary>After</summary>

  ```
  $ python flow.py run --action invalid
  Metaflow 2.19.19 executing EnumFlow for user:ishita
  Usage: flow.py run [OPTIONS]
  Try 'flow.py run --help' for help.

  Error: Invalid value for '--action': invalid choice: invalid. (choose from traffic, labeling)
  ```

  ```
  $ python flow.py run --help
  ...
  --action [traffic|labeling]   The action you want to perform.  [default: traffic]
  ...
  ```

</details>

## Root Cause

`Parameter` currently lacks a native way to enforce categorical string inputs using Click's built-in `Choice` type. This forces users to write repetitive validation logic inside their steps for simple "dropdown-style" parameters.

## Why This Fix Is Correct

I’ve introduced an `EnumTypeClass` that inherits directly from `click.Choice`. By resolving `type="enum"` during `Parameter.init()`, we hook into Click's native validation and help-text generation.

The implementation is minimal and safe:

- Argument cleanup: It explicitly pops `values` and `case_sensitive` from `kwargs` before they reach the `click.Option` constructor, preventing "unexpected keyword" crashes.

- Native Integration: It stays compatible with existing Metaflow patterns like `DeployTimeField`.

## Failure Modes Considered

- Added checks to raise a `MetaflowException` immediately if a user sets `type="enum"` but forgets the `values` list (or provides an empty one).

- Verified that enum-specific keys don't leak into the underlying `click` call, which would otherwise break the CLI.

- Confirmed that `case_sensitive=False` correctly maps to Click’s behavior while still returning the original casing as defined in the `values` list.

## Tests

- [x] Unit tests added/updated 
- [x] Reproduction script provided (required for Core Runtime)
- [x] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

- Supporting non-string enum types (limited to string choices as per `click.Choice` design).
- Modifying behavior of existing `Parameter` types.

## AI Tool Usage

- [ ] No AI tools were used in this contribution
- [x] AI tools were used 
- Tool: Claude Code
- Usage: Assisted in understanding the codebase and comprehensive unit test cases.
- I have reviewed, understood, and tested all code end-to-end to ensure it meets Metaflow's standards.

