### PR TITLE
docs: update pre-requiste part for 07-worldwide for tutorial

### DIFF
--- a/metaflow/tutorials/07-worldview/README.md
+++ b/metaflow/tutorials/07-worldview/README.md
@@ -9,5 +9,15 @@ monitor all of your Metaflow flows.**
 #### Before playing this episode:
 1. ```python -m pip install notebook``` (only locally, if you don't have it already)
 
+2. This tutorial assumes that `HelloCloudFlow` (from Episode 05) has been successfully executed with Kubernetes or cloud configuration. The notebook retrieves runs using:
+
+   ```
+   flow = Flow('HelloCloudFlow')
+   ```
+If you are running Metaflow locally without Kubernetes/cloud configuration, you can modify the notebook to inspect other locally executed flows such as:
+- ```Flow('HelloFlow')```
+- ```Flow('PlayListFlow')```
+
+
 #### To play this episode:
 1. Open ```07-worldview/worldview.ipynb```


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [ ] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [x] Docs / tooling
- [ ] Refactoring

## Summary

While playing the tutorials, user will be able to read a more clarified prerequisite for 07-worldwide explaining user that is if they don't have a kubernetes or cloud configuration they can use the local flows available from previous tutorials.

## Issue

Fixes #2901 

## Why This Fix Is Correct

Users without Kubernetes/cloud configuration may encounter a 
```
MetaflowNotFound: Flow('HelloCloudFlow') does not exist 
```
error when running Episode 07 because it attempts to access `HelloCloudFlow`. This change improves the documentation by clearly stating the assumption and suggesting that users can instead use previously executed local flows such as `HelloFlow` and `PlayListFlow`. This prevents confusion and improves the onboarding experience.

## Tests

- [ ] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

Tests are not necessary for this change.

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

If you used AI tools:
- Which tool(s)?
  - Co-pilot 
- What did you use them for? 
  - To review wording and understanding how this documentation change affects the documentation build process.