### PR TITLE
Fix/kubernetes exception unification

### DIFF
--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -51,6 +51,7 @@ from metaflow.mflog import (
 )
 
 from .kubernetes_client import KubernetesClient
+from .kube_utils import KubernetesException
 
 # Redirect structured logs to $PWD/.logs/
 LOGS_DIR = "$PWD/.logs"
@@ -62,10 +63,6 @@ STDERR_PATH = os.path.join(LOGS_DIR, STDERR_FILE)
 METAFLOW_PARALLEL_STEP_CLI_OPTIONS_TEMPLATE = (
     "{METAFLOW_PARALLEL_STEP_CLI_OPTIONS_TEMPLATE}"
 )
-
-
-class KubernetesException(MetaflowException):
-    headline = "Kubernetes error"
 
 
 class KubernetesKilledException(MetaflowException):

--- a/test/unit/test_kubernetes.py
+++ b/test/unit/test_kubernetes.py
@@ -1,11 +1,17 @@
 import pytest
 
+from metaflow.plugins.kubernetes import kube_utils
 from metaflow.plugins.kubernetes.kubernetes import KubernetesException
 
 from metaflow.plugins.kubernetes.kube_utils import (
     validate_kube_labels,
     parse_kube_keyvalue_list,
 )
+
+
+def test_kubernetes_exception_type_is_shared_across_modules():
+    """Ensure Kubernetes helpers and runtime expose the same exception class."""
+    assert kube_utils.KubernetesException is KubernetesException
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [ ] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

<!-- What user-visible behavior changes? 1-2 sentences. -->

## Issue

<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes #

## Reproduction

<!-- Required for bug fixes. Required for Core Runtime changes. -->
<!-- Provide a minimal reproduction that fails before and succeeds after. -->

**Runtime:** <!-- local / kubernetes / batch / argo / etc. -->

**Commands to run:**
```bash
# paste exact commands
```

**Where evidence shows up:** <!-- parent console / task logs / metadata / UI -->

<details>
<summary>Before (error / log snippet)</summary>

```
paste here
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
paste here
```

</details>

## Root Cause

<!-- Required for Core Runtime. Recommended for all bug fixes. -->
<!-- Explain the causal chain: what invariant was violated, where in the code. -->
<!-- See PRs #2796, #2751, #2714 for examples of the level of detail we're looking for. -->

## Why This Fix Is Correct

<!-- What invariant is restored? Why is the fix minimal? -->

## Failure Modes Considered

<!-- Required for Core Runtime (at least 2). Recommended for all bug fixes. -->
<!-- Examples: concurrency/retries, subprocess output propagation, env-var leakage, backward compat -->

1.
2.

## Tests

- [ ] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

<!-- What you intentionally did not change. Helps reviewers scope their review. -->

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [ ] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)

<!-- If you used AI tools:
- Which tool(s)?
- What did you use them for?
- Did you review, understand, and test all generated code?
-->
