### PR TITLE
Allow extensions to register custom Click parameter types for Runner API

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -8,6 +8,9 @@ from typing import Dict, List, Union, Tuple as TTuple
 from metaflow.exception import MetaflowException
 from metaflow.metaflow_config_funcs import from_conf, get_validate_choice_fn
 
+# Recursive type alias for JSON, used by Runner API type mappings
+JSON = Union[Dict[str, "JSON"], List["JSON"], str, int, float, bool, None]
+
 # Disable multithreading security on MacOS
 if sys.platform == "darwin":
     os.environ["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
@@ -633,6 +636,8 @@ def get_click_to_python_types():
     Returns the mapping from Click parameter types to Python types for Runner API.
     Extensions can override this function to add custom type mappings.
     """
+    # Imports are local to avoid circular dependencies:
+    # metaflow_config -> includefile -> plugins -> ... -> config_options -> debug -> metaflow_config
     from metaflow._vendor.click.types import (
         BoolParamType,
         Choice,
@@ -652,9 +657,6 @@ def get_click_to_python_types():
         MultipleTuple,
         ConfigValue,
     )
-
-    # Define JSON type for type hints
-    JSON = Union[Dict[str, "JSON"], List["JSON"], str, int, float, bool, None]
 
     return {
         StringParamType: str,

--- a/metaflow/runner/click_api.py
+++ b/metaflow/runner/click_api.py
@@ -30,7 +30,11 @@ from metaflow._vendor import click
 from metaflow.decorators import add_decorator_options
 from metaflow.exception import MetaflowException
 from metaflow.flowspec import FlowStateItems
-from metaflow.metaflow_config import CLICK_API_PROCESS_CONFIG, get_click_to_python_types
+from metaflow.metaflow_config import (
+    CLICK_API_PROCESS_CONFIG,
+    JSON,
+    get_click_to_python_types,
+)
 from metaflow.parameters import flow_context
 from metaflow.user_configs.config_options import (
     ConfigValue,
@@ -42,9 +46,6 @@ from metaflow.user_decorators.user_flow_decorator import FlowMutator
 
 # Import Click type mappings from config (allows extensions to add custom types)
 click_to_python_types = get_click_to_python_types()
-
-# Define a recursive type alias for JSON
-JSON = Union[Dict[str, "JSON"], List["JSON"], str, int, float, bool, None]
 
 
 def _method_sanity_check(


### PR DESCRIPTION
## Summary

- Move the hardcoded `click_to_python_types` dict from `click_api.py` into a `get_click_to_python_types()` function in `metaflow_config.py`
- Extensions can now provide their own `get_click_to_python_types` to add custom type mappings (e.g. S3Type, TableType, DateType) which get merged with the base types
- This enables the Runner/Deployer API to work with custom Click parameter types defined by extensions

## Test plan

- [ ] Verify existing Runner/Deployer tests pass (type map is functionally identical)
- [ ] Verify extensions providing `get_click_to_python_types` have their types merged correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)