### PR TITLE
Quality: Ensure stdout/stderr flushing

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -3,6 +3,22 @@ import sys
 import types
 import uuid
 import datetime
+import sys
+
+class FlushStream:
+    def __init__(self, stream):
+        self.stream = stream
+    def write(self, data):
+        self.stream.write(data)
+        self.stream.flush()
+    def flush(self):
+        self.stream.flush()
+    def __getattr__(self, attr):
+        return getattr(self.stream, attr)
+
+if not getattr(sys.stdout, 'isatty', lambda: False)():
+    sys.stdout = FlushStream(sys.stdout)
+    sys.stderr = FlushStream(sys.stderr)
 
 from typing import Dict, List, Union, Tuple as TTuple
 from metaflow.exception import MetaflowException


### PR DESCRIPTION
## ✨ Code Quality

### Problem
Modify the logging configuration or the stream wrapper initialization to ensure that stdout and stderr are unbuffered or flushed frequently, preventing the delay in log output reported in issue #166.

**Severity**: `medium`
**File**: `metaflow/metaflow_config.py`

### Solution
Add a configuration flag or ensure that the `sys.stdout` and `sys.stderr` are wrapped in a custom stream object that calls `.flush()` after every write operation, or specifically after encountering a newline character.

### Changes
- `metaflow/metaflow_config.py` (modified)

## PR Type



- [ ] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [x] Refactoring

## Summary



## Issue



Fixes #

## Reproduction




**Runtime:** 

**Commands to run:**
```bash
# paste exact commands
```

**Where evidence shows up:** 

<details>
<summary>Before (error / log snippet)</summary>

```
paste here
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
paste here
```

</details>

## Root Cause





## Why This Fix Is Correct



## Failure Modes Considered




1.
2.

## Tests

- [ ] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals



## AI Tool Usage



- [ ] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)



---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>
