### PR TITLE
docs: fix broken link, typos, and outdated references

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,6 +1,6 @@
 # Adopters
 
-Below is a partial list of organizations using Metaflow in production. If you'd like to be included in this list, please raise a pull request
+Below is a partial list of organizations using Metaflow in production. If you'd like to be included in this list, please raise a pull request.
 
 - [23andMe](https://www.23andme.com)
 - [Adept](https://www.adept.ai)

--- a/docs/cards.md
+++ b/docs/cards.md
@@ -78,7 +78,7 @@ if __name__ == "__main__":
 The [CardDatastore](../metaflow/plugins/cards/card_datastore.py) is used by the [card_cli](#card-cli) and the [metaflow card client](#access-cards-in-notebooks) (`get_cards`). It exposes methods to get metadata about a card and the paths to cards for a `pathspec`. 
 
 ### Card CLI
-Methods exposed by the [card_cli](../metaflow/plugins/cards/.card_cli.py). :
+Methods exposed by the [card_cli](../metaflow/plugins/cards/card_cli.py):
 
 - `create` : Creates the card in the datastore for a `Task`. Adding a `--render-error-card` will render a `ErrorCard` upon failure to render the card of the selected `type`. If `--render-error-card` is not passed then the CLI will fail loudly with the exception. 
 ```sh

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -262,10 +262,9 @@ execute many request handler tasks concurrently, more so than in parallel.
 
 The downsides of `asyncio` are many:
 
- - `asyncio` is not available in Python 2 and its standard library
-   implementation has been quickly evolving at least until Python 3.6.
-   This makes it practically unusable in Metaflow, which needs to support
-   Python 2 and earlier versions of Python 3.
+ - `asyncio`'s standard library implementation has been quickly evolving
+   at least until Python 3.6, making it difficult to use reliably across
+   different Python 3 versions.
 
  - `asyncio` requires a lot of attention from the programmer. It is very
    easy to introduce issues that tank the performance (e.g. a single blocking

--- a/docs/sidecars.md
+++ b/docs/sidecars.md
@@ -15,7 +15,7 @@ the main process (sidecar class) via
 [pipes](https://www.tutorialspoint.com/inter_process_communication/inter_process_communication_pipes.htm). 
 The sidecar worker consumes messages from the main process via stdin and logs debug and error messages to stderr. 
 Note that since metaflow blocks the completion of a task until the termination of stdout (to collect the logs), 
-the stdout for sidecars is directed to dev/nul instead of inheriting the stdout of the parent process to ensure
+the stdout for sidecars is directed to /dev/null instead of inheriting the stdout of the parent process to ensure
 the process is non-blocking.
  
 <img src="metaflow_sidecar_arch.png" style="width: 80%">


### PR DESCRIPTION
This PR fixes several documentation issues:

- Fix broken relative link in docs/cards.md
- Correct dev/nul → /dev/null in docs/sidecars.md
- Remove outdated Python 2 references from docs/concurrency.md
- Add missing period in ADOPTERS.md