### PR TITLE
Fix card server crash when card count reaches max_cards

### DIFF
--- a/metaflow/plugins/cards/card_server.py
+++ b/metaflow/plugins/cards/card_server.py
@@ -192,9 +192,9 @@ def cards_for_run(
             if card_generator is None:
                 continue
             for card in card_generator:
-                curr_idx += 1
                 if curr_idx >= max_cards:
-                    raise StopIteration
+                    return
+                curr_idx += 1
                 yield task.pathspec, card
 
 

--- a/test/unit/test_card_server.py
+++ b/test/unit/test_card_server.py
@@ -1,0 +1,82 @@
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+if not hasattr(os, "O_NONBLOCK"):
+    os.O_NONBLOCK = 0
+
+if "fcntl" not in sys.modules:
+    fake_fcntl = types.ModuleType("fcntl")
+    fake_fcntl.F_SETFL = 0
+    fake_fcntl.fcntl = lambda *args, **kwargs: None
+    sys.modules["fcntl"] = fake_fcntl
+
+from metaflow.plugins.cards import card_server
+
+
+class MockTask(object):
+    def __init__(self, pathspec, finished=False):
+        self.pathspec = pathspec
+        self.finished = finished
+
+
+class MockStep(object):
+    def __init__(self, tasks):
+        self._tasks = tasks
+
+    def tasks(self):
+        return self._tasks
+
+
+class MockRun(object):
+    def __init__(self, steps):
+        self._steps = steps
+
+    def steps(self):
+        return self._steps
+
+
+def test_cards_for_run_stops_cleanly_at_max_cards(monkeypatch):
+    def fake_cards_for_task(*args, **kwargs):
+        for idx in range(25):
+            yield SimpleNamespace(hash="hash-%d" % idx)
+
+    monkeypatch.setattr(card_server, "cards_for_task", fake_cards_for_task)
+
+    run = MockRun([MockStep([MockTask("MyFlow/1/start/1")])])
+
+    cards = list(
+        card_server.cards_for_run(
+            None,
+            run,
+            only_running=False,
+            max_cards=20,
+        )
+    )
+
+    assert len(cards) == 20
+    assert cards[0][0] == "MyFlow/1/start/1"
+    assert cards[-1][1].hash == "hash-19"
+
+
+def test_cards_for_run_returns_all_cards_below_limit(monkeypatch):
+    def fake_cards_for_task(*args, **kwargs):
+        for idx in range(3):
+            yield SimpleNamespace(hash="hash-%d" % idx)
+
+    monkeypatch.setattr(card_server, "cards_for_task", fake_cards_for_task)
+
+    run = MockRun([MockStep([MockTask("MyFlow/1/start/1")])])
+
+    cards = list(
+        card_server.cards_for_run(
+            None,
+            run,
+            only_running=False,
+            max_cards=20,
+        )
+    )
+
+    assert len(cards) == 3
+    assert [card.hash for _, card in cards] == ["hash-0", "hash-1", "hash-2"]


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Fix the card server crash that occurs when a run has at least `max_cards` cards. The generator now stops cleanly at the configured limit instead of raising `StopIteration` from inside the generator, which Python converts into a `RuntimeError`.

## Issue

Fixes #2946

## Reproduction

**Runtime:** local

**Commands to run:**
```bash
python -m pytest test/unit/test_card_server.py -v
```

**Where evidence shows up:** test output in the local console

<details>
<summary>Before (error / log snippet)</summary>

```text
RuntimeError: generator raised StopIteration
```

This happens because cards_for_run manually raises StopIteration once the card count reaches max_cards.

<details> 
<summary>After (evidence that fix works)</summary>

```text
test/unit/test_card_server.py::test_cards_for_run_stops_cleanly_at_max_cards PASSED
test/unit/test_card_server.py::test_cards_for_run_returns_all_cards_below_limit PASSED
```

## Root Cause
cards_for_run in metaflow/plugins/cards/card_server.py is implemented as a generator. When the number of yielded cards reaches the configured max_cards, it manually raises StopIteration.

In Python 3, raising StopIteration from inside a generator body is not treated as a normal way to end iteration. Per PEP 479, it is converted into RuntimeError: generator raised StopIteration.

That means a run with enough cards to hit the limit can cause the card server to fail while iterating over cards, instead of stopping iteration cleanly.

There is also an off-by-one issue in the original logic: the counter is incremented before the limit check, so the generator attempts to stop as soon as the count reaches max_cards, rather than yielding up to that limit and then stopping.

## Why This Fix Is Correct

The fix replaces the manual StopIteration with a normal generator return, which is the correct way to terminate a generator early.

This restores the intended invariant:

- cards_for_run should yield at most max_cards cards
- stopping at the limit should not raise an exception
- runs below the limit should continue to behave unchanged
- The change is intentionally minimal:

- it does not alter card ordering
- it does not change how cards are fetched
- it only changes how the generator terminates when the limit is reached

## Failure Modes Considered

1. Off-by-one behavior at the limit
The updated logic ensures the generator can yield exactly max_cards cards before stopping, instead of failing as soon as the count reaches the limit.

2. Behavior below the limit
The fix preserves the existing behavior for runs with fewer than max_cards cards. The added regression test verifies that all cards are still returned in that case.

## Tests

- [x] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

Added regression tests in test/unit/test_card_server.py for:

- stopping cleanly when the number of cards exceeds max_cards
- returning all cards when the number of cards is below the limit
Locally ran:
```bash
python -m pytest test/unit/test_card_server.py -v
```

## Non-Goals
This PR does not change:
- card server request handling outside of cards_for_run
- the configured max_cards behavior itself
- card ordering or filtering semantics
- any UI or frontend behavior

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [x] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)

<!-- If you used AI tools:
- Which tool(s)?
- What did you use them for?
- Did you review, understand, and test all generated code?
-->
