### PR TITLE
Fix: Sort inputs by foreach index in join steps (#3003)

### DIFF
--- a/metaflow/datastore/inputs.py
+++ b/metaflow/datastore/inputs.py
@@ -6,8 +6,9 @@ class Inputs(object):
     """
 
     def __init__(self, flows):
-        # TODO sort by foreach index
         self.flows = list(flows)
+        if self.flows and getattr(self.flows[0], "index", None) is not None:
+            self.flows.sort(key=lambda x: x.index)
         for flow in self.flows:
             setattr(self, flow._current_step, flow)
 


### PR DESCRIPTION
Closes #3003.

**What is happening?**
The `Inputs` class in `metaflow/datastore/inputs.py` was not predictably sorting the incoming `flows` from a `foreach` branch. This makes accessing variables by index (e.g., `inputs[0]`, `inputs[1]`) non-deterministic and unreliable.

**Proposed Solution**
This PR modifies the `Inputs` class to explicitly sort the incoming `flows` by their `index` property, if available. This fulfills the existing `TODO` in the file.