### PR TITLE
Fix 1007 current tags

### DIFF
--- a/metaflow/metaflow_current.py
+++ b/metaflow/metaflow_current.py
@@ -25,6 +25,7 @@ class Current(object):
         self._metadata_str = None
         self._is_running = False
         self._tempdir = TEMPDIR
+        self._tags = None
 
         def _raise(ex):
             raise ex

--- a/metaflow/metaflow_current.py
+++ b/metaflow/metaflow_current.py
@@ -263,13 +263,16 @@ class Current(object):
         return self._username
 
     @property
-    def tags(self):
+    def tags(self) -> frozenset:
         """
-        [Legacy function - do not use]
+        A set of tags assigned to the current run.
 
-        Access tags through the Run object instead.
+        Returns
+        -------
+        frozenset
+            Tags assigned to the run.
         """
-        return self._tags
+        return frozenset(self._tags) if self._tags else frozenset()
 
     @property
     def tempdir(self) -> Optional[str]:

--- a/metaflow/metaflow_current.py
+++ b/metaflow/metaflow_current.py
@@ -273,7 +273,7 @@ class Current(object):
         frozenset
             Tags assigned to the run.
         """
-        return frozenset(self._tags) if self._tags else frozenset()
+        return frozenset(self._tags) if self._tags is not None else frozenset()
 
     @property
     def tempdir(self) -> Optional[str]:

--- a/test/core/tests/current_singleton.py
+++ b/test/core/tests/current_singleton.py
@@ -80,7 +80,7 @@ class CurrentSingletonTest(MetaflowTest):
         self.seen_steps.add(current.step_name)
         self.uuid = str(uuid4())
         self.task_data[current.pathspec] = self.uuid
-        self.tags.update(current.tags)
+        self.tags |= current.tags
         self.task_obj = current.task
         self.run_obj = current.run
 
@@ -102,7 +102,7 @@ class CurrentSingletonTest(MetaflowTest):
         self.seen_steps.add(current.step_name)
         self.uuid = str(uuid4())
         self.task_data[current.pathspec] = self.uuid
-        self.tags.update(current.tags)
+        self.tags |= current.tags
         self.task_obj = current.task
         self.run_obj = current.run
 


### PR DESCRIPTION
## Summary
This PR enables flow logic to reliably introspect active execution tags by exposing the set of tags associated with the current run via the `current` singleton.

## Motivation and Context
Depending on the tags assigned to their run, users frequently have to conditionally execute logic within a step. It is not necessary to instantiate and query the Metaflow Client API mid-run if these tags are accessed natively within the `current` singleton state.

Fixes #1007 
## Modifications Made
- Made the `tags` property inside the `Current` class in `metaflow/metaflow_current.py` active instead of a deprecated legacy function.
- - Made sure that an immutable `frozenset` based on `self._tags` is strictly returned by the `tags` property.
## Testing
How these modifications were tested:
Because `frozenset` operations are completely compatible with the current `set` assertions, `test/core/tests/current_singleton.py` will continue to pass correctly.

*Note: Depends on Continuous Integration (CI) to run the entire `test` test suite against all supported Python versions.*