### PR TITLE
Improve GitHub Actions CI runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: ${{ matrix.ver }}
+        cache: 'pip'
       env:
         PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
 
@@ -72,6 +73,14 @@ jobs:
       with:
         r-version: ${{ matrix.ver }}
 
+    - name: Cache R packages
+      uses: actions/cache@v4
+      with:
+        path: ~/R/library
+        key: ${{ runner.os }}-r-${{ matrix.ver }}-${{ hashFiles('R/DESCRIPTION') }}
+        restore-keys: |
+          ${{ runner.os }}-r-${{ matrix.ver }}-
+
     - name: Install R ${{ matrix.ver }} system dependencies
       if: startsWith(matrix.os, 'ubuntu')
       run: sudo apt-get update; sudo apt-get install -y libcurl4-openssl-dev qpdf libgit2-dev libharfbuzz-dev libfribidi-dev libwebp-dev
@@ -81,10 +90,9 @@ jobs:
         python3 -m venv path/to/venv
         source path/to/venv/bin/activate
         python3 -m pip install .
-        Rscript -e 'install.packages(c("devtools", "remotes"), repos="https://cloud.r-project.org", Ncpus=8)'
+        Rscript -e 'install.packages(c("devtools", "remotes", "data.table", "caret", "glmnet", "Matrix", "rjson"), repos="https://cloud.r-project.org", Ncpus=64)'
         Rscript -e 'devtools::install_deps("R", dependencies=TRUE, repos="https://cloud.r-project.org", upgrade="default")'
         R CMD INSTALL R
-        Rscript -e 'install.packages(c("data.table", "caret", "glmnet", "Matrix", "rjson"), repos="https://cloud.r-project.org", Ncpus=8)'
 
     - name: Execute R tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,6 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: ${{ matrix.ver }}
-        cache: 'pip'
       env:
         PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
 
@@ -72,14 +71,6 @@ jobs:
       uses: r-lib/actions/setup-r@33f03a860e4659235eb60a4d87ebc0b2ea65f722 # v2.4.0
       with:
         r-version: ${{ matrix.ver }}
-
-    - name: Cache R packages
-      uses: actions/cache@v4
-      with:
-        path: ~/R/library
-        key: ${{ runner.os }}-r-${{ matrix.ver }}-${{ hashFiles('R/DESCRIPTION') }}
-        restore-keys: |
-          ${{ runner.os }}-r-${{ matrix.ver }}-
 
     - name: Install R ${{ matrix.ver }} system dependencies
       if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-64-cores
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest-64-cores]
         ver: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         include:
           - os: macos-latest
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest-64-cores]
         ver: ['4.4.1']
 
     steps:
@@ -73,7 +73,7 @@ jobs:
         r-version: ${{ matrix.ver }}
 
     - name: Install R ${{ matrix.ver }} system dependencies
-      if: matrix.os == 'ubuntu-22.04'
+      if: startsWith(matrix.os, 'ubuntu')
       run: sudo apt-get update; sudo apt-get install -y libcurl4-openssl-dev qpdf libgit2-dev libharfbuzz-dev libfribidi-dev libwebp-dev
 
     - name: Install R ${{ matrix.ver }} Rlang dependencies

--- a/test_runner
+++ b/test_runner
@@ -16,7 +16,7 @@ install_extensions() {
 }
 
 run_tests() {
-  cd test/core && PYTHONPATH=`pwd`/../../ python3 run_tests.py --num-parallel 8 && cd ../../
+  cd test/core && PYTHONPATH=`pwd`/../../ python3 run_tests.py --num-parallel 64 && cd ../../
 }
 
 # We run realtime cards tests separately because there these tests validate the asynchronous updates to the
@@ -24,7 +24,7 @@ run_tests() {
 # surely fail since a lot of checks have timeouts. 
 run_runtime_card_tests() {
   CARD_GRAPHS="small-foreach,small-parallel,nested-branches,single-linear-step,simple-foreach"
-  cd test/core && PYTHONPATH=`pwd`/../../ python3 run_tests.py --num-parallel 8 --contexts python3-all-local-cards-realtime --graphs $CARD_GRAPHS && cd ../../
+  cd test/core && PYTHONPATH=`pwd`/../../ python3 run_tests.py --num-parallel 64 --contexts python3-all-local-cards-realtime --graphs $CARD_GRAPHS && cd ../../
 }
 
 install_deps && install_extensions && run_tests && run_runtime_card_tests


### PR DESCRIPTION
## Summary
Speed up CI by using larger runners and optimizing test parallelism.

### Changes
- **64-core runners**: Switch all CI jobs from `ubuntu-22.04` to `ubuntu-latest-64-cores` (64 vCPU, 256 GB RAM)
- **Test parallelism**: Bump `--num-parallel` from 8 to 64 in `test_runner` to match available cores
- **R install consolidation**: Merge two `install.packages` calls into one with `Ncpus=64`
- **Runner condition fix**: Update R system deps `if` to use `startsWith(matrix.os, 'ubuntu')` for new runner name

## Test plan
- [ ] Verify all Python test matrices pass on 64-core runners
- [ ] Verify R tests pass with consolidated installs
- [ ] Compare CI run times vs previous runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)