### PR TITLE
Enhance @secrets decorator to support callable sources

### DIFF
--- a/metaflow/plugins/secrets/secrets_decorator.py
+++ b/metaflow/plugins/secrets/secrets_decorator.py
@@ -79,6 +79,11 @@ class SecretsDecorator(StepDecorator):
         sources = self.attributes["sources"]
         if callable(sources):
             sources = sources(flow)
+            if not isinstance(sources, list):
+                raise MetaflowException(
+                    "@secrets sources callable must return a list, got %s"
+                    % type(sources).__name__
+                )
 
         for secret_spec_str_or_dict in sources:
             if isinstance(secret_spec_str_or_dict, str):


### PR DESCRIPTION
Allow the `sources` argument of @secrets to accept a callable (lambda or function), which is evaluated at runtime with the flow instance as its argument. Static list behavior is unchanged.

Fixes #2918

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

`@secrets` previously only accepted static lists for `sources`, resolved at parse time before `self` is available. This change allows `sources` to accept a callable, which is invoked at runtime with the flow instance, enabling dynamic secret configuration in inherited flow classes and OOP patterns.

## Issue

Fixes #2918

## Reproduction

N/A — this is a new feature, not a bug fix.

## Root Cause

N/A

## Why This Fix Is Correct

N/A

## Failure Modes Considered

1. **Backward compatibility** — static list `sources` values follow the exact same code path as before; the callable check (`if callable(sources)`) is a no-op for lists, strings, and any non-callable.
2. **Invalid callable return type** — if the callable returns items that are not `str` or `dict`, the existing validation in the `for` loop raises `MetaflowException` with the same error message as before, so error handling is consistent.

## Tests

- [x] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

Added `TestCallableSources` in `test/unit/test_secrets_decorator.py` with four tests:
- `test_lambda_sources_called_with_flow` — lambda is invoked with the flow instance at runtime
- `test_function_sources_called_with_flow` — regular function works identically
- `test_static_list_sources_unchanged` — static list behavior is preserved (backward compat)
- `test_callable_returning_invalid_item_raises` — callable returning bad types raises `MetaflowException`

## Non-Goals

- No changes to parse-time behavior for static `sources` values.
- No changes to `role`, `allow_override`, or any other `@secrets` attributes.
- No support for async callables.

## AI Tool Usage

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

Cursor (Claude) was used to assist with implementation scaffolding and test generation. All generated code was reviewed, understood, and manually verified. The contributor is the author of the issue and can explain every line of the change.