### PR TITLE
fix: restore working directory on exception in with_dir() in packagin…

### DIFF
--- a/metaflow/packaging_sys/utils.py
+++ b/metaflow/packaging_sys/utils.py
@@ -53,5 +53,7 @@ def suffix_filter(suffixes: List[str]) -> Callable[[str], bool]:
 def with_dir(new_dir):
     current_dir = os.getcwd()
     os.chdir(new_dir)
-    yield new_dir
-    os.chdir(current_dir)
+    try:
+        yield new_dir
+    finally:
+        os.chdir(current_dir)


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Wrap the `yield` in a `try/finally` block.
`finally` is guaranteed to run regardless of whether an exception occurred.
**Branch:** `fix/with-dir-packaging-sys`

**Commit message:**
```
fix: restore working directory on exception in with_dir()
```

**Files changed:** `metaflow/packaging_sys/utils.py`


## Issue

Fixes #2890

## Reproduction


```python
# bug_reproduction.py

import os, sys, tempfile, shutil
sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
from metaflow.packaging_sys.utils import with_dir

tmp_dir = tempfile.mkdtemp()
original_dir = os.getcwd()

print(f"Before : {os.getcwd()}")

try:
    with with_dir(tmp_dir):
        print(f"Inside : {os.getcwd()}")  # moved into tmp_dir
        raise RuntimeError("something went wrong inside the block")
except RuntimeError:
    pass  # exception handled, execution continues

# BUG: os.chdir(current_dir) never called — stuck in wrong directory
print(f"After  : {os.getcwd()}")

if os.getcwd() != original_dir:
    print(f"   Expected: {original_dir}")
    print(f"   Got     : {os.getcwd()}")

shutil.rmtree(tmp_dir, ignore_errors=True)
```

**Actual output:**

```
Before : /home/user/metaflow
Inside : /tmp/tmpXXXXXX
After  : /tmp/tmpXXXXXX


   Expected: /home/user/metaflow
   Got     : /tmp/tmpXXXXXX
```

---

## Expected Behaviour

After the `with with_dir(...)` block exits — whether normally or via an exception —
the working directory **must always** be restored to what it was before entering the block.

**Expected output after fix:**

```
Before : /home/user/metaflow
Inside : /tmp/tmpXXXXXX
After  : /home/user/metaflow

✅ Already fixed
```

---

## AI Tool Usage
- [x] AI tools were used (describe below)
- used to understand the behaviour of the code 
