### PR TITLE
fix(client): validate pathspec format for Flow/Run/Step/Task/DataArti…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# CI shell scripts must use LF so shellcheck and Unix runners behave consistently
+# on Windows checkouts (core.autocrlf).
+devtools/ci/*.sh text eol=lf

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -387,18 +387,19 @@ class MetaflowObject(object):
             # distinguish between "attempt will happen" and "no such
             # attempt exists".
 
-        if pathspec is not None and _object is None:
+        if _object is None:
             _validate_pathspec(pathspec, self._NAME)
+            if pathspec is None:
+                # _NAME not in _PATHSPEC_FORMATS (e.g. "base"): no format hint to give.
+                raise MetaflowInvalidPathspec(
+                    "pathspec for %s cannot be None"
+                    % _CLASS_DISPLAY_NAMES.get(self._NAME, self._NAME)
+                )
             ids = pathspec.rstrip("/").split("/")
 
             self.id = ids[-1]
             self._pathspec = pathspec.rstrip("/")
             self._object = self._get_object(*ids)
-        elif pathspec is None and _object is None:
-            raise MetaflowInvalidPathspec(
-                "pathspec for %s cannot be None"
-                % _CLASS_DISPLAY_NAMES.get(self._NAME, self._NAME)
-            )
         else:
             self._object = _object
             self._pathspec = pathspec

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -91,11 +91,11 @@ def _validate_pathspec(pathspec: Optional[str], obj_name: str) -> None:
         return
 
     class_name = _CLASS_DISPLAY_NAMES.get(obj_name, obj_name)
-    expected_parts, fmt = _PATHSPEC_FORMATS[obj_name]
-
-    if pathspec is None:
+    if pathspec is None or pathspec == "" or pathspec.strip("/") == "":
         raise MetaflowInvalidPathspec(
-            "pathspec for %s cannot be None; expected %s(%s)"
+            "pathspec for %s cannot be empty or None; expected %s(%s)"
+            % (class_name, class_name, fmt)
+        )
             % (class_name, class_name, fmt)
         )
 

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -395,10 +395,7 @@ class MetaflowObject(object):
             self._pathspec = pathspec.rstrip("/")
             self._object = self._get_object(*ids)
         elif pathspec is None and _object is None:
-            raise MetaflowInvalidPathspec(
-                "pathspec for %s cannot be None"
-                % _CLASS_DISPLAY_NAMES.get(self._NAME, self._NAME)
-            )
+            _validate_pathspec(pathspec, self._NAME)
         else:
             self._object = _object
             self._pathspec = pathspec

--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -60,6 +60,75 @@ current_namespace = False
 
 current_metadata = False
 
+# Client pathspec shapes (GitHub #948).
+_PATHSPEC_FORMATS = {
+    "flow": (1, "FlowName"),
+    "run": (2, "FlowName/RunID"),
+    "step": (3, "FlowName/RunID/StepName"),
+    "task": (4, "FlowName/RunID/StepName/TaskID"),
+    "artifact": (5, "FlowName/RunID/StepName/TaskID/ArtifactName"),
+}
+
+_CLASS_DISPLAY_NAMES = {
+    "flow": "Flow",
+    "run": "Run",
+    "step": "Step",
+    "task": "Task",
+    "artifact": "DataArtifact",
+}
+
+
+def _validate_pathspec(pathspec: Optional[str], obj_name: str) -> None:
+    """
+    Validate *pathspec* for a Client object with internal name *obj_name*.
+
+    Raises
+    ------
+    MetaflowInvalidPathspec
+        If *pathspec* is None, empty, has empty segments, or wrong part count.
+    """
+    if obj_name not in _PATHSPEC_FORMATS:
+        return
+
+    class_name = _CLASS_DISPLAY_NAMES.get(obj_name, obj_name)
+    expected_parts, fmt = _PATHSPEC_FORMATS[obj_name]
+
+    if pathspec is None:
+        raise MetaflowInvalidPathspec(
+            "pathspec for %s cannot be None; expected %s(%s)"
+            % (class_name, class_name, fmt)
+        )
+
+    if pathspec == "" or pathspec.strip("/") == "":
+        raise MetaflowInvalidPathspec(
+            "pathspec for %s cannot be empty; expected %s(%s)"
+            % (class_name, class_name, fmt)
+        )
+
+    normalized = pathspec.rstrip("/")
+    parts = normalized.split("/")
+
+    if any(p == "" for p in parts):
+        raise MetaflowInvalidPathspec(
+            "Invalid pathspec '%s' for %s: pathspec contains empty segments. "
+            "Expected %s(%s)." % (pathspec, class_name, class_name, fmt)
+        )
+
+    if len(parts) != expected_parts:
+        raise MetaflowInvalidPathspec(
+            "Invalid pathspec '%s' for %s: expected %s(%s) (%d part%s), got %d part%s."
+            % (
+                pathspec,
+                class_name,
+                class_name,
+                fmt,
+                expected_parts,
+                "" if expected_parts == 1 else "s",
+                len(parts),
+                "" if len(parts) == 1 else "s",
+            )
+        )
+
 
 def metadata(ms: str) -> str:
     """
@@ -318,27 +387,18 @@ class MetaflowObject(object):
             # distinguish between "attempt will happen" and "no such
             # attempt exists".
 
-        if pathspec and _object is None:
-            ids = pathspec.split("/")
-
-            if self._NAME == "flow" and len(ids) != 1:
-                raise MetaflowInvalidPathspec("Expects Flow('FlowName')")
-            elif self._NAME == "run" and len(ids) != 2:
-                raise MetaflowInvalidPathspec("Expects Run('FlowName/RunID')")
-            elif self._NAME == "step" and len(ids) != 3:
-                raise MetaflowInvalidPathspec("Expects Step('FlowName/RunID/StepName')")
-            elif self._NAME == "task" and len(ids) != 4:
-                raise MetaflowInvalidPathspec(
-                    "Expects Task('FlowName/RunID/StepName/TaskID')"
-                )
-            elif self._NAME == "artifact" and len(ids) != 5:
-                raise MetaflowInvalidPathspec(
-                    "Expects DataArtifact('FlowName/RunID/StepName/TaskID/ArtifactName')"
-                )
+        if pathspec is not None and _object is None:
+            _validate_pathspec(pathspec, self._NAME)
+            ids = pathspec.rstrip("/").split("/")
 
             self.id = ids[-1]
-            self._pathspec = pathspec
+            self._pathspec = pathspec.rstrip("/")
             self._object = self._get_object(*ids)
+        elif pathspec is None and _object is None:
+            raise MetaflowInvalidPathspec(
+                "pathspec for %s cannot be None"
+                % _CLASS_DISPLAY_NAMES.get(self._NAME, self._NAME)
+            )
         else:
             self._object = _object
             self._pathspec = pathspec

--- a/test/unit/test_pathspec_validation.py
+++ b/test/unit/test_pathspec_validation.py
@@ -268,17 +268,13 @@ def test_artifact_too_many_parts_raises():
 # fails before fix, passes after fix
 def test_artifact_empty_segment_raises():
     """DataArtifact with an empty segment must raise."""
-    _raises_invalid_pathspec(
-        DataArtifact, "MyFlow//1234/my_step/56789/my_artifact"
-    )
+    _raises_invalid_pathspec(DataArtifact, "MyFlow//1234/my_step/56789/my_artifact")
 
 
 # passes before fix, passes after fix
 def test_artifact_valid_pathspec():
     """DataArtifact('MyFlow/1234/my_step/56789/my_artifact') is valid."""
-    _raises_not_invalid_pathspec(
-        DataArtifact, "MyFlow/1234/my_step/56789/my_artifact"
-    )
+    _raises_not_invalid_pathspec(DataArtifact, "MyFlow/1234/my_step/56789/my_artifact")
 
 
 # ===========================================================================

--- a/test/unit/test_pathspec_validation.py
+++ b/test/unit/test_pathspec_validation.py
@@ -1,0 +1,317 @@
+"""
+Tests for pathspec validation in the Metaflow Client API.
+
+GitHub Issue: https://github.com/Netflix/metaflow/issues/948
+"Pathspec to create Flow/Run/Step/Task/DataArtifact is not validated"
+
+Each test is annotated with:
+ # fails before fix, passes after fix — for cases that must now raise
+ # passes before fix, passes after fix — for valid-format cases (regression guard)
+
+Valid-format pathspecs still raise MetaflowNotFound because there is no real
+metadata backend running during unit tests. That is expected and correct; the
+key assertion is that MetaflowInvalidPathspec is NOT raised for valid formats.
+"""
+
+import pytest
+
+from metaflow import DataArtifact, Flow, Run, Step, Task
+from metaflow.exception import MetaflowInvalidPathspec
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _raises_invalid_pathspec(cls, pathspec, **kwargs):
+    """Assert that constructing cls(pathspec) raises MetaflowInvalidPathspec."""
+    with pytest.raises(MetaflowInvalidPathspec):
+        cls(pathspec, **kwargs)
+
+
+def _raises_not_invalid_pathspec(cls, pathspec, **kwargs):
+    """
+    Assert that constructing cls(pathspec) does NOT raise MetaflowInvalidPathspec.
+
+    It may raise MetaflowNotFound (no backend) or succeed — both are fine.
+    """
+    try:
+        cls(pathspec, **kwargs)
+    except MetaflowInvalidPathspec:
+        pytest.fail(
+            "%s(%r) raised MetaflowInvalidPathspec but should not have."
+            % (cls.__name__, pathspec)
+        )
+    except Exception:
+        # Any other exception (e.g. MetaflowNotFound, connection error) is OK.
+        pass
+
+
+# ===========================================================================
+# Flow
+# ===========================================================================
+
+
+# fails before fix, passes after fix
+def test_flow_none_pathspec_raises():
+    """Flow(None) must raise MetaflowInvalidPathspec."""
+    _raises_invalid_pathspec(Flow, None)
+
+
+# fails before fix, passes after fix
+def test_flow_empty_string_raises():
+    """Flow('') must raise MetaflowInvalidPathspec."""
+    _raises_invalid_pathspec(Flow, "")
+
+
+# fails before fix, passes after fix
+def test_flow_too_many_parts_raises():
+    """Flow('MyFlow/1234') is wrong — Flow takes exactly 1 part."""
+    _raises_invalid_pathspec(Flow, "MyFlow/1234")
+
+
+# fails before fix, passes after fix
+def test_flow_empty_segment_raises():
+    """Flow('') or a slash-only pathspec must raise."""
+    _raises_invalid_pathspec(Flow, "/")
+
+
+# passes before fix, passes after fix
+def test_flow_valid_pathspec():
+    """Flow('MyFlow') is the correct format — validation must not raise."""
+    _raises_not_invalid_pathspec(Flow, "MyFlow")
+
+
+# passes before fix, passes after fix
+def test_flow_trailing_slash_treated_as_valid():
+    """
+    Flow('MyFlow/') should be normalised to 'MyFlow' (1 part) and not raise
+    MetaflowInvalidPathspec; it may raise MetaflowNotFound afterward.
+    """
+    _raises_not_invalid_pathspec(Flow, "MyFlow/")
+
+
+# ===========================================================================
+# Run
+# ===========================================================================
+
+
+# fails before fix, passes after fix
+def test_run_none_pathspec_raises():
+    """Run(None) must raise MetaflowInvalidPathspec."""
+    _raises_invalid_pathspec(Run, None)
+
+
+# fails before fix, passes after fix
+def test_run_empty_string_raises():
+    """Run('') must raise MetaflowInvalidPathspec."""
+    _raises_invalid_pathspec(Run, "")
+
+
+# fails before fix, passes after fix
+def test_run_too_few_parts_raises():
+    """Run('MyFlow') is wrong — Run takes exactly 2 parts."""
+    _raises_invalid_pathspec(Run, "MyFlow")
+
+
+# fails before fix, passes after fix
+def test_run_too_many_parts_raises():
+    """Run('MyFlow/1234/extra') is wrong — Run takes exactly 2 parts."""
+    _raises_invalid_pathspec(Run, "MyFlow/1234/extra")
+
+
+# fails before fix, passes after fix
+def test_run_empty_segment_raises():
+    """Run('MyFlow//1234') contains an empty segment and must raise."""
+    _raises_invalid_pathspec(Run, "MyFlow//1234")
+
+
+# fails before fix, passes after fix — trailing slash strips to 3 parts (step shape)
+def test_run_with_step_like_path_fails_after_normalize():
+    """Run('HelloFlow/1/start/') normalises to 3 parts; Run requires 2."""
+    _raises_invalid_pathspec(Run, "HelloFlow/1/start/")
+
+
+# passes before fix, passes after fix
+def test_run_valid_pathspec():
+    """Run('MyFlow/1234') is the correct format — validation must not raise."""
+    _raises_not_invalid_pathspec(Run, "MyFlow/1234")
+
+
+# ===========================================================================
+# Step
+# ===========================================================================
+
+
+# fails before fix, passes after fix
+def test_step_none_pathspec_raises():
+    """Step(None) must raise MetaflowInvalidPathspec."""
+    _raises_invalid_pathspec(Step, None)
+
+
+# fails before fix, passes after fix
+def test_step_too_few_parts_raises():
+    """Step('MyFlow/1234') is wrong — Step takes exactly 3 parts."""
+    _raises_invalid_pathspec(Step, "MyFlow/1234")
+
+
+# fails before fix, passes after fix
+def test_step_too_many_parts_raises():
+    """Step('MyFlow/1234/my_step/extra') is wrong — Step takes 3 parts."""
+    _raises_invalid_pathspec(Step, "MyFlow/1234/my_step/extra")
+
+
+# fails before fix, passes after fix
+def test_step_empty_segment_raises():
+    """Step('MyFlow//1234/my_step') contains an empty segment."""
+    _raises_invalid_pathspec(Step, "MyFlow//1234/my_step")
+
+
+# passes before fix, passes after fix
+def test_step_valid_pathspec():
+    """Step('MyFlow/1234/my_step') is the correct format."""
+    _raises_not_invalid_pathspec(Step, "MyFlow/1234/my_step")
+
+
+# ===========================================================================
+# Task (the motivating example from the issue)
+# ===========================================================================
+
+
+# fails before fix, passes after fix
+def test_task_none_pathspec_raises():
+    """Task(None) must raise MetaflowInvalidPathspec."""
+    _raises_invalid_pathspec(Task, None)
+
+
+# fails before fix, passes after fix
+def test_task_empty_string_raises():
+    """Task('') must raise MetaflowInvalidPathspec."""
+    _raises_invalid_pathspec(Task, "")
+
+
+# fails before fix, passes after fix
+def test_task_too_few_parts_raises():
+    """
+    Task('MyFlow/1234/my_step') is the exact bug from issue #948.
+    Only 3 parts — Task requires 4.
+    """
+    _raises_invalid_pathspec(Task, "MyFlow/1234/my_step")
+
+
+# fails before fix, passes after fix
+def test_task_too_many_parts_raises():
+    """Task('MyFlow/1234/my_step/56789/extra') has 5 parts — too many."""
+    _raises_invalid_pathspec(Task, "MyFlow/1234/my_step/56789/extra")
+
+
+# fails before fix, passes after fix
+def test_task_empty_segment_raises():
+    """Task('MyFlow//1234/my_step/56789') contains an empty segment."""
+    _raises_invalid_pathspec(Task, "MyFlow//1234/my_step/56789")
+
+
+# fails before fix, passes after fix
+def test_task_trailing_slash_wrong_count_raises():
+    """
+    Task('MyFlow/1234/my_step/') — after stripping the trailing slash this
+    becomes 'MyFlow/1234/my_step' which is only 3 parts, so it must raise.
+    """
+    _raises_invalid_pathspec(Task, "MyFlow/1234/my_step/")
+
+
+# passes before fix, passes after fix
+def test_task_valid_pathspec():
+    """
+    Task('MyFlow/1234/my_step/56789') is the correct 4-part format.
+    Validation must not raise MetaflowInvalidPathspec.
+    (May raise MetaflowNotFound because no real metadata backend is running.)
+    """
+    _raises_not_invalid_pathspec(Task, "MyFlow/1234/my_step/56789")
+
+
+# passes before fix, passes after fix
+def test_task_trailing_slash_valid_normalised():
+    """
+    Task('MyFlow/1234/my_step/56789/') — trailing slash is stripped,
+    leaving 4 valid parts. Must not raise MetaflowInvalidPathspec.
+    """
+    _raises_not_invalid_pathspec(Task, "MyFlow/1234/my_step/56789/")
+
+
+# ===========================================================================
+# DataArtifact
+# ===========================================================================
+
+
+# fails before fix, passes after fix
+def test_artifact_none_pathspec_raises():
+    """DataArtifact(None) must raise MetaflowInvalidPathspec."""
+    _raises_invalid_pathspec(DataArtifact, None)
+
+
+# fails before fix, passes after fix
+def test_artifact_too_few_parts_raises():
+    """DataArtifact('MyFlow/1234/my_step/56789') has only 4 parts — too few."""
+    _raises_invalid_pathspec(DataArtifact, "MyFlow/1234/my_step/56789")
+
+
+# fails before fix, passes after fix
+def test_artifact_too_many_parts_raises():
+    """DataArtifact with 6 parts must raise."""
+    _raises_invalid_pathspec(
+        DataArtifact, "MyFlow/1234/my_step/56789/my_artifact/extra"
+    )
+
+
+# fails before fix, passes after fix
+def test_artifact_empty_segment_raises():
+    """DataArtifact with an empty segment must raise."""
+    _raises_invalid_pathspec(
+        DataArtifact, "MyFlow//1234/my_step/56789/my_artifact"
+    )
+
+
+# passes before fix, passes after fix
+def test_artifact_valid_pathspec():
+    """DataArtifact('MyFlow/1234/my_step/56789/my_artifact') is valid."""
+    _raises_not_invalid_pathspec(
+        DataArtifact, "MyFlow/1234/my_step/56789/my_artifact"
+    )
+
+
+# ===========================================================================
+# Error-message content (spot-check)
+# ===========================================================================
+
+
+def test_error_message_includes_pathspec():
+    """The error message must include the bad pathspec string."""
+    with pytest.raises(MetaflowInvalidPathspec) as exc_info:
+        Task("MyFlow/1234/my_step")
+    assert "MyFlow/1234/my_step" in str(exc_info.value)
+
+
+def test_error_message_includes_class_name():
+    """The error message must mention the class name (Task)."""
+    with pytest.raises(MetaflowInvalidPathspec) as exc_info:
+        Task("MyFlow/1234/my_step")
+    assert "Task" in str(exc_info.value)
+
+
+def test_error_message_includes_expected_format():
+    """The error message must include the expected format."""
+    with pytest.raises(MetaflowInvalidPathspec) as exc_info:
+        Task("MyFlow/1234/my_step")
+    msg = str(exc_info.value)
+    assert "FlowName/RunID/StepName/TaskID" in msg
+
+
+def test_error_message_includes_part_counts():
+    """The error message must mention both expected and actual part counts."""
+    with pytest.raises(MetaflowInvalidPathspec) as exc_info:
+        Task("MyFlow/1234/my_step")
+    msg = str(exc_info.value)
+    assert "4" in msg  # expected parts
+    assert "3" in msg  # actual parts


### PR DESCRIPTION
fix(client): validate pathspec format for Client API (#948)

- Add `_validate_pathspec()` with empty-segment checks and part counts
- Normalise trailing slashes via `rstrip('/')` before split
- Raise `MetaflowInvalidPathspec` when pathspec is missing for user construction
- Add unit tests aligned with PR #3047 plus `Run` step-like trailing-slash case

Made-with: Cursor

## PR Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Client constructors (`Flow`, `Run`, `Step`, `Task`, `DataArtifact`) now reject malformed pathspecs up front: missing/empty pathspecs, empty segments (`//`, leading `/`), wrong number of `/`-separated parts, and misleading trailing slashes (e.g. a path that normalises to a *Step*-shaped string passed to `Run`). Users get `MetaflowInvalidPathspec` with a clear message instead of partially constructed objects or confusing follow-on errors.

## Issue

<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes #948

Related: #3047 (overlapping community PR; happy to consolidate or drop this if maintainers prefer a single implementation).

## Reproduction

<!-- Required for bug fixes. Required for Core Runtime changes. -->
<!-- Provide a minimal reproduction that fails before and succeeds after. -->

**Runtime:** Client API only (no flow execution; local Python).

**Commands to run:**

```bash
cd test/unit
PYTHONPATH=../.. python -m pytest test_pathspec_validation.py -v
```

On environments where `import metaflow` fails during test collection (e.g. some Windows setups without `fcntl`), run the same command on Linux or rely on CI.

**Where evidence shows up:** Python exception type and message in the REPL or test output.

<details>
<summary>Before (error / log snippet)</summary>

```python
# Example from #948: too few components for Task — confusing errors or odd object state.
Task("MyFlow/1234/my_step")  # 3 parts; Task needs 4

# Trailing slash could change segment counts incorrectly for Run.
Run("HelloFlow/1/start/")
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```python
from metaflow import Task, Run
from metaflow.exception import MetaflowInvalidPathspec

Task("MyFlow/1234/my_step")  # MetaflowInvalidPathspec
Run("HelloFlow/1/start/")    # MetaflowInvalidPathspec
```

Valid-shaped pathspecs still raise `MetaflowNotFound` when no metadata exists — unchanged; tests assert `MetaflowInvalidPathspec` is not raised for valid shapes.

</details>

## Root Cause

Pathspec strings were not fully validated before metadata lookup. Wrong segment counts (and slash edge cases) could lead to inconsistent client objects or confusing errors instead of an immediate, explicit `MetaflowInvalidPathspec`.

## Why This Fix Is Correct

Validation runs once, before `_get_object()`, using the same internal object kinds (`flow`, `run`, `step`, `task`, `artifact`) as the Client API. Trailing slashes are normalised with `rstrip('/')` so `Name` and `Name/` behave the same; empty interior segments are rejected. Stored `_pathspec` matches the normalised form.

## Failure Modes Considered

<!-- Required for Core Runtime (at least 2). Recommended for all bug fixes. -->
<!-- Examples: concurrency/retries, subprocess output propagation, env-var leakage, backward compat -->

1. **Overly strict IDs:** We do not validate run or task ID format (numeric vs string); only structure and non-empty segments, so backend-specific IDs stay valid.
2. **Internal construction:** Objects built with `_object=...` and without a user pathspec skip pathspec validation; only the user-facing `pathspec` + `_object is None` path is validated. Pickle/`__setstate__` paths still pass explicit pathspecs through the same constructor logic as before.

## Tests

- [x] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

**Added:** `test/unit/test_pathspec_validation.py`

## Non-Goals

- No changes to metadata providers, runtime, or orchestrator plugins.
- No change to what counts as a valid run/task ID beyond slash-separated structure.

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

**Tool:** Cursor (AI-assisted editing and review).

**Use:** Implementation outline, test cases, and PR description wording.

**Review:** I read the changed code in `metaflow/client/core.py`, reasoned through edge cases (trailing slash, `//`, wrong counts), and aligned tests with that behaviour. Confirm `pytest` on Linux or via CI where `metaflow` imports cleanly.

---

