### PR TITLE
Fix duplicate KubernetesException causing test failures

### DIFF
--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from metaflow import current, util
 from metaflow.exception import MetaflowException
+from metaflow.plugins.kubernetes.kube_utils import KubernetesException
 from metaflow.metaflow_config import (
     ARGO_EVENTS_EVENT,
     ARGO_EVENTS_EVENT_BUS,
@@ -62,10 +63,6 @@ STDERR_PATH = os.path.join(LOGS_DIR, STDERR_FILE)
 METAFLOW_PARALLEL_STEP_CLI_OPTIONS_TEMPLATE = (
     "{METAFLOW_PARALLEL_STEP_CLI_OPTIONS_TEMPLATE}"
 )
-
-
-class KubernetesException(MetaflowException):
-    headline = "Kubernetes error"
 
 
 class KubernetesKilledException(MetaflowException):


### PR DESCRIPTION
## Summary
Remove duplicate `KubernetesException` class from `kubernetes.py` and import the canonical one from `kube_utils.py`.

## Context / Motivation
`KubernetesException` was independently defined in two modules:
- `metaflow/plugins/kubernetes/kube_utils.py` (line 8)
- `metaflow/plugins/kubernetes/kubernetes.py` (line 67)

The utility functions `validate_kube_labels` and `parse_kube_keyvalue_list` in `kube_utils.py` raise `kube_utils.KubernetesException`, but the unit tests import `kubernetes.KubernetesException`. Because Python treats these as two distinct classes, `pytest.raises(KubernetesException)` fails to catch exceptions raised by the utility functions, causing all 8 kubernetes validation tests to fail.

## Changes Made
- Removed the duplicate `KubernetesException` class definition from `metaflow/plugins/kubernetes/kubernetes.py`
- Added `from metaflow.plugins.kubernetes.kube_utils import KubernetesException` to `kubernetes.py`
- No circular dependency: `kube_utils.py` does not import from `kubernetes.py`

## Testing
- All 16 tests in `test/unit/test_kubernetes.py` now pass (9 were previously failing)
- Ran: `python -m pytest test/unit/test_kubernetes.py -v`
- The existing test cases serve as regression tests — they validate that `validate_kube_labels` and `parse_kube_keyvalue_list` raise the expected `KubernetesException` for invalid inputs

## Trade-offs / Design Decisions
- Chose to keep the canonical definition in `kube_utils.py` rather than `kubernetes.py` because `kube_utils.py` is a lower-level utility module with no heavy imports, avoiding circular dependency risks
- `kubernetes_decorator.py` already imports `KubernetesException` from `kubernetes.py`, so this change is transparent to it (re-export works via the new import)

Fixes #2956 