### PR TITLE
Add ContextVar-based metadata client tracing to MetadataProvider

### DIFF
--- a/metaflow/metadata_provider/__init__.py
+++ b/metaflow/metadata_provider/__init__.py
@@ -1,1 +1,2 @@
 from .metadata import DataArtifact, MetadataProvider, MetaDatum
+from .tracer import MetadataTracer, MetadataTraceRecord

--- a/metaflow/metadata_provider/metadata.py
+++ b/metaflow/metadata_provider/metadata.py
@@ -9,6 +9,7 @@ from typing import List
 from metaflow.exception import MetaflowInternalError, MetaflowTaggingError
 from metaflow.tagging_util import validate_tag
 from metaflow.util import get_username, resolve_identity_as_tuple, is_stringish
+from .tracer import get_active_metadata_tracer
 
 DataArtifact = namedtuple("DataArtifact", "name ds_type ds_root url type sha")
 
@@ -428,6 +429,16 @@ class MetadataProvider(object):
                 raise ValueError("Attempt can only be a positive integer")
         else:
             attempt_int = None
+
+        tracer = get_active_metadata_tracer()
+        if tracer is not None:
+            tracer.record(
+                obj_type=obj_type,
+                sub_type=sub_type,
+                depth=type_order,
+                attempt=attempt_int,
+                path="/".join(str(arg) for arg in args if arg is not None),
+            )
 
         pre_filter = cls._get_object_internal(
             obj_type, type_order, sub_type, sub_order, filters, attempt_int, *args

--- a/metaflow/metadata_provider/tracer.py
+++ b/metaflow/metadata_provider/tracer.py
@@ -1,0 +1,60 @@
+from collections import Counter
+from contextvars import ContextVar
+from typing import List, NamedTuple, Optional
+
+
+class MetadataTraceRecord(NamedTuple):
+    obj_type: str
+    sub_type: str
+    depth: int
+    attempt: Optional[int]
+    path: str
+
+_active_metadata_tracer = ContextVar("active_metadata_tracer", default=None)
+
+
+def get_active_metadata_tracer():
+    return _active_metadata_tracer.get()
+
+
+class MetadataTracer(object):
+    """
+    Opt-in tracer for logical metadata client requests.
+
+    Use this as a context manager around client API calls that eventually route
+    through MetadataProvider.get_object().
+    """
+
+    def __init__(self):
+        self.records: List[MetadataTraceRecord] = []
+        self._token = None
+
+    def __enter__(self):
+        self._token = _active_metadata_tracer.set(self)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._token is not None:
+            _active_metadata_tracer.reset(self._token)
+        return False
+
+    @property
+    def request_count(self):
+        return len(self.records)
+
+    def record(self, obj_type, sub_type, depth, attempt, path):
+        self.records.append(
+            MetadataTraceRecord(
+                obj_type=obj_type,
+                sub_type=sub_type,
+                depth=depth,
+                attempt=attempt,
+                path=path,
+            )
+        )
+
+    def summary(self):
+        return {
+            "request_count": self.request_count,
+            "by_obj_type": dict(Counter(record.obj_type for record in self.records)),
+        }

--- a/test/unit/test_metadata_provider_tracer.py
+++ b/test/unit/test_metadata_provider_tracer.py
@@ -1,0 +1,196 @@
+import asyncio
+
+import pytest
+
+from metaflow.exception import MetaflowInternalError
+from metaflow.metadata_provider import MetadataTraceRecord, MetadataTracer
+from metaflow.metadata_provider.metadata import MetadataProvider
+
+
+class _TracingProvider(MetadataProvider):
+    TYPE = "tracing-test"
+
+    @classmethod
+    def _get_object_internal(
+        cls, obj_type, obj_order, sub_type, sub_order, filters, attempt, *args
+    ):
+        if sub_type == "metadata":
+            return [
+                {
+                    "field_name": "attempt",
+                    "value": "0",
+                    "ts_epoch": 1000,
+                    "tags": [],
+                },
+                {
+                    "field_name": "attempt",
+                    "value": "1",
+                    "ts_epoch": 2000,
+                    "tags": [],
+                },
+                {
+                    "field_name": "note",
+                    "value": "attempt-1-only",
+                    "ts_epoch": 2500,
+                    "tags": ["attempt_id:1"],
+                },
+            ]
+        return {"obj_type": obj_type, "sub_type": sub_type, "attempt": attempt}
+
+
+def test_valid_get_object_records_trace():
+    with MetadataTracer() as tracer:
+        result = _TracingProvider.get_object(
+            "run", "step", None, None, "MyFlow", "1"
+        )
+
+    assert result == {"obj_type": "run", "sub_type": "step", "attempt": None}
+    assert tracer.request_count == 1
+    assert tracer.records == [
+        MetadataTraceRecord(
+            obj_type="run",
+            sub_type="step",
+            depth=2,
+            attempt=None,
+            path="MyFlow/1",
+        )
+    ]
+
+
+def test_invalid_calls_raise_and_record_nothing():
+    with MetadataTracer() as tracer:
+        with pytest.raises(MetaflowInternalError):
+            _TracingProvider.get_object("not-a-type", "self", None, None, "MyFlow")
+        with pytest.raises(MetaflowInternalError):
+            _TracingProvider.get_object("run", "run", None, None, "MyFlow", "1")
+        with pytest.raises(ValueError):
+            _TracingProvider.get_object("task", "metadata", None, "bad", "MyFlow")
+
+    assert tracer.request_count == 0
+    assert tracer.records == []
+
+
+def test_attempt_is_normalized_before_recording():
+    with MetadataTracer() as tracer:
+        _TracingProvider.get_object(
+            "task", "artifact", None, "2", "MyFlow", "1", "step", "task"
+        )
+
+    assert tracer.records == [
+        MetadataTraceRecord(
+            obj_type="task",
+            sub_type="artifact",
+            depth=4,
+            attempt=2,
+            path="MyFlow/1/step/task",
+        )
+    ]
+
+
+def test_metadata_attempt_reconstruction_does_not_add_extra_record():
+    with MetadataTracer() as tracer:
+        result = _TracingProvider.get_object(
+            "task", "metadata", None, "1", "MyFlow", "1", "step", "task"
+        )
+
+    assert tracer.request_count == 1
+    assert tracer.records[0] == MetadataTraceRecord(
+        obj_type="task",
+        sub_type="metadata",
+        depth=4,
+        attempt=1,
+        path="MyFlow/1/step/task",
+    )
+    assert result == [
+        {
+            "field_name": "attempt",
+            "value": "1",
+            "ts_epoch": 2000,
+            "tags": [],
+        },
+        {
+            "field_name": "note",
+            "value": "attempt-1-only",
+            "ts_epoch": 2500,
+            "tags": ["attempt_id:1"],
+        }
+    ]
+
+
+def test_nested_contexts_restore_outer_tracer():
+    with MetadataTracer() as outer:
+        _TracingProvider.get_object("run", "step", None, None, "OuterFlow", "1")
+        with MetadataTracer() as inner:
+            _TracingProvider.get_object("step", "task", None, None, "InnerFlow", "2", "start")
+        _TracingProvider.get_object("run", "self", None, None, "OuterFlow", "1")
+
+    assert outer.records == [
+        MetadataTraceRecord(
+            obj_type="run",
+            sub_type="step",
+            depth=2,
+            attempt=None,
+            path="OuterFlow/1",
+        ),
+        MetadataTraceRecord(
+            obj_type="run",
+            sub_type="self",
+            depth=2,
+            attempt=None,
+            path="OuterFlow/1",
+        ),
+    ]
+    assert inner.records == [
+        MetadataTraceRecord(
+            obj_type="step",
+            sub_type="task",
+            depth=3,
+            attempt=None,
+            path="InnerFlow/2/start",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tasks_do_not_leak_traces():
+    async def run_trace(flow_id, step_name):
+        with MetadataTracer() as tracer:
+            await asyncio.sleep(0)
+            _TracingProvider.get_object("step", "task", None, None, flow_id, "1", step_name)
+            await asyncio.sleep(0)
+            return tracer.records
+
+    first, second = await asyncio.gather(
+        run_trace("FlowA", "start"),
+        run_trace("FlowB", "join"),
+    )
+
+    assert first == [
+        MetadataTraceRecord(
+            obj_type="step",
+            sub_type="task",
+            depth=3,
+            attempt=None,
+            path="FlowA/1/start",
+        )
+    ]
+    assert second == [
+        MetadataTraceRecord(
+            obj_type="step",
+            sub_type="task",
+            depth=3,
+            attempt=None,
+            path="FlowB/1/join",
+        )
+    ]
+
+
+def test_public_exports_work():
+    with MetadataTracer() as tracer:
+        _TracingProvider.get_object("run", "self", None, None, "MyFlow", "1")
+
+    assert isinstance(tracer.records[0], MetadataTraceRecord)
+    assert tracer.summary() == {
+        "request_count": 1,
+        "by_obj_type": {"run": 1},
+    }


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [ ] Bug fix
- [ ] New feature
- [x] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Adds an opt-in `MetadataTracer` to the Metaflow client so benchmark and agent scripts can measure logical metadata client requests routed through `MetadataProvider.get_object()`. Tracing is disabled by default, isolated per execution context with `ContextVar`, and records `obj_type`, `sub_type`, `depth`, `attempt`, and `path` for each valid `get_object()` call.

## Issue

<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes [valayDave/metaflow-service#4](https://github.com/valayDave/metaflow-service/issues/4)

## Reproduction

**Runtime:** local dev stack / service metadata provider

**Commands to run:**
```bash
metaflow-dev up
metaflow-dev shell

cat > issue4_demo_flow.py <<'PY'
from metaflow import FlowSpec, step

class Issue4DemoFlow(FlowSpec):
    @step
    def start(self):
        self.next(self.a, self.b, self.c)

    @step
    def a(self):
        self.next(self.join)

    @step
    def b(self):
        self.next(self.join)

    @step
    def c(self):
        self.next(self.join)

    @step
    def join(self, inputs):
        self.next(self.end)

    @step
    def end(self):
        pass

if __name__ == "__main__":
    Issue4DemoFlow()
PY

python issue4_demo_flow.py run

cat > trace_demo.py <<'PY'
from metaflow import Run
from metaflow.metadata_provider import MetadataTracer

with MetadataTracer() as tracer:
    run = Run("Issue4DemoFlow/1")
    for step in run:
        list(step)

print("request_count =", tracer.request_count)
print("records =", tracer.records)
print("summary =", tracer.summary())
PY

python trace_demo.py

env PYTHONPATH=$PWD python -m pytest test/unit/test_metadata_provider_tracer.py -q -p no:cacheprovider
```

**Where evidence shows up:** parent console from trace_demo.py and pytest output

<details>
<summary>Before (error / log snippet)</summary>

```
from metaflow.metadata_provider import MetadataTracer
# ImportError: cannot import name 'MetadataTracer'
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
$ env PYTHONPATH=$PWD python -m pytest test/unit/test_metadata_provider_tracer.py -q -p no:cacheprovider
.......                                                                  [100%]
7 passed in 0.30s
```

</details>

## Root Cause

The client-side semantic choke point for metadata traversal already exists in `MetadataProvider.get_object()`, but there was no built-in hook to observe those logical operations. That meant scripts could not answer basic questions like “how many metadata requests did this client operation generate?” without external packet inspection or runtime patching.

The missing invariant was:

- every valid logical metadata lookup should be observable exactly once
- tracing state must not leak across concurrent client traversals

A class-level tracer would violate the second invariant in async or nested execution contexts, because concurrent calls would overwrite shared mutable state. The correct place to attach observability is inside `get_object()` itself, but the tracer state must be scoped to the current execution context.

## Why This Fix Is Correct

This change restores observability at the exact semantic boundary we care about:

- the hook is inside `MetadataProvider.get_object()`, which is the single path all client traversals already use
- the record is emitted after validation and attempt normalization, so only valid semantic queries are counted
- the hook runs before `_get_object_internal(...)`, so each logical query is captured exactly once regardless of provider implementation
- `_reconstruct_metadata_for_attempt(...)` is intentionally not traced separately because it is in-memory post-processing, not another metadata request
- `ContextVar` keeps tracer state isolated per execution context and restores previous state cleanly for nested tracer scopes

The fix is minimal:

- one new tracer module
- one guarded hook in `get_object()`
- one export update
- focused unit coverage

When tracing is unused, the change is effectively a single `None` check.

## Failure Modes Considered

1. Concurrent or async client traversals leaking records into each other. `ContextVar` is used instead of class-level mutable state so each execution context gets its own tracer state.

2. Nested tracing contexts clobbering outer state. `__enter__` and `__exit__` use the `ContextVar` token API so inner contexts restore the previous tracer on exit.

3. Malformed calls polluting benchmark results. The trace hook runs after validation and attempt parsing, so invalid `obj_type`, `sub_type`, or `attempt` values do not create records.

4. Metadata attempt reconstruction inflating request counts. The implementation records only the outer `get_object()` call and does not add a second record for `_reconstruct_metadata_for_attempt(...)

## Tests

- [x] Unit tests added/updated
- [x] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

- No HTTP transport-level tracing
- No monkeypatch-based external tracer
- No provider-type field in v1
- No timing collection
- No metadata-service API/schema changes
- No pagination or client query optimization work in this PR

## AI Tool Usage

- [x] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)
