### PR TITLE
fix: incorrect boolean operator in Batch tag validation causes crash on non-dict input

### DIFF
--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -184,7 +184,7 @@ class BatchDecorator(StepDecorator):
         if self.attributes["trainium"] is not None:
             self.attributes["inferentia"] = self.attributes["trainium"]
 
-        if not isinstance(BATCH_DEFAULT_TAGS, dict) and not all(
+        if not isinstance(BATCH_DEFAULT_TAGS, dict) or not all(
             isinstance(k, str) and isinstance(v, str)
             for k, v in BATCH_DEFAULT_TAGS.items()
         ):
@@ -193,7 +193,7 @@ class BatchDecorator(StepDecorator):
             )
 
         if self.attributes["aws_batch_tags"] is not None:
-            if not isinstance(self.attributes["aws_batch_tags"], dict) and not all(
+            if not isinstance(self.attributes["aws_batch_tags"], dict) or not all(
                 isinstance(k, str) and isinstance(v, str)
                 for k, v in self.attributes["aws_batch_tags"].items()
             ):


### PR DESCRIPTION
## Summary

- Fix incorrect `and` → `or` in `BATCH_DEFAULT_TAGS` and `aws_batch_tags` validation (`batch_decorator.py` lines 187, 196)
- The `and` operator caused two problems:
  1. **Crash**: If the value is not a dict, `and` evaluates the second condition which calls `.items()` on a non-dict → `AttributeError` instead of `BatchException`
  2. **Skipped validation**: If the value IS a dict, `not isinstance(...)` is `False`, so `and` short-circuits and skips the `all()` content check entirely
- The `or` operator short-circuits correctly per De Morgan's law: raises `BatchException` immediately for non-dicts (without calling `.items()`), validates dict contents for valid dicts

## Test plan

- [x] Verified `and not all` returns 0 matches (both instances fixed)
- [x] Verified `or not all` returns 2 matches on lines 187 and 196
- [x] Module imports successfully
- [x] Logic verified: `or` short-circuits when first condition is True (not a dict), never reaching `.items()`

Closes #2866