### PR TITLE
Fix: Handle empty string input in decompress_list() #3017

### DIFF
--- a/metaflow/util.py
+++ b/metaflow/util.py
@@ -383,6 +383,9 @@ def compress_list(lst, separator=",", rangedelim=":", zlibmarker="!", zlibmin=50
 
 
 def decompress_list(lststr, separator=",", rangedelim=":", zlibmarker="!"):
+    # Handle empty string - inverse of compress_list([]) which returns ""
+    if lststr == "":
+        return []
     # Three input modes:
     if lststr[0] == zlibmarker:
         # 3. zlib-compressed, base64-encoded

--- a/test/unit/test_compress_decompress_list.py
+++ b/test/unit/test_compress_decompress_list.py
@@ -1,4 +1,4 @@
-import pytest
+from metaflow.util import compress_list, decompress_list
 from metaflow.util import compress_list, decompress_list
 
 

--- a/test/unit/test_compress_decompress_list.py
+++ b/test/unit/test_compress_decompress_list.py
@@ -1,0 +1,36 @@
+import pytest
+from metaflow.util import compress_list, decompress_list
+
+
+def test_compress_empty_list():
+    """compress_list([]) should return empty string"""
+    result = compress_list([])
+    assert result == ""
+
+
+def test_decompress_empty_string():
+    """decompress_list("") should return empty list - this tests the fix for issue #3017"""
+    result = decompress_list("")
+    assert result == []
+
+
+def test_roundtrip_empty():
+    """Round-trip: decompress(compress([])) should return [] - tests the invariant"""
+    result = decompress_list(compress_list([]))
+    assert result == []
+
+
+def test_roundtrip_simple_list():
+    """Test round-trip with simple list"""
+    original = ["task1", "task2"]
+    compressed = compress_list(original)
+    decompressed = decompress_list(compressed)
+    assert decompressed == original
+
+
+def test_roundtrip_single_element():
+    """Test round-trip with single element"""
+    original = ["single_task"]
+    compressed = compress_list(original)
+    decompressed = decompress_list(compressed)
+    assert decompressed == original


### PR DESCRIPTION
Root Cause
decompress_list() at line 387 attempted to access lststr[0] without first checking if the input string was empty. While compress_list([]) legitimately returns an empty string "", the inverse function would crash when trying to check if that empty string started with a compression marker. This violated the fundamental invariant that these functions should be inverses of each other.

Why This Fix Is Correct
The fix adds a guard clause that returns an empty list when the input is an empty string, which is the correct inverse of compress_list([]) returning an empty string. The fix:

Restores the round-trip invariant: decompress_list(compress_list(x)) == x for all valid inputs
Is minimal (2 lines added)
Handles the edge case before accessing string indices
Maintains backward compatibility - no existing call sites are broken
Failure Modes Considered
Empty task lists in Argo workflows: If an Argo workflow produces an empty input_paths string (e.g., all paths filtered out by conditional logic), the function no longer crashes.

Round-trip invariant: Without the fix, decompress_list(compress_list([])) would crash. Now it correctly returns [], maintaining the mathematical property.

Tests
 Unit tests added/updated
 CI passes
 All 5 tests passing
Non-Goals
Did not change the three compression modes
Did not modify call sites
Fix is entirely in the utility function
Changes Made
metaflow/util.py (lines 387-388):

Added guard: if lststr == "": return []
test/unit/test_compress_decompress_list.py (new file):

5 comprehensive test cases for empty lists, empty strings, and round-trip invariant
Fix: Handle empty string input in decompress_list() #3017

Fix: Handle empty string input in decompress_list() #3017