### PR TITLE
feat: auto-enable color in subprocesses by propagating FORCE_COLOR

### DIFF
--- a/metaflow/runner/subprocess_manager.py
+++ b/metaflow/runner/subprocess_manager.py
@@ -152,7 +152,7 @@ class SubprocessManager(object):
         int
             The process ID of the subprocess.
         """
-        env = env or {}
+        env = dict(env) if env is not None else {}
         installed_root = os.environ.get("METAFLOW_EXTRACTED_ROOT", get_metaflow_root())
 
         for k, v in MetaflowCodeContent.get_env_vars_for_packaged_metaflow(
@@ -196,7 +196,7 @@ class SubprocessManager(object):
         int
             The process ID of the subprocess.
         """
-        env = env or {}
+        env = dict(env) if env is not None else {}
         if "PYTHONPATH" in env:
             env["PYTHONPATH"] = "%s:%s" % (get_metaflow_root(), env["PYTHONPATH"])
         else:
@@ -256,7 +256,9 @@ class CommandManager(object):
         """
         self.command = command
 
-        self.env = env if env is not None else os.environ.copy()
+        self.env = dict(env) if env is not None else os.environ.copy()
+        if sys.stdout.isatty() and "FORCE_COLOR" not in self.env:
+            self.env["FORCE_COLOR"] = "1"
         self.cwd = cwd or os.getcwd()
 
         self.process = None

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -2227,6 +2227,8 @@ class Worker(object):
             skip_decorators=self._skip_decorators,
         )
         env = dict(os.environ)
+        if sys.stdout.isatty() and "FORCE_COLOR" not in env:
+            env["FORCE_COLOR"] = "1"
 
         if self.task.clone_run_id:
             args.command_options["clone-run-id"] = self.task.clone_run_id


### PR DESCRIPTION
## Summary
Auto-enable color in subprocesses by propagating `FORCE_COLOR=1` when running in a terminal.

## Context / Motivation
Metaflow captures subprocess output via pipes, which causes tools (including our vendored `click`) to strip ANSI codes. This completes the work in #2797 by auto-injecting the env var so colors work out-of-the-box.

Fixes #2797

## Changes Made
- Modified [runtime.py](cci:7://file:///e:/opensource/metaflow/metaflow/runtime.py:0:0-0:0) and [subprocess_manager.py](cci:7://file:///e:/opensource/metaflow/metaflow/runner/subprocess_manager.py:0:0-0:0) to check `sys.stdout.isatty()`.
- Inject `FORCE_COLOR=1` into the subprocess env if it's not already set.
- Added a [dict()](cci:1://file:///e:/opensource/metaflow/metaflow/util.py:415:0-456:43) copy in [CommandManager](cci:2://file:///e:/opensource/metaflow/metaflow/runner/subprocess_manager.py:232:0-555:40) to avoid mutating the caller's env.

## Testing
- Verified colors are preserved in a local run using `click.secho`.
- Confirmed `FORCE_COLOR=0` still works as an override to disable color.