### PR TITLE
Fix:preserve run.created_at during tag mutation

### DIFF
--- a/metaflow/plugins/metadata_providers/local.py
+++ b/metaflow/plugins/metadata_providers/local.py
@@ -484,15 +484,10 @@ class LocalMetadataProvider(MetadataProvider):
             raise MetaflowInternalError(
                 msg="Could not verify Run existence on disk - missing %s" % selfname
             )
-        cls._save_meta(
-            subpath,
-            {
-                "_self": MetadataProvider._run_to_json_static(
-                    flow_id, run_id=run_id, tags=tags, sys_tags=system_tags
-                )
-            },
-            allow_overwrite=True,
-        )
+        current = cls._read_json_file(selfname)
+        current["tags"] = list(tags)
+        current["system_tags"] = list(system_tags)
+        cls._dump_json_to_file(selfname, current, allow_overwrite=True)
 
     def _ensure_meta(
         self, obj_type, run_id, step_name, task_id, tags=None, sys_tags=None

--- a/test/unit/test_run_created_at_stable.py
+++ b/test/unit/test_run_created_at_stable.py
@@ -1,0 +1,59 @@
+import json
+import os
+
+
+def test_modifying_tags_does_not_change_created_at(tmp_path):
+    from metaflow.plugins.metadata_providers.local import (
+        LocalMetadataProvider,
+    )
+    from metaflow.plugins.datastores.local_storage import LocalStorage
+    from metaflow.metaflow_environment import MetaflowEnvironment
+
+    class DummyFlow:
+        name = "TestFlow"
+
+    # Preserve original class-level datastore root
+    original_root = LocalStorage.datastore_root
+
+    try:
+        # Use isolated temporary directory
+        LocalStorage.datastore_root = str(tmp_path)
+
+        # Use real Metaflow environment
+        environment = MetaflowEnvironment(None)
+
+        provider = LocalMetadataProvider(
+            environment=environment,
+            flow=DummyFlow(),
+            event_logger=None,
+            monitor=None,
+        )
+
+        run_id = provider.new_run_id()
+
+        meta_dir = provider._get_metadir("TestFlow", run_id)
+        self_file = os.path.join(meta_dir, "_self.json")
+
+        assert os.path.exists(self_file)
+
+        with open(self_file) as f:
+            before = json.load(f)["ts_epoch"]
+
+        # Mutate tags
+        LocalMetadataProvider._mutate_user_tags_for_run(
+            flow_id="TestFlow",
+            run_id=run_id,
+            tags_to_add=["status:test"],
+            tags_to_remove=[],
+        )
+
+        with open(self_file) as f:
+            after = json.load(f)["ts_epoch"]
+
+        assert before == after
+
+    finally:
+        # Restore original state to avoid test leakage
+        LocalStorage.datastore_root = original_root
+        
+        


### PR DESCRIPTION
##PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see CONTRIBUTING.md)
- [ ] Docs / tooling
- [ ] Refactoring


## Summary

Fixes an issue in the local metadata provider where modifying run tags overwrote the original `created_at` timestamp. The fix ensures that the original creation time of a run remains stable while only tag fields are updated.


## Issue

Fixes #2293


## Reproduction

**Runtime:** local

**Commands to run:**

```bash
python linear_flow.py run

python
from metaflow import *
runs = list(Flow("LinearFlow"))
r = runs[1]
print("Before:", r.created_at)
r.add_tag("status:deleted")
print("After:", r.created_at)

**Where evidence shows up:** <!-- Python client / local metadata -->

<details>
<summary>Before (incorrect behavior)</summary>

```
The created_at timestamp changes after calling add_tag().

Example:

Before: 2025-02-24 19:14:49
After: 2025-02-24 19:18:19
```

</details>

<details>
<summary>After (correct behavior)</summary>

```
The created_at timestamp remains unchanged after modifying tags.

Example:

Before: 2025-02-24 19:14:49
After: 2025-02-24 19:14:49
```

</details>
## Root Cause

In the local metadata provider (`LocalMetadataProvider._persist_tags_for_run`),
the `_self.json` file was rewritten using:

    MetadataProvider._run_to_json_static(...)

This helper regenerates the full run metadata payload, including the
`created_at` timestamp.

As a result, whenever `add_tag()` or `remove_tag()` was called in local mode,
the `_self.json` file was overwritten and a new `created_at` value was written.

This violated the invariant that:

    created_at must represent the original run creation time
    and must remain immutable after run creation.

Because runs are sorted by `created_at`, this also caused:
- Incorrect ordering of runs
- `latest_successful_run` returning wrong results
- Metadata inconsistencies in local mode

Notably, this issue only affected the local metadata backend.


## Why This Fix Is Correct

Instead of regenerating the full run JSON payload, the fix:

1. Reads the existing `_self.json`
2. Preserves the original `created_at`
3. Updates only `tags` and `system_tags`
4. Writes back the modified payload

This restores the invariant that `created_at` is immutable after run creation.

The change is:
- Minimal
- Scoped only to local metadata
- Backward compatible
- Does not modify metadata schema


## Failure Modes Considered

1. Concurrent tag mutations  
   The existing optimistic mutation retry logic remains unchanged.
   The fix only alters how metadata is persisted, not concurrency behavior.

2. Backward compatibility  
   No metadata schema changes were introduced.
   Existing `_self.json` files remain valid.

3. Non-local backends (S3 / service metadata)  
   These backends were not modified and are unaffected.

4. Run sorting behavior  
   Since `created_at` remains stable, sorting and
   `latest_successful_run` behavior are now correct.


## Tests

- [x] Unit tests added/updated
- [x] Reproduction script provided
- [x] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

A regression test was added to verify that modifying tags does not change
`created_at` in local mode.


## Non-Goals

This PR does not:
- Modify S3 or service metadata providers
- Change metadata schema
- Refactor metadata architecture
- Alter run sorting logic

The change is strictly limited to preserving `created_at`
during tag mutation in local metadata.


## AI Tool Usage

- [x] AI tools were used (describe below)

AI assistance (ChatGPT) was used for:
- Structuring the PR explanation
- Reasoning about the root cause
- Reviewing the logical correctness of the fix

All code changes were written, reviewed, and tested manually by the contributor.