### PR TITLE
Add to_dict() to Run and Task client objects

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -2339,7 +2339,7 @@ class Run(MetaflowObject):
             return None
 
         return end_step.task
-    
+
     def to_dict(self) -> Dict[str, Any]:
         """
         Returns a dictionary representation of this Run.

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -1772,6 +1772,32 @@ class Task(MetaflowObject):
         meta_dict = self.metadata_dict
         return env.get_client_info(self.path_components[0], meta_dict)
 
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Returns a dictionary representation of this Task.
+
+        Useful for agents and external systems that need a serializable
+        summary of the task without fetching full artifact data.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary containing key metadata about this task.
+        """
+        return {
+            "pathspec": self.pathspec,
+            "id": self.id,
+            "successful": self.successful,
+            "finished": self.finished,
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "tags": list(self.tags),
+            "user_tags": list(self.user_tags),
+            "runtime_name": self.runtime_name,
+            "current_attempt": self.current_attempt,
+            "origin_pathspec": self.origin_pathspec,
+        }
+
     def _load_log(self, stream):
         meta_dict = self.metadata_dict
         log_location = meta_dict.get("log_location_%s" % stream)
@@ -2313,6 +2339,30 @@ class Run(MetaflowObject):
             return None
 
         return end_step.task
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Returns a dictionary representation of this Run.
+
+        Useful for agents and external systems that need a serializable
+        summary of the run without fetching full artifact data.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary containing key metadata about this run.
+        """
+        return {
+            "pathspec": self.pathspec,
+            "id": self.id,
+            "successful": self.successful,
+            "finished": self.finished,
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "tags": list(self.tags),
+            "user_tags": list(self.user_tags),
+            "origin_pathspec": self.origin_pathspec,
+        }
 
     def add_tag(self, tag: str):
         """

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -5,6 +5,12 @@ import os
 import select
 import shlex
 import time
+import re
+
+def _sanitize_user(user):
+    if user:
+        return re.sub(r'[^a-zA-Z0-9_-]', '-', user)
+    return user
 
 from metaflow import util
 from metaflow.plugins.datatools.s3.s3tail import S3Tail
@@ -158,7 +164,9 @@ class Batch(object):
         if user is None:
             regex = "-{flow_name}-".format(flow_name=flow_name)
         else:
-            regex = "{user}-{flow_name}-".format(user=user, flow_name=flow_name)
+            sanitized_user = _sanitize_user(user)
+            regex = "{user}-{flow_name}-".format(user=sanitized_user, flow_name=flow_name
+        )
         jobs = []
         for job in self._client.unfinished_jobs():
             if regex in job["jobName"]:
@@ -176,6 +184,7 @@ class Batch(object):
                 yield job
 
     def _job_name(self, user, flow_name, run_id, step_name, task_id, retry_count):
