### PR TITLE
fix: three small orchestrator fixes (#1014, #1591, #1164)

### DIFF
--- a/metaflow/plugins/argo/argo_client.py
+++ b/metaflow/plugins/argo/argo_client.py
@@ -117,6 +117,7 @@ class ArgoClient(object):
             ]
         except client.rest.ApiException as e:
             if e.status == 404:
+                _check_crd_exists(client, e, "workflowtemplates")
                 try:
                     return client.CustomObjectsApi().create_namespaced_custom_object(
                         group=self._group,
@@ -126,6 +127,7 @@ class ArgoClient(object):
                         body=workflow_template,
                     )
                 except client.rest.ApiException as e:
+                    _check_crd_exists(client, e, "workflowtemplates")
                     raise ArgoClientException(
                         json.loads(e.body)["message"]
                         if e.body is not None
@@ -465,6 +467,42 @@ class ArgoClient(object):
             if e.status == 404:
                 return None
             raise wrap_api_error(e)
+
+
+def _check_crd_exists(client, api_exception, plural):
+    """
+    Detect whether a 404 error is due to missing Argo CRDs (as opposed to
+    a missing resource instance). When CRDs aren't installed the API server
+    returns a 404 with a generic message like "the server could not find the
+    requested resource". Raise a clear, actionable error in that case.
+    """
+    if api_exception.status != 404:
+        return
+    try:
+        body = json.loads(api_exception.body) if api_exception.body else {}
+    except (json.JSONDecodeError, TypeError):
+        body = {}
+    message = body.get("message", "")
+    reason = body.get("reason", "")
+    # When a specific named resource is not found, Kubernetes returns
+    # reason="NotFound" with a message like '<plural> "name" not found'.
+    # When the CRD itself is missing, the message is typically either
+    # "the server could not find the requested resource" or a generic 404
+    # without the plural resource type in the message.
+    #
+    # Check for a specific named resource: message starts with the plural
+    # followed by a quoted name, e.g. 'workflowtemplates "my-workflow" not found'
+    is_specific_resource = message.startswith('%s "' % plural)
+    if not is_specific_resource and (
+        "could not find the requested resource" in message.lower()
+        or (reason == "NotFound" and plural not in message)
+    ):
+        raise ArgoClientException(
+            "Argo Workflows CRDs do not appear to be installed on this "
+            "Kubernetes cluster. Please install Argo Workflows first.\n"
+            "See: https://argo-workflows.readthedocs.io/en/latest/quick-start/\n"
+            "Original error: %s" % message
+        )
 
 
 def wrap_api_error(error):

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -246,7 +246,14 @@ class ArgoWorkflows(object):
     def _sensor_name(name):
         # Unfortunately, Argo Events Sensor names don't allow for
         # dots (sensors run into an error) which rules out self.name :(
-        return name.replace(".", "-")
+        sanitized = name.replace(".", "-")
+        # Kubernetes names have a 253-character limit. Long flow names
+        # (especially with @project) can exceed this. Truncate and append
+        # a hash suffix to maintain uniqueness.
+        if len(sanitized) > 253:
+            name_hash = sha1(sanitized.encode("utf-8")).hexdigest()[:12]
+            sanitized = sanitized[:240] + "-" + name_hash
+        return sanitized
 
     @staticmethod
     def list_templates(flow_name, all=False, page_size=100):

--- a/metaflow/plugins/aws/aws_utils.py
+++ b/metaflow/plugins/aws/aws_utils.py
@@ -123,6 +123,22 @@ def get_docker_registry(image_uri):
     return registry
 
 
+def _numeric_str(value):
+    """
+    Convert a numeric value to a clean string representation.
+
+    Handles int, float, and string inputs. Produces integer-style strings
+    when the value is a whole number (e.g. 1.0 -> "1", "4096.0" -> "4096")
+    and preserves fractional values (e.g. 0.5 -> "0.5").
+    """
+    f = float(value or 0)
+    # Return an integer-style string if the value is a whole number to avoid
+    # turning cpu=1 into "1.0" which can confuse downstream comparisons.
+    if f == int(f):
+        return str(int(f))
+    return str(f)
+
+
 def compute_resource_attributes(decos, compute_deco, resource_defaults):
     """
     Compute resource values taking into account defaults, the values specified
@@ -153,17 +169,14 @@ def compute_resource_attributes(decos, compute_deco, resource_defaults):
                     continue
                 if my_val is not None and v is not None:
                     try:
-                        # Use Decimals to compare and convert to string here so
-                        # that numbers that can't be exactly represented as
-                        # floats (e.g. 0.8) still look "nice". We don't care
-                        # about precision more that .001 for resources anyway.
-                        result[k] = str(max(float(my_val or 0), float(v or 0)))
-                    except ValueError:
-                        # Here we don't have ints, so we compare the value and raise
-                        # an exception if not equal
-                        if my_val != v:
-                            # TODO: Throw a better exception since the user has no
-                            #       knowledge of 'compute' decorator
+                        # Compare as floats to handle mixed int/float/string types
+                        # (e.g. @resources(cpu=0.5) with @batch(cpu=1)).
+                        # Use _numeric_str to produce clean output ("1" not "1.0").
+                        result[k] = _numeric_str(max(float(my_val or 0), float(v or 0)))
+                    except (ValueError, TypeError):
+                        # Here we don't have numeric values, so we compare
+                        # directly and raise an exception if not equal
+                        if str(my_val) != str(v):
                             raise MetaflowException(
                                 "'resources' and compute decorator have conflicting "
                                 "values for '%s'. Please use consistent values or "

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -374,13 +374,18 @@ class KubernetesDecorator(StepDecorator):
                         if self.defaults[k] is None:
                             # skip if expected value isn't an int/float
                             continue
-                        # We use the larger of @resources and @batch attributes
+                        # We use the larger of @resources and @kubernetes attributes
                         # TODO: Fix https://github.com/Netflix/metaflow/issues/467
                         my_val = self.attributes.get(k)
                         if not (my_val is None and v is None):
-                            self.attributes[k] = str(
-                                max(float(my_val or 0), float(v or 0))
-                            )
+                            # Compare as floats to handle mixed int/float/string
+                            # types (e.g. @resources(cpu=0.5) with @kubernetes(cpu=1)).
+                            # Produce clean string output ("1" not "1.0").
+                            max_val = max(float(my_val or 0), float(v or 0))
+                            if max_val == int(max_val):
+                                self.attributes[k] = str(int(max_val))
+                            else:
+                                self.attributes[k] = str(max_val)
 
         # Check GPU vendor.
         if self.attributes["gpu_vendor"].lower() not in ("amd", "nvidia"):

--- a/test/unit/test_argo_crd_detection.py
+++ b/test/unit/test_argo_crd_detection.py
@@ -1,0 +1,56 @@
+import json
+
+import pytest
+
+from metaflow.plugins.argo.argo_client import ArgoClientException, _check_crd_exists
+
+
+class MockApiException:
+    """Mimics kubernetes.client.rest.ApiException."""
+
+    def __init__(self, status, body=None):
+        self.status = status
+        self.body = body
+
+
+def test_crd_missing_generic_404():
+    """A generic 404 (no specific resource name) should raise a CRD error."""
+    body = json.dumps(
+        {
+            "kind": "Status",
+            "message": "the server could not find the requested resource",
+            "reason": "NotFound",
+        }
+    )
+    exc = MockApiException(404, body)
+    with pytest.raises(ArgoClientException, match="CRDs do not appear to be installed"):
+        _check_crd_exists(None, exc, "workflowtemplates")
+
+
+def test_named_resource_not_found():
+    """A 404 for a specific named resource should NOT raise the CRD error."""
+    body = json.dumps(
+        {
+            "kind": "Status",
+            "message": 'workflowtemplates "my-workflow" not found',
+            "reason": "NotFound",
+        }
+    )
+    exc = MockApiException(404, body)
+    # Should not raise — this is a normal "resource not found" 404
+    _check_crd_exists(None, exc, "workflowtemplates")
+
+
+def test_non_404_ignored():
+    """Non-404 errors should be ignored by _check_crd_exists."""
+    body = json.dumps({"message": "forbidden"})
+    exc = MockApiException(403, body)
+    # Should not raise
+    _check_crd_exists(None, exc, "workflowtemplates")
+
+
+def test_crd_missing_empty_body():
+    """A 404 with no body should not crash."""
+    exc = MockApiException(404, None)
+    # Should not raise (can't determine if CRD is missing without body)
+    _check_crd_exists(None, exc, "workflowtemplates")

--- a/test/unit/test_argo_sensor_name.py
+++ b/test/unit/test_argo_sensor_name.py
@@ -1,0 +1,56 @@
+from metaflow.plugins.argo.argo_workflows import ArgoWorkflows
+
+
+def test_sensor_name_short():
+    """Short names should pass through with only dot replacement."""
+    assert ArgoWorkflows._sensor_name("my.flow.name") == "my-flow-name"
+
+
+def test_sensor_name_no_dots():
+    """Names without dots should be unchanged."""
+    assert ArgoWorkflows._sensor_name("myflowname") == "myflowname"
+
+
+def test_sensor_name_long_truncated():
+    """Names exceeding 253 chars should be truncated with a hash suffix."""
+    long_name = "a" * 300
+    result = ArgoWorkflows._sensor_name(long_name)
+    assert len(result) <= 253
+    # Should contain a hash suffix
+    assert "-" in result[240:]
+    # Hash portion should be 12 hex chars
+    hash_part = result.split("-")[-1]
+    assert len(hash_part) == 12
+    assert all(c in "0123456789abcdef" for c in hash_part)
+
+
+def test_sensor_name_exactly_253():
+    """A name exactly 253 chars should not be truncated."""
+    name = "a" * 253
+    result = ArgoWorkflows._sensor_name(name)
+    assert result == name
+    assert len(result) == 253
+
+
+def test_sensor_name_254():
+    """A name of 254 chars should be truncated."""
+    name = "a" * 254
+    result = ArgoWorkflows._sensor_name(name)
+    assert len(result) <= 253
+
+
+def test_sensor_name_long_deterministic():
+    """Same long input should always produce the same truncated name."""
+    long_name = "project.branch." + "x" * 300 + ".FlowName"
+    result1 = ArgoWorkflows._sensor_name(long_name)
+    result2 = ArgoWorkflows._sensor_name(long_name)
+    assert result1 == result2
+
+
+def test_sensor_name_long_unique():
+    """Different long inputs should produce different truncated names."""
+    name1 = "a" * 300
+    name2 = "b" * 300
+    result1 = ArgoWorkflows._sensor_name(name1)
+    result2 = ArgoWorkflows._sensor_name(name2)
+    assert result1 != result2

--- a/test/unit/test_compute_resource_attributes.py
+++ b/test/unit/test_compute_resource_attributes.py
@@ -37,7 +37,7 @@ def test_compute_resource_attributes():
         [MockDeco("resources", {"cpu": "2"})],
         MockDeco("batch", {"cpu": 1}),
         {"cpu": "3"},
-    ) == {"cpu": "2.0"}
+    ) == {"cpu": "2"}
 
     # take largest of @resources and @batch if both are present
     assert compute_resource_attributes(
@@ -45,6 +45,45 @@ def test_compute_resource_attributes():
         MockDeco("batch", {"cpu": "0.5"}),
         {"cpu": "1"},
     ) == {"cpu": "0.83"}
+
+
+def test_compute_resource_attributes_float_int_compat():
+    """Test that float and int resource values are compared correctly (issue #1014)."""
+
+    # @resources(cpu=0.5) with @batch(cpu=1) should pick the larger value
+    assert compute_resource_attributes(
+        [MockDeco("resources", {"cpu": 0.5})],
+        MockDeco("batch", {"cpu": 1}),
+        {"cpu": "1"},
+    ) == {"cpu": "1"}
+
+    # @resources(cpu=0.5) with @batch default — should use 0.5
+    assert compute_resource_attributes(
+        [MockDeco("resources", {"cpu": 0.5})],
+        MockDeco("batch", {"cpu": None}),
+        {"cpu": "1"},
+    ) == {"cpu": "0.5"}
+
+    # Whole-number floats should produce clean integer strings
+    assert compute_resource_attributes(
+        [MockDeco("resources", {"cpu": 2.0})],
+        MockDeco("batch", {"cpu": 1}),
+        {"cpu": "1"},
+    ) == {"cpu": "2"}
+
+    # @resources(memory=8192.0) with @batch(memory=4096)
+    assert compute_resource_attributes(
+        [MockDeco("resources", {"memory": 8192.0})],
+        MockDeco("batch", {"memory": 4096}),
+        {"memory": "4096"},
+    ) == {"memory": "8192"}
+
+    # Both specify same fractional value — should not raise
+    assert compute_resource_attributes(
+        [MockDeco("resources", {"cpu": 0.5})],
+        MockDeco("batch", {"cpu": 0.5}),
+        {"cpu": "1"},
+    ) == {"cpu": "0.5"}
 
 
 def test_compute_resource_attributes_string():


### PR DESCRIPTION
## Summary
- **Float/int resource comparison**: normalize numeric types before comparing `@resources` and compute decorator values, produce clean integer strings for whole numbers (e.g. `"1"` not `"1.0"`)
- **Argo Events sensor name truncation**: truncate long sensor names to 253 chars with a hash suffix to comply with Kubernetes naming limits
- **Argo CRD detection**: detect missing Argo Workflows CRDs and show a clear error message instead of a cryptic API error

Fixes #1014, fixes #1591, fixes #1164.

## Test plan
- [x] `test/unit/test_compute_resource_attributes.py` — float/int normalization
- [x] `test/unit/test_argo_sensor_name.py` — sensor name truncation
- [x] `test/unit/test_argo_crd_detection.py` — CRD detection error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)