### PR TITLE
fix: restore subclass dispatch for _apply_filter in ServiceMetadataProvider

### DIFF
--- a/metaflow/plugins/metadata_providers/service.py
+++ b/metaflow/plugins/metadata_providers/service.py
@@ -279,7 +279,7 @@ class ServiceMetadataProvider(MetadataProvider):
                 url = ServiceMetadataProvider._obj_path(*args[:obj_order])
             try:
                 v, _ = cls._request(None, url, "GET")
-                return MetadataProvider._apply_filter([v], filters)[0]
+                return cls._apply_filter([v], filters)[0]
             except ServiceException as ex:
                 if ex.http_code == 404:
                     return None
@@ -298,7 +298,7 @@ class ServiceMetadataProvider(MetadataProvider):
             url += "/%ss" % sub_type
         try:
             v, _ = cls._request(None, url, "GET")
-            return MetadataProvider._apply_filter(v, filters)
+            return cls._apply_filter(v, filters)
         except ServiceException as ex:
             if ex.http_code == 404:
                 return None

--- a/test/unit/test_service_metadata_provider.py
+++ b/test/unit/test_service_metadata_provider.py
@@ -1,0 +1,45 @@
+from metaflow.metadata_provider.metadata import ObjectOrder
+from metaflow.plugins.metadata_providers.service import ServiceMetadataProvider
+
+
+class FakeServiceMetadataProvider(ServiceMetadataProvider):
+    @classmethod
+    def _request(cls, monitor, path, method, data=None, headers=None):
+        if path.endswith("/runs/1"):
+            return {"flow_id": "Flow", "run_number": "1", "keep": True}, {}
+        return (
+            [
+                {"flow_id": "Flow", "run_number": "1", "keep": True},
+                {"flow_id": "Flow", "run_number": "2", "keep": False},
+            ],
+            {},
+        )
+
+    @staticmethod
+    def _apply_filter(elts, filters):
+        return [elt for elt in elts if elt.get("keep")]
+
+
+def test_service_metadata_provider_uses_subclass_apply_filter():
+    self_result = FakeServiceMetadataProvider._get_object_internal(
+        "run",
+        ObjectOrder.type_to_order("run"),
+        "self",
+        ObjectOrder.type_to_order("self"),
+        None,
+        None,
+        "Flow",
+        "1",
+    )
+    collection_result = FakeServiceMetadataProvider._get_object_internal(
+        "flow",
+        ObjectOrder.type_to_order("flow"),
+        "run",
+        ObjectOrder.type_to_order("run"),
+        None,
+        None,
+        "Flow",
+    )
+
+    assert self_result == {"flow_id": "Flow", "run_number": "1", "keep": True}
+    assert collection_result == [{"flow_id": "Flow", "run_number": "1", "keep": True}]


### PR DESCRIPTION
Restore subclass dispatch for `_apply_filter` in `ServiceMetadataProvider`.

`ServiceMetadataProvider._get_object_internal` calls
`MetadataProvider._apply_filter(...)` directly, which bypasses subclass overrides.

Switch to `cls._apply_filter(...)` to preserve current behavior for built-in
providers while allowing subclasses to override filtering as expected.

Adds a regression test covering both single-object and collection paths.

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Restore correct subclass dispatch for `_apply_filter` in `ServiceMetadataProvider`.

## Issue

Fixes #

## Reproduction

Covered by the added unit test in `test/unit/test_service_metadata_provider.py`.

## Root Cause

`ServiceMetadataProvider._get_object_internal` calls `_apply_filter` through the
base class (`MetadataProvider._apply_filter(...)`) instead of `cls`, so subclass
overrides are ignored.

## Why This Fix Is Correct

Using `cls._apply_filter(...)` restores normal method dispatch without changing
behavior for built-in providers, since none override `_apply_filter`.

## Failure Modes Considered

1. No behavior change for built-in providers.
2. Subclasses overriding `_apply_filter` now behave as expected.

## Tests

- [x] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [x] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

No changes to filtering logic or provider behavior beyond dispatch.

## AI Tool Usage

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

Used for review and validation. All code and tests were verified manually.