### PR TITLE
fix: add missing fallback return in Batch _command() when S3 offload fails

### DIFF
--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -153,6 +153,7 @@ class Batch(object):
         except Exception as e:
             print(f"Warning: Failed to upload command to S3: {e}")
             print("Falling back to inline command")
+            return command
 
     def _search_jobs(self, flow_name, run_id, user):
         if user is None:


### PR DESCRIPTION
## Summary

- Add missing `return command` in the S3 command offload error handler of `Batch._command()` (`batch.py:155`)
- When S3 upload fails, the method prints "Falling back to inline command" but returns `None` instead of the original command built on line 109
- The caller passes the return value to `.command(...)` which calls `.extend(command)` in `batch_client.py:561` — passing `None` raises `TypeError`
- The fix returns the original inline command (same value returned on line 112 when offloading is disabled), implementing the fallback the warning message claims

## Test plan

- [x] Verified `command` is in scope (defined line 109, before try block on line 124)
- [x] Verified `command` is never mutated in the try block (only read via `command[-1]`)
- [x] Verified return type matches other paths (`shlex.split()` returns `list[str]`)
- [x] Verified caller expects iterable (`.extend()` on line 561 of `batch_client.py`)
- [x] Module imports successfully

Closes #2868