### PR TITLE
Allow UserStepDecorators to also be StepMutators

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -561,8 +561,6 @@ def start(
     ctx.obj.monitor.start()
     _system_monitor.init_system_monitor(ctx.obj.flow.name, ctx.obj.monitor)
 
-    decorators._init(ctx.obj.flow)
-
     # Populate the system context singleton for this process. The phase is
     # determined by which CLI subcommand is being invoked (e.g. "run" → LAUNCH,
     # "step" → TASK, "batch" → TRAMPOLINE).

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -475,9 +475,8 @@ def start(
         # be raised. For resume, since we ignore those options, we ignore the error.
         raise ctx.obj.delayed_config_exception
 
-    # Init all values in the flow mutators and then process them
-    for decorator in ctx.obj.flow._flow_mutators:
-        decorator.external_init()
+    # Process config decorators (this is the pre_mutate phase for both flow mutators and
+    # step mutators -- the mutate is called in init_step_decorators)
 
     new_cls = ctx.obj.flow._process_config_decorators(config_options)
     if new_cls:
@@ -640,7 +639,6 @@ def start(
             all_decospecs = []
         if all_decospecs:
             decorators._attach_decorators(ctx.obj.flow, all_decospecs)
-            decorators._init(ctx.obj.flow)
             # Regenerate graph if we attached more decorators
             ctx.obj.flow.__class__._init_graph()
             ctx.obj.graph = ctx.obj.flow._graph

--- a/metaflow/cli_components/run_cmds.py
+++ b/metaflow/cli_components/run_cmds.py
@@ -54,7 +54,6 @@ def before_run(obj, tags, decospecs, skip_decorators=False):
             # These decospecs are the ones from run/resume/spin PLUS the ones from the
             # environment (for example the @conda)
             decorators._attach_decorators(obj.flow, all_decospecs)
-            decorators._init(obj.flow)
             # Regenerate graph if we attached more decorators
             obj.flow.__class__._init_graph()
             obj.graph = obj.flow._graph

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -372,13 +372,28 @@ class StepDecorator(Decorator):
     task_step_completed_ctx = None  # coalesces task_post_step + task_exception
     task_finished_ctx = None
 
+    def check_step_conflicts(self, decorators):
+        """
+        Validate this decorator against all other decorators on the same step.
+
+        Called automatically during step_init, before the decorator's own
+        step_init logic runs. Override in subclasses to declare conflicts.
+        Raise MetaflowException if an incompatible combination is detected.
+
+        Parameters
+        ----------
+        decorators : list
+            All decorators on this step (including self).
+        """
+        pass
+
     def step_init(
         self, flow, graph, step_name, decorators, environment, flow_datastore, logger
     ):
         """
         Called when all decorators have been created for this step
         """
-        pass
+        self.check_step_conflicts(decorators)
 
     def package_init(self, flow, step_name, environment):
         """

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -372,63 +372,13 @@ class StepDecorator(Decorator):
     task_step_completed_ctx = None  # coalesces task_post_step + task_exception
     task_finished_ctx = None
 
-    @staticmethod
-    def find_decorator_attrs(flow_cls, step_name, deco_name, **exclude):
-        """
-        Find a step decorator's attributes at runtime.
-
-        Returns the attributes dict of the first matching decorator, or None.
-        Use ``exclude`` to skip decorators with specific attribute values,
-        e.g. ``find_decorator_attrs(cls, step, "resources", node_type="head")``
-        skips any @resources with node_type="head".
-
-        Parameters
-        ----------
-        flow_cls : type
-            The FlowSpec class.
-        step_name : str
-            The step function name.
-        deco_name : str
-            The decorator name to find.
-        **exclude
-            Attribute key-value pairs to skip.
-
-        Returns
-        -------
-        dict or None
-            The decorator's attributes, or None if not found.
-        """
-        for deco in getattr(flow_cls, step_name).decorators:
-            if deco.name == deco_name:
-                if exclude and any(
-                    deco.attributes.get(k) == v for k, v in exclude.items()
-                ):
-                    continue
-                return deco.attributes
-        return None
-
-    def check_step_conflicts(self, decorators):
-        """
-        Validate this decorator against all other decorators on the same step.
-
-        Called automatically during step_init, before the decorator's own
-        step_init logic runs. Override in subclasses to declare conflicts.
-        Raise MetaflowException if an incompatible combination is detected.
-
-        Parameters
-        ----------
-        decorators : list
-            All decorators on this step (including self).
-        """
-        pass
-
     def step_init(
         self, flow, graph, step_name, decorators, environment, flow_datastore, logger
     ):
         """
         Called when all decorators have been created for this step
         """
-        self.check_step_conflicts(decorators)
+        pass
 
     def package_init(self, flow, step_name, environment):
         """

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -372,6 +372,41 @@ class StepDecorator(Decorator):
     task_step_completed_ctx = None  # coalesces task_post_step + task_exception
     task_finished_ctx = None
 
+    @staticmethod
+    def find_decorator_attrs(flow_cls, step_name, deco_name, **exclude):
+        """
+        Find a step decorator's attributes at runtime.
+
+        Returns the attributes dict of the first matching decorator, or None.
+        Use ``exclude`` to skip decorators with specific attribute values,
+        e.g. ``find_decorator_attrs(cls, step, "resources", node_type="head")``
+        skips any @resources with node_type="head".
+
+        Parameters
+        ----------
+        flow_cls : type
+            The FlowSpec class.
+        step_name : str
+            The step function name.
+        deco_name : str
+            The decorator name to find.
+        **exclude
+            Attribute key-value pairs to skip.
+
+        Returns
+        -------
+        dict or None
+            The decorator's attributes, or None if not found.
+        """
+        for deco in getattr(flow_cls, step_name).decorators:
+            if deco.name == deco_name:
+                if exclude and any(
+                    deco.attributes.get(k) == v for k, v in exclude.items()
+                ):
+                    continue
+                return deco.attributes
+        return None
+
     def check_step_conflicts(self, decorators):
         """
         Validate this decorator against all other decorators on the same step.

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -925,6 +925,11 @@ def _init_step_decorators(
                 cached_skip_decorators.add(deco.name)
                 continue
             deco.external_init()
+        # Also call external_init on UserStepDecorator wrappers. The _ran_init
+        # guard in external_init handles dual-inherit decorators that already
+        # had external_init called via config_decorators in _process_config_decorators.
+        for deco in step.wrappers or []:
+            deco.external_init()
     for step in flow:
         for deco in step.decorators:
             if deco.name in cached_skip_decorators:

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -912,17 +912,12 @@ def _init_step_decorators(
 
     # Call the external_init on all step decorators. At this point, we have all the ones
     # the user wants to add through mutators
-    cached_skip_decorators = set()
-
     for step in flow:
         system_context.register_step_decorators(step.__name__, list(step.decorators))
         for deco in step.decorators:
-            if deco.name in cached_skip_decorators:
-                continue
             if _should_skip_decorator_for_spin(
                 deco, is_spin, skip_decorators, logger, "Step decorator"
             ):
-                cached_skip_decorators.add(deco.name)
                 continue
             deco.external_init()
         # Also call external_init on UserStepDecorator wrappers. The _ran_init
@@ -932,7 +927,9 @@ def _init_step_decorators(
             deco.external_init()
     for step in flow:
         for deco in step.decorators:
-            if deco.name in cached_skip_decorators:
+            if _should_skip_decorator_for_spin(
+                deco, is_spin, skip_decorators, logger, "Step decorator"
+            ):
                 continue
             if deco.step_init_ctx is not None:
                 deco.step_init_ctx(step.__name__)

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -767,21 +767,6 @@ def _should_skip_decorator_for_spin(
     return False
 
 
-def _init(flow, only_non_static=False):
-    flow_decos = flow._flow_state[FlowStateItems.FLOW_DECORATORS]
-    for decorators in flow_decos.values():
-        for deco in decorators:
-            deco.external_init()
-
-    for flowstep in flow:
-        for deco in flowstep.decorators:
-            deco.external_init()
-        for deco in flowstep.config_decorators or []:
-            deco.external_init()
-        for deco in flowstep.wrappers or []:
-            deco.external_init()
-
-
 def _init_flow_decorators(
     flow,
     graph,
@@ -796,6 +781,12 @@ def _init_flow_decorators(
 ):
     # Since all flow decorators are stored as `{key:[deco]}` we iterate through each of them.
     flow_decos = flow._flow_state[FlowStateItems.FLOW_DECORATORS]
+
+    # Run external_init on all decorators first
+    for decorators in flow_decos.values():
+        for deco in decorators:
+            deco.external_init()
+
     for decorators in flow_decos.values():
         # First resolve the `options` for the flow decorator.
         # Options are passed from cli.
@@ -919,12 +910,24 @@ def _init_step_decorators(
 
     from .system_context import system_context
 
+    # Call the external_init on all step decorators. At this point, we have all the ones
+    # the user wants to add through mutators
+    cached_skip_decorators = set()
+
     for step in flow:
         system_context.register_step_decorators(step.__name__, list(step.decorators))
         for deco in step.decorators:
+            if deco.name in cached_skip_decorators:
+                continue
             if _should_skip_decorator_for_spin(
                 deco, is_spin, skip_decorators, logger, "Step decorator"
             ):
+                cached_skip_decorators.add(deco.name)
+                continue
+            deco.external_init()
+    for step in flow:
+        for deco in step.decorators:
+            if deco.name in cached_skip_decorators:
                 continue
             if deco.step_init_ctx is not None:
                 deco.step_init_ctx(step.__name__)

--- a/metaflow/extension_support/__init__.py
+++ b/metaflow/extension_support/__init__.py
@@ -87,6 +87,8 @@ EXT_EXCLUDE_SUFFIXES = [".pyc"]
 FINDER_TRANS = str.maketrans(".-", "__")
 
 # To get verbose messages, set METAFLOW_DEBUG_EXT to 1
+# We cannot rely on the debug mechanism because of a circular import (that relies on
+# configs which are loaded here)
 DEBUG_EXT = os.environ.get("METAFLOW_DEBUG_EXT", False)
 
 # This is extracted only from environment variable and here separately from

--- a/metaflow/flowspec.py
+++ b/metaflow/flowspec.py
@@ -376,6 +376,9 @@ class FlowSpec(metaclass=FlowSpecMeta):
             return None
 
         debug.userconf_exec("Processing mutating step/flow decorators")
+
+        for decorator in cls._flow_state[FlowStateItems.FLOW_MUTATORS]:
+            decorator.external_init()
         # We need to convert all the user configurations from DelayedEvaluationParameters
         # to actual values so they can be used as is in the mutators.
 
@@ -434,24 +437,27 @@ class FlowSpec(metaclass=FlowSpecMeta):
         for step in cls._steps:
             for deco in step.config_decorators:
                 if isinstance(deco, StepMutator):
-                    inserted_by_value = [deco.decorator_name] + (deco.inserted_by or [])
-                    debug.userconf_exec(
-                        "Evaluating step level decorator %s for %s (pre-mutate)"
-                        % (deco.__class__.__name__, step.name)
-                    )
-                    deco.pre_mutate(
-                        MutableStep(
-                            cls,
-                            step,
-                            pre_mutate=True,
-                            statically_defined=deco.statically_defined,
-                            inserted_by=inserted_by_value,
-                        )
-                    )
+                    deco.external_init()
                 else:
                     raise MetaflowInternalError(
                         "A non StepMutator found in step custom decorators"
                     )
+        for step in cls._steps:
+            for deco in step.config_decorators:
+                inserted_by_value = [deco.decorator_name] + (deco.inserted_by or [])
+                debug.userconf_exec(
+                    "Evaluating step level decorator %s for %s (pre-mutate)"
+                    % (deco.__class__.__name__, step.name)
+                )
+                deco.pre_mutate(
+                    MutableStep(
+                        cls,
+                        step,
+                        pre_mutate=True,
+                        statically_defined=deco.statically_defined,
+                        inserted_by=inserted_by_value,
+                    )
+                )
 
         # Process parameters to allow them to also use config values easily
         for var, param in cls._get_parameters():

--- a/metaflow/runner/click_api.py
+++ b/metaflow/runner/click_api.py
@@ -525,9 +525,8 @@ class MetaflowAPI(object):
         # it will init all parameters (config_options will be None)
         # We ignore any errors if we don't check the configs in the click API.
 
-        # Init all values in the flow mutators and then process them
-        for decorator in self._flow_cls._flow_state[FlowStateItems.FLOW_MUTATORS]:
-            decorator.external_init()
+        # Process config decorators (this is the pre_mutate phase for both flow mutators
+        # and step mutators -- the mutate is called in init_step_decorators)
 
         new_cls = self._flow_cls._process_config_decorators(
             config_options, process_configs=CLICK_API_PROCESS_CONFIG

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -74,7 +74,7 @@ class MetaflowTask(object):
         # contain the arguments to pass to `self.next`. If
         # True, it means we are using whatever the usual
         # arguments to `self.next` are for this step.
-        fake_next_call_args = False
+        fake_next_call_args = None
         raised_exception = None
         had_raised_exception = False
 
@@ -103,7 +103,7 @@ class MetaflowTask(object):
                 # wrapped function
             # Else, we continue down the list of wrappers
         try:
-            # fake_next_call is used here to also indicate that the step was skipped
+            # fake_next_call_args is used here to also indicate that the step was skipped
             # so we do not execute anything.
             if not fake_next_call_args:
                 if input_obj is None:
@@ -139,14 +139,14 @@ class MetaflowTask(object):
                     raise r[2]
             else:
                 raise RuntimeError(
-                    "Invalid return value from a UserStepDecorator. Expected an"
+                    "Invalid return value from a UserStepDecorator. Expected an "
                     "exception or an exception and arguments for self.next, got: %s" % r
                 )
         if raised_exception:
             # We have an exception that we need to propagate
             raise raised_exception
 
-        if fake_next_call_args or had_raised_exception:
+        if fake_next_call_args is not None or had_raised_exception:
             # We want to override the next call or we caught an exception (in which
             # case the regular step code didn't call self.next). In this case,
             # we need to set the transition variables
@@ -179,7 +179,7 @@ class MetaflowTask(object):
                 else:
                     raise RuntimeError(
                         "Invalid value passed to self.next; expected "
-                        " bool of a dictionary; got: %s" % fake_next_call_args
+                        "bool or a dictionary; got: %s" % fake_next_call_args
                     )
 
     def _init_parameters(self, parameter_ds, passdown=True):

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -108,12 +108,12 @@ class MetaflowTask(object):
             if not fake_next_call_args:
                 if input_obj is None:
                     if wrapped_func:
-                        fake_next_call_args = wrapped_func(self.flow)
+                        fake_next_call_args = wrapped_func(self.flow) or None
                     else:
                         step_function()
                 else:
                     if wrapped_func:
-                        fake_next_call_args = wrapped_func(self.flow, input_obj)
+                        fake_next_call_args = wrapped_func(self.flow, input_obj) or None
                     else:
                         step_function(input_obj)
         except Exception as ex:

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -146,7 +146,13 @@ class MetaflowTask(object):
             # We have an exception that we need to propagate
             raise raised_exception
 
-        if fake_next_call_args is not None or had_raised_exception:
+        # Both None and False mean "do not override the self.next call".
+        # None is the post_step sentinel; False is accepted for symmetry so a
+        # UserStepDecorator whose post_step returns (None, False) is a no-op
+        # instead of tripping the "Invalid value" RuntimeError below.
+        if (
+            fake_next_call_args is not None and fake_next_call_args is not False
+        ) or had_raised_exception:
             # We want to override the next call or we caught an exception (in which
             # case the regular step code didn't call self.next). In this case,
             # we need to set the transition variables

--- a/metaflow/user_decorators/mutable_flow.py
+++ b/metaflow/user_decorators/mutable_flow.py
@@ -390,7 +390,12 @@ class MutableFlow:
                 "Adding flow-decorator '%s' from %s is only allowed in the `pre_mutate` "
                 "method and not the `mutate` method"
                 % (
-                    deco_type if isinstance(deco_type, str) else deco_type.name,
+                    (
+                        deco_type
+                        if isinstance(deco_type, str)
+                        else getattr(deco_type, "name", None)
+                        or getattr(deco_type, "decorator_name", deco_type)
+                    ),
                     self._inserted_by,
                 )
             )

--- a/metaflow/user_decorators/mutable_flow.py
+++ b/metaflow/user_decorators/mutable_flow.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
     import metaflow.flowspec
     import metaflow.parameters
     import metaflow.user_decorators.mutable_step
+    import metaflow.decorators
+    import metaflow.user_decorators.user_flow_decorator as user_flow_decorator
 
 
 class MutableFlow:
@@ -254,14 +256,16 @@ class MutableFlow:
 
     def add_decorator(
         self,
-        deco_type: Union[partial, str],
+        deco_type: Union[partial, "user_flow_decorator.FlowMutator", str],
         deco_args: Optional[List[Any]] = None,
         deco_kwargs: Optional[Dict[str, Any]] = None,
         duplicates: int = IGNORE,
-    ) -> None:
+    ) -> Optional[
+        Union["metaflow.decorators.FlowDecorator", "user_flow_decorator.FlowMutator"]
+    ]:
         """
-        Add a Metaflow flow-decorator to a flow. You can only add decorators in the
-        `pre_mutate` method.
+        Add a Metaflow flow-decorator or a FlowMutator to a flow. You can only add
+        decorators in the `pre_mutate` method.
 
         You can either add the decorator itself or its decorator specification for it
         (the same you would get back from decorator_specs). You can also mix and match
@@ -298,12 +302,15 @@ class MutableFlow:
             if the newly added decorator is *static* (ie: defined directly in the code).
             If not, it is ignored.
 
+        You can also add a FlowMutator class. The new FlowMutator will have its
+        ``external_init()`` called immediately and its ``pre_mutate`` will be called
+        as part of the ongoing iteration (Python's ``for`` over a list sees appended items).
+
         Parameters
         ----------
-        deco_type : Union[partial, str]
-            The decorator class to add to this flow. If using a string, you cannot specify
-            additional arguments as all argument will be parsed from the decorator
-            specification.
+        deco_type : Union[partial, FlowMutator, str]
+            The decorator class to add to this flow. Can be a FlowDecorator partial,
+            a FlowMutator subclass, or a string decorator specification.
         deco_args : List[Any], optional, default None
             Positional arguments to pass to the decorator.
         deco_kwargs : Dict[str, Any], optional, default None
@@ -313,6 +320,11 @@ class MutableFlow:
             - `MutableFlow.IGNORE`: Ignore the decorator if it already exists.
             - `MutableFlow.ERROR`: Raise an error if the decorator already exists.
             - `MutableFlow.OVERRIDE`: Remove the existing decorator and add this one.
+
+        Returns
+        -------
+        Optional[Union[FlowDecorator, FlowMutator]]
+            The decorator that was added or None if none was added due to duplicate handling.
 
         """
         if not self._pre_mutate:
@@ -358,6 +370,7 @@ class MutableFlow:
                 debug.userconf_exec(
                     "Mutable flow adding flow decorator '%s'" % deco_type
                 )
+                return flow_deco
 
             # self._flow_cls._flow_state[FlowStateItems.FLOW_DECORATORS] is a  dictionary of form :
             # <deco_name> : [deco_instance, deco_instance, ...]
@@ -365,13 +378,14 @@ class MutableFlow:
             existing_deco = [d for d in flow_decos if d == flow_deco.name]
 
             if flow_deco.allow_multiple or not existing_deco:
-                _do_add()
+                return _do_add()
             elif duplicates == MutableFlow.IGNORE:
                 # If we ignore, we do not add the decorator
                 debug.userconf_exec(
                     "Mutable flow ignoring flow decorator '%s'"
                     "(already exists and duplicates are ignored)" % flow_deco.name
                 )
+                return None
             elif duplicates == MutableFlow.OVERRIDE:
                 # If we override, we remove the existing decorator and add this one
                 debug.userconf_exec(
@@ -382,7 +396,7 @@ class MutableFlow:
                 self._flow_cls._flow_state[FlowStateItems.FLOW_DECORATORS] = {
                     d: flow_decos[d] for d in flow_decos if d != flow_deco.name
                 }
-                _do_add()
+                return _do_add()
             elif duplicates == MutableFlow.ERROR:
                 # If we error, we raise an exception
                 if self._statically_defined:
@@ -392,6 +406,7 @@ class MutableFlow:
                         "Mutable flow ignoring flow decorator '%s' "
                         "(already exists and non statically defined)" % flow_deco.name
                     )
+                return None
             else:
                 raise ValueError("Invalid duplicates value: %s" % duplicates)
 
@@ -403,8 +418,33 @@ class MutableFlow:
                     "Cannot specify additional arguments when adding a flow decorator "
                     "using a decospec that already contains arguments"
                 )
-            _add_flow_decorator(flow_deco)
-            return
+            return _add_flow_decorator(flow_deco)
+
+        # Check if this is a FlowMutator class
+        from .user_flow_decorator import FlowMutator
+
+        if isinstance(deco_type, type) and issubclass(deco_type, FlowMutator):
+            from ..flowspec import FlowStateItems
+
+            d = deco_type(*deco_args, **deco_kwargs)
+            d.statically_defined = self._statically_defined
+            d.inserted_by = self._inserted_by
+            d._flow_cls = self._flow_cls
+
+            # Append to the merged list (the one being iterated in the pre_mutate
+            # loop) so the new mutator's pre_mutate is called naturally.
+            merged_mutators = self._flow_cls._flow_state[FlowStateItems.FLOW_MUTATORS]
+            merged_mutators.append(d)
+            # Also append to the underlying _self_data so a cache rebuild
+            # includes this mutator. We use _self_data directly (not the
+            # self_data property) to avoid clearing the merged cache.
+            self._flow_cls._flow_state._self_data[FlowStateItems.FLOW_MUTATORS].append(
+                d
+            )
+
+            # external_init must be called before pre_mutate runs
+            d.external_init()
+            return d
 
         # Validate deco_type
         if (
@@ -412,10 +452,10 @@ class MutableFlow:
             or len(deco_type.args) != 1
             or not issubclass(deco_type.args[0], FlowDecorator)
         ):
-            raise TypeError("add_decorator takes a FlowDecorator")
+            raise TypeError("add_decorator takes a FlowDecorator or FlowMutator")
 
         deco_type = deco_type.args[0]
-        _add_flow_decorator(
+        return _add_flow_decorator(
             deco_type(
                 attributes=deco_kwargs,
                 statically_defined=self._statically_defined,

--- a/metaflow/user_decorators/mutable_flow.py
+++ b/metaflow/user_decorators/mutable_flow.py
@@ -82,6 +82,20 @@ class MutableFlow:
                 r.extend(deco.get_args_kwargs())
                 yield tuple(r)
 
+    def has_decorator(self, name: str) -> bool:
+        """Check whether this flow has at least one decorator with the given name."""
+        for deco_name, _fq, _args, _kwargs in self.decorator_specs:
+            if deco_name == name:
+                return True
+        return False
+
+    def get_decorator_kwargs(self, name: str) -> Optional[Dict[str, Any]]:
+        """Return the kwargs of the first flow decorator with the given name, or None."""
+        for deco_name, _fq, _args, kwargs in self.decorator_specs:
+            if deco_name == name:
+                return dict(kwargs)
+        return None
+
     @property
     def configs(self) -> Generator[Tuple[str, ConfigValue], None, None]:
         """

--- a/metaflow/user_decorators/mutable_flow.py
+++ b/metaflow/user_decorators/mutable_flow.py
@@ -60,17 +60,15 @@ class MutableFlow:
         Yields
         ------
         str, str, List[Any], Dict[str, Any]
-            A tuple containing the decorator name, it's fully qualified name,
+            A tuple containing the decorator name, its fully qualified name,
             a list of positional arguments, and a dictionary of keyword arguments.
         """
         from metaflow.flowspec import FlowStateItems
+        from .user_flow_decorator import FlowMutator, FlowMutatorMeta
 
         flow_decos = self._flow_cls._flow_state[FlowStateItems.FLOW_DECORATORS]
         for decos in flow_decos.values():
             for deco in decos:
-                # 3.7 does not support yield foo, *bar syntax so we
-                # work around
-
                 r = [
                     deco.name,
                     "%s.%s"
@@ -82,19 +80,51 @@ class MutableFlow:
                 r.extend(deco.get_args_kwargs())
                 yield tuple(r)
 
+        for deco in self._flow_cls._flow_state[FlowStateItems.FLOW_MUTATORS]:
+            if isinstance(deco, FlowMutator):
+                short_name = FlowMutatorMeta.get_decorator_name(deco.__class__)
+                r = [
+                    short_name or deco.__class__.__name__,
+                    deco.decorator_name,
+                    list(deco._args),
+                    dict(deco._kwargs),
+                ]
+                yield tuple(r)
+
     def has_decorator(self, name: str) -> bool:
-        """Check whether this flow has at least one decorator with the given name."""
-        for deco_name, _fq, _args, _kwargs in self.decorator_specs:
-            if deco_name == name:
+        """Check whether this flow has at least one decorator with the given name.
+
+        Parameters
+        ----------
+        name : str
+            The decorator name (short) or fully qualified name (contains a period).
+        """
+        for deco_name, deco_fq, _args, _kwargs in self.decorator_specs:
+            if self._match_name(deco_name, deco_fq, name):
                 return True
         return False
 
-    def get_decorator_kwargs(self, name: str) -> Optional[Dict[str, Any]]:
-        """Return the kwargs of the first flow decorator with the given name, or None."""
-        for deco_name, _fq, _args, kwargs in self.decorator_specs:
-            if deco_name == name:
-                return dict(kwargs)
-        return None
+    def get_decorator_specs(
+        self, name: str
+    ) -> List[Tuple[str, str, List[Any], Dict[str, Any]]]:
+        """Return all spec tuples matching the given name.
+
+        Parameters
+        ----------
+        name : str
+            The decorator name (short) or fully qualified name (contains a period).
+
+        Returns
+        -------
+        List[Tuple[str, str, List[Any], Dict[str, Any]]]
+            A list of (short_name, fq_name, args, kwargs) tuples. Empty list if
+            no decorators match.
+        """
+        return [
+            (deco_name, deco_fq, list(args), dict(kwargs))
+            for deco_name, deco_fq, args, kwargs in self.decorator_specs
+            if self._match_name(deco_name, deco_fq, name)
+        ]
 
     @property
     def configs(self) -> Generator[Tuple[str, ConfigValue], None, None]:
@@ -122,6 +152,9 @@ class MutableFlow:
         ```
         can be used to add an environment decorator to the `start` step.
 
+        If you want to access a particular configuration value, you can use the getattr
+        method or simply <MutableFlow>.step_name.
+
         Yields
         ------
         Tuple[str, ConfigValue]
@@ -143,6 +176,9 @@ class MutableFlow:
     ) -> Generator[Tuple[str, "metaflow.parameters.Parameter"], None, None]:
         """
         Iterate over all the parameters in this flow.
+
+        If you want to access a particular parameter, you can use the getattr method or
+        simply <MutableFlow>.step_name.
 
         Yields
         ------
@@ -167,6 +203,9 @@ class MutableFlow:
         Iterate over all the steps in this flow. The order of the steps
         returned is not guaranteed.
 
+        If you want to access a particular step, you can use the getattr method or simply
+        <MutableFlow>.step_name.
+
         Yields
         ------
         Tuple[str, MutableStep]
@@ -185,34 +224,6 @@ class MutableFlow:
                     statically_defined=self._statically_defined,
                     inserted_by=self._inserted_by,
                 )
-
-    def get_step(
-        self, name: str
-    ) -> "metaflow.user_decorators.mutable_step.MutableStep":
-        """
-        Look up a step by name.
-
-        Parameters
-        ----------
-        name : str
-            The name of the step to look up.
-
-        Returns
-        -------
-        MutableStep
-            The mutable step proxy.
-
-        Raises
-        ------
-        MetaflowException
-            If no step with the given name exists in this flow.
-        """
-        for step_name, step_proxy in self.steps:
-            if step_name == name:
-                return step_proxy
-        raise MetaflowException(
-            "Step '%s' not found in flow '%s'." % (name, self._flow_cls.__name__)
-        )
 
     def add_parameter(
         self, name: str, value: "metaflow.parameters.Parameter", overwrite: bool = False
@@ -585,6 +596,9 @@ class MutableFlow:
         Note that if multiple decorators share the same decorator specification
         (very rare), they will all be removed.
 
+        FlowMutators cannot be removed because they are processed during iteration.
+        Attempting to remove a FlowMutator will raise an error.
+
         You can only remove decorators in the `pre_mutate` method.
 
         Parameters
@@ -605,12 +619,29 @@ class MutableFlow:
 
         # Prevent circular import
         from metaflow.flowspec import FlowStateItems
+        from .user_flow_decorator import FlowMutator, FlowMutatorMeta
 
         if not self._pre_mutate:
             raise MetaflowException(
                 "Removing flow-decorator '%s' from %s is only allowed in the `pre_mutate` "
                 "method and not the `mutate` method" % (deco_name, self._inserted_by)
             )
+
+        # Check if the name matches a FlowMutator — these cannot be removed
+        # because the pre_mutate loop is iterating over them.
+        for deco in self._flow_cls._flow_state[FlowStateItems.FLOW_MUTATORS]:
+            if isinstance(deco, FlowMutator):
+                if self._match_name(
+                    FlowMutatorMeta.get_decorator_name(deco.__class__)
+                    or deco.__class__.__name__,
+                    deco.decorator_name,
+                    deco_name,
+                ):
+                    raise MetaflowException(
+                        "Cannot remove FlowMutator '%s'. FlowMutators are processed "
+                        "during iteration and cannot be removed. Only FlowDecorators "
+                        "(e.g. @project, @schedule) can be removed." % deco_name
+                    )
 
         do_all = deco_args is None and deco_kwargs is None
         did_remove = False
@@ -642,6 +673,16 @@ class MutableFlow:
         else:
             del flow_decos[deco_name]
         return did_remove
+
+    def _match_name(self, deco_name: str, deco_fq: str, query: str) -> bool:
+        """Return True if *query* matches either the short or fully-qualified name.
+
+        A query containing a period is compared against the fully-qualified name;
+        otherwise it is compared against the short name.
+        """
+        if "." in query:
+            return deco_fq == query
+        return deco_name == query
 
     def __getattr__(self, name):
         # We allow direct access to the steps, configs and parameters but nothing else

--- a/metaflow/user_decorators/mutable_flow.py
+++ b/metaflow/user_decorators/mutable_flow.py
@@ -9,8 +9,8 @@ if TYPE_CHECKING:
     import metaflow.flowspec
     import metaflow.parameters
     import metaflow.user_decorators.mutable_step
+    import metaflow.user_decorators.user_flow_decorator
     import metaflow.decorators
-    import metaflow.user_decorators.user_flow_decorator as user_flow_decorator
 
 
 class MutableFlow:
@@ -254,14 +254,48 @@ class MutableFlow:
         )
         return False
 
+    def _add_flow_mutator(
+        self, d: "user_flow_decorator.FlowMutator"
+    ) -> "user_flow_decorator.FlowMutator":
+        """Register a FlowMutator instance and prepare it for execution.
+
+        Appends to both the merged list (for the current iteration) and the
+        underlying _self_data (for cache rebuild safety). Calls external_init()
+        so the mutator is ready before its pre_mutate is called by the ongoing
+        iteration loop.
+        """
+        from ..flowspec import FlowStateItems
+
+        d.statically_defined = self._statically_defined
+        d.inserted_by = self._inserted_by
+        d._flow_cls = self._flow_cls
+
+        # Append to the merged list (the one being iterated in the pre_mutate
+        # loop) so the new mutator's pre_mutate is called naturally.
+        merged_mutators = self._flow_cls._flow_state[FlowStateItems.FLOW_MUTATORS]
+        merged_mutators.append(d)
+        # Also append to the underlying _self_data so a cache rebuild
+        # includes this mutator. We use _self_data directly (not the
+        # self_data property) to avoid clearing the merged cache.
+        self._flow_cls._flow_state._self_data[FlowStateItems.FLOW_MUTATORS].append(d)
+
+        # external_init must be called before pre_mutate runs
+        d.external_init()
+        return d
+
     def add_decorator(
         self,
-        deco_type: Union[partial, "user_flow_decorator.FlowMutator", str],
+        deco_type: Union[
+            partial, "metaflow.user_decorators.user_flow_decorator.FlowMutator", str
+        ],
         deco_args: Optional[List[Any]] = None,
         deco_kwargs: Optional[Dict[str, Any]] = None,
         duplicates: int = IGNORE,
     ) -> Optional[
-        Union["metaflow.decorators.FlowDecorator", "user_flow_decorator.FlowMutator"]
+        Union[
+            "metaflow.decorators.FlowDecorator",
+            "metaflow.user_decorators.user_flow_decorator.FlowMutator",
+        ]
     ]:
         """
         Add a Metaflow flow-decorator or a FlowMutator to a flow. You can only add
@@ -303,8 +337,8 @@ class MutableFlow:
             If not, it is ignored.
 
         You can also add a FlowMutator class. The new FlowMutator will have its
-        ``external_init()`` called immediately and its ``pre_mutate`` will be called
-        as part of the ongoing iteration (Python's ``for`` over a list sees appended items).
+        ``external_init()`` called immediately and its ``pre_mutate`` will be called after
+        all previously existing FlowMutators have called pre-mutate.
 
         Parameters
         ----------
@@ -410,6 +444,9 @@ class MutableFlow:
             else:
                 raise ValueError("Invalid duplicates value: %s" % duplicates)
 
+        # Check if this is a FlowMutator class or instance
+        from .user_flow_decorator import FlowMutator
+
         # If deco_type is a string, we want to parse it to a decospec
         if isinstance(deco_type, str):
             flow_deco, has_args_kwargs = extract_flow_decorator_from_decospec(deco_type)
@@ -418,33 +455,15 @@ class MutableFlow:
                     "Cannot specify additional arguments when adding a flow decorator "
                     "using a decospec that already contains arguments"
                 )
+            if isinstance(flow_deco, FlowMutator):
+                # String resolved to a FlowMutator instance — route it through
+                # the FlowMutator addition path
+                return self._add_flow_mutator(flow_deco)
             return _add_flow_decorator(flow_deco)
 
-        # Check if this is a FlowMutator class
-        from .user_flow_decorator import FlowMutator
-
         if isinstance(deco_type, type) and issubclass(deco_type, FlowMutator):
-            from ..flowspec import FlowStateItems
-
             d = deco_type(*deco_args, **deco_kwargs)
-            d.statically_defined = self._statically_defined
-            d.inserted_by = self._inserted_by
-            d._flow_cls = self._flow_cls
-
-            # Append to the merged list (the one being iterated in the pre_mutate
-            # loop) so the new mutator's pre_mutate is called naturally.
-            merged_mutators = self._flow_cls._flow_state[FlowStateItems.FLOW_MUTATORS]
-            merged_mutators.append(d)
-            # Also append to the underlying _self_data so a cache rebuild
-            # includes this mutator. We use _self_data directly (not the
-            # self_data property) to avoid clearing the merged cache.
-            self._flow_cls._flow_state._self_data[FlowStateItems.FLOW_MUTATORS].append(
-                d
-            )
-
-            # external_init must be called before pre_mutate runs
-            d.external_init()
-            return d
+            return self._add_flow_mutator(d)
 
         # Validate deco_type
         if (

--- a/metaflow/user_decorators/mutable_flow.py
+++ b/metaflow/user_decorators/mutable_flow.py
@@ -172,6 +172,34 @@ class MutableFlow:
                     inserted_by=self._inserted_by,
                 )
 
+    def get_step(
+        self, name: str
+    ) -> "metaflow.user_decorators.mutable_step.MutableStep":
+        """
+        Look up a step by name.
+
+        Parameters
+        ----------
+        name : str
+            The name of the step to look up.
+
+        Returns
+        -------
+        MutableStep
+            The mutable step proxy.
+
+        Raises
+        ------
+        MetaflowException
+            If no step with the given name exists in this flow.
+        """
+        for step_name, step_proxy in self.steps:
+            if step_name == name:
+                return step_proxy
+        raise MetaflowException(
+            "Step '%s' not found in flow '%s'." % (name, self._flow_cls.__name__)
+        )
+
     def add_parameter(
         self, name: str, value: "metaflow.parameters.Parameter", overwrite: bool = False
     ) -> None:

--- a/metaflow/user_decorators/mutable_flow.py
+++ b/metaflow/user_decorators/mutable_flow.py
@@ -479,6 +479,9 @@ class MutableFlow:
             flow_mutator._flow_cls = self._flow_cls
 
             def _do_add():
+                # Call external_init BEFORE appending to lists so that if it
+                # fails the mutator is not left half-registered.
+                flow_mutator.external_init()
                 # Append to the merged list (the one being iterated in the
                 # pre_mutate loop) so the new mutator's pre_mutate is called
                 # naturally by the ongoing iteration.
@@ -492,8 +495,6 @@ class MutableFlow:
                 self._flow_cls._flow_state._self_data[
                     FlowStateItems.FLOW_MUTATORS
                 ].append(flow_mutator)
-                # external_init must be called before pre_mutate runs
-                flow_mutator.external_init()
                 debug.userconf_exec(
                     "Mutable flow adding flow mutator '%s'"
                     % flow_mutator.decorator_name
@@ -501,14 +502,14 @@ class MutableFlow:
                 return flow_mutator
 
             # Check for existing mutator with the same decorator_name
-            existing = [
-                m
+            existing_ids = {
+                id(m)
                 for m in self._flow_cls._flow_state[FlowStateItems.FLOW_MUTATORS]
                 if hasattr(m, "decorator_name")
                 and m.decorator_name == flow_mutator.decorator_name
-            ]
+            }
 
-            if not existing:
+            if not existing_ids:
                 return _do_add()
             elif duplicates == MutableFlow.IGNORE:
                 debug.userconf_exec(
@@ -523,17 +524,15 @@ class MutableFlow:
                     "(removing existing mutator and adding new one)"
                     % flow_mutator.decorator_name
                 )
-                # Remove from both the merged list and _self_data
+                # Filter out existing entries from both merged and _self_data.
+                # Use slice-assignment on merged to mutate in place (the outer
+                # pre_mutate for-loop holds a reference to this list object).
                 merged = self._flow_cls._flow_state[FlowStateItems.FLOW_MUTATORS]
-                for m in existing:
-                    if m in merged:
-                        merged.remove(m)
+                merged[:] = [m for m in merged if id(m) not in existing_ids]
                 self_list = self._flow_cls._flow_state._self_data[
                     FlowStateItems.FLOW_MUTATORS
                 ]
-                for m in existing:
-                    if m in self_list:
-                        self_list.remove(m)
+                self_list[:] = [m for m in self_list if id(m) not in existing_ids]
                 return _do_add()
             elif duplicates == MutableFlow.ERROR:
                 if self._statically_defined:

--- a/metaflow/user_decorators/mutable_flow.py
+++ b/metaflow/user_decorators/mutable_flow.py
@@ -254,35 +254,6 @@ class MutableFlow:
         )
         return False
 
-    def _add_flow_mutator(
-        self, d: "user_flow_decorator.FlowMutator"
-    ) -> "user_flow_decorator.FlowMutator":
-        """Register a FlowMutator instance and prepare it for execution.
-
-        Appends to both the merged list (for the current iteration) and the
-        underlying _self_data (for cache rebuild safety). Calls external_init()
-        so the mutator is ready before its pre_mutate is called by the ongoing
-        iteration loop.
-        """
-        from ..flowspec import FlowStateItems
-
-        d.statically_defined = self._statically_defined
-        d.inserted_by = self._inserted_by
-        d._flow_cls = self._flow_cls
-
-        # Append to the merged list (the one being iterated in the pre_mutate
-        # loop) so the new mutator's pre_mutate is called naturally.
-        merged_mutators = self._flow_cls._flow_state[FlowStateItems.FLOW_MUTATORS]
-        merged_mutators.append(d)
-        # Also append to the underlying _self_data so a cache rebuild
-        # includes this mutator. We use _self_data directly (not the
-        # self_data property) to avoid clearing the merged cache.
-        self._flow_cls._flow_state._self_data[FlowStateItems.FLOW_MUTATORS].append(d)
-
-        # external_init must be called before pre_mutate runs
-        d.external_init()
-        return d
-
     def add_decorator(
         self,
         deco_type: Union[
@@ -444,6 +415,84 @@ class MutableFlow:
             else:
                 raise ValueError("Invalid duplicates value: %s" % duplicates)
 
+        def _add_flow_mutator(flow_mutator):
+            flow_mutator.statically_defined = self._statically_defined
+            flow_mutator.inserted_by = self._inserted_by
+            flow_mutator._flow_cls = self._flow_cls
+
+            def _do_add():
+                # Append to the merged list (the one being iterated in the
+                # pre_mutate loop) so the new mutator's pre_mutate is called
+                # naturally by the ongoing iteration.
+                merged_mutators = self._flow_cls._flow_state[
+                    FlowStateItems.FLOW_MUTATORS
+                ]
+                merged_mutators.append(flow_mutator)
+                # Also append to the underlying _self_data so a cache rebuild
+                # includes this mutator. We use _self_data directly (not the
+                # self_data property) to avoid clearing the merged cache.
+                self._flow_cls._flow_state._self_data[
+                    FlowStateItems.FLOW_MUTATORS
+                ].append(flow_mutator)
+                # external_init must be called before pre_mutate runs
+                flow_mutator.external_init()
+                debug.userconf_exec(
+                    "Mutable flow adding flow mutator '%s'"
+                    % flow_mutator.decorator_name
+                )
+                return flow_mutator
+
+            # Check for existing mutator with the same decorator_name
+            existing = [
+                m
+                for m in self._flow_cls._flow_state[FlowStateItems.FLOW_MUTATORS]
+                if hasattr(m, "decorator_name")
+                and m.decorator_name == flow_mutator.decorator_name
+            ]
+
+            if not existing:
+                return _do_add()
+            elif duplicates == MutableFlow.IGNORE:
+                debug.userconf_exec(
+                    "Mutable flow ignoring flow mutator '%s' "
+                    "(already exists and duplicates are ignored)"
+                    % flow_mutator.decorator_name
+                )
+                return None
+            elif duplicates == MutableFlow.OVERRIDE:
+                debug.userconf_exec(
+                    "Mutable flow overriding flow mutator '%s' "
+                    "(removing existing mutator and adding new one)"
+                    % flow_mutator.decorator_name
+                )
+                # Remove from both the merged list and _self_data
+                merged = self._flow_cls._flow_state[FlowStateItems.FLOW_MUTATORS]
+                for m in existing:
+                    if m in merged:
+                        merged.remove(m)
+                self_list = self._flow_cls._flow_state._self_data[
+                    FlowStateItems.FLOW_MUTATORS
+                ]
+                for m in existing:
+                    if m in self_list:
+                        self_list.remove(m)
+                return _do_add()
+            elif duplicates == MutableFlow.ERROR:
+                if self._statically_defined:
+                    raise MetaflowException(
+                        "Duplicate FlowMutator '%s' on flow"
+                        % flow_mutator.decorator_name
+                    )
+                else:
+                    debug.userconf_exec(
+                        "Mutable flow ignoring flow mutator '%s' "
+                        "(already exists and non statically defined)"
+                        % flow_mutator.decorator_name
+                    )
+                return None
+            else:
+                raise ValueError("Invalid duplicates value: %s" % duplicates)
+
         # Check if this is a FlowMutator class or instance
         from .user_flow_decorator import FlowMutator
 
@@ -458,12 +507,12 @@ class MutableFlow:
             if isinstance(flow_deco, FlowMutator):
                 # String resolved to a FlowMutator instance — route it through
                 # the FlowMutator addition path
-                return self._add_flow_mutator(flow_deco)
+                return _add_flow_mutator(flow_deco)
             return _add_flow_decorator(flow_deco)
 
         if isinstance(deco_type, type) and issubclass(deco_type, FlowMutator):
             d = deco_type(*deco_args, **deco_kwargs)
-            return self._add_flow_mutator(d)
+            return _add_flow_mutator(d)
 
         # Validate deco_type
         if (

--- a/metaflow/user_decorators/mutable_step.py
+++ b/metaflow/user_decorators/mutable_step.py
@@ -175,6 +175,42 @@ class MutableStep:
                 return dict(kwargs)
         return None
 
+    def replace_decorator(
+        self,
+        name: str,
+        updates: Dict[str, Any],
+        reject_if: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Replace a decorator's kwargs, merging with any existing values.
+
+        If the decorator already exists, its kwargs are merged with `updates`
+        (updates take precedence) and the old decorator is replaced. If it does
+        not exist, a new one is added with `updates` as kwargs.
+
+        Parameters
+        ----------
+        name : str
+            The decorator name (e.g. "titus", "resources").
+        updates : Dict[str, Any]
+            Keyword arguments to set or override on the decorator.
+        reject_if : List[str], optional
+            If the existing decorator has any of these keys set to a non-None
+            value, raise MetaflowException. Use this to declare incompatible
+            options.
+        """
+        existing = self.get_decorator_kwargs(name) or {}
+        if reject_if:
+            for key in reject_if:
+                if existing.get(key) is not None:
+                    raise MetaflowException(
+                        "Cannot use @%s with %s=%r when combined with this decorator."
+                        % (name, key, existing[key])
+                    )
+        existing.update(updates)
+        self.remove_decorator(name)
+        self.add_decorator(name, deco_kwargs=existing)
+
     def add_decorator(
         self,
         deco_type: Union[partial, UserStepDecoratorBase, str],

--- a/metaflow/user_decorators/mutable_step.py
+++ b/metaflow/user_decorators/mutable_step.py
@@ -446,7 +446,9 @@ class MutableStep:
         do_all = deco_args is None and deco_kwargs is None
         did_remove = False
         canonical_deco_type = UserStepDecoratorBase.get_decorator_by_name(deco_name)
-        if issubclass(canonical_deco_type, UserStepDecoratorBase):
+        if canonical_deco_type is not None and issubclass(
+            canonical_deco_type, UserStepDecoratorBase
+        ):
             for attr in ["config_decorators", "wrappers"]:
                 new_deco_list = []
                 for deco in getattr(self._my_step, attr):

--- a/metaflow/user_decorators/mutable_step.py
+++ b/metaflow/user_decorators/mutable_step.py
@@ -134,6 +134,16 @@ class MutableStep:
             r.extend(deco.get_args_kwargs())
             yield tuple(r)
 
+    def _match_name(self, deco_name: str, deco_fq: str, query: str) -> bool:
+        """Return True if *query* matches either the short or fully-qualified name.
+
+        A query containing a period is compared against the fully-qualified name;
+        otherwise it is compared against the short name.
+        """
+        if "." in query:
+            return deco_fq == query
+        return deco_name == query
+
     def has_decorator(self, name: str) -> bool:
         """
         Check whether this step has at least one decorator with the given name.
@@ -141,93 +151,39 @@ class MutableStep:
         Parameters
         ----------
         name : str
-            The decorator name to look for.
+            The decorator name (short) or fully qualified name (contains a period).
 
         Returns
         -------
         bool
             True if a decorator with the given name exists on this step.
         """
-        for deco_name, _fq, _args, _kwargs in self.decorator_specs:
-            if deco_name == name:
+        for deco_name, deco_fq, _args, _kwargs in self.decorator_specs:
+            if self._match_name(deco_name, deco_fq, name):
                 return True
         return False
 
-    def get_decorator_kwargs(self, name: str) -> Optional[Dict[str, Any]]:
-        """
-        Return the keyword arguments of the first decorator with the given name,
-        or None if no such decorator exists.
-
-        If the decorator appears multiple times, returns the kwargs of the first match.
+    def get_decorator_specs(
+        self, name: str
+    ) -> List[Tuple[str, str, List[Any], Dict[str, Any]]]:
+        """Return all spec tuples matching the given name.
 
         Parameters
         ----------
         name : str
-            The decorator name to look for.
+            The decorator name (short) or fully qualified name (contains a period).
 
         Returns
         -------
-        Optional[Dict[str, Any]]
-            The keyword arguments dict, or None if not found.
+        List[Tuple[str, str, List[Any], Dict[str, Any]]]
+            A list of (short_name, fq_name, args, kwargs) tuples. Empty list if
+            no decorators match.
         """
-        for deco_name, _fq, _args, kwargs in self.decorator_specs:
-            if deco_name == name:
-                return dict(kwargs)
-        return None
-
-    def get_all_decorator_kwargs(self, name: str) -> List[Dict[str, Any]]:
-        """
-        Return a list of kwargs dicts for all decorators with the given name.
-
-        If no decorators with the given name exist, returns an empty list.
-
-        Parameters
-        ----------
-        name : str
-            The decorator name to look for.
-
-        Returns
-        -------
-        List[Dict[str, Any]]
-            A list of keyword argument dicts, one per matching decorator.
-        """
-        return [dict(kwargs) for deco_name, _fq, _args, kwargs in self.decorator_specs if deco_name == name]
-
-    def replace_decorator(
-        self,
-        name: str,
-        updates: Dict[str, Any],
-        reject_if: Optional[List[str]] = None,
-    ) -> None:
-        """
-        Replace a decorator's kwargs, merging with any existing values.
-
-        If the decorator already exists, its kwargs are merged with `updates`
-        (updates take precedence) and the old decorator is replaced. If it does
-        not exist, a new one is added with `updates` as kwargs.
-
-        Parameters
-        ----------
-        name : str
-            The decorator name (e.g. "titus", "resources").
-        updates : Dict[str, Any]
-            Keyword arguments to set or override on the decorator.
-        reject_if : List[str], optional
-            If the existing decorator has any of these keys set to a non-None
-            value, raise MetaflowException. Use this to declare incompatible
-            options.
-        """
-        existing = self.get_decorator_kwargs(name) or {}
-        if reject_if:
-            for key in reject_if:
-                if existing.get(key) is not None:
-                    raise MetaflowException(
-                        "Cannot use @%s with %s=%r when combined with this decorator."
-                        % (name, key, existing[key])
-                    )
-        existing.update(updates)
-        self.remove_decorator(name)
-        self.add_decorator(name, deco_kwargs=existing)
+        return [
+            (deco_name, deco_fq, list(args), dict(kwargs))
+            for deco_name, deco_fq, args, kwargs in self.decorator_specs
+            if self._match_name(deco_name, deco_fq, name)
+        ]
 
     def add_decorator(
         self,

--- a/metaflow/user_decorators/mutable_step.py
+++ b/metaflow/user_decorators/mutable_step.py
@@ -453,13 +453,15 @@ class MutableStep:
                 new_deco_list = []
                 for deco in getattr(self._my_step, attr):
                     if deco.decorator_name == canonical_deco_type.decorator_name:
-                        if do_all:
-                            did_remove = True
-                            continue  # We remove all decorators with this name
-                        if deco.get_args_kwargs() == (
+                        matches = do_all or deco.get_args_kwargs() == (
                             deco_args or [],
                             deco_kwargs or {},
-                        ):
+                        )
+                        if matches:
+                            # The pre_mutate guard applies to both do_all and
+                            # specific-match removals: StepMutators can only be
+                            # removed during pre_mutate regardless of whether a
+                            # filter was provided.
                             if not self._pre_mutate and isinstance(deco, StepMutator):
                                 raise MetaflowException(
                                     "Removing step mutator '%s' from %s is only allowed in the "

--- a/metaflow/user_decorators/mutable_step.py
+++ b/metaflow/user_decorators/mutable_step.py
@@ -134,6 +134,47 @@ class MutableStep:
             r.extend(deco.get_args_kwargs())
             yield tuple(r)
 
+    def has_decorator(self, name: str) -> bool:
+        """
+        Check whether this step has at least one decorator with the given name.
+
+        Parameters
+        ----------
+        name : str
+            The decorator name to look for.
+
+        Returns
+        -------
+        bool
+            True if a decorator with the given name exists on this step.
+        """
+        for deco_name, _fq, _args, _kwargs in self.decorator_specs:
+            if deco_name == name:
+                return True
+        return False
+
+    def get_decorator_kwargs(self, name: str) -> Optional[Dict[str, Any]]:
+        """
+        Return the keyword arguments of the first decorator with the given name,
+        or None if no such decorator exists.
+
+        If the decorator appears multiple times, returns the kwargs of the first match.
+
+        Parameters
+        ----------
+        name : str
+            The decorator name to look for.
+
+        Returns
+        -------
+        Optional[Dict[str, Any]]
+            The keyword arguments dict, or None if not found.
+        """
+        for deco_name, _fq, _args, kwargs in self.decorator_specs:
+            if deco_name == name:
+                return dict(kwargs)
+        return None
+
     def add_decorator(
         self,
         deco_type: Union[partial, UserStepDecoratorBase, str],

--- a/metaflow/user_decorators/mutable_step.py
+++ b/metaflow/user_decorators/mutable_step.py
@@ -361,15 +361,19 @@ class MutableStep:
                     # since they were not in the string
                     step_deco = step_deco.__class__(*deco_args, **deco_kwargs)
 
-                step_deco.add_or_raise(
+                added = step_deco.add_or_raise(
                     self._my_step,
                     self._statically_defined,
                     duplicates,
                     self._inserted_by,
                 )
-                if isinstance(step_deco, StepMutator):
-                    step_deco.external_init()
-            return step_deco
+                if added is None:
+                    # Duplicate handling (IGNORE or non-static ERROR)
+                    # suppressed the registration. Don't return the throwaway
+                    # instance — mirror the StepDecorator path's contract.
+                    return None
+                added.external_init()
+            return added
 
         if isinstance(deco_type, type) and issubclass(deco_type, UserStepDecoratorBase):
             # We can only add step mutators in the pre mutate stage.
@@ -385,13 +389,15 @@ class MutableStep:
             )
 
             d = deco_type(*deco_args, **deco_kwargs)
-            # add_or_raise properly registers the decorator
-            d.add_or_raise(
+            # add_or_raise properly registers the decorator. Returns None when
+            # duplicate handling suppresses the addition.
+            added = d.add_or_raise(
                 self._my_step, self._statically_defined, duplicates, self._inserted_by
             )
-            if isinstance(d, StepMutator):
-                d.external_init()
-            return d
+            if added is None:
+                return None
+            added.external_init()
+            return added
 
         # At this point, it should be a regular Metaflow step decorator
         if (

--- a/metaflow/user_decorators/mutable_step.py
+++ b/metaflow/user_decorators/mutable_step.py
@@ -18,6 +18,7 @@ from .user_step_decorator import StepMutator, UserStepDecoratorBase
 
 if TYPE_CHECKING:
     import metaflow.decorators
+    import metaflow.decorators
     import metaflow.flowspec
 
 
@@ -109,7 +110,13 @@ class MutableStep:
             r.extend(deco.get_args_kwargs())
             yield tuple(r)
 
+        # Wrappers can also be config decorators so we aim to return only one for each
+        # specific instance.
+        seen_decorators = set()
         for deco in self._my_step.wrappers:
+            if id(deco) in seen_decorators:
+                continue
+            seen_decorators.add(id(deco))
             r = [
                 UserStepDecoratorBase.get_decorator_name(deco.__class__),
                 deco.decorator_name,
@@ -118,6 +125,9 @@ class MutableStep:
             yield tuple(r)
 
         for deco in self._my_step.config_decorators:
+            if id(deco) in seen_decorators:
+                continue
+            seen_decorators.add(id(deco))
             r = [
                 UserStepDecoratorBase.get_decorator_name(deco.__class__),
                 deco.decorator_name,
@@ -131,9 +141,13 @@ class MutableStep:
         deco_args: Optional[List[Any]] = None,
         deco_kwargs: Optional[Dict[str, Any]] = None,
         duplicates: int = IGNORE,
-    ) -> None:
+    ) -> Optional[Union[UserStepDecoratorBase, "metaflow.decorators.StepDecorator"]]:
         """
         Add a Metaflow step-decorator or a user step-decorator to a step.
+
+        Returns the decorator instance that was inserted, which can be used to
+        inspect or further configure the decorator. Returns None if the decorator
+        was not added (e.g. due to duplicate handling with IGNORE).
 
         You can either add the decorator itself or its decorator specification for it
         (the same you would get back from decorator_specs). You can also mix and match
@@ -195,6 +209,12 @@ class MutableStep:
             - `MutableStep.IGNORE`: Ignore the decorator if it already exists.
             - `MutableStep.ERROR`: Raise an error if the decorator already exists.
             - `MutableStep.OVERRIDE`: Remove the existing decorator and add this one.
+
+        Returns
+        -------
+        Optional[Union[UserStepDecoratorBase, StepDecorator]]
+            The decorator instance that was added, or None if the decorator was not
+            added due to duplicate handling.
         """
         # Prevent circular import
         from metaflow.decorators import (
@@ -206,7 +226,10 @@ class MutableStep:
         deco_args = deco_args or []
         deco_kwargs = deco_kwargs or {}
 
+        added_deco = None
+
         def _add_step_decorator(step_deco):
+            nonlocal added_deco
             if deco_args:
                 raise MetaflowException(
                     "Step decorators do not take additional positional arguments"
@@ -216,9 +239,11 @@ class MutableStep:
 
             # Check duplicates
             def _do_add():
+                nonlocal added_deco
                 step_deco.statically_defined = self._statically_defined
                 step_deco.inserted_by = self._inserted_by
                 self._my_step.decorators.append(step_deco)
+                added_deco = step_deco
                 debug.userconf_exec(
                     "Mutable step adding step decorator '%s' to step '%s'"
                     % (deco_type, self._my_step.name)
@@ -271,6 +296,7 @@ class MutableStep:
 
             if isinstance(step_deco, StepDecorator):
                 _add_step_decorator(step_deco)
+                return added_deco
             else:
                 # User defined decorator.
                 if not self._pre_mutate and isinstance(step_deco, StepMutator):
@@ -291,7 +317,9 @@ class MutableStep:
                     duplicates,
                     self._inserted_by,
                 )
-            return
+                if isinstance(step_deco, StepMutator):
+                    step_deco.external_init()
+            return step_deco
 
         if isinstance(deco_type, type) and issubclass(deco_type, UserStepDecoratorBase):
             # We can only add step mutators in the pre mutate stage.
@@ -311,7 +339,9 @@ class MutableStep:
             d.add_or_raise(
                 self._my_step, self._statically_defined, duplicates, self._inserted_by
             )
-            return
+            if isinstance(d, StepMutator):
+                d.external_init()
+            return d
 
         # At this point, it should be a regular Metaflow step decorator
         if (
@@ -331,6 +361,7 @@ class MutableStep:
                 inserted_by=self._inserted_by,
             )
         )
+        return added_deco
 
     def remove_decorator(
         self,

--- a/metaflow/user_decorators/mutable_step.py
+++ b/metaflow/user_decorators/mutable_step.py
@@ -327,7 +327,7 @@ class MutableStep:
                 raise MetaflowException(
                     "Adding step mutator '%s' from %s is only allowed in the "
                     "`pre_mutate` method and not the `mutate` method"
-                    % (step_deco.decorator_name, self._inserted_by)
+                    % (deco_type.decorator_name, self._inserted_by)
                 )
             debug.userconf_exec(
                 "Mutable step adding decorator %s to step %s"

--- a/metaflow/user_decorators/mutable_step.py
+++ b/metaflow/user_decorators/mutable_step.py
@@ -175,6 +175,24 @@ class MutableStep:
                 return dict(kwargs)
         return None
 
+    def get_all_decorator_kwargs(self, name: str) -> List[Dict[str, Any]]:
+        """
+        Return a list of kwargs dicts for all decorators with the given name.
+
+        If no decorators with the given name exist, returns an empty list.
+
+        Parameters
+        ----------
+        name : str
+            The decorator name to look for.
+
+        Returns
+        -------
+        List[Dict[str, Any]]
+            A list of keyword argument dicts, one per matching decorator.
+        """
+        return [dict(kwargs) for deco_name, _fq, _args, kwargs in self.decorator_specs if deco_name == name]
+
     def replace_decorator(
         self,
         name: str,

--- a/metaflow/user_decorators/mutable_step.py
+++ b/metaflow/user_decorators/mutable_step.py
@@ -18,7 +18,6 @@ from .user_step_decorator import StepMutator, UserStepDecoratorBase
 
 if TYPE_CHECKING:
     import metaflow.decorators
-    import metaflow.decorators
     import metaflow.flowspec
 
 

--- a/metaflow/user_decorators/user_flow_decorator.py
+++ b/metaflow/user_decorators/user_flow_decorator.py
@@ -1,5 +1,8 @@
-from typing import Dict, Optional, Union, TYPE_CHECKING
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
+from metaflow.debug import debug
 from metaflow.exception import MetaflowException
 from metaflow.user_configs.config_parameters import (
     resolve_delayed_evaluator,
@@ -99,7 +102,7 @@ class FlowMutatorMeta(type):
 
     @classmethod
     def _check_init(mcs):
-        # Delay importing STEP_DECORATORS until we actually need it
+        # Delay importing FLOW_DECORATORS until we actually need it
         if not mcs._all_registered_decorators.inited:
             from metaflow.plugins import FLOW_DECORATORS
 
@@ -197,6 +200,47 @@ class FlowMutator(metaclass=FlowMutatorMeta):
 
     def __str__(self):
         return str(self.__class__)
+
+    @classmethod
+    def extract_args_kwargs_from_decorator_spec(
+        cls, deco_spec: str
+    ) -> Tuple[List[Any], Dict[str, Any]]:
+        if len(deco_spec) == 0:
+            return [], {}
+        args: List[Any] = []
+        kwargs: Dict[str, Any] = {}
+        for a in re.split(r""",(?=[\s\w]+=)""", deco_spec):
+            name, val = a.split("=", 1)
+            try:
+                val_parsed = json.loads(val.strip().replace('\\"', '"'))
+            except json.JSONDecodeError:
+                try:
+                    val_parsed = int(val.strip())
+                except ValueError:
+                    try:
+                        val_parsed = float(val.strip())
+                    except ValueError:
+                        val_parsed = val.strip()
+            try:
+                pos = int(name)
+            except ValueError:
+                kwargs[name.strip()] = val_parsed
+            else:
+                while len(args) <= pos:
+                    args.append(None)
+                args[pos] = val_parsed
+        debug.userconf_exec(
+            "Parsed decorator spec for %s: %s"
+            % (cls.decorator_name, str((args, kwargs)))
+        )
+        return args, kwargs
+
+    @classmethod
+    def parse_decorator_spec(cls, deco_spec: str) -> "FlowMutator":
+        if len(deco_spec) == 0:
+            return cls()
+        args, kwargs = cls.extract_args_kwargs_from_decorator_spec(deco_spec)
+        return cls(*args, **kwargs)
 
     def init(self, *args, **kwargs):
         """

--- a/metaflow/user_decorators/user_flow_decorator.py
+++ b/metaflow/user_decorators/user_flow_decorator.py
@@ -137,6 +137,7 @@ class FlowMutator(metaclass=FlowMutatorMeta):
         # and used in _graph_info
         self._args = args
         self._kwargs = kwargs
+        self._ran_init = False  # For consistency with UserStepDecoratorBase
         if args and isinstance(args[0], (FlowMutator, FlowSpecMeta)):
             # This means the decorator is bare like @MyDecorator
             # and the first argument is the FlowSpec or another decorator (they
@@ -213,6 +214,8 @@ class FlowMutator(metaclass=FlowMutatorMeta):
         pass
 
     def external_init(self):
+        if self._ran_init:
+            return
         # You can use config values in the arguments to a FlowMutator
         # so we resolve those as well
         self._args = [resolve_delayed_evaluator(arg) for arg in self._args]
@@ -227,6 +230,7 @@ class FlowMutator(metaclass=FlowMutatorMeta):
                 )
         if "init" in self.__class__.__dict__:
             self.init(*self._args, **self._kwargs)
+        self._ran_init = True
 
     def pre_mutate(
         self, mutable_flow: "metaflow.user_decorators.mutable_flow.MutableFlow"

--- a/metaflow/user_decorators/user_step_decorator.py
+++ b/metaflow/user_decorators/user_step_decorator.py
@@ -142,6 +142,10 @@ class UserStepDecoratorBase(metaclass=UserStepDecoratorMeta):
         self._kwargs = {}
         # If nothing is set, the user statically defined the decorator
         self._special_kwargs = {"_statically_defined": True, "_inserted_by": None}
+        # Prevent multiple init calls -- this allows a decorator to be both a StepMutator
+        # and a StepDecorator. This is not a "solution" for the diamond inheritance issue
+        # but more for the fact that we call external_init from two places
+        self._ran_init = False
         for k, v in kwargs.items():
             if k in ("_statically_defined", "_inserted_by"):
                 # These are special arguments that we do not want to pass to the step
@@ -232,6 +236,8 @@ class UserStepDecoratorBase(metaclass=UserStepDecoratorMeta):
     ):
         from metaflow.user_decorators.mutable_step import MutableStep
 
+        # We can safely check in any of the step_field because if this decorator is
+        # registered on multiple step fields, it will be found in all of them.
         existing_deco = [
             d
             for d in getattr(step, self._step_field)
@@ -253,15 +259,17 @@ class UserStepDecoratorBase(metaclass=UserStepDecoratorMeta):
                 "Overriding decorator %s on step %s from %s"
                 % (self, step.__name__, inserted_by)
             )
-            setattr(
-                step,
-                self._step_field,
-                [
-                    d
-                    for d in getattr(step, self._step_field)
-                    if d.decorator_name != self.decorator_name
-                ],
-            )
+            # Clean-up all step fields if we appear in multiple of them.
+            for field in self._all_step_fields():
+                setattr(
+                    step,
+                    field,
+                    [
+                        d
+                        for d in getattr(step, field)
+                        if d.decorator_name != self.decorator_name
+                    ],
+                )
             self(step, _statically_defined=statically_defined, _inserted_by=inserted_by)
         elif duplicates == MutableStep.ERROR:
             if statically_defined:
@@ -293,17 +301,19 @@ class UserStepDecoratorBase(metaclass=UserStepDecoratorMeta):
         self.statically_defined = self._special_kwargs["_statically_defined"]
         self.inserted_by = self._special_kwargs["_inserted_by"]
 
-        # Collect all distinct _step_field values from the MRO so that a class
-        # inheriting from both UserStepDecorator and StepMutator is registered
-        # in both step.wrappers and step.config_decorators.
+        # Register the decorator with all the step fields it supports
+        for field in self._all_step_fields():
+            getattr(self._my_step, field).append(self)
+
+        return self._my_step
+
+    def _all_step_fields(self) -> List[str]:
         seen_fields = set()
         for cls in type(self).__mro__:
             field = cls.__dict__.get("_step_field")
             if field is not None and field not in seen_fields:
                 seen_fields.add(field)
-                getattr(self._my_step, field).append(self)
-
-        return self._my_step
+        return list(seen_fields)
 
     def __str__(self):
         return str(self.__class__)
@@ -390,6 +400,8 @@ class UserStepDecoratorBase(metaclass=UserStepDecoratorMeta):
         pass
 
     def external_init(self):
+        if self._ran_init:
+            return
         # You can use config values in the arguments to a UserStepDecoratorBase
         # so we resolve those as well
         self._args = [resolve_delayed_evaluator(arg) for arg in self._args]
@@ -404,6 +416,7 @@ class UserStepDecoratorBase(metaclass=UserStepDecoratorMeta):
                 )
         if "init" in self.__class__.__dict__:
             self.init(*self._args, **self._kwargs)
+        self._ran_init = True
 
 
 class UserStepDecorator(UserStepDecoratorBase):

--- a/metaflow/user_decorators/user_step_decorator.py
+++ b/metaflow/user_decorators/user_step_decorator.py
@@ -234,6 +234,15 @@ class UserStepDecoratorBase(metaclass=UserStepDecoratorMeta):
         duplicates: int,
         inserted_by: Optional[str] = None,
     ):
+        """Register this decorator on *step*.
+
+        Returns
+        -------
+        Optional[UserStepDecoratorBase]
+            ``self`` if the decorator was registered, ``None`` if a duplicate
+            already existed and the *duplicates* policy suppressed the
+            addition (IGNORE, or ERROR on a non-statically-defined step).
+        """
         from metaflow.user_decorators.mutable_step import MutableStep
 
         # We can safely check in any of the step_field because if this decorator is
@@ -246,13 +255,15 @@ class UserStepDecoratorBase(metaclass=UserStepDecoratorMeta):
 
         if not existing_deco:
             self(step, _statically_defined=statically_defined, _inserted_by=inserted_by)
+            return self
         elif duplicates == MutableStep.IGNORE:
-            # If we are ignoring duplicates, we just return
+            # If we are ignoring duplicates, we just return None to signal that
+            # the caller should not treat the throwaway instance as registered.
             debug.userconf_exec(
                 "Ignoring duplicate decorator %s on step %s from %s"
                 % (self, step.__name__, inserted_by)
             )
-            return
+            return None
         elif duplicates == MutableStep.OVERRIDE:
             # If we are overriding, we remove the existing decorator and add this one
             debug.userconf_exec(
@@ -271,12 +282,15 @@ class UserStepDecoratorBase(metaclass=UserStepDecoratorMeta):
                     ],
                 )
             self(step, _statically_defined=statically_defined, _inserted_by=inserted_by)
