### PR TITLE
Fix incorrect OR operand order when initializing Metaflow instance

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -285,7 +285,7 @@ class MetaflowObject(object):
         # the namespace at the import time is problematic, since there
         # may be other modules that alter environment variables etc.
         # which may affect the namespace setting.
-        self._metaflow = Metaflow(_current_metadata) or _metaflow
+        self._metaflow = _metaflow or Metaflow(_current_metadata)
         self._parent = _parent
         self._path_components = None
         self._attempt = attempt

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -43,12 +43,7 @@ from .filecache import FileCache
 if TYPE_CHECKING:
     from metaflow.metadata_provider import MetadataProvider
 
-try:
-    # python2
-    import cPickle as pickle
-except:  # noqa E722
-    # python3
-    import pickle
+import pickle
 
 # populated at the bottom of this file
 _CLASSES = {}


### PR DESCRIPTION
The current implementation initializes the Metaflow instance as:

self._metaflow = Metaflow(_current_metadata) or _metaflow

Since Metaflow(_current_metadata) always returns a truthy object,
the `_metaflow` operand is never evaluated. This prevents reuse of
an existing Metaflow instance.

Swapping the operands ensures that an existing `_metaflow` instance
is reused when available:

self._metaflow = _metaflow or Metaflow(_current_metadata)
