### PR TITLE
Fix: AWS Batch error masking during local metadata sync

### DIFF
--- a/test/unit/test_remote_metadata_sync.py
+++ b/test/unit/test_remote_metadata_sync.py
@@ -1,0 +1,187 @@
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from metaflow.datastore.exceptions import DataException
+from metaflow.plugins.aws.batch import batch_cli
+from metaflow.plugins.aws.batch.batch import BatchException
+
+
+def test_best_effort_sync_skips_non_local_metadata():
+    flow_datastore = Mock()
+    metadata = SimpleNamespace(TYPE="service")
+
+    batch_cli._sync_local_metadata_from_datastore_best_effort(
+        flow_datastore=flow_datastore,
+        metadata=metadata,
+        run_id="1",
+        step_name="step",
+        task_id="task",
+        attempt=2,
+    )
+
+    flow_datastore.get_task_datastore.assert_not_called()
+
+
+def test_best_effort_sync_uses_allow_not_done_and_attempt():
+    flow_datastore = Mock()
+    task_ds = Mock()
+    task_ds.has_metadata.return_value = False
+    flow_datastore.get_task_datastore.return_value = task_ds
+    metadata = SimpleNamespace(TYPE="local")
+
+    batch_cli._sync_local_metadata_from_datastore_best_effort(
+        flow_datastore=flow_datastore,
+        metadata=metadata,
+        run_id="1",
+        step_name="step",
+        task_id="task",
+        attempt=3,
+    )
+
+    flow_datastore.get_task_datastore.assert_called_once_with(
+        "1",
+        "step",
+        "task",
+        attempt=3,
+        allow_not_done=True,
+    )
+    task_ds.has_metadata.assert_called_once_with("local_metadata")
+
+
+def test_best_effort_sync_loads_local_metadata_when_present(monkeypatch):
+    flow_datastore = Mock()
+    task_ds = Mock()
+    task_ds.has_metadata.return_value = True
+    flow_datastore.get_task_datastore.return_value = task_ds
+    metadata = SimpleNamespace(TYPE="local")
+
+    sync_mock = Mock()
+    monkeypatch.setattr(batch_cli, "sync_local_metadata_from_datastore", sync_mock)
+
+    batch_cli._sync_local_metadata_from_datastore_best_effort(
+        flow_datastore=flow_datastore,
+        metadata=metadata,
+        run_id="1",
+        step_name="step",
+        task_id="task",
+        attempt=0,
+    )
+
+    sync_mock.assert_called_once()
+
+
+def test_best_effort_sync_never_raises():
+    flow_datastore = Mock()
+    flow_datastore.get_task_datastore.side_effect = RuntimeError("boom")
+    metadata = SimpleNamespace(TYPE="local")
+
+    batch_cli._sync_local_metadata_from_datastore_best_effort(
+        flow_datastore=flow_datastore,
+        metadata=metadata,
+        run_id="1",
+        step_name="step",
+        task_id="task",
+        attempt=0,
+    )
+
+
+def test_best_effort_sync_warns_on_failure():
+    flow_datastore = Mock()
+    flow_datastore.get_task_datastore.side_effect = RuntimeError("boom")
+    metadata = SimpleNamespace(TYPE="local")
+    warn_fn = Mock()
+
+    batch_cli._sync_local_metadata_from_datastore_best_effort(
+        flow_datastore=flow_datastore,
+        metadata=metadata,
+        run_id="1",
+        step_name="step",
+        task_id="task",
+        attempt=0,
+        warn_fn=warn_fn,
+    )
+
+    warn_fn.assert_called_once()
+    assert "Failed to sync local metadata" in warn_fn.call_args[0][0]
+
+
+def _make_batch_step_context(flow_datastore, metadata_type="local"):
+    echo_always = Mock()
+    obj = SimpleNamespace(
+        echo_always=echo_always,
+        environment=SimpleNamespace(
+            executable=lambda step_name, executable: "python",
+            get_environment_info=lambda: {"metaflow_version": "test"},
+        ),
+        graph={"train": SimpleNamespace(decorators=[])},
+        monitor=SimpleNamespace(measure=lambda *args, **kwargs: nullcontext()),
+        flow=SimpleNamespace(name="Flow"),
+        flow_datastore=flow_datastore,
+        metadata=SimpleNamespace(TYPE=metadata_type),
+    )
+    return SimpleNamespace(
+        obj=obj,
+        parent=SimpleNamespace(parent=SimpleNamespace(params={})),
+    )
+
+
+def test_batch_step_surfaces_batch_error_when_metadata_sync_fails(monkeypatch):
+    """Regression test for #2557: metadata sync failures must not mask Batch errors."""
+    # Avoid the R code path in this unit test.
+    monkeypatch.setattr(batch_cli.R, "use_r", lambda: False)
+
+    flow_datastore = Mock()
+    log_ds = Mock()
+    log_ds.get_log_location.side_effect = ["stdout-url", "stderr-url"]
+
+    ds_calls = []
+
+    def _get_task_datastore(*args, **kwargs):
+        ds_calls.append((args, kwargs))
+        if kwargs.get("mode") == "w":
+            return log_ds
+        # Simulate the historical failure from metadata sync.
+        raise DataException("No completed attempts")
+
+    flow_datastore.get_task_datastore.side_effect = _get_task_datastore
+
+    class FakeBatch(object):
+        def __init__(self, metadata, environment):
+            pass
+
+        def launch_job(self, *args, **kwargs):
+            pass
+
+        def wait(self, *args, **kwargs):
+            raise BatchException("real batch failure")
+
+    monkeypatch.setattr(batch_cli, "Batch", FakeBatch)
+    ctx = _make_batch_step_context(flow_datastore, metadata_type="local")
+
+    with pytest.raises(BatchException, match="real batch failure"):
+        batch_cli.step.callback.__wrapped__(  # type: ignore[attr-defined]
+            ctx,
+            "train",
+            "{}",
+            "sha",
+            "s3://bucket/code",
+            aws_batch_tags=(),
+            run_id="1",
+            task_id="2",
+            retry_count=0,
+        )
+
+    # Ensure metadata sync was attempted after batch.wait failure:
+    # 1) write-mode task datastore for log locations
+    # 2) read-mode task datastore for local metadata sync, which fails
+    assert len(ds_calls) == 2
+    _, first_call_kwargs = ds_calls[0]
+    _, second_call_kwargs = ds_calls[1]
+    assert first_call_kwargs["mode"] == "w"
+    assert second_call_kwargs["allow_not_done"] is True
+    assert second_call_kwargs["attempt"] == 0
+    ctx.obj.echo_always.assert_called_once()
+    assert "Failed to sync local metadata" in ctx.obj.echo_always.call_args[0][0]


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Fixes an AWS Batch error-masking path where local metadata sync failures in cleanup could hide the original Batch failure.  
This change makes metadata sync best-effort so the original Batch error remains visible, while still surfacing metadata sync failures as warnings.

