### PR TITLE
rename to skypilot_step

### DIFF
--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -44,7 +44,7 @@ unsupported_decorators = {
     "slurm": "Step *%s* is marked for execution on Slurm with Argo Workflows which isn't currently supported.",
     "nvidia": "Step *%s* is marked for execution on Nvidia with Argo Workflows which isn't currently supported.",
     "nvct": "Step *%s* is marked for execution on Nvct with Argo Workflows which isn't currently supported.",
-    "skypilot": "Step *%s* is marked for execution on Skypilot with Argo Workflows which isn't currently supported.",
+    "skypilot_step": "Step *%s* is marked for execution on Skypilot with Argo Workflows which isn't currently supported.",
 }
 
 

--- a/metaflow/plugins/pypi/conda_decorator.py
+++ b/metaflow/plugins/pypi/conda_decorator.py
@@ -185,7 +185,7 @@ class CondaStepDecorator(StepDecorator):
                     "snowpark",
                     "slurm",
                     "nvct",
-                    "skypilot",
+                    "skypilot_step",
                 ]
                 for decorator in next(
                     step for step in self.flow if step.name == self.step

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -391,7 +391,7 @@ class CondaEnvironment(MetaflowEnvironment):
                 "snowpark",
                 "slurm",
                 "nvct",
-                "skypilot",
+                "skypilot_step",
             ]:
                 target_platform = getattr(decorator, "target_platform", "linux-64")
                 break


### PR DESCRIPTION
This is because `@skypilot` will be a mutator instead that uses `@skypilot_step` behind the scenes.