### PR TITLE
fix: argo workflows conditional nested static split joins

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -1413,12 +1413,6 @@ class ArgoWorkflows(object):
                     required_deps = []
 
                 # join steps in_funcs need special handling, as there can be disjoint sets of always-executing and conditional branches.
-                # for example
-                #  switch_step -> a, b, shared_join
-                # a --static-split-> a1, a2, a3 -> shared_join
-                # b --static-split-> b1,b2,b3 -> shared_join
-                #
-                # the shared_join needs to handle dependencies (a1&&a2&&a3) || (b1&&b2&&b3) || switch_step
                 if node.type == "join" and any(
                     self._is_conditional_node(self.graph[fn]) for fn in node.in_funcs
                 ):


### PR DESCRIPTION
Fixes an issue where a join-step nested inside a conditional branch did not have the correct dependencies. This would lead to the join step possibly executing prematurely, before all of its preceding steps had finished.

example flow:
```python
from metaflow import FlowSpec, step 


class JoinBugFlow(FlowSpec):
    @step
    def start(self):
        self.route = "a"
        self.next(self.switch_step)

    @step
    def switch_step(self):
        self.next(
            {"a": self.branch_a, "b": self.branch_b},
            condition="route",
        )

    @step
    def branch_a(self):
        self.next(self.sub_a, self.sub_b)

    @step
    def sub_a(self):
        self.next(self.sub_join)

    @step
    def sub_b(self):
        raise Exception("The sub_join should never start!")
        self.next(self.sub_join)

    @step
    def sub_join(self, inputs):
        self.next(self.shared)

    @step
    def branch_b(self):
        self.next(self.shared)

    @step
    def shared(self):
        self.next(self.end)

    @step
    def end(self):
        pass


if __name__ == "__main__":
    JoinBugFlow()
```