### PR TITLE
fix: globally sort command list in LazyPluginCommandCollection

### DIFF
--- a/metaflow/cli_components/utils.py
+++ b/metaflow/cli_components/utils.py
@@ -75,7 +75,7 @@ class LazyPluginCommandCollection(click.CommandCollection):
         for source_name, source in self.lazy_sources.items():
             subgroup = self._lazy_load(source_name, source)
             base.extend(subgroup.list_commands(ctx))
-        return base
+        return sorted(base)
 
     def get_command(self, ctx, cmd_name):
         base_cmd = super().get_command(ctx, cmd_name)


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Pull Request: Fix <code>LazyPluginCommandCollection.list_commands()</code> Alphabetical Ordering</h1>
<h2>PR Type</h2>
<ul>
<li>[x] Bug fix</li>
<li>[ ] Feature</li>
<li>[ ] Refactor</li>
<li>[ ] Docs</li>
</ul>
<hr>
<h2>Summary</h2>
<p><code>LazyPluginCommandCollection.list_commands()</code> was appending lazily-loaded plugin commands onto the end of the base command list without re-sorting, causing the help output to show commands out of alphabetical order when plugins are loaded.</p>
<hr>
<h2>Issue</h2>
<p>Fixes #</p>
<hr>
<h2>Reproduction</h2>
<p><strong>Runtime:</strong> local</p>
<p><strong>Commands to run:</strong></p>
<pre><code class="language-bash">python -m metaflow --help
</code></pre>
<p><strong>Where evidence shows up:</strong> The <code>Commands:</code> section printed to the console.</p>

  | Output
-- | --
Before | (error / log snippet)
After | (evidence that fix works)


<hr>
<h2>Root Cause</h2>
<p><code>click.Group.list_commands()</code> in <code>metaflow/_vendor/click/core.py</code> always returns <code>sorted(self.commands)</code>.</p>
<p><code>LazyPluginCommandCollection.list_commands()</code> calls <code>super().list_commands(ctx)</code> to get that sorted base, but then does:</p>
<pre><code class="language-python">for source_name, source in self.lazy_sources.items():
    subgroup = self._lazy_load(source_name, source)
    base.extend(subgroup.list_commands(ctx))
return base   # never re-sorted after plugins are appended
</code></pre>
<p>Each plugin block is individually sorted, but blocks are appended in source-registration order, so the final list is only <strong>partially ordered</strong>. The visible consequence is that <code>python -m metaflow --help</code> shows commands out of order when one or more plugins are active.</p>
<hr>
<h2>Why This Fix Is Correct</h2>
<p>Returning <code>sorted(base)</code> restores the same guarantee that <code>click.Group</code> itself provides — callers always receive a globally alphabetical list. The fix is a <strong>single word on a single line</strong>.</p>
<p>Nothing else changes: lazy loading, caching, <code>get_command</code>, and <code>invoke</code> are all untouched.</p>
<hr>
<h2>Failure Modes Considered</h2>
<p><strong>Duplicate command names across sources</strong>
<code>sorted()</code> on a list handles duplicates without error. <code>get_command</code> resolution order (base sources first, lazy sources in registration order) is unchanged, so priority between any duplicates stays consistent.</p>
<p><strong>No lazy sources registered</strong>
<code>self.lazy_sources</code> is empty, the loop is a no-op, and <code>sorted(base)</code> produces the same result as the previous <code>return base</code> since <code>super().list_commands()</code> already returns a sorted list. No regression possible here.</p>
<hr>
<h2>Tests</h2>
<ul>
<li>[ ] Unit tests added/updated</li>
<li>[ ] Reproduction script provided</li>
<li>[ ] CI passes</li>
<li>[ ] <strong>If tests are impractical:</strong> the change is a single <code>sorted()</code> call on a plain Python list. Manual verification via <code>python -m metaflow --help</code> with plugins loaded confirms correct alphabetical ordering.</li>
</ul>
<hr>
<h2>Non-Goals</h2>
<ul>
<li>Did not change <code>LazyGroup.list_commands()</code> — it already produces correct order for its use case.</li>
<li>Did not modify command resolution priority, the lazy-loading cache, or the <code>invoke</code> override.</li>
<li>Did not change plugin registration order or any public API.</li>
</ul>
<hr>
<h2>AI Tool Usage</h2>
<ul>
<li>[x] AI tools were used</li>
</ul>
<blockquote>
<p>Used an AI assistant to help locate the root cause in the codebase. The fix was reviewed and understood before committing. It is a one-word change (<code>sorted</code>) and was manually verified to produce correct output.</p>
</blockquote></body></html><!--EndFragment-->
</body>
</html>