### PR TITLE
fix: use identity check for None comparison (PEP 8 E711)

### DIFF
--- a/metaflow/plugins/argo/argo_events.py
+++ b/metaflow/plugins/argo/argo_events.py
@@ -102,7 +102,7 @@ class ArgoEvent(object):
             If True, events are created on a best effort basis - errors are silently ignored.
         """
 
-        if payload == None:
+        if payload is None:
             payload = {}
         # Publish event iff forced or running on Argo Workflows
         if force or os.environ.get("ARGO_WORKFLOW_TEMPLATE"):


### PR DESCRIPTION
## Summary

Replace `== None` with `is None` identity check in `argo_events.py` per PEP 8 (E711).

Python's `is` operator is the recommended way to compare with singletons like `None`. Using `==` can produce unexpected results if a class defines a custom `__eq__` method.

**Change:**
```python
# Before
if payload == None:

# After
if payload is None:
```

## Testing
No behavior change — identity check with `is` is functionally equivalent to `==` for `None` comparisons in standard usage.