### PR TITLE
fix: broken timeout stack trace filter and incorrect max_swap error message

### DIFF
--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -278,7 +278,7 @@ class BatchJob(object):
                     and int(max_swap) >= 0
                 ):
                     raise BatchJobException(
-                        "Invalid swappiness value ({}); "
+                        "Invalid max_swap value ({}); "
                         "(should be 0 or greater)".format(max_swap)
                     )
                 else:

--- a/metaflow/plugins/timeout_decorator.py
+++ b/metaflow/plugins/timeout_decorator.py
@@ -81,7 +81,7 @@ class TimeoutDecorator(StepDecorator):
     def _sigalrm_handler(self, signum, frame):
         def pretty_print_stack():
             for line in traceback.format_stack():
-                if "timeout_decorators.py" not in line:
+                if "timeout_decorator.py" not in line:
                     for part in line.splitlines():
                         yield ">  %s" % part
 


### PR DESCRIPTION
## Summary

- Fix broken stack trace filter in `timeout_decorator.py:84` — `pretty_print_stack()` checks for `"timeout_decorators.py"` (plural) but the actual file is `timeout_decorator.py` (singular). The filter has never matched since introduction (commit `5186c6c5b`, 2021), so every timeout error shows noisy internal `_sigalrm_handler` and `pretty_print_stack` frames that should be hidden from users.
- Fix copy-paste error message in `batch_client.py:281` — `max_swap` validation says `"Invalid swappiness value"` instead of `"Invalid max_swap value"`. Both validation blocks were added in the same commit (`87d86f33`) and the error message was never updated for the `max_swap` block.

## Test plan

- [x] Verified no file named `timeout_decorators.py` (plural) has ever existed in the codebase
- [x] Verified `"timeout_decorators"` (plural) returns 0 grep matches in `timeout_decorator.py`
- [x] Verified `"Invalid swappiness"` appears only once (line 268, the correct swappiness validation)
- [x] Verified `"Invalid max_swap"` appears on line 281 (the fixed max_swap validation)
- [x] Both modules import successfully

Closes #2902