### PR TITLE
Docs: Clarify Episode 07 prerequisite of HelloCloudFlow execution

### DIFF
--- a/metaflow/tutorials/07-worldview/README.md
+++ b/metaflow/tutorials/07-worldview/README.md
@@ -6,8 +6,15 @@ monitor all of your Metaflow flows.**
 #### Showcasing:
 - The Metaflow client API.
 
-#### Before playing this episode:
-1. ```python -m pip install notebook``` (only locally, if you don't have it already)
+##### Before playing this episode:
+1. `python -m pip install notebook` (only locally, if you don't have it already)
+2. Complete Episode 05 (`HelloCloudFlow`) so that the flow exists in your Metaflow metadata.
+
+If `HelloCloudFlow` has not been executed, you may encounter:
+```
+MetaflowNotFound: Flow('HelloCloudFlow') does not exist
+```
+If you are running Metaflow locally without cloud/Kubernetes configuration, you can modify the notebook to inspect locally executed flows such as `HelloFlow` (Episode 00) or `PlayListFlow` (Episode 01).
 
 #### To play this episode:
 1. Open ```07-worldview/worldview.ipynb```


### PR DESCRIPTION
Clarifies that Episode 07 assumes prior execution of HelloCloudFlow (Episode 05).

Adds:
- Explicit prerequisite note
- Explanation of MetaflowNotFound error
- Suggestion for local alternatives

Fixes #2901