### PR TITLE
Fail fast on AWS sandbox STS endpoint timeout/connection failures

### DIFF
--- a/metaflow/plugins/aws/aws_client.py
+++ b/metaflow/plugins/aws/aws_client.py
@@ -57,9 +57,21 @@ class Boto3ClientProvider(object):
                 url = "%s/auth/token" % AWS_SANDBOX_STS_ENDPOINT_URL
                 headers = {"x-api-key": AWS_SANDBOX_API_KEY}
                 try:
-                    r = requests.get(url, headers=headers)
+                    r = requests.get(url, headers=headers, timeout=(5, 30))
                     r.raise_for_status()
                     cached_aws_sandbox_creds = r.json()
+                except requests.exceptions.Timeout as e:
+                    raise MetaflowException(
+                        "Timed out connecting to AWS sandbox STS endpoint %s: %s. "
+                        "Check that AWS_SANDBOX_STS_ENDPOINT_URL is reachable."
+                        % (AWS_SANDBOX_STS_ENDPOINT_URL, repr(e))
+                    )
+                except requests.exceptions.ConnectionError as e:
+                    raise MetaflowException(
+                        "Could not connect to AWS sandbox STS endpoint %s: %s. "
+                        "Check that AWS_SANDBOX_STS_ENDPOINT_URL is reachable."
+                        % (AWS_SANDBOX_STS_ENDPOINT_URL, repr(e))
+                    )
                 except requests.exceptions.HTTPError as e:
                     raise MetaflowException(repr(e))
             if with_error:

--- a/test/unit/test_aws_client.py
+++ b/test/unit/test_aws_client.py
@@ -1,0 +1,107 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+import metaflow.metaflow_config as metaflow_config
+from metaflow.exception import MetaflowException
+from metaflow.plugins.aws import aws_client
+
+
+class DummySession(object):
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def client(self, module, **client_params):
+        return {"module": module, "client_params": client_params, "creds": self.kwargs}
+
+
+@pytest.fixture(autouse=True)
+def reset_cached_creds():
+    aws_client.cached_aws_sandbox_creds = None
+    yield
+    aws_client.cached_aws_sandbox_creds = None
+
+
+def _enable_sandbox(monkeypatch):
+    monkeypatch.setattr(metaflow_config, "AWS_SANDBOX_ENABLED", True)
+    monkeypatch.setattr(
+        metaflow_config, "AWS_SANDBOX_STS_ENDPOINT_URL", "http://sandbox.local"
+    )
+    monkeypatch.setattr(metaflow_config, "AWS_SANDBOX_API_KEY", "test-api-key")
+
+
+def _fake_sandbox_creds():
+    return {
+        "aws_access_key_id": "test_key",
+        "aws_secret_access_key": "test_secret",
+        "aws_session_token": "test_token",
+        "region_name": "us-east-1",
+    }
+
+
+def test_sandbox_sts_request_uses_timeout_tuple(monkeypatch):
+    _enable_sandbox(monkeypatch)
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = _fake_sandbox_creds()
+
+    with patch("requests.get", return_value=response) as mock_get:
+        with patch("boto3.session.Session", DummySession):
+            client = aws_client.Boto3ClientProvider.get_client("s3")
+
+    assert client["module"] == "s3"
+    assert mock_get.call_count == 1
+    call_kwargs = mock_get.call_args.kwargs
+    assert call_kwargs["timeout"] == (5, 30)
+    assert call_kwargs["headers"] == {"x-api-key": "test-api-key"}
+    assert mock_get.call_args.args[0] == "http://sandbox.local/auth/token"
+
+
+def test_sandbox_timeout_raises_metaflowexception(monkeypatch):
+    _enable_sandbox(monkeypatch)
+
+    with patch("requests.get", side_effect=requests.exceptions.Timeout("timed out")):
+        with pytest.raises(MetaflowException) as exc:
+            aws_client.Boto3ClientProvider.get_client("s3")
+
+    assert "Timed out connecting to AWS sandbox STS endpoint" in str(exc.value)
+    assert "http://sandbox.local" in str(exc.value)
+
+
+def test_sandbox_connection_error_raises_metaflowexception(monkeypatch):
+    _enable_sandbox(monkeypatch)
+
+    with patch(
+        "requests.get",
+        side_effect=requests.exceptions.ConnectionError("network unreachable"),
+    ):
+        with pytest.raises(MetaflowException) as exc:
+            aws_client.Boto3ClientProvider.get_client("s3")
+
+    assert "Could not connect to AWS sandbox STS endpoint" in str(exc.value)
+    assert "http://sandbox.local" in str(exc.value)
+
+
+def test_sandbox_http_error_still_wrapped(monkeypatch):
+    _enable_sandbox(monkeypatch)
+    response = MagicMock()
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError("403")
+
+    with patch("requests.get", return_value=response):
+        with pytest.raises(MetaflowException) as exc:
+            aws_client.Boto3ClientProvider.get_client("s3")
+
+    assert "HTTPError" in str(exc.value)
+
+
+def test_cached_sandbox_creds_skip_network_call(monkeypatch):
+    _enable_sandbox(monkeypatch)
+    aws_client.cached_aws_sandbox_creds = _fake_sandbox_creds()
+
+    with patch("requests.get") as mock_get:
+        with patch("boto3.session.Session", DummySession):
+            client = aws_client.Boto3ClientProvider.get_client("s3")
+
+    assert client["creds"]["aws_access_key_id"] == "test_key"
+    mock_get.assert_not_called()


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] New feature
- [x] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Fail fast when AWS sandbox STS endpoint is unreachable by adding explicit request timeout and error wrapping in `Boto3ClientProvider.get_client`.

