### PR TITLE
fix(core):prevent fatal Windows initialization crashes from POSIX-only imports

### DIFF
--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -1,6 +1,9 @@
 import copy
 import errno
-import fcntl
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 import functools
 import io
 import json

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -535,7 +535,8 @@ class CondaEnvironment(MetaflowEnvironment):
                 raise
         with os.fdopen(os.open(path, os.O_RDWR | os.O_CREAT), "r+") as f:
             try:
-                fcntl.flock(f, fcntl.LOCK_EX)
+                if fcntl is not None:
+                    fcntl.flock(f, fcntl.LOCK_EX)
                 d = {}
                 if os.path.getsize(path) > 0:
                     f.seek(0)
@@ -552,7 +553,8 @@ class CondaEnvironment(MetaflowEnvironment):
                 if e.errno != errno.EAGAIN:
                     raise
             finally:
-                fcntl.flock(f, fcntl.LOCK_UN)
+                if fcntl is not None:
+                    fcntl.flock(f, fcntl.LOCK_UN)
 
 
 class LazyOpen(BufferedIOBase):

--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -66,6 +66,9 @@ def temporary_fifo() -> ContextManager[Tuple[str, int]]:
     int
         File descriptor of the temporary FIFO.
     """
+    import sys
+    if sys.platform == "win32":
+        raise NotImplementedError("FIFO (Named Pipes) are not supported natively on Windows.")
     with tempfile.TemporaryDirectory() as temp_dir:
         path = os.path.join(temp_dir, "fifo")
         os.mkfifo(path)

--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -4,7 +4,10 @@ import time
 import asyncio
 import tempfile
 import select
-import fcntl
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 from contextlib import contextmanager
 from subprocess import CalledProcessError
 from typing import Any, Dict, TYPE_CHECKING, ContextManager, Tuple

--- a/metaflow/sidecar/sidecar_subprocess.py
+++ b/metaflow/sidecar/sidecar_subprocess.py
@@ -1,14 +1,23 @@
 from __future__ import print_function
 
 import subprocess
-import fcntl
+try:
+    import fcntl
+    from fcntl import F_SETFL, F_GETFL
+except ImportError:
+    fcntl = None
+    F_SETFL = None
+    F_GETFL = None
 import select
 import os
 import sys
 import platform
 
-from fcntl import F_SETFL
-from os import O_NONBLOCK
+
+try:
+    from os import O_NONBLOCK
+except ImportError:
+    O_NONBLOCK = None
 
 from .sidecar_messages import Message, MessageTypes
 from ..debug import debug

--- a/metaflow/sidecar/sidecar_subprocess.py
+++ b/metaflow/sidecar/sidecar_subprocess.py
@@ -7,7 +7,6 @@ try:
 except ImportError:
     fcntl = None
     F_SETFL = None
-    F_GETFL = None
 import select
 import os
 import sys
@@ -94,6 +93,11 @@ class SidecarSubProcess(object):
             self._poller = NullPoller()
             self._process = None
             self._logger("No sidecar started")
+        elif sys.platform == "win32":
+            # Fast-fail on Windows to prevent POSIX-only select.poll and fcntl.fcntl crashes
+            self._poller = NullPoller()
+            self._process = None
+            self._logger("Sidecars are not supported on Windows.")
         else:
             self._starting = True
             from select import poll


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Fixes fatal `ModuleNotFoundError` and `ImportError` crashes on Windows caused by unconditional POSIX-only imports (`fcntl`, `os.O_NONBLOCK`). This allows the Metaflow core engine, test suite, and local developer environment to successfully initialize on `win32` systems without throwing immediate collection errors.

## Issue

Fixes # N/A (Discovered independently during local Windows developer setup)

## Reproduction

1. Clone the repository on a native Windows machine (`win32`).
2. Install developer dependencies: `pip install -e ".[dev]"`
3. Attempt to run the test suite: `python -m pytest test/unit/`
4. Observe the immediate fatal collection errors: `ModuleNotFoundError: No module named 'fcntl'` originating from `sidecar_subprocess.py`, `conda_environment.py`, and `runner/utils.py`.

## Solution

Wrapped the POSIX-only imports (`fcntl`, `F_SETFL`, and `os.O_NONBLOCK`) in standard `try/except ImportError` blocks. This allows the modules to safely initialize on Windows without crashing the core Metaflow import tree, while preserving native behavior on macOS/Linux.

*(Note: Caught this infrastructure bug while setting up my local environment to familiarize myself with the codebase ahead of the GSoC 2026 deadline for the Kubernetes Integration CI project).*