### PR TITLE
Renamed the inner loop variable from attempt to current_attempt

### DIFF
--- a/metaflow/datastore/flow_datastore.py
+++ b/metaflow/datastore/flow_datastore.py
@@ -174,7 +174,7 @@ class FlowDataStore(object):
             task_attempt_range = attempt_range
             if len(task_splits) == 5:
                 task_attempt_range = [int(task_splits[4])]
-            for attempt in task_attempt_range:
+            for current_attempt in task_attempt_range:
                 for suffix in [
                     TaskDataStore.METADATA_DATA_SUFFIX,
                     TaskDataStore.METADATA_ATTEMPT_SUFFIX,
@@ -183,7 +183,9 @@ class FlowDataStore(object):
                     urls.append(
                         self._storage_impl.path_join(
                             task_url,
-                            TaskDataStore.metadata_name_for_attempt(suffix, attempt),
+                            TaskDataStore.metadata_name_for_attempt(
+                                suffix, current_attempt
+                            ),
                         )
                     )
 


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

<!-- What user-visible behavior changes? 1-2 sentences. -->
Fixed a variable shadowing bug in get_task_datastores where the method's attempt parameter was overwritten by an inner loop variable.
## Issue

<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes #2878 

## Reproduction

<!-- Required for bug fixes. Required for Core Runtime changes. -->
<!-- Provide a minimal reproduction that fails before and succeeds after. -->

**Runtime:** <!-- local / kubernetes / batch / argo / etc. -->

**Commands to run:**
```bash
# paste exact commands
```

**Where evidence shows up:** <!-- parent console / task logs / metadata / UI -->

<details>
<summary>Before (error / log snippet)</summary>

```
 For the first task, attempt=None, so it fetches the correct range.
 For the second task, attempt holds the last integer from the previous inner loop.
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
 All tasks works with attempt=None or the specific integer passed by the user for every iteration of  task_urls.
```

</details>

## Root Cause

<!-- Required for Core Runtime. Recommended for all bug fixes. -->
<!-- Explain the causal chain: what invariant was violated, where in the code. -->
<!-- See PRs #2796, #2751, #2714 for examples of the level of detail we're looking for. -->

## Why This Fix Is Correct

<!-- What invariant is restored? Why is the fix minimal? -->

## Failure Modes Considered

<!-- Required for Core Runtime (at least 2). Recommended for all bug fixes. -->
<!-- Examples: concurrency/retries, subprocess output propagation, env-var leakage, backward compat -->

1.
2.

## Tests

- [ ] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

<!-- What you intentionally did not change. Helps reviewers scope their review. -->

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [x] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)

<!-- If you used AI tools:
- Which tool(s)?
- What did you use them for?
- Did you review, understand, and test all generated code?
-->
