### PR TITLE
Fix variable shadowing of `attempt` parameter in get_task_datastores

### DIFF
--- a/metaflow/datastore/flow_datastore.py
+++ b/metaflow/datastore/flow_datastore.py
@@ -174,7 +174,7 @@ class FlowDataStore(object):
             task_attempt_range = attempt_range
             if len(task_splits) == 5:
                 task_attempt_range = [int(task_splits[4])]
-            for attempt in task_attempt_range:
+            for attempt_id in task_attempt_range:
                 for suffix in [
                     TaskDataStore.METADATA_DATA_SUFFIX,
                     TaskDataStore.METADATA_ATTEMPT_SUFFIX,
@@ -183,7 +183,7 @@ class FlowDataStore(object):
                     urls.append(
                         self._storage_impl.path_join(
                             task_url,
-                            TaskDataStore.metadata_name_for_attempt(suffix, attempt),
+                            TaskDataStore.metadata_name_for_attempt(suffix, attempt_id),
                         )
                     )
 


### PR DESCRIPTION
## Summary
Fix variable shadowing in `FlowDataStore.get_task_datastores`.

## Problem
The inner loop reused the name `attempt`, which shadows the
function parameter due to Python's function-level scoping.
After iteration, the parameter value was overwritten,
causing incorrect attempt range evaluation.

## Solution
Rename the loop variable to avoid shadowing while preserving
existing behavior.

## Testing
Core test suite loads successfully locally without
collection errors.

Fixes #2878