### PR TITLE
fix: prevent crash when include is None in dump CLI

### DIFF
--- a/metaflow/cli_components/dump_cmd.py
+++ b/metaflow/cli_components/dump_cmd.py
@@ -48,7 +48,7 @@ def dump(obj, input_path, private=None, max_value_size=None, include=None, file=
     kwargs = {
         "show_private": private,
         "max_value_size": None if file is not None else max_value_size,
-        "include": {t for t in include.split(",") if t},
+        "include": {t for t in (include or "").split(",") if t},
     }
 
     # Pathspec can either be run_id/step_name or run_id/step_name/task_id.


### PR DESCRIPTION
### PR Type

- [X] Bug fix
- [ ] New feature
- [ ] Core Runtime change 
- [ ] Docs / tooling
- [ ] Refactoring

### Summary
`include` argument in the dump CLI could be `None`, calling `.split(",")` on `None` raises an exception which causes the CLI to crash

added a small guard by converting `None` to an empty string before splitting, preventing the crash while keeping the behaviour unchanged for valid inputs.

### Reproduction

**Runtime:** local

**Where evidence shows up:** Console output (terminal)

<details>
<summary>Before</summary>

```python
kwargs = {
    "show_private": private,
    "max_value_size": None if file is not None else max_value_size,
    "include": {t for t in include.split(",") if t},
}
```
Command:
```bash
python - <<EOF
include = None
result = {t for t in include.split(",") if t}
print(result)
EOF
```
Output:
`Traceback (most recent call last):
  File "<stdin>", line 6, in <module>
AttributeError: 'NoneType' object has no attribute 'split'
`
</details>

<details>
<summary>After</summary>

```python
kwargs = {
    "show_private": private,
    "max_value_size": None if file is not None else max_value_size,
    "include": {t for t in (include or "").split(",") if t},
}
```
Command:
```bash
python - <<EOF
include = None
result = {t for t in (include or "").split(",") if t}
print(result)
EOF
```
output:
`set()`
</details>

### Root Cause
the code assumed that the `include` variable was always a string, however, when `include` is `None`, calling `.split(",")` raises an exception because `NoneType` does not have a `split` method.

### Why This Fix Is Correct

the fix converts None to an empty string before splitting.


### Failure Modes Considered
1. Empty input handling: 
If include is `None` or empty, the result becomes an empty set, which is consistent with expected behaviour.

## Tests

- [ ] Unit tests added/updated
- [X] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [X] If tests are impractical: explain why below and provide manual evidence above

## AI Tool Usage

- [X] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)
