### PR TITLE
Fix spelling errors in comments and docstrings

### DIFF
--- a/metaflow/_vendor/click/_bashcomplete.py
+++ b/metaflow/_vendor/click/_bashcomplete.py
@@ -160,7 +160,7 @@ def start_of_option(param_str):
 def is_incomplete_option(all_args, cmd_param):
     """
     :param all_args: the full original list of args supplied
-    :param cmd_param: the current command paramter
+    :param cmd_param: the current command parameter
     :return: whether or not the last option declaration (i.e. starts
         "-" or "--") is incomplete and corresponds to this cmd_param. In
         other words whether this cmd_param option can still accept

--- a/metaflow/plugins/pypi/utils.py
+++ b/metaflow/plugins/pypi/utils.py
@@ -5,12 +5,12 @@ if sys.version_info < (3, 6):
 
     class Tags:
         __getattr__ = lambda self, name: (_ for _ in ()).throw(
-            Exception("packaging.tags is not avaliable for Python < 3.6")
+            Exception("packaging.tags is not available for Python < 3.6")
         )
 
     tags = Tags()
     parse_wheel_filename = lambda: (_ for _ in ()).throw(
-        RuntimeError("packaging.utils is not avaliable for Python < 3.6")
+        RuntimeError("packaging.utils is not available for Python < 3.6")
     )
 else:
     from metaflow._vendor.packaging import tags

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -1845,7 +1845,7 @@ class Task(object):
     def resume_done(self):
         assert (
             self.step == "_parameters"
-        ), "Only _parameters step can check wheather resume is complete."
+        ), "Only _parameters step can check whether resume is complete."
         return self._resume_done
 
     def mark_resume_done(self):

--- a/test/core/tests/card_component_refresh_test.py
+++ b/test/core/tests/card_component_refresh_test.py
@@ -136,7 +136,7 @@ class CardComponentRefreshTest(MetaflowTest):
             meta_check_dict = checker.artifact_dict_if_exists(step.name, "final_data")
             # Which ever steps ran the actual card testing code
             # contains the `final_data` attribute and the `step_name` attribute.
-            # If these exist then we can succesfully validate the card data since it is meant to exist.
+            # If these exist then we can successfully validate the card data since it is meant to exist.
             step_done_check_dict = checker.artifact_dict_if_exists(
                 step.name, "step_name"
             )
@@ -163,6 +163,6 @@ class CardComponentRefreshTest(MetaflowTest):
                 )
                 assert_equals(data_has_latest_artifact, True)
                 print(
-                    "Succesfully validated task pathspec %s"
+                    "Successfully validated task pathspec %s"
                     % run[step.name][task_id].pathspec
                 )

--- a/test/core/tests/card_refresh_test.py
+++ b/test/core/tests/card_refresh_test.py
@@ -12,12 +12,12 @@ class CardWithRefreshTest(MetaflowTest):
     1. In step code:
         1. We create a random array of strings.
         2. We call `current.card.refresh` with the array.
-        3. We check if the card is present given that we have called referesh and the card
+        3. We check if the card is present given that we have called refresh and the card
             should have reached the backend in some short period of time
         4. Keep adding new data to the array and keep calling refresh.
         5. The data-update that got shipped should *atleast* be a subset the actual data present in the runtime code.
     2. In check_results:
-        1. We check if the data that got shipped can be access post task completion
+        1. We check if the data that got shipped can be accessed post task completion
         2. We check if the data that got shipped is a subset of the actual data created during the runtime code.
     """
 
@@ -136,7 +136,7 @@ class CardWithRefreshTest(MetaflowTest):
             meta_check_dict = checker.artifact_dict_if_exists(step.name, "final_data")
             # Which ever steps ran the actual card testing code
             # contains the `final_data` attribute and the `step_name` attribute.
-            # If these exist then we can succesfully validate the card data since it is meant to exist.
+            # If these exist then we can successfully validate the card data since it is meant to exist.
             step_done_check_dict = checker.artifact_dict_if_exists(
                 step.name, "step_name"
             )
@@ -160,6 +160,6 @@ class CardWithRefreshTest(MetaflowTest):
                 )
                 assert_equals(data_has_latest_artifact, True)
                 print(
-                    "Succesfully validated task pathspec %s"
+                    "Successfully validated task pathspec %s"
                     % run[step.name][task_id].pathspec
                 )


### PR DESCRIPTION
This PR fixes spelling and grammar issues in comments, docstrings,
and string literals across several files in the Metaflow codebase.

Scope:
- Only documentation text was modified
- No changes to runtime behavior, APIs, or function signatures

All fixes were manually reviewed before committing.

This improves code readability and documentation quality.

Fixes #2954