### PR TITLE
Fix Tuple[()] stub generation for empty tuple types

### DIFF
--- a/metaflow/cmd/develop/stub_generator.py
+++ b/metaflow/cmd/develop/stub_generator.py
@@ -594,6 +594,9 @@ class StubGenerator:
                     if args_str[0] != "...":
                         call_args = "[" + ", ".join(args_str[:-1]) + "]"
                         args_str = [call_args, args_str[-1]]
+                elif element._name == "Tuple" and not args_str:
+                    # Tuple[()] means an empty tuple; Tuple[] is invalid syntax
+                    return "typing.Tuple[()]"
                 return "typing.%s[%s]" % (element._name, ", ".join(args_str))
             else:
                 # Handle the case where we have a generic type without a _name


### PR DESCRIPTION
## Problem

When generating `.pyi` stubs, `typing.Tuple[()]` (an empty tuple type) was being emitted as `typing.Tuple[]`, which is invalid Python syntax and causes mypy to fail with a parse error.

**Root cause:** In `_get_element_name_with_module`, when `element._name == "Tuple"` and `element.__args__ == ()`, `args_str` is an empty list. `", ".join([])` produces `""`, so the return becomes `"typing.Tuple[]"`.

## Fix

Add a special case: when `element._name == "Tuple"` and `args_str` is empty, return `"typing.Tuple[()]"` directly (the correct syntax for an empty tuple type annotation).

## Reproducer

```python
import typing
# typing.Tuple[()] has __args__ == ()
t = typing.Tuple[()]
print(t.__args__)  # ()
```

The stub generator would emit `typing.Tuple[]` for this type, which mypy rejects as invalid syntax.