### PR TITLE
fix: remove duplicate import and useless exception re-raises in compute backend plugins

### DIFF
--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -20,7 +20,6 @@ from metaflow.util import get_username, to_bytes, to_unicode, version_parse
 
 from .production_token import load_token, new_token, store_token
 from .step_functions import StepFunctions
-from metaflow.tagging_util import validate_tags
 from ..aws_utils import validate_aws_tag
 
 VALID_NAME = re.compile(r"[^a-zA-Z0-9_\-\.]")

--- a/metaflow/plugins/aws/step_functions/step_functions_client.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_client.py
@@ -87,8 +87,6 @@ class StepFunctionsClient(object):
             return response
         except self._client.exceptions.ExecutionDoesNotExist:
             raise ValueError("The execution ARN %s does not exist." % execution_arn)
-        except Exception as e:
-            raise e
 
     def _default_logging_configuration(self, log_execution_history):
         if log_execution_history:

--- a/metaflow/plugins/kubernetes/kube_utils.py
+++ b/metaflow/plugins/kubernetes/kube_utils.py
@@ -102,7 +102,5 @@ def parse_kube_keyvalue_list(items: List[str], requires_both: bool = True):
                 raise KubernetesException("Duplicate key found: %s" % str(item[0]))
             ret[str(item[0])] = str(item[1]) if len(item) > 1 else None
         return ret
-    except KubernetesException as e:
-        raise e
     except (AttributeError, IndexError):
         raise KubernetesException("Unable to parse kubernetes list: %s" % items)


### PR DESCRIPTION
## Summary

- Remove duplicate `from metaflow.tagging_util import validate_tags` import in `step_functions_cli.py` (lines 18 and 23 were identical; line 18 retained, used on line 182)
- Remove useless `except Exception as e: raise e` in `step_functions_client.py:terminate_execution()` — exception propagates identically without this handler
- Remove useless `except KubernetesException as e: raise e` in `kube_utils.py:parse_kube_keyvalue_list()` — `KubernetesException` (inherits from `MetaflowException`) is not a subclass of `AttributeError`/`IndexError`, so it can never fall through to the next handler

## Test plan

- [x] Verified `validate_tags` has exactly 1 import (line 18) + 1 usage (line 181) — no duplicate
- [x] Verified `raise e` returns 0 matches in both `step_functions_client.py` and `kube_utils.py`
- [x] All modified modules import successfully
- [x] Ran `test/unit/test_kubernetes.py` — no new failures (1 pre-existing label validation failure on master)

Closes #2860