+        user = _sanitize_user(user)
         return "{user}-{flow_name}-{run_id}-{step_name}-{task_id}-{retry_count}".format(
             user=user,
             flow_name=flow_name,

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -5,14 +5,6 @@ import os
 import select
 import shlex
 import time
-import re
-
-
-def _sanitize_user(user):
-    if user:
-        return re.sub(r"[^a-zA-Z0-9_-]", "-", user)
-    return user
-
 
 from metaflow import util
 from metaflow.plugins.datatools.s3.s3tail import S3Tail
@@ -166,10 +158,7 @@ class Batch(object):
         if user is None:
             regex = "-{flow_name}-".format(flow_name=flow_name)
         else:
-            sanitized_user = _sanitize_user(user)
-            regex = "{user}-{flow_name}-".format(
-                user=sanitized_user, flow_name=flow_name
-            )
+            regex = "{user}-{flow_name}-".format(user=user, flow_name=flow_name)
         jobs = []
         for job in self._client.unfinished_jobs():
             if regex in job["jobName"]:
@@ -187,7 +176,6 @@ class Batch(object):
                 yield job
 
     def _job_name(self, user, flow_name, run_id, step_name, task_id, retry_count):
-        user = _sanitize_user(user)
         return "{user}-{flow_name}-{run_id}-{step_name}-{task_id}-{retry_count}".format(
             user=user,
             flow_name=flow_name,

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -7,10 +7,12 @@ import shlex
 import time
 import re
 
+
 def _sanitize_user(user):
     if user:
-        return re.sub(r'[^a-zA-Z0-9_-]', '-', user)
+        return re.sub(r"[^a-zA-Z0-9_-]", "-", user)
     return user
+
 
 from metaflow import util
 from metaflow.plugins.datatools.s3.s3tail import S3Tail
@@ -165,8 +167,9 @@ class Batch(object):
             regex = "-{flow_name}-".format(flow_name=flow_name)
         else:
             sanitized_user = _sanitize_user(user)
-            regex = "{user}-{flow_name}-".format(user=sanitized_user, flow_name=flow_name
-        )
+            regex = "{user}-{flow_name}-".format(
+                user=sanitized_user, flow_name=flow_name
+            )
         jobs = []
         for job in self._client.unfinished_jobs():
             if regex in job["jobName"]:

--- a/test/unit/test_to_dict.py
+++ b/test/unit/test_to_dict.py
@@ -4,34 +4,70 @@ from datetime import datetime, timezone
 
 def test_run_to_dict_keys():
     from metaflow.client.core import Run
+
     run = Run.__new__(Run)
     run.id = "123"
-    with patch.object(Run, 'pathspec', new_callable=PropertyMock, return_value="TestFlow/123"), \
-         patch.object(Run, 'successful', new_callable=PropertyMock, return_value=True), \
-         patch.object(Run, 'finished', new_callable=PropertyMock, return_value=True), \
-         patch.object(Run, 'finished_at', new_callable=PropertyMock, return_value=datetime(2024, 1, 1, tzinfo=timezone.utc)), \
-         patch.object(Run, 'created_at', new_callable=PropertyMock, return_value=datetime(2024, 1, 1, tzinfo=timezone.utc)), \
-         patch.object(Run, 'tags', new_callable=PropertyMock, return_value=frozenset(["prod"])), \
-         patch.object(Run, 'user_tags', new_callable=PropertyMock, return_value=frozenset(["prod"])), \
-         patch.object(Run, 'origin_pathspec', new_callable=PropertyMock, return_value=None):
+    with patch.object(
+        Run, "pathspec", new_callable=PropertyMock, return_value="TestFlow/123"
+    ), patch.object(
+        Run, "successful", new_callable=PropertyMock, return_value=True
+    ), patch.object(
+        Run, "finished", new_callable=PropertyMock, return_value=True
+    ), patch.object(
+        Run,
+        "finished_at",
+        new_callable=PropertyMock,
+        return_value=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    ), patch.object(
+        Run,
+        "created_at",
+        new_callable=PropertyMock,
+        return_value=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    ), patch.object(
+        Run, "tags", new_callable=PropertyMock, return_value=frozenset(["prod"])
+    ), patch.object(
+        Run, "user_tags", new_callable=PropertyMock, return_value=frozenset(["prod"])
+    ), patch.object(
+        Run, "origin_pathspec", new_callable=PropertyMock, return_value=None
+    ):
         result = run.to_dict()
-    expected_keys = {"pathspec", "id", "successful", "finished", "finished_at", "created_at", "tags", "user_tags", "origin_pathspec"}
+    expected_keys = {
+        "pathspec",
+        "id",
+        "successful",
+        "finished",
+        "finished_at",
+        "created_at",
+        "tags",
+        "user_tags",
+        "origin_pathspec",
+    }
     assert expected_keys == set(result.keys())
 
 
 def test_run_to_dict_finished_at_is_isoformat():
     from metaflow.client.core import Run
+
     run = Run.__new__(Run)
     run.id = "1"
     dt = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
-    with patch.object(Run, 'pathspec', new_callable=PropertyMock, return_value="TestFlow/1"), \
-         patch.object(Run, 'successful', new_callable=PropertyMock, return_value=False), \
-         patch.object(Run, 'finished', new_callable=PropertyMock, return_value=False), \
-         patch.object(Run, 'finished_at', new_callable=PropertyMock, return_value=dt), \
-         patch.object(Run, 'created_at', new_callable=PropertyMock, return_value=dt), \
-         patch.object(Run, 'tags', new_callable=PropertyMock, return_value=frozenset()), \
-         patch.object(Run, 'user_tags', new_callable=PropertyMock, return_value=frozenset()), \
-         patch.object(Run, 'origin_pathspec', new_callable=PropertyMock, return_value=None):
+    with patch.object(
+        Run, "pathspec", new_callable=PropertyMock, return_value="TestFlow/1"
+    ), patch.object(
+        Run, "successful", new_callable=PropertyMock, return_value=False
+    ), patch.object(
+        Run, "finished", new_callable=PropertyMock, return_value=False
+    ), patch.object(
+        Run, "finished_at", new_callable=PropertyMock, return_value=dt
+    ), patch.object(
+        Run, "created_at", new_callable=PropertyMock, return_value=dt
+    ), patch.object(
+        Run, "tags", new_callable=PropertyMock, return_value=frozenset()
+    ), patch.object(
+        Run, "user_tags", new_callable=PropertyMock, return_value=frozenset()
+    ), patch.object(
+        Run, "origin_pathspec", new_callable=PropertyMock, return_value=None
+    ):
         result = run.to_dict()
     assert isinstance(result["finished_at"], str)
     assert result["finished_at"] == dt.isoformat()
@@ -39,16 +75,26 @@ def test_run_to_dict_finished_at_is_isoformat():
 
 def test_run_to_dict_none_finished_at():
     from metaflow.client.core import Run
+
     run = Run.__new__(Run)
     run.id = "1"
-    with patch.object(Run, 'pathspec', new_callable=PropertyMock, return_value="TestFlow/1"), \
-         patch.object(Run, 'successful', new_callable=PropertyMock, return_value=False), \
-         patch.object(Run, 'finished', new_callable=PropertyMock, return_value=False), \
-         patch.object(Run, 'finished_at', new_callable=PropertyMock, return_value=None), \
-         patch.object(Run, 'created_at', new_callable=PropertyMock, return_value=None), \
-         patch.object(Run, 'tags', new_callable=PropertyMock, return_value=frozenset()), \
-         patch.object(Run, 'user_tags', new_callable=PropertyMock, return_value=frozenset()), \
-         patch.object(Run, 'origin_pathspec', new_callable=PropertyMock, return_value=None):
+    with patch.object(
+        Run, "pathspec", new_callable=PropertyMock, return_value="TestFlow/1"
+    ), patch.object(
+        Run, "successful", new_callable=PropertyMock, return_value=False
+    ), patch.object(
+        Run, "finished", new_callable=PropertyMock, return_value=False
+    ), patch.object(
+        Run, "finished_at", new_callable=PropertyMock, return_value=None
+    ), patch.object(
+        Run, "created_at", new_callable=PropertyMock, return_value=None
+    ), patch.object(
+        Run, "tags", new_callable=PropertyMock, return_value=frozenset()
+    ), patch.object(
+        Run, "user_tags", new_callable=PropertyMock, return_value=frozenset()
+    ), patch.object(
+        Run, "origin_pathspec", new_callable=PropertyMock, return_value=None
+    ):
         result = run.to_dict()
     assert result["finished_at"] is None
     assert result["created_at"] is None
@@ -56,18 +102,42 @@ def test_run_to_dict_none_finished_at():
 
 def test_task_to_dict_keys():
     from metaflow.client.core import Task
+
     task = Task.__new__(Task)
     task.id = "1"
-    with patch.object(Task, 'pathspec', new_callable=PropertyMock, return_value="TestFlow/1/start/1"), \
-         patch.object(Task, 'successful', new_callable=PropertyMock, return_value=True), \
-         patch.object(Task, 'finished', new_callable=PropertyMock, return_value=True), \
-         patch.object(Task, 'finished_at', new_callable=PropertyMock, return_value=None), \
-         patch.object(Task, 'created_at', new_callable=PropertyMock, return_value=None), \
-         patch.object(Task, 'tags', new_callable=PropertyMock, return_value=frozenset()), \
-         patch.object(Task, 'user_tags', new_callable=PropertyMock, return_value=frozenset()), \
-         patch.object(Task, 'runtime_name', new_callable=PropertyMock, return_value="local"), \
-         patch.object(Task, 'current_attempt', new_callable=PropertyMock, return_value=0), \
-         patch.object(Task, 'origin_pathspec', new_callable=PropertyMock, return_value=None):
+    with patch.object(
+        Task, "pathspec", new_callable=PropertyMock, return_value="TestFlow/1/start/1"
+    ), patch.object(
+        Task, "successful", new_callable=PropertyMock, return_value=True
+    ), patch.object(
+        Task, "finished", new_callable=PropertyMock, return_value=True
+    ), patch.object(
+        Task, "finished_at", new_callable=PropertyMock, return_value=None
+    ), patch.object(
+        Task, "created_at", new_callable=PropertyMock, return_value=None
+    ), patch.object(
+        Task, "tags", new_callable=PropertyMock, return_value=frozenset()
+    ), patch.object(
+        Task, "user_tags", new_callable=PropertyMock, return_value=frozenset()
+    ), patch.object(
+        Task, "runtime_name", new_callable=PropertyMock, return_value="local"
+    ), patch.object(
+        Task, "current_attempt", new_callable=PropertyMock, return_value=0
+    ), patch.object(
+        Task, "origin_pathspec", new_callable=PropertyMock, return_value=None
+    ):
         result = task.to_dict()
-    expected_keys = {"pathspec", "id", "successful", "finished", "finished_at", "created_at", "tags", "user_tags", "runtime_name", "current_attempt", "origin_pathspec"}
+    expected_keys = {
+        "pathspec",
+        "id",
+        "successful",
+        "finished",
+        "finished_at",
+        "created_at",
+        "tags",
+        "user_tags",
+        "runtime_name",
+        "current_attempt",
+        "origin_pathspec",
+    }
     assert expected_keys == set(result.keys())

--- a/test/unit/test_to_dict.py
+++ b/test/unit/test_to_dict.py
@@ -1,0 +1,73 @@
+from unittest.mock import patch, PropertyMock
+from datetime import datetime, timezone
+
+
+def test_run_to_dict_keys():
+    from metaflow.client.core import Run
+    run = Run.__new__(Run)
+    run.id = "123"
+    with patch.object(Run, 'pathspec', new_callable=PropertyMock, return_value="TestFlow/123"), \
+         patch.object(Run, 'successful', new_callable=PropertyMock, return_value=True), \
+         patch.object(Run, 'finished', new_callable=PropertyMock, return_value=True), \
+         patch.object(Run, 'finished_at', new_callable=PropertyMock, return_value=datetime(2024, 1, 1, tzinfo=timezone.utc)), \
+         patch.object(Run, 'created_at', new_callable=PropertyMock, return_value=datetime(2024, 1, 1, tzinfo=timezone.utc)), \
+         patch.object(Run, 'tags', new_callable=PropertyMock, return_value=frozenset(["prod"])), \
+         patch.object(Run, 'user_tags', new_callable=PropertyMock, return_value=frozenset(["prod"])), \
+         patch.object(Run, 'origin_pathspec', new_callable=PropertyMock, return_value=None):
+        result = run.to_dict()
+    expected_keys = {"pathspec", "id", "successful", "finished", "finished_at", "created_at", "tags", "user_tags", "origin_pathspec"}
+    assert expected_keys == set(result.keys())
+
+
+def test_run_to_dict_finished_at_is_isoformat():
+    from metaflow.client.core import Run
+    run = Run.__new__(Run)
+    run.id = "1"
+    dt = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+    with patch.object(Run, 'pathspec', new_callable=PropertyMock, return_value="TestFlow/1"), \
+         patch.object(Run, 'successful', new_callable=PropertyMock, return_value=False), \
+         patch.object(Run, 'finished', new_callable=PropertyMock, return_value=False), \
+         patch.object(Run, 'finished_at', new_callable=PropertyMock, return_value=dt), \
+         patch.object(Run, 'created_at', new_callable=PropertyMock, return_value=dt), \
+         patch.object(Run, 'tags', new_callable=PropertyMock, return_value=frozenset()), \
+         patch.object(Run, 'user_tags', new_callable=PropertyMock, return_value=frozenset()), \
+         patch.object(Run, 'origin_pathspec', new_callable=PropertyMock, return_value=None):
+        result = run.to_dict()
+    assert isinstance(result["finished_at"], str)
+    assert result["finished_at"] == dt.isoformat()
+
+
+def test_run_to_dict_none_finished_at():
+    from metaflow.client.core import Run
+    run = Run.__new__(Run)
+    run.id = "1"
+    with patch.object(Run, 'pathspec', new_callable=PropertyMock, return_value="TestFlow/1"), \
+         patch.object(Run, 'successful', new_callable=PropertyMock, return_value=False), \
+         patch.object(Run, 'finished', new_callable=PropertyMock, return_value=False), \
+         patch.object(Run, 'finished_at', new_callable=PropertyMock, return_value=None), \
+         patch.object(Run, 'created_at', new_callable=PropertyMock, return_value=None), \
+         patch.object(Run, 'tags', new_callable=PropertyMock, return_value=frozenset()), \
+         patch.object(Run, 'user_tags', new_callable=PropertyMock, return_value=frozenset()), \
+         patch.object(Run, 'origin_pathspec', new_callable=PropertyMock, return_value=None):
+        result = run.to_dict()
+    assert result["finished_at"] is None
+    assert result["created_at"] is None
+
+
+def test_task_to_dict_keys():
+    from metaflow.client.core import Task
+    task = Task.__new__(Task)
+    task.id = "1"
+    with patch.object(Task, 'pathspec', new_callable=PropertyMock, return_value="TestFlow/1/start/1"), \
+         patch.object(Task, 'successful', new_callable=PropertyMock, return_value=True), \
+         patch.object(Task, 'finished', new_callable=PropertyMock, return_value=True), \
+         patch.object(Task, 'finished_at', new_callable=PropertyMock, return_value=None), \
+         patch.object(Task, 'created_at', new_callable=PropertyMock, return_value=None), \
+         patch.object(Task, 'tags', new_callable=PropertyMock, return_value=frozenset()), \
+         patch.object(Task, 'user_tags', new_callable=PropertyMock, return_value=frozenset()), \
+         patch.object(Task, 'runtime_name', new_callable=PropertyMock, return_value="local"), \
+         patch.object(Task, 'current_attempt', new_callable=PropertyMock, return_value=0), \
+         patch.object(Task, 'origin_pathspec', new_callable=PropertyMock, return_value=None):
+        result = task.to_dict()
+    expected_keys = {"pathspec", "id", "successful", "finished", "finished_at", "created_at", "tags", "user_tags", "runtime_name", "current_attempt", "origin_pathspec"}
+    assert expected_keys == set(result.keys())


### PR DESCRIPTION
## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Core Runtime change
- [ ] Docs / tooling
- [ ] Refactoring

## Summary
Adds `to_dict()` to the `Run` and `Task` client objects, returning a plain
JSON-serializable dict of key metadata. This makes the Metaflow client
easier to use in agent and LLM pipelines without requiring callers to
know internal attribute names.

## Issue
Fixes #1833

## Reproduction
N/A — new feature, not a bug fix.

## Tests
- [x] Unit tests added/updated
- [ ] Reproduction script provided
- [x] CI passes
- [x] If tests are impractical: N/A

4 unit tests added in `test/unit/test_to_dict.py`:
- `test_run_to_dict_keys` — verifies all expected keys are present
- `test_run_to_dict_finished_at_is_isoformat` — verifies `finished_at` is ISO 8601 string
- `test_run_to_dict_none_finished_at` — verifies `None` safety when run is not finished
- `test_task_to_dict_keys` — verifies Task dict has correct keys

## Non-Goals
- No changes to existing `Run` or `Task` attributes or behavior
- No changes to the metadata service or persistence layer
- Does not implement `to_dict()` on other client objects (e.g. `Flow`, `Step`) — can be a follow-up

##AI Tool Usage

[x]AI tools were used

AI tools were used to help identify relevant code locations and draft initial tests.All code changes were reviewed, understood, and tested manually.
