### PR TITLE
Add YAML support for Config files (JSON-first with YAML fallback)

### DIFF
--- a/metaflow/user_configs/config_options.py
+++ b/metaflow/user_configs/config_options.py
@@ -4,7 +4,7 @@ import os
 from collections.abc import Mapping
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-from metaflow._vendor import click
+from metaflow._vendor import click, yaml
 from metaflow.debug import debug
 
 from .config_parameters import ConfigValue
@@ -382,13 +382,23 @@ class ConfigInput:
                     else:
                         try:
                             read_value = json.loads(val)
-                        except json.JSONDecodeError as e:
-                            msgs.append(
-                                "configuration value for '%s' is not valid JSON: %s"
-                                % (name, e)
-                            )
-                            continue
-                        # TODO: Support YAML
+                        except json.JSONDecodeError:
+                            # JSON parse failed — try YAML (a superset of JSON).
+                            # yaml.safe_load is used intentionally to prevent
+                            # arbitrary code execution from untrusted config files.
+                            try:
+                                read_value = yaml.safe_load(val)
+                                if not isinstance(read_value, Mapping):
+                                    raise ValueError(
+                                        "expected a mapping (got %s)"
+                                        % type(read_value).__name__
+                                    )
+                            except Exception as e:
+                                msgs.append(
+                                    "configuration value for '%s' is not valid "
+                                    "JSON or YAML: %s" % (name, e)
+                                )
+                                continue
                 flow_cls._flow_state.self_data[FlowStateItems.CONFIGS][name] = (
                     read_value,
                     is_plain,


### PR DESCRIPTION
## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Config files passed via `--config` are now parsed as YAML if JSON parsing fails.
Users can pass `.yaml` / `.yml` config files directly with no code changes — the
resulting `ConfigValue` object behaves identically to one parsed from JSON.

## Issue

Fixes #2977 

## Reproduction

**Runtime:** local

**Commands to run:**
```bash
cat > /tmp/my_flow.py << 'EOF'
from metaflow import FlowSpec, step, Config

class MyFlow(FlowSpec):
    cfg = Config("cfg")

    @step
    def start(self):
        print(self.cfg.model.layers)   # should print 6
        self.next(self.end)

    @step
    def end(self):
        pass

if __name__ == "__main__":
    MyFlow()
EOF

cat > /tmp/model_config.yaml << 'EOF'
# YAML comments now work!
model:
  layers: 6
  hidden_dim: 512
  dropout: 0.1
EOF

python /tmp/my_flow.py run --config cfg /tmp/model_config.yaml
```

**Where evidence shows up:** task stdout

<details>
<summary>Before (error / log snippet)</summary>

```
Bad values passed for configuration options:
configuration value for 'cfg' is not valid JSON:
Expecting value: line 1 column 1 (char 0)
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
6
```

</details>

## Root Cause

The config parse path in `ConfigInput.process_configs` called `json.loads(val)` with
no fallback. The original code had a `# TODO: Support YAML` comment immediately after
the `except json.JSONDecodeError` block, acknowledging the gap:

```python
# metaflow/user_configs/config_options.py  (before)
try:
    read_value = json.loads(val)
except json.JSONDecodeError as e:
    msgs.append(
        "configuration value for '%s' is not valid JSON: %s" % (name, e)
    )
    continue
# TODO: Support YAML
```

Any valid YAML that is not simultaneously valid JSON (files with `#` comments,
unquoted strings, block scalars, anchors) always hit the error path and prevented
the flow from starting.

## Why This Fix Is Correct

- **No new dependency.** PyYAML 5.3.1 is already vendored at `metaflow/_vendor/yaml/`
  and is imported in several other modules (`includefile.py`, `plugins/parsers.py`,
  `plugins/kubernetes/kubernetes_jobsets.py`). The import pattern used here is
  identical to existing usage.

- **No breaking change.** JSON parsing is still tried first. Valid JSON files
  continue to work exactly as before — the YAML path is only reached on
  `JSONDecodeError`.

- **Safe parsing.** `yaml.safe_load` is used instead of `yaml.load` to prevent
  arbitrary Python object construction from untrusted config files.

- **Type checked.** After YAML parsing, the result is verified with
  `isinstance(read_value, Mapping)` — the same contract that JSON configs satisfy —
  so a YAML file that produces a scalar or list gets a clear, actionable error.

- **Minimal diff.** One import line updated and one `except` block extended.
  All downstream `ConfigValue` wrapping and `FlowStateItems.CONFIGS` storage
  is completely unchanged.

```python
# metaflow/user_configs/config_options.py  (after)
try:
    read_value = json.loads(val)
except json.JSONDecodeError:
    # JSON parse failed — try YAML (a superset of JSON).
    # yaml.safe_load is used intentionally to prevent
    # arbitrary code execution from untrusted config files.
    try:
        read_value = yaml.safe_load(val)
        if not isinstance(read_value, Mapping):
            raise ValueError(
                "expected a mapping (got %s)" % type(read_value).__name__
            )
    except Exception as e:
        msgs.append(
            "configuration value for '%s' is not valid "
            "JSON or YAML: %s" % (name, e)
        )
        continue
```

## Failure Modes Considered

1. **YAML file that produces a scalar (`42`, `"hello"`)** — `isinstance(read_value, Mapping)`
   raises `ValueError`; caught by outer `except Exception`, appended to `msgs` with a
   clear message. Flow does not start.

2. **YAML file with syntax errors** — `yaml.safe_load` raises `yaml.YAMLError`;
   caught by outer `except Exception`, reported as `"not valid JSON or YAML: ..."`.
   No crash.

3. **YAML anchors / aliases (`&anchor`, `*alias`)** — `safe_load` supports these
   safely (they are standard YAML, not Python-specific). Resolves correctly.

4. **Existing JSON configs** — `json.loads` succeeds on the first try; YAML branch
   is never reached. Zero behavioral change.

## Tests

- [ ] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

**Manual evidence:** Run the reproduction script above.
Before: `Bad values passed for configuration options: ... is not valid JSON`.
After: step prints `6` and the flow completes successfully.

## Non-Goals

- YAML support for `--config-value` inline values (ambiguous for short strings;
  JSON is clearer for inline use — can be a follow-up).
- Multi-document YAML (`---` separator) — `Config` maps to a single dict;
  `yaml.safe_load` already returns only the first document.
- OmegaConf / Hydra variable interpolation — out of scope for this PR.

## Files Changed

| File | Lines | Change |
|------|-------|--------|
| `metaflow/user_configs/config_options.py` | L7 | Added `yaml` to existing vendor import |
| `metaflow/user_configs/config_options.py` | L383–401 | JSON-first, YAML-fallback parse block, updated error message |
