### PR TITLE
feat(events_decorator): fix mutation of immutable ConfigValue in process_event

### DIFF
--- a/metaflow/plugins/events_decorator.py
+++ b/metaflow/plugins/events_decorator.py
@@ -104,6 +104,7 @@ class TriggerDecorator(FlowDecorator):
         if is_stringish(event):
             return {"name": str(event)}
         elif isinstance(event, dict):
+            event = dict(event)  # make a copy since we will modify the dict
             if "name" not in event:
                 raise MetaflowException(
                     "The *event* attribute for *@trigger* is missing the *name* key."

--- a/test/unit/test_events_decorator.py
+++ b/test/unit/test_events_decorator.py
@@ -1,0 +1,22 @@
+import pytest
+from metaflow.plugins.events_decorator import TriggerDecorator
+from metaflow.user_configs.config_parameters import ConfigValue
+
+
+def make_decorator():
+    return TriggerDecorator(
+        attributes={"event": None, "events": [], "options": {}},
+        statically_defined=True,
+    )
+
+
+def test_process_event_does_not_mutate_config_value():
+    """Regression test for https://github.com/Netflix/metaflow/issues/3080
+    process_event() must not crash when event is a ConfigValue (immutable dict).
+    """
+    d = make_decorator()
+    event = ConfigValue({"name": "my_event", "parameters": {"alpha": "beta"}})
+    # Must not raise TypeError: ConfigValue is immutable
+    result = d.process_event(event)
+    assert result["name"] == "my_event"
+    assert result["parameters"] == {"alpha": "beta"}


### PR DESCRIPTION
Fixes #3080

## PR Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

<!-- What user-visible behavior changes? 1-2 sentences. -->
`@trigger(events=config_expr(...))` crashes with `TypeError: ConfigValue is immutable` 
because `process_event()` tries to mutate the event dict in-place, but dicts coming 
from `config_expr` are wrapped in `ConfigValue` which is immutable.
## Issue

<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes #3080

## Reproduction

<!-- Required for bug fixes. Required for Core Runtime changes. -->
<!-- Provide a minimal reproduction that fails before and succeeds after. -->

**Runtime:** <!-- local / kubernetes / batch / argo / etc. -->
local
**Commands to run:**
```bash
USERNAME=testuser python test_bug.py show
```

**Where evidence shows up:** <!-- parent console / task logs / metadata / UI -->

<details>
<summary>Before (error / log snippet)</summary>

```
File "metaflow/plugins/events_decorator.py", line 122, in process_event
event["parameters"] = self.process_parameters(
TypeError: ConfigValue is immutable
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
Metaflow 2.19.22 executing MultiEventConfigTest for user:testuser
Project: test, Branch: user.testuser
Step start
?
=> end
Step end
?
```

</details>

## Root Cause

<!-- Required for Core Runtime. Recommended for all bug fixes. -->
<!-- Explain the causal chain: what invariant was violated, where in the code. -->
<!-- See PRs #2796, #2751, #2714 for examples of the level of detail we're looking for. -->
`config_expr` returns values wrapped in `ConfigValue`, an immutable dict subclass. `process_event()` assumes the event is a plain mutable dict and writes to it directly with `event["parameters"] = ...`, which hits the immutability guard.
## Why This Fix Is Correct

<!-- What invariant is restored? Why is the fix minimal? -->
Adding `event = dict(event)` at the top of the `isinstance(event, dict)` branch creates a plain mutable copy before any writes happen. Works for both plain dicts and ConfigValue objects. The original object is never modified.
## Failure Modes Considered

<!-- Required for Core Runtime (at least 2). Recommended for all bug fixes. -->
<!-- Examples: concurrency/retries, subprocess output propagation, env-var leakage, backward compat -->

1. Plain dict events — unaffected, `dict(event)` on a plain dict is just acopy, behaviour identical.
2.  Nested ConfigValue — `parameters` inside the event is also a ConfigValue but it is only read via `event.get("parameters", {})` and passed to `process_parameters()` which handles it correctly.

## Tests

- [x] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

<!-- What you intentionally did not change. Helps reviewers scope their review. -->

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

<!-- If you used AI tools:
- Which tool(s)?
- What did you use them for?
- Did you review, understand, and test all generated code?
-->
AI tool- gemini was used for generating PR summary, content etc and unit test was added after greptile suggestion.
All code changes reviewed and tested manually.