### PR TITLE
[For discussion only]tolerate empty __init__.py in namespace package discovery

### DIFF
--- a/metaflow/extension_support/__init__.py
+++ b/metaflow/extension_support/__init__.py
@@ -530,12 +530,18 @@ def _get_extension_packages(ignore_info_file=False, restrict_to_directories=None
             # the extension and __init__.py file)
             if len(parts) == 2:
                 # Ensure that we don't have a __init__.py to force this package to
-                # be a NS package
+                # be a NS package.  Tolerate empty (0-byte) __init__.py files
+                # because build systems like Bazel's rules_python auto-generate
+                # them for every directory, even namespace packages.
                 if parts[1] == "__init__.py":
-                    raise RuntimeError(
-                        "Package '%s' providing '%s' is not an implicit namespace "
-                        "package as required" % (state["name"], EXT_PKG)
-                    )
+                    init_path = os.path.join(root_dir, file)
+                    if os.path.isfile(init_path) and os.path.getsize(init_path) > 0:
+                        raise RuntimeError(
+                            "Package '%s' providing '%s' is not an implicit "
+                            "namespace package as required"
+                            % (state["name"], EXT_PKG)
+                        )
+                    return
                 # Check for any metadata; we can only have one metadata per
                 # distribution at most
                 if EXT_META_REGEXP.match(parts[1]) is not None:
@@ -596,7 +602,11 @@ def _get_extension_packages(ignore_info_file=False, restrict_to_directories=None
 
                     if len(parts) == len(ext_list) + 3 and (
                         EXT_CONFIG_REGEXP.match(parts[-1]) is not None
-                        or parts[-1] == "__init__.py"
+                        or (
+                            parts[-1] == "__init__.py"
+                            and os.path.isfile(os.path.join(root_dir, *parts))
+                            and os.path.getsize(os.path.join(root_dir, *parts)) > 0
+                        )
                     ):
                         parts[-1] = parts[-1][:-3]  # Remove the .py
                         config_module = ".".join(parts)


### PR DESCRIPTION
Build systems like Bazel's rules_python auto-generate empty (0-byte) __init__.py files for every directory, including those that are meant to be implicit namespace packages.  This causes metaflow's extension discovery to reject the metaflow_extensions namespace package with:

    RuntimeError: Package '...' providing 'metaflow_extensions' is not
    an implicit namespace package as required

An empty __init__.py is functionally equivalent to no __init__.py for namespace package purposes, so we can safely skip it.

Two changes:

1. At the metaflow_extensions/ top level: skip empty __init__.py instead of raising RuntimeError, since the file carries no package initialization code.

2. At extension point directories (e.g. alias/, config/): do not treat an empty __init__.py as a configuration file.  Only __init__.py files with actual content should be considered config modules.

Fixes compatibility with Bazel's rules_python which sets enable_implicit_namespace_pkgs=True but still generates empty __init__.py files in extracted pip wheels.

Made-with: Cursor

Here's the filled-in PR template:

---

## PR Type

- [x] Bug fix

## Summary

Tolerate empty (0-byte) `__init__.py` files in `metaflow_extensions` namespace package discovery. Build systems like Bazel's `rules_python` auto-generate these for every directory, breaking metaflow's extension loading with `RuntimeError: Package '...' providing 'metaflow_extensions' is not an implicit namespace package as required`.

## Issue

No existing issue. This affects any metaflow user running under Bazel with `rules_python` pip integration.

Fixes compatibility with Bazel's `rules_python` (tested with v1.8.4) which generates empty `__init__.py` files in extracted pip wheels even when `enable_implicit_namespace_pkgs=True`.

## Reproduction

**Runtime:** local (Bazel `rules_python` 1.8.4, Python 3.10)

**Commands to run:**
```bash
# Given a flow that depends on @genai_pip//nflx_metaflow and @genai_pip//metaflow
# via Bazel's pip.parse with enable_implicit_namespace_pkgs=True:
./bazel run //path/to:flow -- package info
```

**Where evidence shows up:** parent console

<details>
<summary>Before (error / log snippet)</summary>

```
File ".../metaflow/extension_support/__init__.py", line 535, in process_file
    raise RuntimeError(
RuntimeError: Package '_pythonpath_0' providing 'metaflow_extensions' is not an implicit namespace package as required
```

Additionally, even after patching only the top-level check, a second error surfaces at extension point directories (e.g. `alias/`, `config/`) where empty `__init__.py` is incorrectly treated as a configuration file:

```
RuntimeError: Package '_pythonpath_0[nflx]' defines more than one configuration file for 'alias':
  'metaflow_extensions.nflx.alias.__init__' and 'metaflow_extensions.nflx.alias.mfextinit_nflxfastdata'
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
Metaflow 2.19.18+nflxfastdata(2.22.1) executing TestContentQAInferenceResults for user:yinglaol
Package size: 12.09 MB
Number of files: 621

Metaflow version: 2.19.18+nflxfastdata(2.22.1)

Metaflow extensions packaged:
  - nflx-fastdata (<unk>) @ 2.22.1
  - nflx-metaflow (<unk>) @ 2.22.1
  - _pythonpath_0 (nflxfastdata) @ _local_
```

No workaround code needed in the flow file -- plain `from metaflow import ...` works.

</details>

## Root Cause

Bazel's `rules_python` extracts each pip wheel into its own isolated `site-packages` directory. For namespace packages like `metaflow_extensions`, it generates empty (0-byte) `__init__.py` files even when `enable_implicit_namespace_pkgs=True` is set (this is a known `rules_python` issue).

In `_get_extension_packages()` → `process_file()`:

1. **Line 534**: Any `metaflow_extensions/__init__.py` triggers an unconditional `RuntimeError`, even if the file is empty and carries no package initialization code.

2. **Line 597-599**: `__init__.py` in extension point directories (e.g. `alias/`) is unconditionally treated as a configuration file. When Bazel puts `nflx-metaflow` and `nflx-fastdata` in separate `sys.path` entries, each has its own `alias/__init__.py` (auto-generated, empty). This causes a "more than one configuration file" conflict since the empty `__init__.py` is counted alongside the real `mfextinit_*.py` config.

In a standard pip install, both packages merge into a single `site-packages/metaflow_extensions/` directory with no `__init__.py` at the namespace levels, so neither issue surfaces.

## Why This Fix Is Correct

An empty `__init__.py` is functionally equivalent to no `__init__.py` for namespace package purposes -- it contains no initialization code and Python treats the directory identically. The fix preserves the existing invariant (reject non-empty `__init__.py` that would make `metaflow_extensions` a regular package) while tolerating the harmless empty files that build tools generate.

The fix is minimal: two `os.path.getsize() == 0` checks, no behavioral change for any non-empty `__init__.py`.

## Failure Modes Considered

1. **Non-empty `__init__.py` still rejected**: If someone intentionally creates a `metaflow_extensions/__init__.py` with content (which would break namespace package merging), the `RuntimeError` still fires because `getsize() > 0`.

2. **Missing file on disk**: If `__init__.py` appears in a directory listing but doesn't exist on disk (e.g. broken symlink), `os.path.isfile()` returns `False` and we skip it, which is the safe default -- a missing file can't break namespace package semantics.

3. **Backward compatibility with pip installs**: In a standard pip/uv install, `metaflow_extensions/__init__.py` doesn't exist at all, so the new code path is never reached. Behavior is identical to before.

4. **Extension config file detection**: Empty `__init__.py` in extension point dirs (e.g. `alias/`) is no longer treated as a config module. Only `__init__.py` with actual content and files matching `EXT_CONFIG_REGEXP` are considered. This matches the intended behavior since empty `__init__.py` was never meant to be a config file.

## Tests
apply the fix locally and it works

```
genai_venv) algo-dev yinglaol ~/algo $ ./bazel run genai/medc_experiment_workflows/metaflow_assets/medc/content_qa/inference_results:flow -- package info

INFO: Invocation ID: 5a10a6fe-a9ba-426f-998d-567d784fb288
INFO: Streaming build results to: https://netflix.buildbuddy.io/invocation/5a10a6fe-a9ba-426f-998d-567d784fb288
INFO: Analyzed target //genai/medc_experiment_workflows/metaflow_assets/medc/content_qa/inference_results:flow (876 packages loaded, 61406 targets configured).
INFO: Found 1 target...
Target //genai/medc_experiment_workflows/metaflow_assets/medc/content_qa/inference_results:flow up-to-date:
  bazel-bin/genai/medc_experiment_workflows/metaflow_assets/medc/content_qa/inference_results/flow
INFO: Elapsed time: 4.255s, Critical Path: 0.23s
INFO: 1 process: 27 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/genai/medc_experiment_workflows/metaflow_assets/medc/content_qa/inference_results/flow <args omitted>
INFO: Streaming build results to: https://netflix.buildbuddy.io/invocation/5a10a6fe-a9ba-426f-998d-567d784fb288
Metaflow 2.19.18+nflxfastdata(2.22.1) executing TestContentQAInferenceResults for user:yinglaol
Package size: 12.09 MB
Number of files: 621

Metaflow version: 2.19.18+nflxfastdata(2.22.1)

Metaflow extensions packaged:
  - nflx-fastdata (<unk>) @ 2.22.1
  - nflx-metaflow (<unk>) @ 2.22.1
  - _pythonpath_0 (nflxfastdata) @ _local_

User code in flow flow TestContentQAInferenceResults:
  - Packaged from directory /home/coder/.local/share/tmp/rrv2-bazel/bzl/bazel__home_coder_algo/execroot/_main/bazel-out/k8-fastbuild/bin/genai/medc_experiment_workflows/metaflow_assets/medc/content_qa/inference_results/flow.runfiles/_main/genai/medc_experiment_workflows/metaflow_assets/medc/content_qa/inference_results/
  - Filtered by suffixes: .py, .RDS, .R
  - Excluded directories: .mf_code, .mf_meta, _escape_trampolines
(genai_venv) algo-dev yinglaol ~/algo $ 
```
## Non-Goals

<!-- What you intentionally did not change. Helps reviewers scope their review. -->

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [ ] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)

<!-- If you used AI tools:
- Which tool(s)?
- What did you use them for?
- Did you review, understand, and test all generated code?
-->
