### PR TITLE
fix: _FlowState.__iter__ yields keys instead of values

### DIFF
--- a/metaflow/flowspec.py
+++ b/metaflow/flowspec.py
@@ -135,7 +135,7 @@ class _FlowState(MutableMapping):
     def __iter__(self):
         # All keys are in self._self_data
         for key in self._self_data:
-            yield self[key]
+            yield key
 
     def __len__(self):
         return len(self._self_data)


### PR DESCRIPTION
## Summary

`_FlowState.__iter__` was yielding `self[key]` (values) instead of `key`, violating the `MutableMapping` contract which requires `__iter__` to yield keys.

## Fix

One-line change in `metaflow/flowspec.py`: `yield self[key]` → `yield key`.

Fixes #2837