### PR TITLE
fix: _FlowState.__delitem__ double-fault logic (#2863)

### DIFF
--- a/metaflow/flowspec.py
+++ b/metaflow/flowspec.py
@@ -127,10 +127,11 @@ class _FlowState(MutableMapping):
         self._self_data[key] = value
 
     def __delitem__(self, key):
-        if key in self._non_inherited_items:
-            del self._self_data[key]
+        # Always remove from _self_data (the authoritative store for all keys).
+        del self._self_data[key]
 
-        del self._merged_data[key]
+        # Evict the cached merged value if one was computed for this key.
+        self._merged_data.pop(key, None)
 
     def __iter__(self):
         # All keys are in self._self_data

--- a/test/unit/test_flowstate_delitem.py
+++ b/test/unit/test_flowstate_delitem.py
@@ -1,0 +1,73 @@
+"""Tests for _FlowState.__delitem__ correctness.
+
+_FlowState and FlowStateItems only depend on stdlib (MutableMapping, Enum),
+but importing metaflow.flowspec triggers transitive imports that may fail on
+some platforms (e.g. fcntl on Windows).  We use pytest.importorskip so that
+only ImportError / ModuleNotFoundError cause a skip — any other exception
+(e.g. a real regression in flowspec) will still surface as a test failure.
+"""
+
+import pytest
+
+_flowspec = pytest.importorskip(
+    "metaflow.flowspec",
+    reason="metaflow.flowspec is not importable on this platform",
+)
+_FlowState = _flowspec._FlowState
+FlowStateItems = _flowspec.FlowStateItems
+
+
+def _make_flowstate():
+    """Create a _FlowState with standard FlowSpec initialization keys."""
+    return _FlowState(
+        {
+            FlowStateItems.FLOW_MUTATORS: [],
+            FlowStateItems.FLOW_DECORATORS: {},
+            FlowStateItems.CONFIGS: {},
+            FlowStateItems.CACHED_PARAMETERS: None,
+            FlowStateItems.SET_CONFIG_PARAMETERS: [],
+        }
+    )
+
+
+class TestFlowStateDelItem:
+    """Verify __delitem__ correctly removes keys from all backing stores."""
+
+    def test_delete_non_inherited_key(self):
+        """Deleting a non-inherited key (e.g. CONFIGS) should not raise KeyError."""
+        fs = _make_flowstate()
+        del fs[FlowStateItems.CONFIGS]
+        assert FlowStateItems.CONFIGS not in fs._self_data
+        assert len(fs) == 4
+
+    def test_delete_inherited_key(self):
+        """Deleting an inherited key should remove it from _self_data so it
+        cannot be recomputed on subsequent access."""
+        fs = _make_flowstate()
+        del fs[FlowStateItems.FLOW_MUTATORS]
+        assert FlowStateItems.FLOW_MUTATORS not in fs._self_data
+        with pytest.raises(KeyError):
+            _ = fs[FlowStateItems.FLOW_MUTATORS]
+
+    def test_delete_inherited_key_clears_merged_cache(self):
+        """If a merged value was cached, deleting the key should evict it."""
+        fs = _make_flowstate()
+        # Force a cached merge by accessing the key.
+        _ = fs[FlowStateItems.FLOW_DECORATORS]
+        assert FlowStateItems.FLOW_DECORATORS in fs._merged_data
+
+        del fs[FlowStateItems.FLOW_DECORATORS]
+        assert FlowStateItems.FLOW_DECORATORS not in fs._merged_data
+        assert FlowStateItems.FLOW_DECORATORS not in fs._self_data
+
+    def test_delete_missing_key_raises(self):
+        """Deleting a key that doesn't exist should raise KeyError."""
+        fs = _make_flowstate()
+        with pytest.raises(KeyError):
+            del fs["no_such_key"]
+
+    def test_len_after_delete(self):
+        fs = _make_flowstate()
+        original_len = len(fs)
+        del fs[FlowStateItems.CACHED_PARAMETERS]
+        assert len(fs) == original_len - 1


### PR DESCRIPTION
Two bugs in _FlowState.__delitem__:

1. Non-inherited keys (CONFIGS, CACHED_PARAMETERS, SET_CONFIG_PARAMETERS) were never stored in _merged_data, so the unconditional del self._merged_data[key] raised KeyError.

2. Inherited keys (FLOW_MUTATORS, FLOW_DECORATORS) were only removed from _merged_data but not _self_data, so the next __getitem__ call recomputed the merged value, effectively un-deleting the item.

Fix: always delete from _self_data (authoritative store) and use _merged_data.pop(key, None) to safely evict any cached merge.

Added 5 unit tests for __delitem__ correctness.

Fixes #2863

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

`_FlowState.__delitem__` had two logic bugs: (1) deleting non-inherited keys raised `KeyError` because they were never in `_merged_data`, and (2) deleting inherited keys only cleared the cache but left `_self_data` intact, so the item silently reappeared on next access. Fixed by always deleting from `_self_data` and safely evicting the merge cache.

## Issue

Fixes #2863

## Reproduction

**Runtime:** local

**Commands to run:**
```bash
python -c "
from collections.abc import MutableMapping
from enum import Enum

class FlowStateItems(Enum):
    FLOW_MUTATORS = 1
    FLOW_DECORATORS = 2
    CONFIGS = 3
    CACHED_PARAMETERS = 4
    SET_CONFIG_PARAMETERS = 5

class _FlowState(MutableMapping):
    _non_inherited_items = [
        FlowStateItems.CONFIGS,
        FlowStateItems.CACHED_PARAMETERS,
        FlowStateItems.SET_CONFIG_PARAMETERS,
    ]
    def __init__(self, *args, **kwargs):
        self._self_data = dict(*args, **kwargs)
        self._merged_data = {}
        self._inherited = {}
    def __getitem__(self, key):
        if key in self._non_inherited_items:
            return self._self_data[key]
        if key in self._merged_data:
            return self._merged_data[key]
        self_value = self._self_data.get(key)
        inherited_value = self._inherited.get(key)
        if self_value is not None:
            self._merged_data[key] = inherited_value or type(self_value)()
            return self._merged_data[key]
        raise KeyError(key)
    def __setitem__(self, key, value):
        self._self_data[key] = value
    def __delitem__(self, key):
        if key in self._non_inherited_items:
            del self._self_data[key]
        del self._merged_data[key]  # BUG
    def __iter__(self):
        for key in self._self_data:
            yield key
    def __len__(self):
        return len(self._self_data)

fs = _FlowState({
    FlowStateItems.FLOW_MUTATORS: [],
    FlowStateItems.FLOW_DECORATORS: {},
    FlowStateItems.CONFIGS: {},
    FlowStateItems.CACHED_PARAMETERS: None,
    FlowStateItems.SET_CONFIG_PARAMETERS: [],
})

# Bug 1: non-inherited key raises KeyError
try:
    del fs[FlowStateItems.CONFIGS]
    print('BUG 1: no error (unexpected)')
except KeyError as e:
    print(f'BUG 1 CONFIRMED: KeyError raised when deleting non-inherited key: {e}')

# Bug 2: inherited key silently un-deletes
_ = fs[FlowStateItems.FLOW_DECORATORS]  # cache merge
del fs[FlowStateItems.FLOW_DECORATORS]
try:
    val = fs[FlowStateItems.FLOW_DECORATORS]
    print(f'BUG 2 CONFIRMED: deleted key reappeared with value: {val}')
except KeyError:
    print('BUG 2: properly deleted (unexpected)')
"
```

**Where evidence shows up:** parent console

<details>
<summary>Before (error / log snippet)</summary>

```
BUG 1 CONFIRMED: KeyError raised when deleting non-inherited key: <FlowStateItems.CONFIGS: 3>
BUG 2 CONFIRMED: deleted key reappeared with value: {}
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
$ python -m pytest test/unit/test_flowstate_delitem.py -v
============================= test session starts =============================
collected 5 items

test/unit/test_flowstate_delitem.py::TestFlowStateDelItem::test_delete_non_inherited_key PASSED
test/unit/test_flowstate_delitem.py::TestFlowStateDelItem::test_delete_inherited_key PASSED
test/unit/test_flowstate_delitem.py::TestFlowStateDelItem::test_delete_inherited_key_clears_merged_cache PASSED
test/unit/test_flowstate_delitem.py::TestFlowStateDelItem::test_delete_missing_key_raises PASSED
test/unit/test_flowstate_delitem.py::TestFlowStateDelItem::test_len_after_delete PASSED

============================== 5 passed ==============================
```

</details>

## Root Cause

In `metaflow/flowspec.py` lines 129-133, `_FlowState.__delitem__` was implemented as:

```python
def __delitem__(self, key):
    if key in self._non_inherited_items:
        del self._self_data[key]

    del self._merged_data[key]
```

**Bug 1 — Non-inherited keys raise `KeyError`:** For keys in `_non_inherited_items` (CONFIGS, CACHED_PARAMETERS, SET_CONFIG_PARAMETERS), `__getitem__` returns directly from `_self_data` — they are **never** stored in `_merged_data`. The unconditional `del self._merged_data[key]` on the last line therefore raises `KeyError`.

**Bug 2 — Inherited keys silently un-delete:** For inherited keys (FLOW_MUTATORS, FLOW_DECORATORS), the `if key in self._non_inherited_items` guard is `False`, so `_self_data` is **not** touched — only `_merged_data` is cleared. Since `_self_data` still holds the key, the next `__getitem__` call recomputes the merged value from `_self_data` and `_inherited`, effectively **un-deleting** the item.

## Why This Fix Is Correct

The fix changes `__delitem__` to:

```python
def __delitem__(self, key):
    del self._self_data[key]
    self._merged_data.pop(key, None)
```

1. `del self._self_data[key]` - always removes from the authoritative store. If the key doesn't exist, `KeyError` is raised (correct MutableMapping behavior). This fixes Bug 2.
2. `self._merged_data.pop(key, None)` - safely evicts any cached merged value without raising if absent. This fixes Bug 1.

The fix is minimal (net -1 line changed) and restores the invariant that deletion from a `MutableMapping` makes the key inaccessible.

## Failure Modes Considered

1. **No callers use `__delitem__` today:** Searched the entire codebase - no code calls `del _flow_state[...]`. This means the bug has never been triggered in production, and the fix carries zero regression risk. However, having correct `MutableMapping` semantics is important for any future code that relies on deletion.

2. **Inherited keys with cached merges:** After the fix, deleting a key that has a cached merge in `_merged_data` correctly evicts both the source (`_self_data`) and the cache (`_merged_data`). The key becomes fully inaccessible - `__getitem__` will raise `KeyError` because `_self_data.get(key)` returns `None`.

## Tests

- [x] Unit tests added/updated
- [x] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

5 unit tests added in `test/unit/test_flowstate_delitem.py`:
- `test_delete_non_inherited_key` - previously raised `KeyError` (Bug 1)
- `test_delete_inherited_key` - previously silently un-deleted (Bug 2)
- `test_delete_inherited_key_clears_merged_cache` - verifies cache eviction
- `test_delete_missing_key_raises` - `KeyError` for absent keys
- `test_len_after_delete` - length decrements correctly

Tests skip gracefully on Windows (where `fcntl` transitive import fails) via `pytest.skip(allow_module_level=True)`.

## Non-Goals

- Did not fix `_FlowState.__iter__` (separate bug yielding values instead of keys - tracked in a separate PR).
- Did not address Windows platform incompatibilities (`fcntl`, `os.fork()`, etc.)  separate scope.

## AI Tool Usage

- [x] AI tools were used (describe below)

- **Tool:** GitHub Copilot
- **Used for:** test authoring
