### PR TITLE
Improve error message for Unix-only dependencies on Windows during plugin loading

### DIFF
--- a/metaflow/extension_support/plugins.py
+++ b/metaflow/extension_support/plugins.py
@@ -1,17 +1,22 @@
 import importlib
 import traceback
+import sys
 
 from metaflow.metaflow_config_funcs import from_conf
 
 from . import _ext_debug, alias_submodules, get_modules, lazy_load_aliases
+
+
 # Unix-only standard library modules not available on Windows
-_UNIX_ONLY_MODULES = frozenset({
-    "fcntl",
-    "termios",
-    "resource",
-    "grp",
-    "pwd",
-})
+_UNIX_ONLY_MODULES = frozenset(
+    {
+        "fcntl",
+        "termios",
+        "resource",
+        "grp",
+        "pwd",
+    }
+)
 
 
 def process_plugins(module_globals):
@@ -108,7 +113,7 @@ def get_plugin(category, class_path, name):
     except ImportError as e:
         missing_module = getattr(e, "name", "")
 
-        if missing_module in _UNIX_ONLY_MODULES:
+        if missing_module in _UNIX_ONLY_MODULES and sys.platform == "win32":
             raise RuntimeError(
                 "\n Metaflow plugin requires Unix-only modules.\n\n"
                 "The plugin '%s' depends on '%s', which is not available on Windows.\n\n"
@@ -116,8 +121,7 @@ def get_plugin(category, class_path, name):
                 "  1) Use WSL (Windows Subsystem for Linux)\n"
                 "  2) Run Metaflow on Linux or macOS\n"
                 "  3) Disable this plugin if not needed\n\n"
-                "Docs: https://docs.metaflow.org\n"
-                % (name, missing_module)
+                "Docs: https://docs.metaflow.org\n" % (name, missing_module)
             ) from e
         raise ValueError(
             "Cannot locate %s plugin '%s' at '%s'" % (category, name, path)


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix

## Summary

This PR improves Metaflow’s usability on Windows by providing a clear, actionable error message when plugin loading fails due to Unix-only dependencies (e.g., `fcntl`).

Currently, such failures produce a long stack trace that obscures the root cause and offers no guidance to users.

## Issue

Some plugins (notably the AWS Batch plugin) depend on modules that are only available on Unix-like systems. When Metaflow is run on Windows, importing these plugins raises:

    ModuleNotFoundError: No module named 'fcntl'

This exception is wrapped and surfaces as a generic plugin-loading failure, resulting in a confusing traceback.

This experience is particularly problematic for first-time users, who may assume Metaflow is broken rather than encountering a platform limitation.

Fixes: Netflix/metaflow#2895

## Reproduction

**Runtime:** local (Windows)

**Commands to run:**
```bash
python -m metaflow --help
```

**Where evidence shows up:** Parent console output
 
Before


<img width="1920" height="1020" alt="Screenshot 2026-02-23 221054" src="https://github.com/user-attachments/assets/6b195123-00a9-41ff-91ed-b716c4d1d641" />



After 


<img width="1920" height="1020" alt="Screenshot 2026-02-23 222419" src="https://github.com/user-attachments/assets/8b1e31e9-7e97-4bac-b266-95a51cd3c0a4" />



## Root Cause

During plugin resolution, Metaflow attempts to import all configured plugins. The AWS Batch plugin imports the fcntl module, which is available only on Unix-like systems.

On Windows, this import raises ModuleNotFoundError. The exception is caught and re-raised as a generic plugin loading error, which hides the actual platform incompatibility and produces a verbose traceback.

## Why This Fix Is Correct

The fix detects ImportError cases caused by missing Unix-only modules (e.g., fcntl) and replaces the generic error with a concise, actionable message explaining the platform limitation.

This restores the invariant that user-facing errors should clearly communicate both the cause and the remediation steps.

The change is minimal and affects only failure scenarios during plugin loading.

Failure Modes Considered

1. Non-platform-related import failures
— These continue to use the original behavior to avoid masking real errors unrelated to OS compatibility.

2. Behavior on supported platforms (Linux/macOS)
— Unaffected, since the required modules are present and no exception is triggered.

## Tests

- [x] CI passes
- [x] If tests are impractical: explain why below and provide manual evidence above

Automated testing is impractical because the issue depends on platform-specific module availability. Manual testing on Windows confirms the improved behavior.

## Non-Goals

- No changes to plugin APIs or runtime behavior

- No automatic disabling of incompatible plugins

- No modifications to supported-platform behavior

- No new features introduced

## AI Tool Usage

- [x] AI tools were used (describe below)

I used ChatGPT to help analyze the traceback and identify the likely root cause of the issue (Unix-only dependency `fcntl` being imported on Windows). All code changes, testing, and validation were performed manually.