### PR TITLE
fix: optionally use schedules for cronjob

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -474,7 +474,9 @@ ARGO_EVENTS_SENSOR_NAMESPACE = from_conf(
 # Prefix for namespaced events (used by @trigger with namespaced=True)
 NAMESPACED_EVENTS_PREFIX = from_conf("NAMESPACED_EVENTS_PREFIX", "mfns")
 
+# Additional argo workflows options
 ARGO_WORKFLOWS_UI_URL = from_conf("ARGO_WORKFLOWS_UI_URL")
+ARGO_WORKFLOWS_USE_SCHEDULES = from_conf("ARGO_WORKFLOWS_USE_SCHEDULES", True)
 
 ##
 # Airflow Configuration

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -476,7 +476,10 @@ NAMESPACED_EVENTS_PREFIX = from_conf("NAMESPACED_EVENTS_PREFIX", "mfns")
 
 # Additional argo workflows options
 ARGO_WORKFLOWS_UI_URL = from_conf("ARGO_WORKFLOWS_UI_URL")
-ARGO_WORKFLOWS_USE_SCHEDULES = from_conf("ARGO_WORKFLOWS_USE_SCHEDULES", True)
+# `schedules` (list) requires Argo Workflows >= 3.6. Default to the legacy
+# singular `schedule` so existing deployments on older Argo are unaffected;
+# opt in by setting METAFLOW_ARGO_WORKFLOWS_USE_SCHEDULES=true.
+ARGO_WORKFLOWS_USE_SCHEDULES = from_conf("ARGO_WORKFLOWS_USE_SCHEDULES", False)
 
 ##
 # Airflow Configuration

--- a/metaflow/plugins/argo/argo_client.py
+++ b/metaflow/plugins/argo/argo_client.py
@@ -1,6 +1,9 @@
 import json
 
-from metaflow.metaflow_config import ARGO_EVENTS_SENSOR_NAMESPACE
+from metaflow.metaflow_config import (
+    ARGO_EVENTS_SENSOR_NAMESPACE,
+    ARGO_WORKFLOWS_USE_SCHEDULES,
+)
 from metaflow.exception import MetaflowException
 from metaflow.plugins.kubernetes.kubernetes_client import KubernetesClient
 
@@ -318,6 +321,13 @@ class ArgoClient(object):
     def schedule_workflow_template(self, name, schedule=None, timezone=None):
         # Unfortunately, Kubernetes client does not handle optimistic
         # concurrency control by itself unlike kubectl
+
+        if ARGO_WORKFLOWS_USE_SCHEDULES:
+            schedules_key = "schedules"
+            schedules_val = [schedule]
+        else:
+            schedules_key = "schedule"
+            schedules_val = schedule
         client = self._client.get()
         body = {
             "apiVersion": "argoproj.io/v1alpha1",
@@ -325,7 +335,7 @@ class ArgoClient(object):
             "metadata": {"name": name},
             "spec": {
                 "suspend": schedule is None,
-                "schedule": schedule,
+                schedules_key: schedules_val,
                 "timezone": timezone,
                 "failedJobsHistoryLimit": 10000,  # default is unfortunately 1
                 "successfulJobsHistoryLimit": 10000,  # default is unfortunately 3

--- a/metaflow/plugins/argo/argo_client.py
+++ b/metaflow/plugins/argo/argo_client.py
@@ -324,7 +324,7 @@ class ArgoClient(object):
 
         if ARGO_WORKFLOWS_USE_SCHEDULES:
             schedules_key = "schedules"
-            schedules_val = [schedule]
+            schedules_val = [schedule] if schedule else schedule
         else:
             schedules_key = "schedule"
             schedules_val = schedule

--- a/metaflow/plugins/argo/argo_client.py
+++ b/metaflow/plugins/argo/argo_client.py
@@ -62,6 +62,23 @@ class ArgoClient(object):
                 json.loads(e.body)["message"] if e.body is not None else e.reason
             )
 
+    def get_cronworkflow(self, name):
+        client = self._client.get()
+        try:
+            return client.CustomObjectsApi().get_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural="cronworkflows",
+                name=name,
+            )
+        except client.rest.ApiException as e:
+            if e.status == 404:
+                return None
+            raise ArgoClientException(
+                json.loads(e.body)["message"] if e.body is not None else e.reason
+            )
+
     def get_workflow_templates(self, page_size=100):
         client = self._client.get()
         continue_token = None
@@ -321,13 +338,12 @@ class ArgoClient(object):
     def schedule_workflow_template(self, name, schedule=None, timezone=None):
         # Unfortunately, Kubernetes client does not handle optimistic
         # concurrency control by itself unlike kubectl
-
         if ARGO_WORKFLOWS_USE_SCHEDULES:
-            schedules_key = "schedules"
-            schedules_val = [schedule] if schedule else schedule
+            # `schedules` is a list field; use an empty list (not null) when
+            # there is no schedule so the suspended CronWorkflow stays valid.
+            schedule_spec = {"schedules": [] if schedule is None else [schedule]}
         else:
-            schedules_key = "schedule"
-            schedules_val = schedule
+            schedule_spec = {"schedule": schedule}
         client = self._client.get()
         body = {
             "apiVersion": "argoproj.io/v1alpha1",
@@ -335,7 +351,7 @@ class ArgoClient(object):
             "metadata": {"name": name},
             "spec": {
                 "suspend": schedule is None,
-                schedules_key: schedules_val,
+                **schedule_spec,
                 "timezone": timezone,
                 "failedJobsHistoryLimit": 10000,  # default is unfortunately 1
                 "successfulJobsHistoryLimit": 10000,  # default is unfortunately 3

--- a/test/ux/core/test_lifecycle.py
+++ b/test/ux/core/test_lifecycle.py
@@ -71,3 +71,62 @@ def test_deployed_flow_status(exec_mode, decospecs, compute_env, tag, scheduler_
     run = wait_for_deployed_run(deployed_flow)
     assert run.successful, "Run was not successful"
     assert run.finished, "Run did not finish"
+
+
+@pytest.mark.lifecycle
+@pytest.mark.scheduler_only
+@pytest.mark.parametrize("use_schedules", [True, False], ids=["schedules", "schedule"])
+def test_argo_schedule_uses_configured_field(
+    exec_mode, decospecs, compute_env, tag, scheduler_config, use_schedules
+):
+    """On Argo, the @schedule cron actually lands in the configured CronWorkflow
+    field (`schedules` list vs legacy `schedule`) and the workflow is not
+    suspended. Guards ARGO_WORKFLOWS_USE_SCHEDULES and the empty-list fix."""
+    if exec_mode != "deployer":
+        pytest.skip("lifecycle tests require deployer mode")
+    if scheduler_config.scheduler_type != "argo-workflows":
+        pytest.skip("schedules/schedule field is Argo-specific")
+
+    # Lazy imports: only the argo backend has `kubernetes` + a kubeconfig available.
+    from metaflow.metaflow_config import KUBERNETES_NAMESPACE
+    from metaflow.plugins.argo.argo_client import ArgoClient
+
+    test_unique_tag = (
+        f"test_argo_schedule_{'schedules' if use_schedules else 'schedule'}"
+    )
+    combined_tags = tag + [test_unique_tag]
+
+    # The flag is read at import time inside the deployer subprocess, so it must
+    # be set in the subprocess env (not the test process).
+    env = dict(compute_env)
+    env["METAFLOW_ARGO_WORKFLOWS_USE_SCHEDULES"] = "true" if use_schedules else "false"
+    tl_args = {"decospecs": decospecs, "env": env}
+
+    deployed_flow = deploy_flow_to_scheduler(
+        flow_name="lifecycle/schedule_flow.py",
+        tl_args=tl_args,
+        scheduler_args={"cluster": scheduler_config.cluster},
+        deploy_args={"tags": combined_tags, **(scheduler_config.deploy_args or {})},
+        scheduler_type=scheduler_config.scheduler_type,
+    )
+
+    try:
+        cron = ArgoClient(namespace=KUBERNETES_NAMESPACE).get_cronworkflow(
+            deployed_flow.name
+        )
+        assert cron is not None, "CronWorkflow was not created"
+        spec = cron["spec"]
+
+        # The schedule actually landed and the cron is active.
+        assert spec.get("suspend") is False
+        scheduled_crons = ([spec["schedule"]] if spec.get("schedule") else []) + (
+            spec.get("schedules") or []
+        )
+        assert "0 0 * * *" in scheduled_crons
+
+        if use_schedules:
+            # New default path: list field, no null, legacy field absent.
+            assert spec.get("schedules") == ["0 0 * * *"]
+            assert "schedule" not in spec
+    finally:
+        deployed_flow.delete()


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix
- [x] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Changes the default way of creating schedules to the new argo workflows `schedules` instead of `schedule`.  If you want to keep the current legacy behavior as a default, feel free to change the option in the metaflow config.

## Issue

- Fixes #2351

## Reproduction

<!-- Required for bug fixes. Required for Core Runtime changes. -->
<!-- Provide a minimal reproduction that fails before and succeeds after. -->

**Runtime:** <!-- local / kubernetes / batch / argo / etc. -->

**Commands to run:**
```bash
# paste exact commands
```

**Where evidence shows up:** <!-- parent console / task logs / metadata / UI -->

<details>
<summary>Before (error / log snippet)</summary>

```
paste here
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
paste here
```

</details>

## Root Cause

<!-- Required for Core Runtime. Recommended for all bug fixes. -->
<!-- Explain the causal chain: what invariant was violated, where in the code. -->
<!-- See PRs #2796, #2751, #2714 for examples of the level of detail we're looking for. -->

## Why This Fix Is Correct

<!-- What invariant is restored? Why is the fix minimal? -->

## Failure Modes Considered

<!-- Required for Core Runtime (at least 2). Recommended for all bug fixes. -->
<!-- Examples: concurrency/retries, subprocess output propagation, env-var leakage, backward compat -->

1.
2.

## Tests

- [ ] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

<!-- What you intentionally did not change. Helps reviewers scope their review. -->

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [ ] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)

<!-- If you used AI tools:
- Which tool(s)?
- What did you use them for?
- Did you review, understand, and test all generated code?
-->
