### PR TITLE
Fix uv bootstrap tar extraction for Python < 3.12

### DIFF
--- a/test/unit/test_uv_bootstrap.py
+++ b/test/unit/test_uv_bootstrap.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+
+from metaflow.plugins.uv.bootstrap import _extract_uv_binary
+
+
+def test_extract_uv_binary_uses_filter_when_supported():
+    calls = []
+
+    class FilterCapableTar(object):
+        def extractall(self, path, filter=None, members=None):
+            calls.append((path, filter, members))
+
+    tar = FilterCapableTar()
+    marker = object()
+    _extract_uv_binary(tar, "/tmp/uv", marker)
+
+    assert len(calls) == 1
+    assert calls[0] == ("/tmp/uv", marker, None)
+
+
+def test_extract_uv_binary_falls_back_for_legacy_tarfile():
+    calls = []
+    members = [SimpleNamespace(name="nested/uv"), SimpleNamespace(name="nested/readme")]
+
+    class LegacyTar(object):
+        def extractall(self, path, filter=None, members=None):
+            if filter is not None and members is None:
+                raise TypeError(
+                    "extractall() got an unexpected keyword argument 'filter'"
+                )
+            calls.append((path, filter, members))
+
+        def getmembers(self):
+            return members
+
+    tar = LegacyTar()
+    _extract_uv_binary(tar, "/tmp/uv", object())
+
+    assert len(calls) == 1
+    path, filter_arg, extracted_members = calls[0]
+    assert path == "/tmp/uv"
+    assert filter_arg is None
+    assert len(extracted_members) == 1
+    assert extracted_members[0].name == "uv"


### PR DESCRIPTION
## Summary
Fixes `--environment=uv` bootstrap compatibility for Python versions before 3.12.

## Context / Motivation
`metaflow/plugins/uv/bootstrap.py` currently calls:

```python
tar.extractall(..., filter=_tar_filter)
```

The `filter` argument is only available in Python 3.12+, so on older supported Python versions this raises `TypeError`, breaking uv bootstrap.

Fixes #2759.

## Changes Made
- Added `_extract_uv_binary(...)` helper in `metaflow/plugins/uv/bootstrap.py`
- Behavior:
  - First try modern path: `extractall(..., filter=...)`
  - On `TypeError` (legacy tarfile), fallback to:
    - collect only `uv` member(s)
    - sanitize member names to basename
    - extract via `extractall(..., members=...)`
- Replaced direct `extractall(..., filter=...)` call with this helper.

## Testing
Added `test/unit/test_uv_bootstrap.py` with two focused unit tests:
- uses filter path when supported
- falls back correctly when legacy tarfile raises `TypeError`

Executed:
- `pytest -q test/unit/test_uv_bootstrap.py` -> `2 passed` (Linux Docker)
- `pre-commit run --files metaflow/plugins/uv/bootstrap.py test/unit/test_uv_bootstrap.py` -> passed
