### PR TITLE
Fix an issue with properly resetting LD_LIBRARY_PATH for escape hatch

### DIFF
--- a/metaflow/plugins/env_escape/client.py
+++ b/metaflow/plugins/env_escape/client.py
@@ -82,15 +82,18 @@ class Client(object):
             raise RuntimeError("Existing socket: %s" % self._socket_path)
         env = os.environ.copy()
         env["PYTHONPATH"] = pythonpath
-        # When coming from a conda environment, LD_LIBRARY_PATH may be set to
+        # When coming from a conda environment, LD_LIBRARY_PATH will be set to
         # first include the Conda environment's library. When breaking out to
         # the underlying python, we need to reset it to the original LD_LIBRARY_PATH
         ld_lib_path = env.get("LD_LIBRARY_PATH")
         orig_ld_lib_path = env.get("MF_ORIG_LD_LIBRARY_PATH")
-        if ld_lib_path is not None and orig_ld_lib_path is not None:
+        if orig_ld_lib_path is None and ld_lib_path is not None:
+            del env["LD_LIBRARY_PATH"]
+
+        if orig_ld_lib_path is not None:
             env["LD_LIBRARY_PATH"] = orig_ld_lib_path
-            if orig_ld_lib_path is not None:
-                del env["MF_ORIG_LD_LIBRARY_PATH"]
+            del env["MF_ORIG_LD_LIBRARY_PATH"]
+
         self._server_process = Popen(
             [
                 python_executable,


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [ X] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Addresses edge case with resetting LD_LIBRARY_PATH

## Issue

<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes #

## Reproduction

<!-- Required for bug fixes. Required for Core Runtime changes. -->
<!-- Provide a minimal reproduction that fails before and succeeds after. -->

**Runtime:** <!-- local / kubernetes / batch / argo / etc. -->

**Commands to run:**
```bash
# paste exact commands
```

**Where evidence shows up:** <!-- parent console / task logs / metadata / UI -->

<details>
<summary>Before (error / log snippet)</summary>

```
paste here
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
paste here
```

</details>

## Root Cause

<!-- Required for Core Runtime. Recommended for all bug fixes. -->
<!-- Explain the causal chain: what invariant was violated, where in the code. -->
<!-- See PRs #2796, #2751, #2714 for examples of the level of detail we're looking for. -->

## Why This Fix Is Correct

<!-- What invariant is restored? Why is the fix minimal? -->

## Failure Modes Considered

<!-- Required for Core Runtime (at least 2). Recommended for all bug fixes. -->
<!-- Examples: concurrency/retries, subprocess output propagation, env-var leakage, backward compat -->

1.
2.

## Tests

- [ ] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

<!-- What you intentionally did not change. Helps reviewers scope their review. -->

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [ ] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)

<!-- If you used AI tools:
- Which tool(s)?
- What did you use them for?
- Did you review, understand, and test all generated code?
-->