## Issue

Fixes #2557

## Reproduction

**Runtime:** batch

**Commands to run:**
```bash
./.venv/bin/python -m pytest -v test/unit/test_remote_metadata_sync.py::test_batch_step_surfaces_batch_error_when_metadata_sync_fails
./.venv/bin/python -m pytest -v test/unit/test_remote_metadata_sync.py
./.venv/bin/python -m pytest -v test/unit/test_aws_util.py
```

**Where evidence shows up:** batch_cli.step

<details>
<summary>Before (error / log snippet)</summary>

```
Data store error:
No completed attempts of the task was found for task '...'

(Original Batch failure could be masked by metadata sync failure raised during cleanup/finally.)
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
test/unit/test_remote_metadata_sync.py::test_batch_step_surfaces_batch_error_when_metadata_sync_fails PASSED

Assertions in the regression test confirm:
- raised exception remains BatchException("real batch failure")
- metadata sync reads with allow_not_done=True
- attempt is pinned to retry_count (attempt=0 in test case)
- metadata sync failure is emitted as warning (echo_always called)

```

</details>

## Root Cause

batch_cli.step runs metadata sync in cleanup (finally).
Previously, metadata sync used a datastore read path that could raise for incomplete attempts; because this happened in cleanup, that secondary exception could override the primary exception from batch.wait()

## Why This Fix Is Correct

The fix restores that invariant with a minimal change:
- move cleanup sync into a best-effort helper
- fetch datastore with attempt=int(retry_count) and allow_not_done=True
- guard on has_metadata("local_metadata")
- catch sync exceptions and emit warning via ctx.obj.echo_always instead of raising

So task failure reporting remains correct and sync failures are still observable.

## Failure Modes Considered

- batch.wait() fails and metadata sync also fails: original Batch exception must remain surfaced.
- Retry/incomplete attempt metadata lookup: sync should not hard-fail (allow_not_done=True + explicit attempt pinning).
- Non-local metadata provider: sync helper should no-op and preserve existing behavior.

## Tests

- [x] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

- No Kubernetes CLI behavior changes.
- No redesign of metadata subsystem.
- No public API changes

## AI Tool Usage

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

I used GPT-5.3-Codex, Reasoning Effort: Ultra high.
I used AI for writing/refining code and regression tests .
I reviewed, understood, and tested all the generated code.