### PR TITLE
fixed float conflict between @resources and compute decorators #1014

### DIFF
--- a/metaflow/plugins/aws/aws_utils.py
+++ b/metaflow/plugins/aws/aws_utils.py
@@ -1,6 +1,7 @@
 import re
 
 from metaflow.exception import MetaflowException
+from decimal import Decimal, InvalidOperation
 
 
 def parse_s3_full_path(s3_uri):
@@ -157,11 +158,13 @@ def compute_resource_attributes(decos, compute_deco, resource_defaults):
                         # that numbers that can't be exactly represented as
                         # floats (e.g. 0.8) still look "nice". We don't care
                         # about precision more that .001 for resources anyway.
-                        result[k] = str(max(float(my_val or 0), float(v or 0)))
-                    except ValueError:
+                        result[k] = str(
+                            max(Decimal(str(my_val or 0)), Decimal(str(v or 0)))
+                        )
+                    except (ValueError, TypeError, InvalidOperation):
                         # Here we don't have ints, so we compare the value and raise
                         # an exception if not equal
-                        if my_val != v:
+                        if str(my_val) != str(v):
                             # TODO: Throw a better exception since the user has no
                             #       knowledge of 'compute' decorator
                             raise MetaflowException(

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -3,6 +3,7 @@ import os
 import platform
 import sys
 import time
+from decimal import Decimal
 
 from metaflow import current
 from metaflow.decorators import StepDecorator
@@ -379,7 +380,7 @@ class KubernetesDecorator(StepDecorator):
                         my_val = self.attributes.get(k)
                         if not (my_val is None and v is None):
                             self.attributes[k] = str(
-                                max(float(my_val or 0), float(v or 0))
+                                max(Decimal(str(my_val or 0)), Decimal(str(v or 0)))
                             )
 
         # Check GPU vendor.

--- a/test/unit/test_compute_resource_attributes.py
+++ b/test/unit/test_compute_resource_attributes.py
@@ -37,7 +37,7 @@ def test_compute_resource_attributes():
         [MockDeco("resources", {"cpu": "2"})],
         MockDeco("batch", {"cpu": 1}),
         {"cpu": "3"},
-    ) == {"cpu": "2.0"}
+    ) == {"cpu": "2"}
 
     # take largest of @resources and @batch if both are present
     assert compute_resource_attributes(
@@ -75,3 +75,21 @@ def test_compute_resource_attributes_string():
         MockDeco("batch", {"instance_type": None}),
         {"cpu": "1", "instance_type": "p4.xlarge"},
     ) == {"cpu": "1", "instance_type": "p4.xlarge"}
+
+
+def test_compute_resource_attributes_floats():
+    """Test float-valued resource attributes to prevent regression of #1014"""
+
+    # take largest of @resources and @batch with floats
+    assert compute_resource_attributes(
+        [MockDeco("resources", {"cpu": 1.5})],
+        MockDeco("batch", {"cpu": "1.0"}),
+        {"cpu": "1"},
+    ) == {"cpu": "1.5"}
+
+    # handle float vs int comparison natively without throwing conflicting values error
+    assert compute_resource_attributes(
+        [MockDeco("resources", {"cpu": "2.0"})],
+        MockDeco("batch", {"cpu": 2}),
+        {"cpu": "1"},
+    ) == {"cpu": "2"}


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

<!-- What user-visible behavior changes? 1-2 sentences. -->
This fixes an error when using float values (like cpu=1.5) in @resources.
Earlier it gave a confusing conflict error with @batch, @step_functions, or @kubernetes.
Now it works properly.

## Issue

<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes #1014 

## Reproduction

<!-- Required for bug fixes. Required for Core Runtime changes. -->
<!-- Provide a minimal reproduction that fails before and succeeds after. -->

**Runtime:** <!-- local / kubernetes / batch / argo / etc. -->

**Commands to run:**
```bash
# paste exact commands
```

**Where evidence shows up:** <!-- parent console / task logs / metadata / UI -->

<details>
<summary>Before (error / log snippet)</summary>

```
paste here
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
paste here
```

</details>

## Root Cause

<!-- Required for Core Runtime. Recommended for all bug fixes. -->
<!-- Explain the causal chain: what invariant was violated, where in the code. -->
<!-- See PRs #2796, #2751, #2714 for examples of the level of detail we're looking for. -->
The function compute_resource_attributes was not comparing float values correctly.
When @resources used a float and the compute decorator used an int or string, it sometimes showed a wrong conflict error.
Because of this it raises MetaflowException even when the values were actually valid.
## Why This Fix Is Correct

<!-- What invariant is restored? Why is the fix minimal? -->

## Failure Modes Considered

<!-- Required for Core Runtime (at least 2). Recommended for all bug fixes. -->
<!-- Examples: concurrency/retries, subprocess output propagation, env-var leakage, backward compat -->

1.
2.

## Tests

- [x] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [x] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

<!-- What you intentionally did not change. Helps reviewers scope their review. -->

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

<!-- If you used AI tools:
- Which tool(s)?
- What did you use them for?
- Did you review, understand, and test all generated code?
-->
Gemini is used to identify the actual problem in the codebase to solve the issue.
CodeRabbit is used for reviewing all changes.

And I reviewed and tested the code locally with pytest.