### PR TITLE
Normalize empty worker namespace in step commands

### DIFF
--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -122,7 +122,7 @@ def step(
     if ubf_context == "none":
         ubf_context = None
     if opt_namespace is not None:
-        namespace(opt_namespace)
+        namespace(opt_namespace or None)
 
     func = None
     try:
@@ -276,7 +276,7 @@ def spin_step(
         echo = echo_always
 
     if opt_namespace is not None:
-        namespace(opt_namespace)
+        namespace(opt_namespace or None)
 
     input_paths = decompress_list(input_paths) if input_paths else []
 

--- a/test/unit/spin/flows/global_namespace_flow.py
+++ b/test/unit/spin/flows/global_namespace_flow.py
@@ -1,0 +1,28 @@
+from metaflow import FlowSpec, Run, current, get_namespace, namespace, step
+
+# Reproduces the real user-facing scenario from #2734:
+# global namespace is selected at module scope.
+namespace(None)
+
+
+class GlobalNamespaceFlow(FlowSpec):
+    @step
+    def start(self):
+        # This client access is what regresses if the worker receives ""
+        # instead of None for the namespace.
+        self.worker_namespace = get_namespace()
+        self.resolved_run_pathspec = Run(
+            f"{current.flow_name}/{current.run_id}"
+        ).pathspec
+        self.next(self.end)
+
+    @step
+    def end(self):
+        self.worker_namespace = get_namespace()
+        self.resolved_run_pathspec = Run(
+            f"{current.flow_name}/{current.run_id}"
+        ).pathspec
+
+
+if __name__ == "__main__":
+    GlobalNamespaceFlow()

--- a/test/unit/spin/test_spin.py
+++ b/test/unit/spin/test_spin.py
@@ -147,6 +147,34 @@ def test_spin_with_parameters_raises_error(simple_parameter_run):
         ):
             pass
 
+def test_spin_preserves_global_namespace_end_to_end():
+      flow_path = os.path.join(FLOWS_DIR, "global_namespace_flow.py")
+
+      print(f"Running global namespace regression test for {flow_path}")
+
+      # First run the flow through the normal runtime path.
+      with Runner(flow_path, cwd=FLOWS_DIR).run() as running:
+          run = running.run
+          start_task = run["start"].task
+          end_task = run["end"].task
+
+          # These assertions fail before the fix because the worker-side client
+          # access raises a namespace mismatch.
+          assert start_task["worker_namespace"].data is None
+          assert start_task["resolved_run_pathspec"].data == run.pathspec
+          assert end_task["worker_namespace"].data is None
+          assert end_task["resolved_run_pathspec"].data == run.pathspec
+
+      # Then exercise the spin worker path as well.
+      with Runner(flow_path, cwd=FLOWS_DIR).spin(
+          start_task.pathspec,
+          persist=True,
+      ) as spin:
+          spin_task = spin.task
+          spin_run_pathspec = "/".join(spin_task.pathspec.split("/")[:2])
+
+          assert spin_task["worker_namespace"].data is None
+          assert spin_task["resolved_run_pathspec"].data == spin_run_pathspec
 
 # NOTE: This test has to be the last test because it modifies the metadata
 # provider when calling inspect_spin


### PR DESCRIPTION
Fixes #2734

## PR Type

- [x] Bug fix
- [ ] New feature
- [x] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring


## Summary

This fixes a namespace regression in the worker-side `step` and `spin_step` paths. When `namespace(None)` is used to select the global namespace, the worker could receive an empty string instead, which caused client access inside the worker to fail with `Object not in namespace ''`.

## Issue

Fixes #2734

## Reproduction

**Runtime:** local

**Commands to run:**
```bash
python -m pytest test/unit/spin/test_spin.py -v -k global_namespace

Where evidence shows up: parent console / task logs from the local runtime

<details>
<summary>Before (error / log snippet)</summary>
test/unit/spin/test_spin.py::test_spin_preserves_global_namespace_end_to_end FAILED
Running global namespace regression test for /mnt/c/Users/ASUS/Documents/
Projets_Personnel/metaflow/test/unit/spin/flows/global_namespace_flow.py
Metaflow 2.19.22-dirty executing GlobalNamespaceFlow for user:sahar Validating your flow...
    The graph looks good!
Running pylint...
    Pylint not found, so extra checks are disabled.
2026-03-30 14:13:10.524 Workflow starting (run-id 1774876390494017):
2026-03-30 14:13:10.932 [1774876390494017/start/1 (pid 949)] Task is starting.
2026-03-30 14:13:15.475 [1774876390494017/start/1 (pid 949)] <flow GlobalNamespaceFlow step start> failed:
2026-03-30 14:13:15.738 [1774876390494017/start/1 (pid 949)] Object not in the current namespace:
2026-03-30 14:13:15.773 [1774876390494017/start/1 (pid 949)] Object not in namespace ''
2026-03-30 14:13:15.785 [1774876390494017/start/1 (pid 949)] Task failed.
2026-03-30 14:13:15.800 Workflow failed.
</details>

<details>
<summary>After (evidence that fix works)</summary>
=========================== test session starts============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /mnt/c/
Users/ASUS/Documents/Projets_Personnel/metaflow/.venv/bin/python
cachedir: .pytest_cache
rootdir:/mnt/c/Users/ASUS/Documents/Projets_Personnel/metaflow
collected 13 items / 12 deselected / 1 selected
test/unit/spin/test_spin.py::test_spin_preserves_global_namespace_end_to_end PASSED [100%]
=============== 1 passed, 12 deselected, 1 warning in 24.81s ===============
</details>

```
## Root Cause

The runtime forwards the current namespace to worker-side commands in the step and spin-step paths using get_namespace() or "".
That preserves explicit namespaces, but it changes the meaning of the global namespace case. namespace(None) is intended to mean "no namespace
filtering", but once it reaches the worker as "", the worker-side code applies namespace(opt_namespace) and treats the empty string as a real namespace value instead of restoring None.
That breaks worker-side client access and leads to Object not in namespace ' ' .

 
 ## Why This Fix Is Correct

This change restores the intended behavior by normalizing the empty worker-side namespace value back to None.

The fix is intentionally small:
1- it keeps the runtime-side behavior unchanged
2- it normalizes the namespace only at the worker boundary
3- it applies the same fix in both step and spin_step

Explicit non-empty namespaces continue to behave the same way.


## Failure Modes Considered

1. Explicit namespaces should remain unchanged. This fix only affects the empty-value case and preserves non-empty namespace values as-is.
2. Both the normal runtime path and the spin path need to be covered. The regression test exercises both.


## Tests

- [x] Unit tests added/updated
- [x] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [x] If tests are impractical: explain why below and provide manual evidence above

Added an end-to-end regression test covering the real runtime and spin paths.

Executed:

python -m pytest test/unit/spin/test_spin.py -v -k global_namespace

I also ran:

python -m pytest test/unit/spin/test_spin.py -v

The full test_spin.py suite is blocked in my local environment by unrelated setup issues:
 - complex_dag_flow.py fails during conda/micromamba resolution because scikit-learn==1.3.0 is incompatible with Python 3.12 in that environment
  - test_card_flow requires pandas, which is not installed in my local environment


## Non-Goals

This PR does not change broader namespace handling in the runtime, client, or metadata layers. It only restores the intended worker-side behavior for the empty-value case in step and spin_step.

## AI Tool Usage

  - [ ] No AI tools were used in this contribution
  - [x] AI tools were used (describe below)

I used AI assistance during investigation and drafting. I reviewed, understood, and tested the final changes myself.