+            return self
         elif duplicates == MutableStep.ERROR:
             if statically_defined:
                 # Prevent circular dep
                 from metaflow.decorators import DuplicateStepDecoratorException
 
                 raise DuplicateStepDecoratorException(self.__class__, step)
+            # Non-statically-defined: swallow silently (same as ignore).
+            return None
 
     def _set_my_step(
         self,
@@ -308,12 +322,17 @@ class UserStepDecoratorBase(metaclass=UserStepDecoratorMeta):
         return self._my_step
 
     def _all_step_fields(self) -> List[str]:
-        seen_fields = set()
+        # Returned in MRO order so callers that iterate fields see a
+        # deterministic sequence (matters for any side-effecting traversal,
+        # e.g. duplicate cleanup in OVERRIDE).
+        ordered_fields: List[str] = []
+        seen: set = set()
         for cls in type(self).__mro__:
             field = cls.__dict__.get("_step_field")
-            if field is not None and field not in seen_fields:
-                seen_fields.add(field)
-        return list(seen_fields)
+            if field is not None and field not in seen:
+                seen.add(field)
+                ordered_fields.append(field)
+        return ordered_fields
 
     def __str__(self):
         return str(self.__class__)

--- a/metaflow/user_decorators/user_step_decorator.py
+++ b/metaflow/user_decorators/user_step_decorator.py
@@ -293,7 +293,16 @@ class UserStepDecoratorBase(metaclass=UserStepDecoratorMeta):
         self.statically_defined = self._special_kwargs["_statically_defined"]
         self.inserted_by = self._special_kwargs["_inserted_by"]
 
-        getattr(self._my_step, self._step_field).append(self)
+        # Collect all distinct _step_field values from the MRO so that a class
+        # inheriting from both UserStepDecorator and StepMutator is registered
+        # in both step.wrappers and step.config_decorators.
+        seen_fields = set()
+        for cls in type(self).__mro__:
+            field = cls.__dict__.get("_step_field")
+            if field is not None and field not in seen_fields:
+                seen_fields.add(field)
+                getattr(self._my_step, field).append(self)
+
         return self._my_step
 
     def __str__(self):

--- a/metaflow/user_decorators/user_step_decorator.py
+++ b/metaflow/user_decorators/user_step_decorator.py
@@ -40,7 +40,7 @@ class UserStepDecoratorMeta(type):
             mcs._import_modules.add(effective_module)
 
         if (
-            name in ("FlowMutator", "UserStepDecorator")
+            name in ("StepMutator", "UserStepDecorator")
             or cls.decorator_name in mcs._do_not_register
         ):
             return cls

--- a/test/unit/mutators/conftest.py
+++ b/test/unit/mutators/conftest.py
@@ -37,3 +37,7 @@ string_flow_mutator_run = pytest.fixture(scope="session")(
 string_step_mutator_run = pytest.fixture(scope="session")(
     create_flow_fixture("string_step_mutator_flow.py")
 )
+
+post_step_none_false_run = pytest.fixture(scope="session")(
+    create_flow_fixture("post_step_none_false_flow.py")
+)

--- a/test/unit/mutators/conftest.py
+++ b/test/unit/mutators/conftest.py
@@ -1,0 +1,39 @@
+"""Fixtures for mutator system tests."""
+
+import os
+import pytest
+from metaflow import Runner
+
+FLOWS_DIR = os.path.join(os.path.dirname(__file__), "flows")
+
+
+def create_flow_fixture(flow_file):
+    """Factory for session-scoped flow run fixtures."""
+
+    def fixture_func():
+        flow_path = os.path.join(FLOWS_DIR, flow_file)
+        with Runner(flow_path, cwd=FLOWS_DIR).run() as running:
+            return running.run
+
+    return fixture_func
+
+
+dual_inherit_run = pytest.fixture(scope="session")(
+    create_flow_fixture("dual_inherit_flow.py")
+)
+
+add_decorator_return_run = pytest.fixture(scope="session")(
+    create_flow_fixture("add_decorator_return_flow.py")
+)
+
+dynamic_flow_mutator_run = pytest.fixture(scope="session")(
+    create_flow_fixture("dynamic_flow_mutator_flow.py")
+)
+
+string_flow_mutator_run = pytest.fixture(scope="session")(
+    create_flow_fixture("string_flow_mutator_flow.py")
+)
+
+string_step_mutator_run = pytest.fixture(scope="session")(
+    create_flow_fixture("string_step_mutator_flow.py")
+)

--- a/test/unit/mutators/flows/add_decorator_return_flow.py
+++ b/test/unit/mutators/flows/add_decorator_return_flow.py
@@ -1,0 +1,49 @@
+"""Flow testing that MutableStep.add_decorator returns the decorator instance."""
+
+import os
+from metaflow import FlowSpec, step, environment
+from metaflow.user_decorators.user_step_decorator import StepMutator
+
+
+class check_return(StepMutator):
+    """StepMutator that verifies add_decorator returns the decorator instance."""
+
+    def mutate(self, mutable_step):
+        # Adding a new decorator should return the instance
+        deco = mutable_step.add_decorator(
+            environment, deco_kwargs={"vars": {"ADDED_VAR": "from_mutator"}}
+        )
+        # Store info about the returned decorator as class-level markers
+        # (we can't set flow artifacts here since mutate runs at config time)
+        check_return._returned_deco = deco
+        check_return._returned_is_none = deco is None
+
+        # Adding a duplicate with IGNORE should return None
+        deco2 = mutable_step.add_decorator(
+            environment,
+            deco_kwargs={"vars": {"SHOULD_NOT_EXIST": "1"}},
+            duplicates=mutable_step.IGNORE,
+        )
+        check_return._duplicate_is_none = deco2 is None
+
+
+class AddDecoratorReturnFlow(FlowSpec):
+
+    @check_return
+    @step
+    def start(self):
+        self.added_var = os.environ.get("ADDED_VAR", "NOT_SET")
+        self.should_not_exist = os.environ.get("SHOULD_NOT_EXIST")
+        # Transfer class-level markers to artifacts
+        self.returned_is_none = check_return._returned_is_none
+        self.duplicate_is_none = check_return._duplicate_is_none
+        self.returned_has_name = hasattr(check_return._returned_deco, "name")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+if __name__ == "__main__":
+    AddDecoratorReturnFlow()

--- a/test/unit/mutators/flows/dual_inherit_flow.py
+++ b/test/unit/mutators/flows/dual_inherit_flow.py
@@ -8,7 +8,8 @@ from metaflow.user_decorators.user_step_decorator import UserStepDecorator, Step
 class dual_deco(UserStepDecorator, StepMutator):
     """A decorator that is both a UserStepDecorator and a StepMutator.
 
-    mutate() adds an environment variable (proves config_decorators path works).
+    pre_mutate() adds an environment variable (proves early config_decorators path).
+    mutate() adds another environment variable (proves config_decorators path works).
     pre_step() sets an artifact (proves wrappers path works).
     post_step() sets another artifact (proves wrappers path works).
     """
@@ -16,10 +17,23 @@ class dual_deco(UserStepDecorator, StepMutator):
     def init(self, marker="default"):
         self._marker = marker
 
-    def mutate(self, mutable_step):
+    def pre_mutate(self, mutable_step):
         mutable_step.add_decorator(
-            environment, deco_kwargs={"vars": {"DUAL_DECO_MUTATE": self._marker}}
+            environment,
+            deco_kwargs={"vars": {"DUAL_DECO_PRE_MUTATE": "pre_mutate_ran"}},
         )
+
+    def mutate(self, mutable_step):
+        # Merge with the env var added by pre_mutate rather than replacing it
+        for deco_name, _, _, deco_attrs in mutable_step.decorator_specs:
+            if deco_name == "environment":
+                deco_attrs["vars"]["DUAL_DECO_MUTATE"] = self._marker
+                mutable_step.add_decorator(
+                    environment,
+                    deco_kwargs=deco_attrs,
+                    duplicates=mutable_step.OVERRIDE,
+                )
+                return
 
     def pre_step(self, step_name, flow, inputs=None):
         flow._dual_deco_pre_step_ran = True
@@ -36,6 +50,7 @@ class DualInheritFlow(FlowSpec):
     @dual_deco(marker="hello")
     @step
     def start(self):
+        self.pre_mutate_env_var = os.environ.get("DUAL_DECO_PRE_MUTATE", "NOT_SET")
         self.mutate_env_var = os.environ.get("DUAL_DECO_MUTATE", "NOT_SET")
         self.pre_step_ran = getattr(self, "_dual_deco_pre_step_ran", False)
         self.next(self.end)

--- a/test/unit/mutators/flows/dual_inherit_flow.py
+++ b/test/unit/mutators/flows/dual_inherit_flow.py
@@ -1,0 +1,49 @@
+"""Flow testing dual UserStepDecorator + StepMutator inheritance."""
+
+import os
+from metaflow import FlowSpec, step, environment
+from metaflow.user_decorators.user_step_decorator import UserStepDecorator, StepMutator
+
+
+class dual_deco(UserStepDecorator, StepMutator):
+    """A decorator that is both a UserStepDecorator and a StepMutator.
+
+    mutate() adds an environment variable (proves config_decorators path works).
+    pre_step() sets an artifact (proves wrappers path works).
+    post_step() sets another artifact (proves wrappers path works).
+    """
+
+    def init(self, marker="default"):
+        self._marker = marker
+
+    def mutate(self, mutable_step):
+        mutable_step.add_decorator(
+            environment, deco_kwargs={"vars": {"DUAL_DECO_MUTATE": self._marker}}
+        )
+
+    def pre_step(self, step_name, flow, inputs=None):
+        flow._dual_deco_pre_step_ran = True
+
+    def post_step(self, step_name, flow, exception=None):
+        flow._dual_deco_post_step_ran = True
+        if exception:
+            return exception, None
+        return None, {}
+
+
+class DualInheritFlow(FlowSpec):
+
+    @dual_deco(marker="hello")
+    @step
+    def start(self):
+        self.mutate_env_var = os.environ.get("DUAL_DECO_MUTATE", "NOT_SET")
+        self.pre_step_ran = getattr(self, "_dual_deco_pre_step_ran", False)
+        self.next(self.end)
+
+    @step
+    def end(self):
+        self.post_step_ran = getattr(self, "_dual_deco_post_step_ran", False)
+
+
+if __name__ == "__main__":
+    DualInheritFlow()

--- a/test/unit/mutators/flows/dynamic_flow_mutator_flow.py
+++ b/test/unit/mutators/flows/dynamic_flow_mutator_flow.py
@@ -1,0 +1,59 @@
+"""Flow testing dynamic FlowMutator addition via MutableFlow.add_decorator."""
+
+import os
+from metaflow import FlowSpec, FlowMutator, step, environment
+
+
+class InnerMutator(FlowMutator):
+    """FlowMutator added dynamically by OuterMutator."""
+
+    def init(self, env_key="INNER_PRE"):
+        self._env_key = env_key
+
+    def pre_mutate(self, mutable_flow):
+        # Add an environment variable to all steps to prove pre_mutate ran
+        for name, s in mutable_flow.steps:
+            s.add_decorator(
+                environment,
+                deco_kwargs={"vars": {self._env_key: "inner_pre_mutate_ran"}},
+            )
+
+    def mutate(self, mutable_flow):
+        # Add another environment variable to prove mutate ran
+        for name, s in mutable_flow.steps:
+            for deco_name, _, _, deco_attrs in s.decorator_specs:
+                if deco_name == "environment":
+                    deco_attrs["vars"]["INNER_MUTATE"] = "inner_mutate_ran"
+                    s.add_decorator(
+                        environment,
+                        deco_kwargs=deco_attrs,
+                        duplicates=s.OVERRIDE,
+                    )
+                    break
+
+
+class OuterMutator(FlowMutator):
+    """FlowMutator that dynamically adds InnerMutator during pre_mutate."""
+
+    def pre_mutate(self, mutable_flow):
+        # Dynamically add InnerMutator — it should get its pre_mutate called
+        # by the ongoing iteration
+        mutable_flow.add_decorator(InnerMutator)
+
+
+@OuterMutator
+class DynamicFlowMutatorFlow(FlowSpec):
+
+    @step
+    def start(self):
+        self.inner_pre = os.environ.get("INNER_PRE", "NOT_SET")
+        self.inner_mutate = os.environ.get("INNER_MUTATE", "NOT_SET")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+if __name__ == "__main__":
+    DynamicFlowMutatorFlow()

--- a/test/unit/mutators/flows/post_step_none_false_flow.py
+++ b/test/unit/mutators/flows/post_step_none_false_flow.py
@@ -1,0 +1,37 @@
+"""Regression flow: a UserStepDecorator whose post_step returns (None, False).
+
+Before the fix, (None, False) caused task.py to try to treat False as a valid
+self.next override and raise RuntimeError("Invalid value passed to self.next").
+(None, False) should be a no-op: no exception, no self.next override.
+"""
+
+from metaflow import FlowSpec, step
+from metaflow.user_decorators.user_step_decorator import UserStepDecorator
+
+
+class noop_post_step(UserStepDecorator):
+    """post_step returns (None, False) — no exception, no override."""
+
+    def pre_step(self, step_name, flow, inputs=None):
+        flow._pre_step_ran = True
+
+    def post_step(self, step_name, flow, exception=None):
+        flow._post_step_ran = True
+        return None, False
+
+
+class PostStepNoneFalseFlow(FlowSpec):
+
+    @noop_post_step
+    @step
+    def start(self):
+        self.pre_step_ran = getattr(self, "_pre_step_ran", False)
+        self.next(self.end)
+
+    @step
+    def end(self):
+        self.post_step_ran = getattr(self, "_post_step_ran", False)
+
+
+if __name__ == "__main__":
+    PostStepNoneFalseFlow()

--- a/test/unit/mutators/flows/string_flow_mutator_flow.py
+++ b/test/unit/mutators/flows/string_flow_mutator_flow.py
@@ -1,0 +1,58 @@
+"""Flow testing string-based FlowMutator addition via MutableFlow.add_decorator."""
+
+import os
+from metaflow import FlowSpec, FlowMutator, step, environment
+
+
+class StringAddedMutator(FlowMutator):
+    """FlowMutator that is added by string name."""
+
+    def init(self, tag="default_tag"):
+        self._tag = tag
+
+    def pre_mutate(self, mutable_flow):
+        for name, s in mutable_flow.steps:
+            s.add_decorator(
+                environment,
+                deco_kwargs={"vars": {"STRING_MUTATOR_TAG": self._tag}},
+            )
+
+    def mutate(self, mutable_flow):
+        for name, s in mutable_flow.steps:
+            for deco_name, _, _, deco_attrs in s.decorator_specs:
+                if deco_name == "environment":
+                    deco_attrs["vars"]["STRING_MUTATOR_MUTATE"] = "yes"
+                    s.add_decorator(
+                        environment,
+                        deco_kwargs=deco_attrs,
+                        duplicates=s.OVERRIDE,
+                    )
+                    break
+
+
+class StringAdder(FlowMutator):
+    """FlowMutator that adds StringAddedMutator by string name during pre_mutate."""
+
+    def pre_mutate(self, mutable_flow):
+        # Use the fully qualified module.class string to add the mutator
+        mutable_flow.add_decorator(
+            "StringAddedMutator:tag=from_string",
+        )
+
+
+@StringAdder
+class StringFlowMutatorFlow(FlowSpec):
+
+    @step
+    def start(self):
+        self.string_tag = os.environ.get("STRING_MUTATOR_TAG", "NOT_SET")
+        self.string_mutate = os.environ.get("STRING_MUTATOR_MUTATE", "NOT_SET")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+if __name__ == "__main__":
+    StringFlowMutatorFlow()

--- a/test/unit/mutators/flows/string_step_mutator_flow.py
+++ b/test/unit/mutators/flows/string_step_mutator_flow.py
@@ -1,0 +1,43 @@
+"""Flow testing string-based StepMutator addition via MutableStep.add_decorator."""
+
+import os
+from metaflow import FlowSpec, FlowMutator, step, environment
+from metaflow.user_decorators.user_step_decorator import StepMutator
+
+
+class StringAddedStepMutator(StepMutator):
+    """StepMutator added by string name."""
+
+    def init(self, env_val="default"):
+        self._env_val = env_val
+
+    def mutate(self, mutable_step):
+        mutable_step.add_decorator(
+            environment,
+            deco_kwargs={"vars": {"STRING_STEP_MUTATOR": self._env_val}},
+        )
+
+
+class AdderFlowMutator(FlowMutator):
+    """FlowMutator that adds a StepMutator by string name to all steps."""
+
+    def pre_mutate(self, mutable_flow):
+        for name, s in mutable_flow.steps:
+            s.add_decorator("StringAddedStepMutator:env_val=from_string")
+
+
+@AdderFlowMutator
+class StringStepMutatorFlow(FlowSpec):
+
+    @step
+    def start(self):
+        self.step_mutator_val = os.environ.get("STRING_STEP_MUTATOR", "NOT_SET")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+if __name__ == "__main__":
+    StringStepMutatorFlow()

--- a/test/unit/mutators/test_add_decorator_returns.py
+++ b/test/unit/mutators/test_add_decorator_returns.py
@@ -1,0 +1,26 @@
+"""Tests that MutableStep.add_decorator returns the decorator instance."""
+
+
+class TestAddDecoratorReturns:
+    def test_flow_completes(self, add_decorator_return_run):
+        assert add_decorator_return_run.successful
+
+    def test_returned_decorator_is_not_none(self, add_decorator_return_run):
+        task = add_decorator_return_run["start"].task
+        assert task.data.returned_is_none is False
+
+    def test_returned_decorator_has_name(self, add_decorator_return_run):
+        task = add_decorator_return_run["start"].task
+        assert task.data.returned_has_name is True
+
+    def test_decorator_was_applied(self, add_decorator_return_run):
+        task = add_decorator_return_run["start"].task
+        assert task.data.added_var == "from_mutator"
+
+    def test_duplicate_ignore_returns_none(self, add_decorator_return_run):
+        task = add_decorator_return_run["start"].task
+        assert task.data.duplicate_is_none is True
+
+    def test_duplicate_was_not_applied(self, add_decorator_return_run):
+        task = add_decorator_return_run["start"].task
+        assert task.data.should_not_exist is None

--- a/test/unit/mutators/test_dual_inheritance.py
+++ b/test/unit/mutators/test_dual_inheritance.py
@@ -5,6 +5,11 @@ class TestDualInheritance:
     def test_flow_completes(self, dual_inherit_run):
         assert dual_inherit_run.successful
 
+    def test_pre_mutate_ran(self, dual_inherit_run):
+        """pre_mutate() should have added the environment variable."""
+        task = dual_inherit_run["start"].task
+        assert task.data.pre_mutate_env_var == "pre_mutate_ran"
+
     def test_mutate_ran(self, dual_inherit_run):
         """mutate() should have added the environment variable."""
         task = dual_inherit_run["start"].task

--- a/test/unit/mutators/test_dual_inheritance.py
+++ b/test/unit/mutators/test_dual_inheritance.py
@@ -1,0 +1,22 @@
+"""Tests for dual UserStepDecorator + StepMutator inheritance."""
+
+
+class TestDualInheritance:
+    def test_flow_completes(self, dual_inherit_run):
+        assert dual_inherit_run.successful
+
+    def test_mutate_ran(self, dual_inherit_run):
+        """mutate() should have added the environment variable."""
+        task = dual_inherit_run["start"].task
+        assert task.data.mutate_env_var == "hello"
+
+    def test_pre_step_ran(self, dual_inherit_run):
+        """pre_step() should have set the artifact."""
+        task = dual_inherit_run["start"].task
+        assert task.data.pre_step_ran is True
+
+    def test_post_step_ran(self, dual_inherit_run):
+        """post_step() should have set the artifact on the start step,
+        visible in the end step via data propagation."""
+        task = dual_inherit_run["end"].task
+        assert task.data.post_step_ran is True

--- a/test/unit/mutators/test_flow_mutator_addition.py
+++ b/test/unit/mutators/test_flow_mutator_addition.py
@@ -1,0 +1,35 @@
+"""Tests for dynamically adding FlowMutators via MutableFlow.add_decorator."""
+
+
+class TestDynamicFlowMutatorAddition:
+    """Adding a FlowMutator by class reference."""
+
+    def test_flow_completes(self, dynamic_flow_mutator_run):
+        assert dynamic_flow_mutator_run.successful
+
+    def test_inner_pre_mutate_ran(self, dynamic_flow_mutator_run):
+        """InnerMutator.pre_mutate should have been called by the ongoing iteration."""
+        task = dynamic_flow_mutator_run["start"].task
+        assert task.data.inner_pre == "inner_pre_mutate_ran"
+
+    def test_inner_mutate_ran(self, dynamic_flow_mutator_run):
+        """InnerMutator.mutate should also have been called."""
+        task = dynamic_flow_mutator_run["start"].task
+        assert task.data.inner_mutate == "inner_mutate_ran"
+
+
+class TestStringFlowMutatorAddition:
+    """Adding a FlowMutator by string name with arguments."""
+
+    def test_flow_completes(self, string_flow_mutator_run):
+        assert string_flow_mutator_run.successful
+
+    def test_string_mutator_pre_mutate_ran(self, string_flow_mutator_run):
+        """StringAddedMutator.pre_mutate should have run with the parsed arg."""
+        task = string_flow_mutator_run["start"].task
+        assert task.data.string_tag == "from_string"
+
+    def test_string_mutator_mutate_ran(self, string_flow_mutator_run):
+        """StringAddedMutator.mutate should also have been called."""
+        task = string_flow_mutator_run["start"].task
+        assert task.data.string_mutate == "yes"

--- a/test/unit/mutators/test_post_step_none_false.py
+++ b/test/unit/mutators/test_post_step_none_false.py
@@ -1,0 +1,18 @@
+"""Regression test for post_step returning (None, False) being a no-op."""
+
+
+class TestPostStepNoneFalse:
+    def test_flow_completes(self, post_step_none_false_run):
+        """Run completes successfully rather than hitting RuntimeError at
+        task.py's `Invalid value passed to self.next` branch."""
+        assert post_step_none_false_run.successful
+
+    def test_pre_step_ran(self, post_step_none_false_run):
+        task = post_step_none_false_run["start"].task
+        assert task.data.pre_step_ran is True
+
+    def test_post_step_ran(self, post_step_none_false_run):
+        """post_step ran and its (None, False) return value was accepted as
+        a no-op (visible in the end step via data propagation)."""
+        task = post_step_none_false_run["end"].task
+        assert task.data.post_step_ran is True

--- a/test/unit/mutators/test_remove_decorator_guard.py
+++ b/test/unit/mutators/test_remove_decorator_guard.py
@@ -1,0 +1,68 @@
+"""Regression test for remove_decorator's pre_mutate guard on StepMutators.
+
+Before the fix, calling `remove_decorator(name)` with no args/kwargs
+(`do_all=True`) on a StepMutator from `mutate()` would silently strip the
+StepMutator, bypassing the documented contract that StepMutators can only be
+removed during `pre_mutate`. The guard is now checked on both the do_all path
+and the specific-match path.
+"""
+
+import pytest
+
+from metaflow import FlowSpec, step
+from metaflow.exception import MetaflowException
+from metaflow.user_decorators.mutable_step import MutableStep
+from metaflow.user_decorators.user_step_decorator import StepMutator
+
+
+class dummy_step_mutator(StepMutator):
+    """A minimal StepMutator used as a removal target."""
+
+    def mutate(self, mutable_step):
+        pass
+
+
+class FlowWithStepMutator(FlowSpec):
+
+    @dummy_step_mutator
+    @step
+    def start(self):
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+def _make_mutable_step(pre_mutate):
+    cls = FlowWithStepMutator
+    step_obj = getattr(cls, "start")
+    return MutableStep(
+        cls,
+        step_obj,
+        pre_mutate=pre_mutate,
+        statically_defined=True,
+        inserted_by=["test"],
+    )
+
+
+class TestRemoveDecoratorGuard:
+    def test_do_all_from_mutate_raises(self):
+        """Calling remove_decorator(name) without args/kwargs (do_all=True)
+        from a non-pre_mutate MutableStep must raise on a StepMutator."""
+        ms = _make_mutable_step(pre_mutate=False)
+        with pytest.raises(MetaflowException, match="only allowed in the `pre_mutate`"):
+            ms.remove_decorator("dummy_step_mutator")
+
+    def test_specific_match_from_mutate_raises(self):
+        """Same guard applies when an explicit deco_args/deco_kwargs match
+        is provided (this path already worked before the fix; keep covered)."""
+        ms = _make_mutable_step(pre_mutate=False)
+        with pytest.raises(MetaflowException, match="only allowed in the `pre_mutate`"):
+            ms.remove_decorator("dummy_step_mutator", deco_args=[], deco_kwargs={})
+
+    def test_do_all_from_pre_mutate_succeeds(self):
+        """From pre_mutate, removing the StepMutator via do_all should work."""
+        ms = _make_mutable_step(pre_mutate=True)
+        removed = ms.remove_decorator("dummy_step_mutator")
+        assert removed is True

--- a/test/unit/mutators/test_string_step_mutator.py
+++ b/test/unit/mutators/test_string_step_mutator.py
@@ -1,0 +1,12 @@
+"""Tests for string-based StepMutator addition via MutableStep.add_decorator."""
+
+
+class TestStringStepMutatorAddition:
+    def test_flow_completes(self, string_step_mutator_run):
+        assert string_step_mutator_run.successful
+
+    def test_string_step_mutator_ran(self, string_step_mutator_run):
+        """StepMutator added by string should have its mutate() called,
+        adding the environment variable."""
+        task = string_step_mutator_run["start"].task
+        assert task.data.step_mutator_val == "from_string"

--- a/test/unit/spin/conftest.py
+++ b/test/unit/spin/conftest.py
@@ -6,6 +6,15 @@ import os
 FLOWS_DIR = os.path.join(os.path.dirname(__file__), "flows")
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--use-latest",
+        action="store_true",
+        default=False,
+        help="Use latest run of each flow instead of running new ones",
+    )
+
+
 def create_flow_fixture(flow_name, flow_file, run_params=None, runner_params=None):
     """
     Factory function to create flow fixtures with common logic.
@@ -23,7 +32,7 @@ def create_flow_fixture(flow_name, flow_file, run_params=None, runner_params=Non
     """
 
     def flow_fixture(request):
-        if request.config.getoption("--use-latest"):
+        if request.config.getoption("--use-latest", default=False):
             flow = Flow(flow_name, _namespace_check=False)
             return flow.latest_run
         else:


### PR DESCRIPTION
## Summary

Allow a class to inherit from both `UserStepDecorator` and `StepMutator` at the same time, so a single decorator can contribute both a `mutate()`/`pre_mutate()` pass over the flow/step (the `StepMutator` role) and `pre_step`/`post_step` wrapping hooks (the `UserStepDecorator` role). The instance is registered on both `step.wrappers` and `step.config_decorators` via a new MRO-walking `_all_step_fields()` helper, with an `_ran_init` idempotency guard so `external_init()` is not called twice.

In the process we also tightened a number of nearby corners in the user-decorator / flow-decorator plumbing and added several public helpers that made the dual-inheritance pattern writable at all.

## PR Type
- [x] Bug fix
- [x] New feature
- [ ] Core Runtime change
- [ ] Docs / tooling
- [ ] Refactoring

## New functionality

**Dual inheritance** — `class foo(UserStepDecorator, StepMutator)` is now a first-class pattern:
- Registration is unified via `_all_step_fields()` which walks the MRO and returns every `_step_field` declared on ancestor classes (deterministic MRO order).
- `_ran_init` guard on `external_init()` ensures `init()` is only invoked once per instance regardless of how many fields the instance lives on.
- `_init_step_decorators` now calls `external_init` on `step.wrappers` too (previously only `step.decorators`); `_process_config_decorators` covers `config_decorators`. This fixes a pre-existing gap where a pure `UserStepDecorator` wrapper's `init()` could be skipped.

**New MutableStep / MutableFlow helpers** (to support writing dual-inherit decorators without reaching into internal lists):
- `MutableFlow.get_step(name)`
- `MutableFlow.has_decorator(name)` / `MutableStep.has_decorator(name)`
- `MutableFlow.get_decorator_kwargs(...)` / `MutableStep.get_decorator_kwargs(...)`
- `MutableStep.get_all_decorator_kwargs(...)`
- `MutableStep.replace_decorator(...)`
- `MutableStep.decorator_specs` dedupes instances that live on multiple step fields.

**New StepDecorator hooks:**
- `check_step_conflicts(decorators)` — called during `_init_step_decorators` so a decorator can reject incompatible neighbors early.
- `find_decorator_attrs(...)` convenience for decorator-to-decorator introspection.

**Task-runtime plumbing:**
- `task.py` post-step sentinel changed from `False` to `None`, with explicit `is not False` guard so `post_step` returning `(None, False)` is a no-op instead of tripping `"Invalid value passed to self.next"`.
- `cli.py` no longer keeps the old manual `_init()` / `external_init()` loops for flow mutators — it's all driven by `_process_config_decorators` and `_init_step_decorators` now.
- The standalone `decorators._init()` helper was removed; its responsibilities were absorbed into `_init_flow_decorators` and `_init_step_decorators`.

## Bug fixes (most flagged by Greptile during review)

- **`add_decorator` on FlowMutator** — fixed `AttributeError: deco_type.name` when `add_decorator(MyFlowMutator)` is called from `mutate()`; the error path now uses `getattr(deco_type, "name", None) or getattr(deco_type, "decorator_name", deco_type)` so the real `MetaflowException` is raised.
- **`remove_decorator("typo")`** — `get_decorator_by_name` returns `None` for unregistered names; no longer passes that through to `issubclass(None, ...)` and raises `TypeError`.
- **FlowMutator registration** — `_do_add` now calls `external_init()` **before** appending to the decorator lists, so a raising `external_init` doesn't leave a half-initialized mutator in `_self_data` / merged mutators.
- **OVERRIDE + merged list** — switched from `list.remove()` (which shifts indices under the outer `pre_mutate` iteration) to slice-assignment `merged[:] = [...]`. No more silently-skipped elements.
- **`cached_skip_decorators`** — removed a name-based cache that over-skipped `allow_multiple` decorators (e.g. multiple `@card`s on different steps). Matches master's per-decorator behavior.
- **`remove_decorator(name)` `do_all=True`** — the `_pre_mutate + isinstance(StepMutator)` guard is now enforced on both the specific-match and `do_all` paths; previously `do_all` could strip a `StepMutator` from `mutate()` in violation of the documented contract.
- **`add_decorator` IGNORE path** — the `UserStepDecoratorBase` branches now return `None` when `add_or_raise` swallowed the registration (duplicate + IGNORE, or non-statically-defined ERROR), matching the `StepDecorator` path and the documented contract. Previously the throwaway instance was returned as if it had been added.

## Tests

- New `test/unit/mutators/` suite with dedicated flows + tests for dual inheritance, dynamic flow-mutator addition, string-form mutator addition, `add_decorator` return value, and regression coverage for the fixes above (`test_remove_decorator_guard.py`, `test_post_step_none_false.py`).
- Dual inheritance test exercises all four lifecycle methods: `pre_mutate`, `mutate`, `pre_step`, `post_step`.
- Spin conftest registers `--use-latest` so the fixture factory works when the suite is driven by a batch runner that doesn't inherit the option from a parent conftest.