## Issue

Fixes #2924

## Reproduction

**Runtime:** local

**Commands to run:**
```bash
export METAFLOW_AWS_SANDBOX_ENABLED=1
export METAFLOW_AWS_SANDBOX_STS_ENDPOINT_URL="http://192.0.2.1"
python -c "from metaflow.plugins.aws.aws_client import Boto3ClientProvider; Boto3ClientProvider.get_client('s3')"
```

**Where evidence shows up:** parent console traceback

<details>
<summary>Before (error / log snippet)</summary>

```text
Sandbox STS fetch may hang for a long time due to missing timeout, then fail with networking exceptions.
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```text
Sandbox STS fetch fails fast with MetaflowException for timeout/connection failures,
including endpoint context and reachability guidance.
```

</details>

## Root Cause

In sandbox mode, STS token fetch used `requests.get` without an explicit timeout. Unreachable/misconfigured endpoints relied on OS/network timeout behavior, causing long hangs. Also, timeout and connection failures were not wrapped into `MetaflowException`, yielding less actionable failures.

## Why This Fix Is Correct

The patch restores predictable fail-fast behavior by setting an explicit `(connect, read)` timeout tuple and wrapping timeout/connection failures as `MetaflowException` with endpoint context. Scope is limited to sandbox credential fetch path and does not alter non-sandbox AWS client behavior.

## Failure Modes Considered

1. Endpoint accepts connection but stalls response: handled via explicit read timeout.
2. Endpoint unreachable / routing / DNS failure: handled via `ConnectionError` and wrapped with actionable message.

## Tests

- [x] Unit tests added/updated
- [x] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

Added `test/unit/test_aws_client.py` with focused coverage for:
- timeout tuple usage in sandbox STS request
- timeout error path
- connection error path
- existing HTTPError wrapping behavior
- cached sandbox credentials path (no STS refetch)

## Non-Goals

- No retry/backoff policy changes.
- No changes to non-sandbox AWS credential acquisition paths.

## AI Tool Usage

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

Used AI tooling for drafting and iterating patch/test scaffolding. All changes were reviewed, adjusted, and validated by me before submission.
