### PR TITLE
Fix StepMutator.mutate() not seeing late-attached platform decorators

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -901,16 +901,22 @@ def _process_late_attached_decorator(
     skip_decorators=False,
 ):
 
+    # Collect steps that received a late-attached decorator so we only
+    # re-run mutators on those steps (avoids breaking non-idempotent mutators).
+    late_attached_step_names = set()
     for s in flow:
         for deco in s.decorators:
             if deco.name in deco_names:
                 deco.external_init()
+                late_attached_step_names.add(s.__name__)
 
     # Re-run step mutators so they can see the late-attached decorators.
     # This is needed because _init_step_decorators (which runs mutators) may
     # have already executed before the late-attached decorators were added.
     cls = flow.__class__
     for step in cls._steps:
+        if step.name not in late_attached_step_names:
+            continue
         for deco in step.config_decorators:
             if isinstance(deco, StepMutator):
                 inserted_by_value = [deco.decorator_name] + (
@@ -933,6 +939,7 @@ def _process_late_attached_decorator(
     # Rebuild the graph so that node.decorators reflects any changes
     # made by the mutators above (e.g. add_decorator with OVERRIDE).
     cls._init_graph()
+    graph = flow._graph
 
     for s in flow:
         for deco in s.decorators:

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -906,6 +906,34 @@ def _process_late_attached_decorator(
             if deco.name in deco_names:
                 deco.external_init()
 
+    # Re-run step mutators so they can see the late-attached decorators.
+    # This is needed because _init_step_decorators (which runs mutators) may
+    # have already executed before the late-attached decorators were added.
+    cls = flow.__class__
+    for step in cls._steps:
+        for deco in step.config_decorators:
+            if isinstance(deco, StepMutator):
+                inserted_by_value = [deco.decorator_name] + (
+                    deco.inserted_by or []
+                )
+                debug.userconf_exec(
+                    "Re-evaluating step level decorator %s for %s (mutate)"
+                    % (deco.__class__.__name__, step.name)
+                )
+                deco.mutate(
+                    MutableStep(
+                        cls,
+                        step,
+                        pre_mutate=False,
+                        statically_defined=deco.statically_defined,
+                        inserted_by=inserted_by_value,
+                    )
+                )
+
+    # Rebuild the graph so that node.decorators reflects any changes
+    # made by the mutators above (e.g. add_decorator with OVERRIDE).
+    cls._init_graph()
+
     for s in flow:
         for deco in s.decorators:
             if deco.name in deco_names:

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -944,6 +944,13 @@ def _process_late_attached_decorator(
         cls._init_graph()
         graph = flow._graph
 
+        # Ensure any replacement decorators created by add_decorator(OVERRIDE)
+        # have external_init() called before step_init().
+        for s in flow:
+            for deco in s.decorators:
+                if deco.name in deco_names and not deco._ran_init:
+                    deco.external_init()
+
     for s in flow:
         for deco in s.decorators:
             if deco.name in deco_names:

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -938,8 +938,9 @@ def _process_late_attached_decorator(
 
     # Rebuild the graph so that node.decorators reflects any changes
     # made by the mutators above (e.g. add_decorator with OVERRIDE).
-    cls._init_graph()
-    graph = flow._graph
+    if late_attached_step_names:
+        cls._init_graph()
+        graph = flow._graph
 
     for s in flow:
         for deco in s.decorators:

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -913,6 +913,7 @@ def _process_late_attached_decorator(
     # Re-run step mutators so they can see the late-attached decorators.
     # This is needed because _init_step_decorators (which runs mutators) may
     # have already executed before the late-attached decorators were added.
+    mutators_ran = False
     cls = flow.__class__
     for step in cls._steps:
         if step.name not in late_attached_step_names:
@@ -935,10 +936,11 @@ def _process_late_attached_decorator(
                         inserted_by=inserted_by_value,
                     )
                 )
+                mutators_ran = True
 
     # Rebuild the graph so that node.decorators reflects any changes
     # made by the mutators above (e.g. add_decorator with OVERRIDE).
-    if late_attached_step_names:
+    if mutators_ran:
         cls._init_graph()
         graph = flow._graph
 

--- a/test/unit/test_late_attached_mutator.py
+++ b/test/unit/test_late_attached_mutator.py
@@ -144,6 +144,12 @@ def test_process_late_attached_reruns_mutators():
         f"Expected memory=8192, got {k8s_decos[0].attributes['memory']}"
     )
 
+    # Verify end step was NOT overridden (no mutator on it).
+    end_k8s = [d for d in end_step.decorators if d.name == "kubernetes"]
+    assert len(end_k8s) == 1
+    assert str(end_k8s[0].attributes["cpu"]) == "1"
+    assert str(end_k8s[0].attributes["memory"]) == "4096"
+
 
 def test_process_late_attached_preserves_defaults_without_mutator():
     """

--- a/test/unit/test_late_attached_mutator.py
+++ b/test/unit/test_late_attached_mutator.py
@@ -1,0 +1,214 @@
+"""
+Test that StepMutators can see and modify late-attached platform decorators.
+
+When deploying to Argo Workflows, @kubernetes is attached to steps after
+_init_step_decorators (which runs StepMutator.mutate()) has already executed.
+_process_late_attached_decorator must re-run mutators so they get a chance
+to see and modify the late-attached decorators.
+
+Regression test for the ordering change introduced in 2.19.14 (PR #2719).
+"""
+
+from unittest.mock import MagicMock
+
+from metaflow import FlowSpec, StepMutator, step
+from metaflow.plugins.kubernetes.kubernetes_decorator import KubernetesDecorator
+from metaflow.user_decorators.mutable_step import MutableStep
+from metaflow import decorators
+
+
+class kubernetes_override(StepMutator):
+    """A StepMutator that overrides @kubernetes attributes."""
+
+    def init(self, *args, **kwargs):
+        self.deco_kwargs = kwargs
+
+    def mutate(self, mutable_step):
+        for deco_name, _, _, attributes in mutable_step.decorator_specs:
+            if deco_name == "kubernetes":
+                attributes.update(self.deco_kwargs)
+                mutable_step.add_decorator(
+                    deco_type=deco_name,
+                    deco_kwargs=attributes,
+                    duplicates=mutable_step.OVERRIDE,
+                )
+
+
+class _MockFlow:
+    """
+    Minimal wrapper that makes a FlowSpec class work with
+    _process_late_attached_decorator without invoking the CLI.
+
+    _process_late_attached_decorator needs:
+    - iteration (for s in flow) to yield steps
+    - flow.__class__._steps for mutator re-run
+    - flow.__class__._init_graph() for graph rebuild
+    - flow._graph for graph access
+    """
+
+    def __init__(self, flow_cls, steps):
+        # Use the real FlowSpec class so _init_graph, _steps etc. work.
+        self.__class__ = flow_cls
+        self._steps_list = steps
+
+    def __iter__(self):
+        return iter(self._steps_list)
+
+
+def test_process_late_attached_reruns_mutators():
+    """
+    Verify that _process_late_attached_decorator re-runs step mutators
+    after late-attaching platform decorators.
+
+    This reproduces the Argo Workflows deployment path:
+    1. _init_step_decorators runs mutators (@kubernetes NOT yet attached)
+    2. _attach_decorators adds @kubernetes to all steps
+    3. _process_late_attached_decorator must re-run mutators
+
+    Without the fix, the mutator never sees @kubernetes and the
+    override silently doesn't apply.
+    """
+
+    class TestFlow(FlowSpec):
+        @kubernetes_override(cpu=2, memory=8192)
+        @step
+        def start(self):
+            self.next(self.end)
+
+        @step
+        def end(self):
+            pass
+
+    start_step = TestFlow.start
+    end_step = TestFlow.end
+
+    # Initialize mutators (calls init()).
+    for deco in start_step.config_decorators:
+        if isinstance(deco, StepMutator):
+            deco.external_init()
+
+    # Step 1: Simulate _init_step_decorators running mutators.
+    # No @kubernetes yet, so mutator finds nothing.
+    for deco in start_step.config_decorators:
+        if isinstance(deco, StepMutator):
+            inserted_by_value = [deco.decorator_name] + (
+                deco.inserted_by or []
+            )
+            deco.mutate(
+                MutableStep(
+                    TestFlow,
+                    start_step,
+                    pre_mutate=False,
+                    statically_defined=deco.statically_defined,
+                    inserted_by=inserted_by_value,
+                )
+            )
+
+    # Confirm: no @kubernetes yet.
+    assert not any(d.name == "kubernetes" for d in start_step.decorators)
+
+    # Step 2: Late-attach @kubernetes to all steps.
+    decorators._attach_decorators_to_step(
+        start_step, [KubernetesDecorator.name]
+    )
+    decorators._attach_decorators_to_step(
+        end_step, [KubernetesDecorator.name]
+    )
+
+    # @kubernetes is there but has defaults.
+    k8s = [d for d in start_step.decorators if d.name == "kubernetes"][0]
+    assert str(k8s.attributes["cpu"]) == "1"
+
+    # Step 3: Call _process_late_attached_decorator.
+    # This should re-run the mutator so it can override the @kubernetes.
+    mock_flow = _MockFlow(TestFlow, [start_step, end_step])
+    mock_datastore = MagicMock()
+    mock_datastore.TYPE = "gs"
+    decorators._process_late_attached_decorator(
+        [KubernetesDecorator.name],
+        mock_flow,
+        TestFlow._graph,
+        environment=None,
+        flow_datastore=mock_datastore,
+        logger=MagicMock(),
+    )
+
+    # Verify: start step @kubernetes should have overridden values.
+    k8s_decos = [d for d in start_step.decorators if d.name == "kubernetes"]
+    assert len(k8s_decos) == 1, (
+        "Expected exactly one @kubernetes on start step"
+    )
+    assert str(k8s_decos[0].attributes["cpu"]) == "2", (
+        f"Expected cpu=2, got {k8s_decos[0].attributes['cpu']}"
+    )
+    assert str(k8s_decos[0].attributes["memory"]) == "8192", (
+        f"Expected memory=8192, got {k8s_decos[0].attributes['memory']}"
+    )
+
+
+def test_process_late_attached_preserves_defaults_without_mutator():
+    """
+    Steps without a StepMutator should retain default @kubernetes values
+    after _process_late_attached_decorator.
+    """
+
+    class TestFlow(FlowSpec):
+        @kubernetes_override(cpu=4, memory=16384)
+        @step
+        def start(self):
+            self.next(self.end)
+
+        @step
+        def end(self):
+            pass
+
+    end_step = TestFlow.end
+
+    # Late-attach @kubernetes to end step (no mutator on end).
+    decorators._attach_decorators_to_step(
+        end_step, [KubernetesDecorator.name]
+    )
+
+    # Verify defaults are preserved.
+    k8s_decos = [d for d in end_step.decorators if d.name == "kubernetes"]
+    assert len(k8s_decos) == 1
+    assert str(k8s_decos[0].attributes["cpu"]) == "1"
+    assert str(k8s_decos[0].attributes["memory"]) == "4096"
+
+
+def test_mutator_is_noop_without_late_attachment():
+    """
+    If @kubernetes is never attached, the mutator's iteration over
+    decorator_specs should find nothing and be a no-op.
+    """
+
+    class TestFlow(FlowSpec):
+        @kubernetes_override(cpu=2, memory=8192)
+        @step
+        def start(self):
+            self.next(self.end)
+
+        @step
+        def end(self):
+            pass
+
+    start_step = TestFlow.start
+
+    for deco in start_step.config_decorators:
+        if isinstance(deco, StepMutator):
+            deco.external_init()
+            inserted_by_value = [deco.decorator_name] + (
+                deco.inserted_by or []
+            )
+            deco.mutate(
+                MutableStep(
+                    TestFlow,
+                    start_step,
+                    pre_mutate=False,
+                    statically_defined=deco.statically_defined,
+                    inserted_by=inserted_by_value,
+                )
+            )
+
+    # No @kubernetes should exist.
+    assert not any(d.name == "kubernetes" for d in start_step.decorators)

--- a/test/unit/test_late_attached_mutator.py
+++ b/test/unit/test_late_attached_mutator.py
@@ -11,10 +11,15 @@ Regression test for the ordering change introduced in 2.19.14 (PR #2719).
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from metaflow import FlowSpec, StepMutator, step
-from metaflow.plugins.kubernetes.kubernetes_decorator import KubernetesDecorator
 from metaflow.user_decorators.mutable_step import MutableStep
 from metaflow import decorators
+
+KubernetesDecorator = pytest.importorskip(
+    "metaflow.plugins.kubernetes.kubernetes_decorator"
+).KubernetesDecorator
 
 
 class kubernetes_override(StepMutator):

--- a/test/unit/test_late_attached_mutator.py
+++ b/test/unit/test_late_attached_mutator.py
@@ -44,20 +44,14 @@ class _MockFlow:
     Minimal wrapper that makes a FlowSpec class work with
     _process_late_attached_decorator without invoking the CLI.
 
-    _process_late_attached_decorator needs:
-    - iteration (for s in flow) to yield steps
-    - flow.__class__._steps for mutator re-run
-    - flow.__class__._init_graph() for graph rebuild
-    - flow._graph for graph access
+    Reassigning __class__ to flow_cls delegates _steps, _init_graph,
+    _graph, and __iter__ (which iterates cls._steps) to the real
+    FlowSpec class.
     """
 
-    def __init__(self, flow_cls, steps):
-        # Use the real FlowSpec class so _init_graph, _steps etc. work.
+    def __init__(self, flow_cls):
+        # Use the real FlowSpec class so _init_graph, _steps, __iter__ etc. work.
         self.__class__ = flow_cls
-        self._steps_list = steps
-
-    def __iter__(self):
-        return iter(self._steps_list)
 
 
 def test_process_late_attached_reruns_mutators():
@@ -126,7 +120,7 @@ def test_process_late_attached_reruns_mutators():
 
     # Step 3: Call _process_late_attached_decorator.
     # This should re-run the mutator so it can override the @kubernetes.
-    mock_flow = _MockFlow(TestFlow, [start_step, end_step])
+    mock_flow = _MockFlow(TestFlow)
     mock_datastore = MagicMock()
     mock_datastore.TYPE = "gs"
     decorators._process_late_attached_decorator(
@@ -184,7 +178,7 @@ def test_process_late_attached_preserves_defaults_without_mutator():
     )
 
     # Run _process_late_attached_decorator (exercises the new code path).
-    mock_flow = _MockFlow(TestFlow, [start_step, end_step])
+    mock_flow = _MockFlow(TestFlow)
     mock_datastore = MagicMock()
     mock_datastore.TYPE = "gs"
     decorators._process_late_attached_decorator(
@@ -205,8 +199,10 @@ def test_process_late_attached_preserves_defaults_without_mutator():
 
 def test_mutator_is_noop_without_late_attachment():
     """
-    If @kubernetes is never attached, the mutator's iteration over
-    decorator_specs should find nothing and be a no-op.
+    If @kubernetes is never attached, _process_late_attached_decorator
+    should find no matching decorators, the mutator re-run loop should
+    be skipped (empty late_attached_step_names), and no @kubernetes
+    should appear on any step.
     """
 
     class TestFlow(FlowSpec):
@@ -224,18 +220,20 @@ def test_mutator_is_noop_without_late_attachment():
     for deco in start_step.config_decorators:
         if isinstance(deco, StepMutator):
             deco.external_init()
-            inserted_by_value = [deco.decorator_name] + (
-                deco.inserted_by or []
-            )
-            deco.mutate(
-                MutableStep(
-                    TestFlow,
-                    start_step,
-                    pre_mutate=False,
-                    statically_defined=deco.statically_defined,
-                    inserted_by=inserted_by_value,
-                )
-            )
+
+    # Call _process_late_attached_decorator without attaching @kubernetes.
+    # This exercises the empty late_attached_step_names path.
+    mock_flow = _MockFlow(TestFlow)
+    mock_datastore = MagicMock()
+    mock_datastore.TYPE = "gs"
+    decorators._process_late_attached_decorator(
+        [KubernetesDecorator.name],
+        mock_flow,
+        TestFlow._graph,
+        environment=None,
+        flow_datastore=mock_datastore,
+        logger=MagicMock(),
+    )
 
     # No @kubernetes should exist.
     assert not any(d.name == "kubernetes" for d in start_step.decorators)

--- a/test/unit/test_late_attached_mutator.py
+++ b/test/unit/test_late_attached_mutator.py
@@ -190,6 +190,12 @@ def test_process_late_attached_preserves_defaults_without_mutator():
         logger=MagicMock(),
     )
 
+    # Verify start step @kubernetes was overridden by the mutator.
+    start_k8s = [d for d in start_step.decorators if d.name == "kubernetes"]
+    assert len(start_k8s) == 1
+    assert str(start_k8s[0].attributes["cpu"]) == "4"
+    assert str(start_k8s[0].attributes["memory"]) == "16384"
+
     # Verify defaults are preserved on end step (no mutator).
     k8s_decos = [d for d in end_step.decorators if d.name == "kubernetes"]
     assert len(k8s_decos) == 1

--- a/test/unit/test_late_attached_mutator.py
+++ b/test/unit/test_late_attached_mutator.py
@@ -162,14 +162,36 @@ def test_process_late_attached_preserves_defaults_without_mutator():
         def end(self):
             pass
 
+    start_step = TestFlow.start
     end_step = TestFlow.end
 
-    # Late-attach @kubernetes to end step (no mutator on end).
+    # Initialize mutators on start step.
+    for deco in start_step.config_decorators:
+        if isinstance(deco, StepMutator):
+            deco.external_init()
+
+    # Late-attach @kubernetes to both steps.
+    decorators._attach_decorators_to_step(
+        start_step, [KubernetesDecorator.name]
+    )
     decorators._attach_decorators_to_step(
         end_step, [KubernetesDecorator.name]
     )
 
-    # Verify defaults are preserved.
+    # Run _process_late_attached_decorator (exercises the new code path).
+    mock_flow = _MockFlow(TestFlow, [start_step, end_step])
+    mock_datastore = MagicMock()
+    mock_datastore.TYPE = "gs"
+    decorators._process_late_attached_decorator(
+        [KubernetesDecorator.name],
+        mock_flow,
+        TestFlow._graph,
+        environment=None,
+        flow_datastore=mock_datastore,
+        logger=MagicMock(),
+    )
+
+    # Verify defaults are preserved on end step (no mutator).
     k8s_decos = [d for d in end_step.decorators if d.name == "kubernetes"]
     assert len(k8s_decos) == 1
     assert str(k8s_decos[0].attributes["cpu"]) == "1"


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

`_process_late_attached_decorator` now re-runs `StepMutator.mutate()` after late-attaching platform decorators, so mutators can see and modify decorators like `@kubernetes` that are attached after `_init_step_decorators` has already executed.

## Issue

Fixes #3025

## Reproduction

**Runtime:** Argo Workflows

<details>
<summary>test_flow.py</summary>

```python
from metaflow import FlowSpec, StepMutator, step
from metaflow.user_decorators.mutable_step import MutableStep

class kubernetes_override(StepMutator):
    """Override @kubernetes attributes via StepMutator."""

    def init(self, *args, **kwargs):
        self.deco_kwargs = kwargs

    def mutate(self, mutable_step):
        for deco_name, _, _, attributes in mutable_step.decorator_specs:
            if deco_name == "kubernetes":
                attributes.update(self.deco_kwargs)
                mutable_step.add_decorator(
                    deco_type=deco_name,
                    deco_kwargs=attributes,
                    duplicates=mutable_step.OVERRIDE,
                )

class MyFlow(FlowSpec):
    @kubernetes_override(cpu=2, memory=8192)
    @step
    def start(self):
        self.next(self.end)

    @step
    def end(self):
        pass

if __name__ == "__main__":
    MyFlow()
```

</details>

**Commands to run:**
```bash
python test_flow.py argo-workflows create --only-json | grep -A5 '"resources"'
```

**Where evidence shows up:** Generated Argo workflow JSON — resource requests on steps

<details>
<summary>Before (error / log snippet)</summary>

```
# StepMutator sets cpu=2, memory=8192 but output shows defaults:
"resources": {
    "requests": {
        "cpu": "1",
        "memory": "4096M",
    }
}
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
# StepMutator overrides are now correctly applied:
"resources": {
    "requests": {
        "cpu": "2",
        "memory": "8192M",
    }
}
```

</details>

## Root Cause

PR #2719 moved `_init_step_decorators()` from Argo's `make_flow()` into `cli.py start()`. This means mutators now run **before** Argo attaches `@kubernetes` to steps. The new `_process_late_attached_decorator()` function calls `external_init()` and `step_init()` on the late-attached decorators but never re-runs `StepMutator.mutate()`, so mutators that iterate `decorator_specs` looking for `"kubernetes"` find nothing.

**2.19.13 order (working):**
1. `_attach_decorators` adds `@kubernetes`
2. `_init_step_decorators` runs `mutate()` — mutators see `@kubernetes` ✅

**2.19.14 order (broken):**
1. `_init_step_decorators` runs `mutate()` — no `@kubernetes` yet ❌
2. `_attach_decorators` adds `@kubernetes`
3. `_process_late_attached_decorator` — does not re-run `mutate()`

## Why This Fix Is Correct

The fix adds a mutator re-run loop inside `_process_late_attached_decorator`, between `external_init()` and the `step_init()` loop. This restores the invariant that `mutate()` always sees the full set of decorators on a step. After mutators run, `cls._init_graph()` is called to rebuild the graph so `node.decorators` reflects any changes made by `add_decorator(OVERRIDE)`.

## Failure Modes Considered

1. **Steps without mutators**: Steps that have no `StepMutator` in `config_decorators` are unaffected — the inner loop simply doesn't execute. Verified by `test_process_late_attached_preserves_defaults_without_mutator`.
2. **Mutators without target decorators**: If `@kubernetes` is never late-attached, the mutator's iteration over `decorator_specs` finds nothing and is a no-op. Verified by `test_mutator_is_noop_without_late_attachment`.
3. **Graph consistency**: `cls._init_graph()` is called after mutator re-run to ensure `node.decorators` matches `step.decorators`. Without this, the Argo compiler reads stale decorator references from graph nodes.
4. **Double-init**: `external_init()` is only called once (in the existing code, before the mutator re-run). The mutator re-run only calls `mutate()`, not `init()` again.

## Tests

- [x] Unit tests added/updated
- [x] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

Three regression tests added in `test/unit/test_late_attached_mutator.py`:
- `test_process_late_attached_reruns_mutators` — verifies mutator overrides apply after late attachment (fails without fix, passes with fix)
- `test_process_late_attached_preserves_defaults_without_mutator` — verifies steps without mutators retain defaults
- `test_mutator_is_noop_without_late_attachment` — verifies mutator is a no-op when target decorator is never attached

## Non-Goals

- No changes to the `StepMutator` API or `MutableStep` interface.
- No changes to how `_init_step_decorators` works — only `_process_late_attached_decorator` is modified.
- No changes to existing tests.

## AI Tool Usage

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

AI tooling was used to verify the solution against the test suite and to help write the PR description. All code changes were reviewed, understood, and tested manually.