### PR TITLE
Fix: Refactor typeguard loading in click_api and add unit tests

### DIFF
--- a/test/unit/test_runner_click_api.py
+++ b/test/unit/test_runner_click_api.py
@@ -1,0 +1,79 @@
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+
+def _run_python_snippet(snippet):
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = (
+        repo_root
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([repo_root, env["PYTHONPATH"]])
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(snippet)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout.strip())
+
+
+def test_click_api_import_does_not_eagerly_load_typeguard():
+    result = _run_python_snippet(
+        """
+        import json
+        import sys
+        import metaflow.runner.click_api  # noqa: F401
+
+        print(
+            json.dumps(
+                {
+                    "typeguard": "metaflow._vendor.typeguard" in sys.modules,
+                    "typeguard_v3_7": "metaflow._vendor.v3_7.typeguard" in sys.modules,
+                }
+            )
+        )
+        """
+    )
+    assert result == {"typeguard": False, "typeguard_v3_7": False}
+
+
+def test_click_api_loads_typeguard_when_type_checking():
+    result = _run_python_snippet(
+        """
+        import json
+        import sys
+        from collections import OrderedDict
+        from metaflow._vendor import click
+        from metaflow.runner.click_api import _method_sanity_check
+
+        before = (
+            "metaflow._vendor.typeguard" in sys.modules
+            or "metaflow._vendor.v3_7.typeguard" in sys.modules
+        )
+
+        _method_sanity_check(
+            OrderedDict(),
+            OrderedDict(
+                [("quiet", click.Option(["--quiet"], is_flag=True, default=False))]
+            ),
+            OrderedDict([("quiet", bool)]),
+            OrderedDict([("quiet", False)]),
+            quiet=True,
+        )
+
+        after = (
+            "metaflow._vendor.typeguard" in sys.modules
+            or "metaflow._vendor.v3_7.typeguard" in sys.modules
+        )
+
+        print(json.dumps({"before": before, "after": after}))
+        """
+    )
+    assert result == {"before": False, "after": True}


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] New feature
- [x] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Fixes a Runner API import-time regression where loading a flow file could trigger vendored `typing_extensions` monkey-patching and break valid generic type definitions on Python 3.11.  
The fix makes `typeguard` loading lazy in `runner/click_api.py`, so flow extraction/import no longer mutates typing behavior before user code is imported.

## Issue

Fixes #2462

## Reproduction

**Runtime:** local (Runner API path)

**Commands to run:**
```bash
# 1) Save repro.py
cat > repro.py <<'PY'
from typing import Generic, Protocol, TypeVar
from typing_extensions import ParamSpec
from metaflow import FlowSpec, step

P = ParamSpec("P")
RV = TypeVar("RV", covariant=True)

class CachedMethod(Protocol, Generic[P, RV]):
    pass

class Flow(FlowSpec):
    @step
    def start(self):
        self.next(self.end)

    @step
    def end(self):
        pass

if __name__ == "__main__":
    Flow()
PY

# 2) Save runner.py
cat > runner.py <<'PY'
from metaflow import Runner
from pydantic import BaseModel  # reproducer trigger reported in issue

with Runner(flow_file="repro.py") as runner:
    runner.run()
PY

# 3) Baseline CLI path works
python3 repro.py run

# 4) Runner path fails before fix
python3 runner.py
Where evidence shows up: parent console during Runner initialization / flow file import

<details> <summary>Before (error / log snippet)</summary>


TypeError: Type parameter +RV without a default follows type parameter with a default
...
File ".../metaflow/_vendor/typing_extensions.py", line ..., in _collect_parameters
</details> <details> <summary>After (evidence that fix works)</summary>
text

python3 runner.py
# Runner initializes and executes without the above TypeError
# (no traceback during extract_flow_class_from_file path)
Additionally, regression tests:

cd test/unit
PYTHONPATH=$(pwd)/../.. python3 -m pytest -v test_runner_click_api.py
 2 passed
```
</details>

## Root Cause
click_api.py imported vendored typeguard at module import time.
Vendored typeguard imports vendored typing_extensions, which monkey-patches typing._collect_parameters.
Runner’s flow loading path (MetaflowAPI.from_cli -> extract_flow_class_from_file) then executes user flow code under altered typing semantics, violating the invariant that flow discovery/import should not mutate host typing behavior before user module import.

## Why This Fix Is Correct
The fix defers typeguard import until _method_sanity_check is called, which is when Runner actually needs runtime type validation of command parameters.
This restores the invariant that flow extraction/import is side-effect free with respect to typing monkey patches, while preserving existing type-check behavior where needed.

## Failure Modes Considered
Import-time side effects still happening: covered by a test asserting metaflow.runner.click_api import does not load vendored typeguard.
Type checking accidentally disabled: covered by a test asserting _method_sanity_check triggers lazy typeguard load and still runs.
Python-version branch regression (3.8+ vs 3.7 vendor path): logic preserved in _get_typeguard() and only import timing changed.

## Tests
 Unit tests added/updated
 Reproduction script provided (required for Core Runtime)
 CI passes
 If tests are impractical: explain why below and provide manual evidence above
Non-Goals
Did not update vendored typing_extensions version.
Did not remove or alter typing monkey-patch behavior globally.
Did not change Runner command semantics beyond import timing of typeguard.

## AI Tool Usage
AI tools were used 
Used AI assistance to draft and refine the lazy-import patch and unit test scaffolding.
All changes were manually reviewed, understood, and validated with targeted pytest runs.