### PR TITLE
cleanup: remove unnecessary NameError handling from boto3 import

### DIFF
--- a/metaflow/plugins/aws/aws_client.py
+++ b/metaflow/plugins/aws/aws_client.py
@@ -30,7 +30,7 @@ class Boto3ClientProvider(object):
             import botocore
             from botocore.exceptions import ClientError
             from botocore.config import Config
-        except (NameError, ImportError):
+        except ImportError:
             raise MetaflowException(
                 "Could not import module 'boto3'. Install boto3 first."
             )


### PR DESCRIPTION
### PR Type

- [ ] Bug fix
- [ ] New feature
- [ ] Core Runtime change 
- [ ] Docs / tooling
- [X] Refactoring

### Summary
while exploring the codebase and understanding how the aws client provider initializes dependencies, i noticed that the `try/except` block handling the import of `boto3` was catching both `ImportError` and `NameError`.

```python
try:
    import boto3
    import botocore
    from botocore.exceptions import ClientError
    from botocore.config import Config
except (NameError, ImportError):
    raise MetaflowException(
        "Could not import module 'boto3'. Install boto3 first."
    )
```
in this PR, `NameError` has been removed and the block now only catches `ImportError` because `NameError` is not typically raised during module imports.

### Tests

- [ ] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [X] CI passes
- [X] If tests are impractical: explain why below and provide manual evidence above

this change only improves documentation and error messaging

### Non-Goals

This PR does not introduce new functionality or modify aws client behaviour. The goal is only to make the exception handling more precise and prevent unrelated errors from being silently caught.

### AI Tool Usage

- [X] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)
