### PR TITLE
feat: add YAML support for config files

### DIFF
--- a/metaflow/user_configs/config_options.py
+++ b/metaflow/user_configs/config_options.py
@@ -382,12 +382,20 @@ class ConfigInput:
                     else:
                         try:
                             read_value = json.loads(val)
-                        except json.JSONDecodeError as e:
-                            msgs.append(
-                                "configuration value for '%s' is not valid JSON: %s"
-                                % (name, e)
-                            )
-                            continue
+                        except json.JSONDecodeError:
+                            try:
+                                from metaflow._vendor import yaml
+                                read_value = yaml.safe_load(val)
+                                
+                                if not isinstance(read_value, dict):
+                                    raise ValueError("YAML did not produce a dictionary")
+
+                            except Exception as e:
+                                msgs.append(
+                                    "configuration value for '%s' is not valid JSON or YAML: %s"
+                                    % (name, e)
+                                )
+                                continue
                         # TODO: Support YAML
                 flow_cls._flow_state.self_data[FlowStateItems.CONFIGS][name] = (
                     read_value,


### PR DESCRIPTION
This PR adds YAML support for config files.

Currently, Metaflow only supports JSON. This change adds a fallback to YAML parsing using yaml.safe_load.

- JSON-first parsing preserved
- YAML support added
- Ensures YAML returns a dictionary

Tested locally using a sample flow with YAML config.