### PR TITLE
Fix: avoid unresolved conditional branches in Argo input-paths

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -1353,6 +1353,7 @@ class ArgoWorkflows(object):
                                 "argo-{{workflow.name}}/%s/{{tasks.%s.outputs.parameters.task-id}}"
                                 % (n, self._sanitize(n))
                                 for n in node.in_funcs
+                                if not self._is_conditional_node(self.graph[n])
                             ],
                             # NOTE: We set zlibmin to infinite because zlib compression for the Argo input-paths breaks template value substitution.
                             zlibmin=inf,


### PR DESCRIPTION
Fixes unresolved task references in Argo input paths when using conditionl branches

Previously all upstream branches (node.in_funcs) were included unconditionally in input paths With newer Argo ReplaceStrict behavior this leads to failures when skipped branches are referenced
This change filters out conditional nodes while constructing input-paths, avoiding references to branches that may not execute.
This is an initial fix and I woiuld be happy to iterate further based on feedback
Note This approach filters conditional nodes as an initial safeguard, though a more comprehensive handling of conditional joins may be needed