### PR TITLE
fix: ensure global alphabetical ordering in LazyPluginCommandCollection.list_commands

### DIFF
--- a/metaflow/cli_components/utils.py
+++ b/metaflow/cli_components/utils.py
@@ -75,7 +75,7 @@ class LazyPluginCommandCollection(click.CommandCollection):
         for source_name, source in self.lazy_sources.items():
             subgroup = self._lazy_load(source_name, source)
             base.extend(subgroup.list_commands(ctx))
-        return base
+        return sorted(base)
 
     def get_command(self, ctx, cmd_name):
         base_cmd = super().get_command(ctx, cmd_name)


### PR DESCRIPTION
## PR Type

<!-- Check one -->

&#9745; Bug fix
[ ] New feature
[ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
[ ] Docs / tooling
[ ] Refactoring

## Summary

Made a issue of this problem yesterday, got no response so made a PR, ensured deterministic and globally alphabetical ordering of CLI commands returned by `LazyPluginCommandCollection.list_commands`

## Issue

Fixes #2953

## Reproduction

**Runtime:**  local

**Commands to run:**
```bash
metaflow --help
```
Where evidence shows up: Parent console output

<details> <summary>Before</summary>

Command ordering could vary depending on plugin registration order since the list was returned unsorted.

```python
return base
```
</details> <details> <summary>After</summary>

Commands are now globally sorted alphabetically:
```python
return sorted(base)
```
now if we run,
```bash
metaflow --help
```
consistently displays commands in alphabetical order.

</details>

## Root Cause

`LazyPluginCommandCollection.list_commands` returned the aggregated command list without enforcing ordering.
Because plugin commands may be registered in varying order depending on load sequence, the final CLI output was not guaranteed to be globally alphabetical.

## Why This Fix Is Correct

The fix explicitly sorts the aggregated command list before returning it:
```python
return sorted(base)
```
This restores deterministic CLI behaviour while preserving existing functionality.

## Tests

[ ] Unit tests added/updated
[ ] Reproduction script provided (required for Core Runtime)
 &#9745; CI passes
 &#9745; If tests are impractical: explain why below and provide manual evidence above

Unit tests were not modified as the change affects CLI ordering only. Behaviour was manually verified using ```metaflow --help```.

## AI Tool Usage

 [ ] No AI tools were used in this contribution
&#9745; AI tools were used

Used AI assistance (ChatGPT)  for structuring the PR description.
All code changes were written, reviewed and tested manually.
