### PR TITLE
Feature: Add cache clearing functionality for configuration

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -31,6 +31,7 @@ from metaflow.exception import (
 )
 from metaflow.includefile import IncludedFile
 from metaflow.metaflow_config import DEFAULT_METADATA, MAX_ATTEMPTS
+from metaflow.metaflow_config_funcs import reset_config_cache
 from metaflow.metaflow_environment import MetaflowEnvironment
 from metaflow.package import MetaflowPackage
 from metaflow.packaging_sys import ContentType

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -6,7 +6,7 @@ import datetime
 
 from typing import Dict, List, Union, Tuple as TTuple
 from metaflow.exception import MetaflowException
-from metaflow.metaflow_config_funcs import from_conf, get_validate_choice_fn
+from metaflow.metaflow_config_funcs import from_conf, get_validate_choice_fn, reset_config_cache
 
 # Recursive type alias for JSON, used by Runner API type mappings
 JSON = Union[Dict[str, "JSON"], List["JSON"], str, int, float, bool, None]

--- a/metaflow/metaflow_config_funcs.py
+++ b/metaflow/metaflow_config_funcs.py
@@ -70,6 +70,13 @@ METAFLOW_LOCAL_CONFIG = None
 _all_configs = {}
 
 
+def reset_config_cache():
+    global METAFLOW_CONFIG, METAFLOW_LOCAL_CONFIG, _all_configs
+    METAFLOW_CONFIG = None
+    METAFLOW_LOCAL_CONFIG = None
+    _all_configs = {}
+
+
 def config_values(include=0):
     # By default, we just return non-null values and that
     # are not default. This is the common use case because in all other cases, the code


### PR DESCRIPTION
## 🚀 New Feature

### Problem
The configuration loader caches results in global variables. We need a way to invalidate these caches so that `metaflow_config` can be re-evaluated when the profile changes.

**Severity**: `high`
**File**: `metaflow/metaflow_config_funcs.py`

### Solution
Add a function `reset_config_cache()` that sets `METAFLOW_CONFIG`, `METAFLOW_LOCAL_CONFIG`, and `_all_configs` to `None` or empty dictionaries.

### Changes
- `metaflow/metaflow_config_funcs.py` (modified)
- `metaflow/metaflow_config.py` (modified)
- `metaflow/client/core.py` (modified)

## PR Type



- [ ] Bug fix
- [x] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary



## Issue



Fixes #

## Reproduction




**Runtime:** 

**Commands to run:**
```bash
# paste exact commands
```

**Where evidence shows up:** 

<details>
<summary>Before (error / log snippet)</summary>

```
paste here
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
paste here
```

</details>

## Root Cause





## Why This Fix Is Correct



## Failure Modes Considered




1.
2.

## Tests

- [ ] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals



## AI Tool Usage



- [ ] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)



---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #2274