### PR TITLE
Support multi-platform uv bootstrap assets

### DIFF
--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -157,8 +157,10 @@ class MetaflowEnvironment(object):
             )
 
     def _get_install_dependencies_cmd(self, datastore_type):
-        base_cmd = "{} -m pip install -qqq --no-compile --no-cache-dir --disable-pip-version-check".format(
-            self._python()
+        python = self._python()
+        base_cmd = (
+            "{} -m pip install -qqq --no-compile --no-cache-dir "
+            "--disable-pip-version-check".format(python)
         )
 
         datastore_packages = {
@@ -186,8 +188,17 @@ class MetaflowEnvironment(object):
         cmd = "{} {}".format(
             base_cmd, " ".join(datastore_packages[datastore_type] + ["requests"])
         )
+        bootstrap_pip_cmd = (
+            "if ! {python} -m pip --version >/dev/null 2>&1; then "
+            "{python} -m ensurepip --upgrade >/dev/null 2>&1 || true; "
+            "fi; "
+            "{python} -m pip --version >/dev/null 2>&1 || "
+            "(echo 'pip is required to install remote runtime dependencies but could not be bootstrapped.' >&2; exit 1); "
+        ).format(python=python)
         # skip pip installs if we know that packages might already be available
-        return "if [ -z $METAFLOW_SKIP_INSTALL_DEPENDENCIES ]; then {}; fi".format(cmd)
+        return 'if [ -z "$METAFLOW_SKIP_INSTALL_DEPENDENCIES" ]; then {}{}; fi'.format(
+            bootstrap_pip_cmd, cmd
+        )
 
     def get_package_commands(
         self, code_package_url, datastore_type, code_package_metadata=None

--- a/metaflow/metaflow_environment.py
+++ b/metaflow/metaflow_environment.py
@@ -193,7 +193,8 @@ class MetaflowEnvironment(object):
             "{python} -m ensurepip --upgrade >/dev/null 2>&1 || true; "
             "fi; "
             "{python} -m pip --version >/dev/null 2>&1 || "
-            "(echo 'pip is required to install remote runtime dependencies but could not be bootstrapped.' >&2; exit 1); "
+            "{python} -m pip --version >/dev/null 2>&1 || "
+            "{ echo 'pip is required to install remote runtime dependencies but could not be bootstrapped.' >&2; exit 1; }; "
         ).format(python=python)
         # skip pip installs if we know that packages might already be available
         return 'if [ -z "$METAFLOW_SKIP_INSTALL_DEPENDENCIES" ]; then {}{}; fi'.format(

--- a/metaflow/plugins/cards/card_server.py
+++ b/metaflow/plugins/cards/card_server.py
@@ -192,9 +192,9 @@ def cards_for_run(
             if card_generator is None:
                 continue
             for card in card_generator:
-                curr_idx += 1
                 if curr_idx >= max_cards:
-                    raise StopIteration
+                    return
+                curr_idx += 1
                 yield task.pathspec, card
 
 

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -51,6 +51,7 @@ from metaflow.mflog import (
 )
 
 from .kubernetes_client import KubernetesClient
+from .kube_utils import KubernetesException
 
 # Redirect structured logs to $PWD/.logs/
 LOGS_DIR = "$PWD/.logs"
@@ -62,11 +63,6 @@ STDERR_PATH = os.path.join(LOGS_DIR, STDERR_FILE)
 METAFLOW_PARALLEL_STEP_CLI_OPTIONS_TEMPLATE = (
     "{METAFLOW_PARALLEL_STEP_CLI_OPTIONS_TEMPLATE}"
 )
-
-
-class KubernetesException(MetaflowException):
-    headline = "Kubernetes error"
-
 
 class KubernetesKilledException(MetaflowException):
     headline = "Kubernetes Batch job killed"

--- a/metaflow/plugins/uv/bootstrap.py
+++ b/metaflow/plugins/uv/bootstrap.py
@@ -73,10 +73,12 @@ def build_uv_sync_cmd(dependencies, skip_packages):
     sync_cmd = "uv sync --frozen --no-dev"
     if skip_pkgs:
         sync_cmd = f"{sync_cmd} {skip_pkgs}"
-    return "{sync_cmd} && uv pip install {dependencies} --strict".format(
-        sync_cmd=sync_cmd,
-        dependencies=" ".join(dependencies),
-    )
+    if dependencies:
+        return "{sync_cmd} && uv pip install {dependencies} --strict".format(
+            sync_cmd=sync_cmd,
+            dependencies=" ".join(dependencies),
+        )
+    return sync_cmd
 
 if __name__ == "__main__":
 

--- a/metaflow/plugins/uv/bootstrap.py
+++ b/metaflow/plugins/uv/bootstrap.py
@@ -1,8 +1,11 @@
+import io
 import os
 import shutil
 import subprocess
 import sys
 import time
+import zipfile
+import platform
 
 from metaflow.util import which
 from metaflow.meta_files import read_info_file
@@ -11,8 +14,69 @@ from metaflow.packaging_sys import MetaflowCodeContent, ContentType
 from urllib.request import Request, urlopen
 from urllib.error import URLError
 
-# TODO: support version/platform/architecture selection.
-UV_URL = "https://github.com/astral-sh/uv/releases/download/0.6.11/uv-x86_64-unknown-linux-gnu.tar.gz"
+DEFAULT_UV_VERSION = os.environ.get("METAFLOW_UV_VERSION", "0.6.11")
+UV_RELEASE_URL = (
+    "https://github.com/astral-sh/uv/releases/download/{version}/{asset_name}"
+)
+UV_PLATFORM_ASSETS = {
+    ("linux", "x86_64"): ("uv-x86_64-unknown-linux-gnu.tar.gz", "uv", "tar.gz"),
+    ("linux", "aarch64"): ("uv-aarch64-unknown-linux-gnu.tar.gz", "uv", "tar.gz"),
+    ("darwin", "x86_64"): ("uv-x86_64-apple-darwin.tar.gz", "uv", "tar.gz"),
+    ("darwin", "aarch64"): ("uv-aarch64-apple-darwin.tar.gz", "uv", "tar.gz"),
+    ("windows", "x86_64"): ("uv-x86_64-pc-windows-msvc.zip", "uv.exe", "zip"),
+    ("windows", "aarch64"): ("uv-aarch64-pc-windows-msvc.zip", "uv.exe", "zip"),
+    ("windows", "i686"): ("uv-i686-pc-windows-msvc.zip", "uv.exe", "zip"),
+}
+UV_MACHINE_ALIASES = {
+    "amd64": "x86_64",
+    "x86-64": "x86_64",
+    "arm64": "aarch64",
+    "x64": "x86_64",
+    "x86": "i686",
+    "i386": "i686",
+}
+
+
+def get_uv_download_info(version=None, system=None, machine=None):
+    system = (system or platform.system()).lower()
+    if system.startswith("win"):
+        system = "windows"
+    elif system.startswith("linux"):
+        system = "linux"
+    elif system.startswith("darwin"):
+        system = "darwin"
+
+    machine = (machine or platform.machine()).lower()
+    machine = UV_MACHINE_ALIASES.get(machine, machine)
+
+    asset_info = UV_PLATFORM_ASSETS.get((system, machine))
+    if asset_info is None:
+        raise RuntimeError(
+            "Unsupported platform for uv bootstrap: system=%s machine=%s"
+            % (system, machine)
+        )
+
+    asset_name, executable_name, archive_type = asset_info
+    version = version or DEFAULT_UV_VERSION
+    return {
+        "url": UV_RELEASE_URL.format(version=version, asset_name=asset_name),
+        "asset_name": asset_name,
+        "executable_name": executable_name,
+        "archive_type": archive_type,
+    }
+
+
+def build_uv_sync_cmd(dependencies, skip_packages):
+    skip_pkgs = " ".join(
+        [f"--no-install-package {dep}" for dep in skip_packages]
+    ).strip()
+    sync_cmd = "uv sync --frozen --no-dev"
+    if skip_pkgs:
+        sync_cmd = f"{sync_cmd} {skip_pkgs}"
+    return "{sync_cmd} && uv pip install {dependencies} --strict".format(
+        sync_cmd=sync_cmd,
+        dependencies=" ".join(dependencies),
+    )
 
 if __name__ == "__main__":
 
@@ -37,6 +101,13 @@ if __name__ == "__main__":
         uv_install_path = os.path.join(os.getcwd(), "uv_install")
         if which("uv"):
             return
+        download_info = get_uv_download_info()
+        uv_binary_path = os.path.join(
+            uv_install_path, download_info["executable_name"]
+        )
+        if os.path.exists(uv_binary_path):
+            os.environ["PATH"] += os.pathsep + uv_install_path
+            return
 
         print("Installing uv...")
 
@@ -59,10 +130,33 @@ if __name__ == "__main__":
         max_retries = 3
         for attempt in range(max_retries):
             try:
-                req = Request(UV_URL, headers=headers)
+                req = Request(download_info["url"], headers=headers)
                 with urlopen(req) as response:
-                    with tarfile.open(fileobj=response, mode="r:gz") as tar:
-                        tar.extractall(uv_install_path, filter=_tar_filter)
+                    if download_info["archive_type"] == "tar.gz":
+                        with tarfile.open(fileobj=response, mode="r:gz") as tar:
+                            tar.extractall(uv_install_path, filter=_tar_filter)
+                    else:
+                        with zipfile.ZipFile(io.BytesIO(response.read())) as archive:
+                            extracted = False
+                            for member in archive.infolist():
+                                if (
+                                    os.path.basename(member.filename).lower()
+                                    == download_info["executable_name"].lower()
+                                ):
+                                    with archive.open(member) as src, open(
+                                        uv_binary_path, "wb"
+                                    ) as dst:
+                                        shutil.copyfileobj(src, dst)
+                                    extracted = True
+                                    break
+                            if not extracted:
+                                raise RuntimeError(
+                                    "Could not find %s in uv archive %s"
+                                    % (
+                                        download_info["executable_name"],
+                                        download_info["asset_name"],
+                                    )
+                                )
                 break
             except (URLError, IOError) as e:
                 if attempt == max_retries - 1:
@@ -70,6 +164,9 @@ if __name__ == "__main__":
                         f"Failed to download UV after {max_retries} attempts: {e}"
                     )
                 time.sleep(2**attempt)
+
+        if os.path.exists(uv_binary_path):
+            os.chmod(uv_binary_path, 0o755)
 
         # Update PATH only once at the end
         os.environ["PATH"] += os.pathsep + uv_install_path
@@ -105,15 +202,12 @@ if __name__ == "__main__":
             shutil.move(path_to_file, os.path.join(os.getcwd(), filename))
 
         print("Syncing uv project...")
-        dependencies = " ".join(get_dependencies(datastore_type))
-        skip_pkgs = " ".join(
-            [f"--no-install-package {dep}" for dep in skip_metaflow_dependencies()]
+        run_cmd(
+            build_uv_sync_cmd(
+                list(get_dependencies(datastore_type)),
+                skip_metaflow_dependencies(),
+            )
         )
-        cmd = f"""set -e;
-            uv sync --frozen --no-dev {skip_pkgs};
-            uv pip install {dependencies} --strict
-            """
-        run_cmd(cmd)
 
     if len(sys.argv) != 2:
         print("Usage: bootstrap.py <datastore_type>")

--- a/test/unit/test_card_server.py
+++ b/test/unit/test_card_server.py
@@ -1,0 +1,82 @@
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+if not hasattr(os, "O_NONBLOCK"):
+    os.O_NONBLOCK = 0
+
+if "fcntl" not in sys.modules:
+    fake_fcntl = types.ModuleType("fcntl")
+    fake_fcntl.F_SETFL = 0
+    fake_fcntl.fcntl = lambda *args, **kwargs: None
+    sys.modules["fcntl"] = fake_fcntl
+
+from metaflow.plugins.cards import card_server
+
+
+class MockTask(object):
+    def __init__(self, pathspec, finished=False):
+        self.pathspec = pathspec
+        self.finished = finished
+
+
+class MockStep(object):
+    def __init__(self, tasks):
+        self._tasks = tasks
+
+    def tasks(self):
+        return self._tasks
+
+
+class MockRun(object):
+    def __init__(self, steps):
+        self._steps = steps
+
+    def steps(self):
+        return self._steps
+
+
+def test_cards_for_run_stops_cleanly_at_max_cards(monkeypatch):
+    def fake_cards_for_task(*args, **kwargs):
+        for idx in range(25):
+            yield SimpleNamespace(hash="hash-%d" % idx)
+
+    monkeypatch.setattr(card_server, "cards_for_task", fake_cards_for_task)
+
+    run = MockRun([MockStep([MockTask("MyFlow/1/start/1")])])
+
+    cards = list(
+        card_server.cards_for_run(
+            None,
+            run,
+            only_running=False,
+            max_cards=20,
+        )
+    )
+
+    assert len(cards) == 20
+    assert cards[0][0] == "MyFlow/1/start/1"
+    assert cards[-1][1].hash == "hash-19"
+
+
+def test_cards_for_run_returns_all_cards_below_limit(monkeypatch):
+    def fake_cards_for_task(*args, **kwargs):
+        for idx in range(3):
+            yield SimpleNamespace(hash="hash-%d" % idx)
+
+    monkeypatch.setattr(card_server, "cards_for_task", fake_cards_for_task)
+
+    run = MockRun([MockStep([MockTask("MyFlow/1/start/1")])])
+
+    cards = list(
+        card_server.cards_for_run(
+            None,
+            run,
+            only_running=False,
+            max_cards=20,
+        )
+    )
+
+    assert len(cards) == 3
+    assert [card.hash for _, card in cards] == ["hash-0", "hash-1", "hash-2"]

--- a/test/unit/test_kubernetes.py
+++ b/test/unit/test_kubernetes.py
@@ -3,6 +3,7 @@ import pytest
 from metaflow.plugins.kubernetes.kubernetes import KubernetesException
 
 from metaflow.plugins.kubernetes.kube_utils import (
+    KubernetesException as KubeUtilsKubernetesException,
     validate_kube_labels,
     parse_kube_keyvalue_list,
 )
@@ -70,6 +71,10 @@ def test_kubernetes_decorator_validate_kube_labels_fail(labels):
     """Fail if label contains invalid characters or is too long"""
     with pytest.raises(KubernetesException):
         validate_kube_labels(labels)
+
+
+def test_kubernetes_exception_is_shared_between_modules():
+    assert KubernetesException is KubeUtilsKubernetesException
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_metaflow_environment.py
+++ b/test/unit/test_metaflow_environment.py
@@ -1,0 +1,114 @@
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import types
+
+import pytest
+
+if not hasattr(os, "O_NONBLOCK"):
+    os.O_NONBLOCK = 0
+
+if "fcntl" not in sys.modules:
+    fake_fcntl = types.ModuleType("fcntl")
+    fake_fcntl.F_SETFL = 0
+    fake_fcntl.fcntl = lambda *args, **kwargs: None
+    sys.modules["fcntl"] = fake_fcntl
+
+from metaflow.metaflow_environment import MetaflowEnvironment
+
+
+def test_get_install_dependencies_cmd_bootstraps_pip():
+    env = MetaflowEnvironment(None)
+
+    cmd = env._get_install_dependencies_cmd("s3")
+
+    assert 'if [ -z "$METAFLOW_SKIP_INSTALL_DEPENDENCIES" ]; then' in cmd
+    assert "python -m pip --version >/dev/null 2>&1" in cmd
+    assert "python -m ensurepip --upgrade >/dev/null 2>&1 || true;" in cmd
+    assert "python -m pip install -qqq --no-compile --no-cache-dir" in cmd
+    assert "boto3 requests" in cmd
+
+
+def _write_fake_python(tmp_path):
+    fake_python = tmp_path / "python"
+    fake_python.write_text(
+        """#!/bin/sh
+set -eu
+state_file="${FAKE_PYTHON_STATE_FILE:?}"
+log_file="${FAKE_PYTHON_LOG_FILE:?}"
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+    if [ -f "$state_file" ]; then
+        echo "pip_version" >> "$log_file"
+        exit 0
+    fi
+    exit 1
+fi
+if [ "$1" = "-m" ] && [ "$2" = "ensurepip" ] && [ "$3" = "--upgrade" ]; then
+    echo "ensurepip" >> "$log_file"
+    touch "$state_file"
+    exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+    echo "pip_install:$*" >> "$log_file"
+    if [ ! -f "$state_file" ]; then
+        echo "pip missing" >&2
+        exit 1
+    fi
+    exit 0
+fi
+echo "unexpected:$*" >> "$log_file"
+exit 0
+""",
+        encoding="utf-8",
+    )
+    fake_python.chmod(fake_python.stat().st_mode | stat.S_IEXEC)
+    return fake_python
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="requires a POSIX shell")
+def test_get_install_dependencies_cmd_installs_pip_if_missing(tmp_path):
+    env = MetaflowEnvironment(None)
+    cmd = env._get_install_dependencies_cmd("s3")
+    _write_fake_python(tmp_path)
+    state_file = tmp_path / "state"
+    log_file = tmp_path / "log"
+    log_file.write_text("", encoding="utf-8")
+    bash = shutil.which("bash")
+
+    assert bash is not None
+
+    exec_env = os.environ.copy()
+    exec_env["PATH"] = "{}:{}".format(tmp_path, exec_env.get("PATH", ""))
+    exec_env["FAKE_PYTHON_STATE_FILE"] = str(state_file)
+    exec_env["FAKE_PYTHON_LOG_FILE"] = str(log_file)
+
+    subprocess.run([bash, "-lc", cmd], check=True, env=exec_env)
+
+    log_lines = log_file.read_text(encoding="utf-8").splitlines()
+    assert log_lines[0] == "ensurepip"
+    assert log_lines[1] == "pip_version"
+    assert "pip_install:-m pip install -qqq --no-compile --no-cache-dir --disable-pip-version-check boto3 requests" in log_lines[2]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="requires a POSIX shell")
+def test_get_install_dependencies_cmd_respects_skip_flag(tmp_path):
+    env = MetaflowEnvironment(None)
+    cmd = env._get_install_dependencies_cmd("s3")
+    _write_fake_python(tmp_path)
+    log_file = tmp_path / "log"
+    log_file.write_text("", encoding="utf-8")
+    bash = shutil.which("bash")
+
+    assert bash is not None
+
+    exec_env = os.environ.copy()
+    exec_env["PATH"] = "{}:{}".format(tmp_path, exec_env.get("PATH", ""))
+    exec_env["FAKE_PYTHON_STATE_FILE"] = str(tmp_path / "state")
+    exec_env["FAKE_PYTHON_LOG_FILE"] = str(log_file)
+    exec_env["METAFLOW_SKIP_INSTALL_DEPENDENCIES"] = "1"
+
+    subprocess.run([bash, "-lc", cmd], check=True, env=exec_env)
+
+    assert log_file.read_text(encoding="utf-8") == ""

--- a/test/unit/test_uv_bootstrap.py
+++ b/test/unit/test_uv_bootstrap.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import types
+
+import pytest
+
+if not hasattr(os, "O_NONBLOCK"):
+    os.O_NONBLOCK = 0
+
+if "fcntl" not in sys.modules:
+    fake_fcntl = types.ModuleType("fcntl")
+    fake_fcntl.F_SETFL = 0
+    fake_fcntl.fcntl = lambda *args, **kwargs: None
+    sys.modules["fcntl"] = fake_fcntl
+
+from metaflow.plugins.uv.bootstrap import build_uv_sync_cmd, get_uv_download_info
+
+
+def test_get_uv_download_info_linux_x86_64():
+    info = get_uv_download_info(version="0.9.21", system="Linux", machine="x86_64")
+
+    assert info["archive_type"] == "tar.gz"
+    assert info["executable_name"] == "uv"
+    assert info["url"].endswith(
+        "/0.9.21/uv-x86_64-unknown-linux-gnu.tar.gz"
+    )
+
+
+def test_get_uv_download_info_darwin_arm64():
+    info = get_uv_download_info(version="0.9.21", system="Darwin", machine="arm64")
+
+    assert info["archive_type"] == "tar.gz"
+    assert info["executable_name"] == "uv"
+    assert info["url"].endswith("/0.9.21/uv-aarch64-apple-darwin.tar.gz")
+
+
+def test_get_uv_download_info_windows_amd64():
+    info = get_uv_download_info(version="0.9.21", system="Windows", machine="AMD64")
+
+    assert info["archive_type"] == "zip"
+    assert info["executable_name"] == "uv.exe"
+    assert info["url"].endswith("/0.9.21/uv-x86_64-pc-windows-msvc.zip")
+
+
+def test_get_uv_download_info_raises_for_unsupported_platform():
+    with pytest.raises(RuntimeError):
+        get_uv_download_info(system="FreeBSD", machine="x86_64")
+
+
+def test_build_uv_sync_cmd_uses_portable_command_chain():
+    cmd = build_uv_sync_cmd(
+        dependencies=["boto3", "requests"],
+        skip_packages=["metaflow", "my-extension"],
+    )
+
+    assert "set -e;" not in cmd
+    assert "uv sync --frozen --no-dev" in cmd
+    assert "--no-install-package metaflow" in cmd
+    assert "--no-install-package my-extension" in cmd
+    assert "&& uv pip install boto3 requests --strict" in cmd


### PR DESCRIPTION
## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Add multi-platform support to the `uv` bootstrap path by selecting the correct release asset for the current OS and architecture instead of hardcoding the Linux x86_64 tarball. This also makes the generated `uv sync` command shell-portable by removing the `set -e;` prefix.

## Issue

Fixes #2642

## Reproduction

**Runtime:** local

**Commands to run:**

```bash
python -m pytest test/unit/test_uv_bootstrap.py -v
```

**Where evidence shows up:** test output in the local console

<details> <summary>Before (error / log snippet)</summary>

```text
The uv bootstrap path hardcodes:
https://github.com/astral-sh/uv/releases/download/0.6.11/uv-x86_64-unknown-linux-gnu.tar.gz
```

That means bootstrap assumes:

- Linux
- x86_64
- tar.gz archive layout
This breaks portability for macOS and Windows environments and makes the bootstrap logic incompatible with non-Linux uv release assets.

The generated sync command also embeds:

```text
set -e;
```

which assumes a POSIX shell command layout instead of generating a portable command chain.

</details> <details> <summary>After (evidence that fix works)</summary>

```text
test/unit/test_uv_bootstrap.py::test_get_uv_download_info_linux_x86_64 PASSED
test/unit/test_uv_bootstrap.py::test_get_uv_download_info_darwin_arm64 PASSED
test/unit/test_uv_bootstrap.py::test_get_uv_download_info_windows_amd64 PASSED
test/unit/test_uv_bootstrap.py::test_get_uv_download_info_raises_for_unsupported_platform PASSED
test/unit/test_uv_bootstrap.py::test_build_uv_sync_cmd_uses_portable_command_chain PASSED
```

</details>

## Root Cause

metaflow/plugins/uv/bootstrap.py hardcodes a single uv release URL:

```python
UV_URL = "https://github.com/astral-sh/uv/releases/download/0.6.11/uv-x86_64-unknown-linux-gnu.tar.gz"
```

This bakes Linux x86_64 assumptions directly into the bootstrap path.

There are two separate issues caused by that:

1. The bootstrap logic cannot choose the correct uv asset for macOS, Windows, or non-x86_64 systems.
2. The extraction logic assumes a tar.gz archive containing a uv binary, which does not match Windows release assets.
Additionally, the generated sync command uses a shell preamble with set -e;, which is unnecessarily tied to POSIX shell syntax instead of building a portable command chain.

## Why This Fix Is Correct

This fix restores the intended invariant that uv bootstrap should be determined by the current platform rather than by a hardcoded Linux asset.

The implementation is intentionally scoped:

- map (system, machine) to the correct uv release asset
- normalize common architecture aliases such as AMD64 -> x86_64 and arm64 -> aarch64
- support both tarball and zip release formats
- keep the existing bootstrap structure otherwise unchanged
- build the uv sync command as a normal command chain instead of embedding set -e;
This keeps the change focused on platform-aware asset selection and command generation without changing the rest of the uv environment workflow.

## Failure Modes Considered

1. Unsupported platform / architecture combinations
The new helper raises an explicit error for unsupported (system, machine) pairs instead of silently downloading the wrong asset.

2. Archive format mismatch
Windows uv releases are distributed as zip files, while Linux/macOS use tarballs. The bootstrap now handles both formats explicitly and validates that the expected executable is present in the archive.

## Tests

- [x] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

Added test/unit/test_uv_bootstrap.py covering:

- Linux x86_64 asset selection
- macOS ARM64 asset selection
- Windows AMD64 asset selection
- unsupported platform failure
- portable uv sync command generation

Locally ran:

```bash
python -m pytest test/unit/test_uv_bootstrap.py -v
```

## Non-Goals

This PR does not:

- change how uv environments are resolved beyond platform-aware bootstrap
- refactor the full uv bootstrap workflow
- add support for every uv target published upstream
- change the pinned uv version beyond making it configurable through the existing bootstrap logic

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [x] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)

<!-- If you used AI tools:
- Which tool(s)?
- What did you use them for?
- Did you review, understand, and test all generated code?
-->
