### PR TITLE
Add echo to SystemContext and flow_init_ctx to ProjectDecorator

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -577,6 +577,7 @@ def start(
         flow_datastore=ctx.obj.flow_datastore,
         metadata=ctx.obj.metadata,
         logger=ctx.obj.logger,
+        echo=ctx.obj.echo,
     )
 
     # It is important to initialize flow decorators early as some of the

--- a/metaflow/plugins/project_decorator.py
+++ b/metaflow/plugins/project_decorator.py
@@ -110,6 +110,56 @@ class ProjectDecorator(FlowDecorator):
 
     defaults = {"name": None, **{k: v["default"] for k, v in options.items()}}
 
+    def flow_init_ctx(self, options):
+        ctx = self.system_ctx
+        self._option_values = options
+        project_name = self.attributes.get("name")
+        for op in options:
+            if (
+                op in self._user_defined_attributes
+                and options[op] != self.defaults[op]
+                and self.attributes[op] != options[op]
+            ):
+                raise MetaflowException(
+                    "You cannot pass %s as both a command-line argument and an attribute "
+                    "of the @project decorator." % op
+                )
+        if "branch" in self._user_defined_attributes:
+            project_branch = self.attributes["branch"]
+        else:
+            project_branch = options["branch"]
+
+        if "production" in self._user_defined_attributes:
+            project_production = self.attributes["production"]
+        else:
+            project_production = options["production"]
+
+        project_flow_name, branch_name = format_name(
+            ctx.flow.name,
+            project_name,
+            project_production,
+            project_branch,
+            get_username(),
+        )
+        is_user_branch = project_branch is None and not project_production
+        ctx.echo(
+            "Project: *%s*, Branch: *%s*" % (project_name, branch_name),
+            fg="magenta",
+            highlight="green",
+        )
+        current._update_env(
+            {
+                "project_name": project_name,
+                "branch_name": branch_name,
+                "is_user_branch": is_user_branch,
+                "is_production": project_production,
+                "project_flow_name": project_flow_name,
+            }
+        )
+        ctx.metadata.add_sticky_tags(
+            sys_tags=["project:%s" % project_name, "project_branch:%s" % branch_name]
+        )
+
     def flow_init(
         self, flow, graph, environment, flow_datastore, metadata, logger, echo, options
     ):
@@ -121,13 +171,6 @@ class ProjectDecorator(FlowDecorator):
                 and options[op] != self.defaults[op]
                 and self.attributes[op] != options[op]
             ):
-                # Exception if:
-                #  - the user provides a value in the attributes field
-                #  - AND the user provided a value in the command line (non default)
-                #  - AND the values are different
-                # Note that this won't raise an error if the user provided the default
-                # value in the command line and provided one in attribute but although
-                # slightly inconsistent, it is not incorrect.
                 raise MetaflowException(
                     "You cannot pass %s as both a command-line argument and an attribute "
                     "of the @project decorator." % op

--- a/metaflow/plugins/project_decorator.py
+++ b/metaflow/plugins/project_decorator.py
@@ -120,6 +120,13 @@ class ProjectDecorator(FlowDecorator):
                 and options[op] != self.defaults[op]
                 and self.attributes[op] != options[op]
             ):
+                # Exception if:
+                #  - the user provides a value in the attributes field
+                #  - AND the user provided a value in the command line (non default)
+                #  - AND the values are different
+                # Note that this won't raise an error if the user provided the default
+                # value in the command line and provided one in attribute but although
+                # slightly inconsistent, it is not incorrect.
                 raise MetaflowException(
                     "You cannot pass %s as both a command-line argument and an attribute "
                     "of the @project decorator." % op

--- a/metaflow/system_context.py
+++ b/metaflow/system_context.py
@@ -105,6 +105,7 @@ class SystemContext:
         self._flow_datastore = None
         self._metadata = None
         self._logger = None
+        self._echo = None
 
         # Inter-decorator shared state (keyed by step_name)
         self._shared = {}  # { step_name: { namespace: { key: value } } }
@@ -183,6 +184,11 @@ class SystemContext:
     def logger(self) -> Optional[Callable[..., Any]]:
         """The logger callable."""
         return self._logger
+
+    @property
+    def echo(self) -> Optional[Callable[..., Any]]:
+        """The echo callable for styled terminal output (available after ``flow_init``)."""
+        return self._echo
 
     @property
     def metadata(self) -> Optional[Any]:

--- a/test/unit/spin/conftest.py
+++ b/test/unit/spin/conftest.py
@@ -6,6 +6,15 @@ import os
 FLOWS_DIR = os.path.join(os.path.dirname(__file__), "flows")
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--use-latest",
+        action="store_true",
+        default=False,
+        help="Use the latest run of each flow instead of running them",
+    )
+
+
 def create_flow_fixture(flow_name, flow_file, run_params=None, runner_params=None):
     """
     Factory function to create flow fixtures with common logic.


### PR DESCRIPTION
## PR Type

- [X] New feature
- [X] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [X] Refactoring

## Summary

Follow-up to #2969 (New decorator hooks). The new `system_ctx` includes `logger` but not `echo` — the styled terminal output callable that `@project` and other FlowDecorators use.

Extension decorators that subclass `@project` and override `flow_init` cannot cleanly migrate to `flow_init_ctx` because `ProjectDecorator` itself doesn't have one. They're forced to reconstruct all 8 positional args from `system_ctx` just to call the parent:

```python
# What extensions have to do today:
def flow_init_ctx(self, options):
    ctx = self.system_ctx
    ProjectDecorator.flow_init(
        self, ctx.flow, ctx.graph, ctx.environment,
        ctx.flow_datastore, ctx.metadata, ctx.logger, None, options
    )
```

This change:
- Adds `echo` to `SystemContext`, populated alongside `logger` during CLI init
- Adds `flow_init_ctx` to `ProjectDecorator` using `self.system_ctx`
- Keeps the old `flow_init` for backward compatibility

After this, extensions can do:
```python
def flow_init_ctx(self, options):
    ProjectDecorator.flow_init_ctx(self, options)
    # extension-specific logic using self.system_ctx
```

## Tests

- [ ] Existing `test/unit/test_system_context.py` tests continue to pass
- [ ] `@project` decorator behavior unchanged (both `flow_init` and `flow_init_ctx` paths)

## AI Tool Usage

- [X] AI tools were used (describe below)

Guided Claude for the implementation.

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>