### PR TITLE
Send step and project context to monitor for metric tagging

### DIFF
--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -774,7 +774,7 @@ class MetaflowTask(object):
         }
 
         monitor_tags = {
-            k: v
+            k: str(v)
             for k, v in {
                 "step_name": step_name,
                 "project_name": current.get("project_name"),

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -773,6 +773,19 @@ class MetaflowTask(object):
             "trace_id": trace_id or None,
         }
 
+        monitor_tags = {
+            k: v
+            for k, v in {
+                "step_name": step_name,
+                "project_name": current.get("project_name"),
+                "branch_name": current.get("branch_name"),
+                "is_production": current.get("is_production"),
+                "is_user_branch": current.get("is_user_branch"),
+            }.items()
+            if v is not None
+        }
+        self.monitor.send(Message(MessageTypes.MUST_SEND, monitor_tags))
+
         from_start("MetaflowTask: task metadata initialized")
         start = time.time()
         self.metadata.start_task_heartbeat(self.flow.name, run_id, step_name, task_id)


### PR DESCRIPTION
## Summary
- Sends `step_name`, `project_name`, `branch_name`, `is_production`, and `is_user_branch` as a `MUST_SEND` context update to the monitor at the start of `run_step`
- Enables monitor implementations to include per-step and per-project tags on all metrics emitted during step execution
- Filters out `None` values to avoid invalid tags

## Motivation
The monitor currently only receives flow-level context (flow_name, username, metaflow_version, etc.) at init time. Per-step context like `step_name` and project metadata are available in `run_step` but never propagated to the monitor. This makes it impossible to slice metrics by step or project without custom workarounds.

## Test plan
- [ ] Verify existing monitor tests pass
- [ ] Verify `NullMonitor.send()` (base class) forwards the message to the sidecar without error
- [ ] Verify custom monitor implementations that override `send()` receive the new tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)