### PR TITLE
fix remove_decorator return value when removing all matches

### DIFF
--- a/metaflow/user_decorators/mutable_step.py
+++ b/metaflow/user_decorators/mutable_step.py
@@ -371,6 +371,7 @@ class MutableStep:
                 for deco in getattr(self._my_step, attr):
                     if deco.decorator_name == canonical_deco_type.decorator_name:
                         if do_all:
+                            did_remove = True
                             continue  # We remove all decorators with this name
                         if deco.get_args_kwargs() == (
                             deco_args or [],
@@ -399,6 +400,7 @@ class MutableStep:
         for deco in self._my_step.decorators:
             if deco.name == deco_name:
                 if do_all:
+                    did_remove = True
                     continue  # We remove all decorators with this name
                 # Check if the decorator specification matches
                 if deco.get_args_kwargs() == (deco_args, deco_kwargs):

--- a/test/unit/test_remove_decorator.py
+++ b/test/unit/test_remove_decorator.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+from metaflow.user_decorators.mutable_step import MutableStep
+from metaflow.user_decorators.user_step_decorator import UserStepDecoratorBase
+
+
+class DummyStepDecorator:
+    def __init__(self, name):
+        self.name = name
+
+    def get_args_kwargs(self):
+        return [], {}
+
+
+def test_remove_decorator(monkeypatch):
+    step = MutableStep.__new__(MutableStep)
+    step._pre_mutate = True
+    step._inserted_by = "test"
+    step._my_step = SimpleNamespace(
+        name="my_step",
+        decorators=[
+            DummyStepDecorator("retry"),
+            DummyStepDecorator("retry"),
+        ],
+        wrappers=[],
+        config_decorators=[],
+    )
+
+    monkeypatch.setattr(
+        UserStepDecoratorBase,
+        "get_decorator_by_name",
+        staticmethod(lambda _: object),
+    )
+
+    removed = step.remove_decorator("retry")
+
+    assert step._my_step.decorators == []
+    assert removed is True


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [ ] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

<!-- What user-visible behavior changes? 1-2 sentences. -->

## Issue

<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes #

## Reproduction

<!-- Required for bug fixes. Required for Core Runtime changes. -->
<!-- Provide a minimal reproduction that fails before and succeeds after. -->

**Runtime:** <!-- local / kubernetes / batch / argo / etc. -->

**Commands to run:**
```bash
# paste exact commands
```

**Where evidence shows up:** <!-- parent console / task logs / metadata / UI -->

<details>
<summary>Before (error / log snippet)</summary>

```
paste here
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
paste here
```

</details>

## Root Cause

<!-- Required for Core Runtime. Recommended for all bug fixes. -->
<!-- Explain the causal chain: what invariant was violated, where in the code. -->
<!-- See PRs #2796, #2751, #2714 for examples of the level of detail we're looking for. -->

## Why This Fix Is Correct

<!-- What invariant is restored? Why is the fix minimal? -->

## Failure Modes Considered

<!-- Required for Core Runtime (at least 2). Recommended for all bug fixes. -->
<!-- Examples: concurrency/retries, subprocess output propagation, env-var leakage, backward compat -->

1.
2.

## Tests

- [ ] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

<!-- What you intentionally did not change. Helps reviewers scope their review. -->

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [ ] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)

<!-- If you used AI tools:
- Which tool(s)?
- What did you use them for?
- Did you review, understand, and test all generated code?
-->
