### PR TITLE
fix: use bash parameter expansion for SFN resume CLI opts

### DIFF
--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -1035,7 +1035,8 @@ class StepFunctions(object):
         step_cmd = " ".join(entrypoint + top_level + step)
         resume_opts = (
             "${METAFLOW_RESUME_ORIGIN_RUN_ID:+"
-            "--resume-origin-run-id $METAFLOW_RESUME_ORIGIN_RUN_ID "
+            "--resume-origin-run-id $METAFLOW_RESUME_ORIGIN_RUN_ID}"
+            " ${METAFLOW_RESUME_STEPS_TO_RERUN:+"
             "--resume-steps-to-rerun $METAFLOW_RESUME_STEPS_TO_RERUN}"
         )
         cmds.append("%s %s" % (step_cmd, resume_opts))

--- a/metaflow/plugins/aws/step_functions/step_functions.py
+++ b/metaflow/plugins/aws/step_functions/step_functions.py
@@ -1027,7 +1027,18 @@ class StepFunctions(object):
             step.extend("--tag %s" % tag for tag in self.tags)
         if self.namespace is not None:
             step.append("--namespace=%s" % self.namespace)
-        cmds.append(" ".join(entrypoint + top_level + step))
+        # Build the step command, then append resume options that are only
+        # included when the env vars are non-empty (normal triggers set them
+        # to empty strings).  We use bash parameter expansion ${VAR:+...}
+        # instead of $(if ...) to avoid double-quote issues with shlex.split
+        # in batch.py's _command().
+        step_cmd = " ".join(entrypoint + top_level + step)
+        resume_opts = (
+            "${METAFLOW_RESUME_ORIGIN_RUN_ID:+"
+            "--resume-origin-run-id $METAFLOW_RESUME_ORIGIN_RUN_ID "
+            "--resume-steps-to-rerun $METAFLOW_RESUME_STEPS_TO_RERUN}"
+        )
+        cmds.append("%s %s" % (step_cmd, resume_opts))
         return " && ".join(cmds)
 
 


### PR DESCRIPTION
## Summary
- Fix SFN resume CLI commands breaking when `--resume-steps-to-rerun` is empty
- Use bash `${VAR:+...}` parameter expansion (matching the Argo implementation) so resume options are only included when the env vars are non-empty
- Avoids double-quote issues with `shlex.split` in `batch.py`'s `_command()`

## Test plan
- [ ] Verify SFN resume with steps-to-rerun set works correctly
- [ ] Verify SFN resume with empty steps-to-rerun doesn't break the CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)