### PR TITLE
Fix loop variable shadowing 'attempt' parameter in get_task_datastores

### DIFF
--- a/metaflow/datastore/flow_datastore.py
+++ b/metaflow/datastore/flow_datastore.py
@@ -174,7 +174,7 @@ class FlowDataStore(object):
             task_attempt_range = attempt_range
             if len(task_splits) == 5:
                 task_attempt_range = [int(task_splits[4])]
-            for attempt in task_attempt_range:
+            for _attempt in task_attempt_range:
                 for suffix in [
                     TaskDataStore.METADATA_DATA_SUFFIX,
                     TaskDataStore.METADATA_ATTEMPT_SUFFIX,
@@ -183,7 +183,7 @@ class FlowDataStore(object):
                     urls.append(
                         self._storage_impl.path_join(
                             task_url,
-                            TaskDataStore.metadata_name_for_attempt(suffix, attempt),
+                            TaskDataStore.metadata_name_for_attempt(suffix, _attempt),
                         )
                     )
 


### PR DESCRIPTION
## Summary

The inner loop variable `attempt` in `get_task_datastores` (line 177) shadows the method parameter `attempt` (line 85). After the first iteration of the outer `for task_url in task_urls` loop, the parameter value is lost and replaced with the last integer from `task_attempt_range`.

## Fix

Rename the inner loop variable from `attempt` to `_attempt` to avoid shadowing the method parameter.

Fixes #2878