### PR TITLE
fix: export all Argo manifests (cron workflow, sensor) in --only-json

### DIFF
--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -194,6 +194,37 @@ class ArgoWorkflows(object):
     def __str__(self):
         return str(self._workflow_template)
 
+    def _cron_workflow_json(self):
+        """Build the CronWorkflow manifest as a dict (without deploying it)."""
+        if self._schedule is None:
+            return None
+        return {
+            "apiVersion": "argoproj.io/v1alpha1",
+            "kind": "CronWorkflow",
+            "metadata": {"name": self.name},
+            "spec": {
+                "suspend": False,
+                "schedule": self._schedule,
+                "timezone": self._timezone,
+                "failedJobsHistoryLimit": 10000,
+                "successfulJobsHistoryLimit": 10000,
+                "workflowSpec": {"workflowTemplateRef": {"name": self.name}},
+                "startingDeadlineSeconds": 3540,
+            },
+        }
+
+    def export_all_json(self):
+        """Return a JSON string with all Argo manifests for this flow."""
+        result = {
+            "workflow_template": self._workflow_template.to_json(),
+        }
+        cron = self._cron_workflow_json()
+        if cron is not None:
+            result["cron_workflow"] = cron
+        if self._sensor is not None:
+            result["sensor"] = self._sensor.to_json()
+        return json.dumps(result, indent=4)
+
     def deploy(self):
         self.cleanup_previous_sensors()
         try:

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -28,6 +28,7 @@ from metaflow.metaflow_config import (
     ARGO_WORKFLOWS_ENV_VARS_TO_SKIP,
     ARGO_WORKFLOWS_KUBERNETES_SECRETS,
     ARGO_WORKFLOWS_UI_URL,
+    ARGO_WORKFLOWS_USE_SCHEDULES,
     AWS_SECRETS_MANAGER_DEFAULT_REGION,
     AZURE_KEY_VAULT_PREFIX,
     AZURE_STORAGE_BLOB_SERVICE_ENDPOINT,
@@ -197,16 +198,25 @@ class ArgoWorkflows(object):
         return str(self._workflow_template)
 
     def _cron_workflow_json(self):
-        """Build the CronWorkflow manifest as a dict (without deploying it)."""
+        """Build the CronWorkflow manifest as a dict (without deploying it).
+
+        Mirrors the schedule spec structure that ArgoClient.schedule_workflow_template
+        produces: when ARGO_WORKFLOWS_USE_SCHEDULES is True, uses a "schedules" list;
+        otherwise uses the legacy "schedule" scalar.
+        """
         if self._schedule is None:
             return None
+        if ARGO_WORKFLOWS_USE_SCHEDULES:
+            schedule_spec = {"schedules": [self._schedule]}
+        else:
+            schedule_spec = {"schedule": self._schedule}
         return {
             "apiVersion": "argoproj.io/v1alpha1",
             "kind": "CronWorkflow",
             "metadata": {"name": self.name},
             "spec": {
                 "suspend": False,
-                "schedule": self._schedule,
+                **schedule_spec,
                 "timezone": self._timezone,
                 "failedJobsHistoryLimit": 10000,
                 "successfulJobsHistoryLimit": 10000,

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -196,6 +196,37 @@ class ArgoWorkflows(object):
     def __str__(self):
         return str(self._workflow_template)
 
+    def _cron_workflow_json(self):
+        """Build the CronWorkflow manifest as a dict (without deploying it)."""
+        if self._schedule is None:
+            return None
+        return {
+            "apiVersion": "argoproj.io/v1alpha1",
+            "kind": "CronWorkflow",
+            "metadata": {"name": self.name},
+            "spec": {
+                "suspend": False,
+                "schedule": self._schedule,
+                "timezone": self._timezone,
+                "failedJobsHistoryLimit": 10000,
+                "successfulJobsHistoryLimit": 10000,
+                "workflowSpec": {"workflowTemplateRef": {"name": self.name}},
+                "startingDeadlineSeconds": 3540,
+            },
+        }
+
+    def export_all_json(self):
+        """Return a JSON string with all Argo manifests for this flow."""
+        result = {
+            "workflow_template": self._workflow_template.to_json(),
+        }
+        cron = self._cron_workflow_json()
+        if cron is not None:
+            result["cron_workflow"] = cron
+        if self._sensor is not None:
+            result["sensor"] = self._sensor.to_json()
+        return json.dumps(result, indent=4)
+
     def deploy(self):
         self.cleanup_previous_sensors()
         try:

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -364,8 +364,7 @@ def create(
     )
 
     if only_json:
-        obj.echo_always(str(flow), err=False, no_bold=True)
-        # TODO: Support echo-ing Argo Events Sensor template
+        obj.echo_always(flow.export_all_json(), err=False, no_bold=True)
     else:
         flow.deploy()
         obj.echo(

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -374,8 +374,7 @@ def create(
             deployer_attribute_file,
             additional_info={"workflow_template": flow._workflow_template.to_json()},
         )
-        obj.echo_always(str(flow), err=False, no_bold=True)
-        # TODO: Support echo-ing Argo Events Sensor template
+        obj.echo_always(flow.export_all_json(), err=False, no_bold=True)
     else:
         flow.deploy()
         obj.echo(

--- a/test/ux/core/test_argo_manifests.py
+++ b/test/ux/core/test_argo_manifests.py
@@ -69,9 +69,8 @@ def _get_compile_env():
         os.path.join(os.path.dirname(__file__), "..", "..", "..")
     )
     env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
-    # Clear devstack-specific profile so tests work outside the devstack too.
-    env.pop("METAFLOW_PROFILE", None)
-    env.pop("METAFLOW_HOME", None)
+    # Keep METAFLOW_HOME/METAFLOW_PROFILE if set (e.g. devstack config that
+    # provides S3/cloud datastore settings needed by --only-json).
     return env
 
 
@@ -108,6 +107,10 @@ def _compile_flow_to_json(flow_path, **extra_tl_args):
         if "ConnectionRefusedError" in stderr or "ConnectionError" in stderr:
             pytest.skip(
                 "Argo backend not configured (connection refused to metadata service)"
+            )
+        if "requires --datastore=" in stderr:
+            pytest.skip(
+                "Cloud datastore not configured (--only-json requires s3/azure/gs)"
             )
         pytest.fail(f"Compilation failed:\nstderr: {stderr}\nstdout: {stdout}")
 

--- a/test/ux/core/test_argo_manifests.py
+++ b/test/ux/core/test_argo_manifests.py
@@ -1,16 +1,19 @@
 """
 Tests for `argo-workflows create --only-json` manifest export.
 
-Verifies that export_all_json() outputs all Argo manifests (workflow template,
+Verifies that the CLI outputs all Argo manifests (workflow template,
 cron workflow, and sensor) as a single JSON object, not just the workflow
 template.
 
-These tests exercise the ArgoWorkflows.export_all_json() method directly,
-bypassing the CLI and cluster access requirements.
+Includes both:
+- Unit tests exercising ArgoWorkflows.export_all_json() directly
+- Integration tests running the actual CLI via subprocess against the devstack
 """
 
 import json
-from unittest.mock import MagicMock
+import os
+import subprocess
+import sys
 
 import pytest
 
@@ -19,6 +22,13 @@ from metaflow.plugins.argo.argo_workflows import (
     Sensor,
     WorkflowTemplate,
 )
+
+pytestmark = [pytest.mark.argo_manifests]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def _make_argo_workflows(schedule=None, timezone=None, sensor=None):
@@ -29,7 +39,6 @@ def _make_argo_workflows(schedule=None, timezone=None, sensor=None):
     """
     obj = object.__new__(ArgoWorkflows)
 
-    # Build a minimal WorkflowTemplate
     wt = WorkflowTemplate()
     wt.payload = {
         "apiVersion": "argoproj.io/v1alpha1",
@@ -44,6 +53,75 @@ def _make_argo_workflows(schedule=None, timezone=None, sensor=None):
     obj._sensor = sensor
 
     return obj
+
+
+def _get_compile_env():
+    """Get environment variables for compilation-only tests.
+
+    Overrides metadata to 'local' so no metadata service is needed, and
+    ensures the source tree is on PYTHONPATH so the subprocess can import
+    metaflow from the repo.
+    """
+    env = os.environ.copy()
+    env["METAFLOW_DEFAULT_METADATA"] = "local"
+    # Ensure the repo root is on PYTHONPATH for subprocess imports.
+    repo_root = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..")
+    )
+    env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+    # Clear devstack-specific profile so tests work outside the devstack too.
+    env.pop("METAFLOW_PROFILE", None)
+    env.pop("METAFLOW_HOME", None)
+    return env
+
+
+def _compile_flow_to_json(flow_path, **extra_tl_args):
+    """Compile a flow to Argo JSON using the CLI with --only-json.
+
+    Runs `python <flow> --no-pylint argo-workflows create --only-json`
+    and parses the JSON from stdout.
+    """
+    from .test_utils import _resolve_flow_path
+
+    full_path = _resolve_flow_path(flow_path)
+
+    cmd = [sys.executable, full_path, "--no-pylint"]
+    for k, v in extra_tl_args.items():
+        if v is not None:
+            cmd.extend([f"--{k.replace('_', '-')}", str(v)])
+    cmd.extend(["argo-workflows", "create", "--only-json"])
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=_get_compile_env(),
+    )
+    if result.returncode != 0:
+        stderr = result.stderr or ""
+        stdout = result.stdout or ""
+        if "No such command" in stderr or "No such command" in stdout:
+            pytest.skip(
+                "argo-workflows CLI not available (extension may override plugins)"
+            )
+        if "ConnectionRefusedError" in stderr or "ConnectionError" in stderr:
+            pytest.skip(
+                "Argo backend not configured (connection refused to metadata service)"
+            )
+        pytest.fail(f"Compilation failed:\nstderr: {stderr}\nstdout: {stdout}")
+
+    stdout = result.stdout.strip()
+    json_start = stdout.find("{")
+    if json_start == -1:
+        pytest.fail(f"No JSON found in compilation output:\n{stdout}")
+
+    return json.loads(stdout[json_start:])
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — exercise export_all_json() directly with mock objects
+# ---------------------------------------------------------------------------
 
 
 class TestExportAllJsonScheduled:
@@ -89,12 +167,6 @@ class TestExportAllJsonTriggered:
         }
         return sensor
 
-    def test_contains_workflow_template(self):
-        argo = _make_argo_workflows(sensor=self._make_sensor())
-        data = json.loads(argo.export_all_json())
-        assert "workflow_template" in data
-        assert data["workflow_template"]["kind"] == "WorkflowTemplate"
-
     def test_contains_sensor(self):
         argo = _make_argo_workflows(sensor=self._make_sensor())
         data = json.loads(argo.export_all_json())
@@ -116,13 +188,6 @@ class TestExportAllJsonPlain:
         assert "workflow_template" in data
         assert "cron_workflow" not in data
         assert "sensor" not in data
-
-    def test_output_is_valid_json(self):
-        argo = _make_argo_workflows()
-        raw = argo.export_all_json()
-        # Should parse without error
-        data = json.loads(raw)
-        assert isinstance(data, dict)
 
 
 class TestExportAllJsonBothScheduleAndTrigger:
@@ -149,16 +214,6 @@ class TestExportAllJsonBothScheduleAndTrigger:
         assert "cron_workflow" in data
         assert "sensor" in data
 
-    def test_cron_schedule_value(self):
-        argo = _make_argo_workflows(
-            schedule="*/5 * * * *",
-            timezone="UTC",
-            sensor=self._make_sensor(),
-        )
-        data = json.loads(argo.export_all_json())
-        assert data["cron_workflow"]["spec"]["schedule"] == "*/5 * * * *"
-        assert data["cron_workflow"]["spec"]["timezone"] == "UTC"
-
 
 class TestCronWorkflowJson:
     """Tests for the _cron_workflow_json() helper method."""
@@ -183,3 +238,53 @@ class TestCronWorkflowJson:
         assert cron["spec"]["workflowSpec"] == {
             "workflowTemplateRef": {"name": "test-flow"}
         }
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — run the actual CLI via subprocess
+# ---------------------------------------------------------------------------
+
+
+class TestArgoCliOnlyJsonPlainFlow:
+    """Run `argo-workflows create --only-json` on a plain flow via subprocess."""
+
+    def test_plain_flow_has_workflow_template(self):
+        data = _compile_flow_to_json("basic/helloworld.py")
+        assert "workflow_template" in data
+        assert data["workflow_template"]["kind"] == "WorkflowTemplate"
+
+    def test_plain_flow_no_cron_or_sensor(self):
+        data = _compile_flow_to_json("basic/helloworld.py")
+        assert "cron_workflow" not in data
+        assert "sensor" not in data
+
+    def test_output_is_valid_json_object(self):
+        data = _compile_flow_to_json("basic/helloworld.py")
+        assert isinstance(data, dict)
+
+
+class TestArgoCliOnlyJsonScheduledFlow:
+    """Run `argo-workflows create --only-json` on a @schedule flow via subprocess."""
+
+    def test_scheduled_flow_has_cron_workflow(self):
+        data = _compile_flow_to_json("lifecycle/schedule_flow.py")
+        assert "cron_workflow" in data
+        cron = data["cron_workflow"]
+        assert cron["kind"] == "CronWorkflow"
+        assert cron["apiVersion"] == "argoproj.io/v1alpha1"
+
+    def test_scheduled_flow_has_workflow_template(self):
+        data = _compile_flow_to_json("lifecycle/schedule_flow.py")
+        assert "workflow_template" in data
+        assert data["workflow_template"]["kind"] == "WorkflowTemplate"
+
+    def test_cron_schedule_matches_decorator(self):
+        data = _compile_flow_to_json("lifecycle/schedule_flow.py")
+        cron = data["cron_workflow"]
+        assert cron["spec"]["schedule"] == "0 0 * * *"
+
+    def test_cron_references_workflow_template(self):
+        data = _compile_flow_to_json("lifecycle/schedule_flow.py")
+        cron = data["cron_workflow"]
+        wt_name = data["workflow_template"]["metadata"]["name"]
+        assert cron["spec"]["workflowSpec"]["workflowTemplateRef"]["name"] == wt_name

--- a/test/ux/core/test_argo_manifests.py
+++ b/test/ux/core/test_argo_manifests.py
@@ -1,0 +1,185 @@
+"""
+Tests for `argo-workflows create --only-json` manifest export.
+
+Verifies that export_all_json() outputs all Argo manifests (workflow template,
+cron workflow, and sensor) as a single JSON object, not just the workflow
+template.
+
+These tests exercise the ArgoWorkflows.export_all_json() method directly,
+bypassing the CLI and cluster access requirements.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from metaflow.plugins.argo.argo_workflows import (
+    ArgoWorkflows,
+    Sensor,
+    WorkflowTemplate,
+)
+
+
+def _make_argo_workflows(schedule=None, timezone=None, sensor=None):
+    """Create an ArgoWorkflows instance with pre-set internal state via mocking.
+
+    We bypass __init__ to avoid the many dependencies (graph, flow, datastore, etc.)
+    and directly set the three internal attributes that export_all_json() reads.
+    """
+    obj = object.__new__(ArgoWorkflows)
+
+    # Build a minimal WorkflowTemplate
+    wt = WorkflowTemplate()
+    wt.payload = {
+        "apiVersion": "argoproj.io/v1alpha1",
+        "kind": "WorkflowTemplate",
+        "metadata": {"name": "test-flow"},
+        "spec": {},
+    }
+    obj._workflow_template = wt
+    obj.name = "test-flow"
+    obj._schedule = schedule
+    obj._timezone = timezone
+    obj._sensor = sensor
+
+    return obj
+
+
+class TestExportAllJsonScheduled:
+    """A flow with @schedule should export both workflow_template and cron_workflow."""
+
+    def test_contains_workflow_template(self):
+        argo = _make_argo_workflows(schedule="0 10 * * *", timezone="US/Pacific")
+        data = json.loads(argo.export_all_json())
+        assert "workflow_template" in data
+        assert data["workflow_template"]["kind"] == "WorkflowTemplate"
+
+    def test_contains_cron_workflow(self):
+        argo = _make_argo_workflows(schedule="0 10 * * *", timezone="US/Pacific")
+        data = json.loads(argo.export_all_json())
+        assert "cron_workflow" in data
+        cron = data["cron_workflow"]
+        assert cron["kind"] == "CronWorkflow"
+        assert cron["apiVersion"] == "argoproj.io/v1alpha1"
+        assert cron["spec"]["schedule"] == "0 10 * * *"
+        assert cron["spec"]["timezone"] == "US/Pacific"
+        assert cron["spec"]["suspend"] is False
+        assert cron["metadata"]["name"] == "test-flow"
+        assert (
+            cron["spec"]["workflowSpec"]["workflowTemplateRef"]["name"] == "test-flow"
+        )
+
+    def test_no_sensor_without_trigger(self):
+        argo = _make_argo_workflows(schedule="0 10 * * *", timezone="US/Pacific")
+        data = json.loads(argo.export_all_json())
+        assert "sensor" not in data
+
+
+class TestExportAllJsonTriggered:
+    """A flow with @trigger should export both workflow_template and sensor."""
+
+    def _make_sensor(self):
+        sensor = Sensor()
+        sensor.payload = {
+            "apiVersion": "argoproj.io/v1alpha1",
+            "kind": "Sensor",
+            "metadata": {"name": "test-flow"},
+            "spec": {"dependencies": [], "triggers": []},
+        }
+        return sensor
+
+    def test_contains_workflow_template(self):
+        argo = _make_argo_workflows(sensor=self._make_sensor())
+        data = json.loads(argo.export_all_json())
+        assert "workflow_template" in data
+        assert data["workflow_template"]["kind"] == "WorkflowTemplate"
+
+    def test_contains_sensor(self):
+        argo = _make_argo_workflows(sensor=self._make_sensor())
+        data = json.loads(argo.export_all_json())
+        assert "sensor" in data
+        assert data["sensor"]["kind"] == "Sensor"
+
+    def test_no_cron_without_schedule(self):
+        argo = _make_argo_workflows(sensor=self._make_sensor())
+        data = json.loads(argo.export_all_json())
+        assert "cron_workflow" not in data
+
+
+class TestExportAllJsonPlain:
+    """A plain flow (no @schedule, no @trigger) exports only the workflow template."""
+
+    def test_only_workflow_template(self):
+        argo = _make_argo_workflows()
+        data = json.loads(argo.export_all_json())
+        assert "workflow_template" in data
+        assert "cron_workflow" not in data
+        assert "sensor" not in data
+
+    def test_output_is_valid_json(self):
+        argo = _make_argo_workflows()
+        raw = argo.export_all_json()
+        # Should parse without error
+        data = json.loads(raw)
+        assert isinstance(data, dict)
+
+
+class TestExportAllJsonBothScheduleAndTrigger:
+    """A flow with both @schedule and @trigger exports all three manifests."""
+
+    def _make_sensor(self):
+        sensor = Sensor()
+        sensor.payload = {
+            "apiVersion": "argoproj.io/v1alpha1",
+            "kind": "Sensor",
+            "metadata": {"name": "test-flow"},
+            "spec": {"dependencies": [], "triggers": []},
+        }
+        return sensor
+
+    def test_all_three_present(self):
+        argo = _make_argo_workflows(
+            schedule="*/5 * * * *",
+            timezone="UTC",
+            sensor=self._make_sensor(),
+        )
+        data = json.loads(argo.export_all_json())
+        assert "workflow_template" in data
+        assert "cron_workflow" in data
+        assert "sensor" in data
+
+    def test_cron_schedule_value(self):
+        argo = _make_argo_workflows(
+            schedule="*/5 * * * *",
+            timezone="UTC",
+            sensor=self._make_sensor(),
+        )
+        data = json.loads(argo.export_all_json())
+        assert data["cron_workflow"]["spec"]["schedule"] == "*/5 * * * *"
+        assert data["cron_workflow"]["spec"]["timezone"] == "UTC"
+
+
+class TestCronWorkflowJson:
+    """Tests for the _cron_workflow_json() helper method."""
+
+    def test_returns_none_when_no_schedule(self):
+        argo = _make_argo_workflows()
+        assert argo._cron_workflow_json() is None
+
+    def test_returns_dict_when_schedule_set(self):
+        argo = _make_argo_workflows(schedule="0 0 * * *", timezone="UTC")
+        cron = argo._cron_workflow_json()
+        assert isinstance(cron, dict)
+        assert cron["kind"] == "CronWorkflow"
+
+    def test_cron_spec_matches_argo_client(self):
+        """Verify the cron body matches what ArgoClient.schedule_workflow_template builds."""
+        argo = _make_argo_workflows(schedule="0 10 * * *", timezone="US/Pacific")
+        cron = argo._cron_workflow_json()
+        assert cron["spec"]["failedJobsHistoryLimit"] == 10000
+        assert cron["spec"]["successfulJobsHistoryLimit"] == 10000
+        assert cron["spec"]["startingDeadlineSeconds"] == 3540
+        assert cron["spec"]["workflowSpec"] == {
+            "workflowTemplateRef": {"name": "test-flow"}
+        }

--- a/test/ux/core/test_argo_manifests.py
+++ b/test/ux/core/test_argo_manifests.py
@@ -14,6 +14,7 @@ import json
 import os
 import subprocess
 import sys
+from unittest import mock
 
 import pytest
 
@@ -241,6 +242,30 @@ class TestCronWorkflowJson:
         assert cron["spec"]["workflowSpec"] == {
             "workflowTemplateRef": {"name": "test-flow"}
         }
+
+    def test_cron_spec_use_schedules_flag_produces_list(self):
+        """When ARGO_WORKFLOWS_USE_SCHEDULES=True, spec uses 'schedules' (list), not 'schedule' (scalar)."""
+        argo = _make_argo_workflows(schedule="0 10 * * *", timezone="US/Pacific")
+        with mock.patch(
+            "metaflow.plugins.argo.argo_workflows.ARGO_WORKFLOWS_USE_SCHEDULES",
+            True,
+        ):
+            cron = argo._cron_workflow_json()
+        assert "schedules" in cron["spec"], "'schedules' key missing under ARGO_WORKFLOWS_USE_SCHEDULES=True"
+        assert "schedule" not in cron["spec"], "'schedule' (scalar) must not appear when ARGO_WORKFLOWS_USE_SCHEDULES=True"
+        assert cron["spec"]["schedules"] == ["0 10 * * *"]
+
+    def test_cron_spec_default_flag_produces_scalar(self):
+        """When ARGO_WORKFLOWS_USE_SCHEDULES=False (default), spec uses 'schedule' (scalar)."""
+        argo = _make_argo_workflows(schedule="0 10 * * *", timezone="US/Pacific")
+        with mock.patch(
+            "metaflow.plugins.argo.argo_workflows.ARGO_WORKFLOWS_USE_SCHEDULES",
+            False,
+        ):
+            cron = argo._cron_workflow_json()
+        assert "schedule" in cron["spec"], "'schedule' key missing under ARGO_WORKFLOWS_USE_SCHEDULES=False"
+        assert "schedules" not in cron["spec"], "'schedules' (list) must not appear when ARGO_WORKFLOWS_USE_SCHEDULES=False"
+        assert cron["spec"]["schedule"] == "0 10 * * *"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `argo-workflows create --only-json` now exports all Argo manifests, not just the WorkflowTemplate
- Output is a JSON object with up to three keys: `workflow_template` (always), `cron_workflow` (when `@schedule` is used), and `sensor` (when `@trigger`/`@trigger_on_finish` is used)
- Previously the CronWorkflow and Sensor configs were silently dropped
- `_cron_workflow_json()` now mirrors `ARGO_WORKFLOWS_USE_SCHEDULES` — uses `"schedules": [...]` (list) when the flag is True, matching what `ArgoClient.schedule_workflow_template` actually deploys

Fixes #1730, fixes #1940.

## ⚠️ Breaking change: output format

The output of `--only-json` has changed from a bare WorkflowTemplate JSON object to a wrapper envelope:

**Before:**
```json
{"apiVersion": "argoproj.io/v1alpha1", "kind": "WorkflowTemplate", ...}
```

**After:**
```json
{"workflow_template": {...}, "cron_workflow": {...}}
```

If you have scripts parsing the old output, update them to add `.workflow_template`:

```bash
# old
python flow.py argo-workflows create --only-json | jq '.spec.templates'

# new
python flow.py argo-workflows create --only-json | jq '.workflow_template.spec.templates'
```

## Test plan
- [x] Added `test/ux/core/test_argo_manifests.py` with tests for all manifest export scenarios
- [x] Added `mock.patch` tests for both `ARGO_WORKFLOWS_USE_SCHEDULES=True` and `False` paths in `TestCronWorkflowJson`

🤖 Generated with [Claude Code](https://claude.com/claude-code)