### PR TITLE
feat: add --dump-manifests flag to argo-workflows create

### DIFF
--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -707,13 +707,15 @@ def make_flow(
     enable_error_msg_capture,
     workflow_title,
     workflow_description,
+    dump_manifests=False,
 ):
-    # TODO: Make this check less specific to Amazon S3 as we introduce
-    #       support for more cloud object stores.
-    if obj.flow_datastore.TYPE not in ("azure", "gs", "s3"):
-        raise MetaflowException(
-            "Argo Workflows requires --datastore=s3 or --datastore=azure or --datastore=gs"
-        )
+    if not dump_manifests:
+        # TODO: Make this check less specific to Amazon S3 as we introduce
+        #       support for more cloud object stores.
+        if obj.flow_datastore.TYPE not in ("azure", "gs", "s3"):
+            raise MetaflowException(
+                "Argo Workflows requires --datastore=s3 or --datastore=azure or --datastore=gs"
+            )
 
     if (notify_on_error or notify_on_success) and not (
         notify_slack_webhook_url
@@ -754,30 +756,39 @@ def make_flow(
     )
     obj.graph = obj.flow._graph
 
-    # Save the code package in the flow datastore so that both user code and
-    # metaflow package can be retrieved during workflow execution.
-    obj.package = MetaflowPackage(
-        obj.flow,
-        obj.environment,
-        obj.echo,
-        suffixes=obj.package_suffixes,
-        flow_datastore=obj.flow_datastore if FEAT_ALWAYS_UPLOAD_CODE_PACKAGE else None,
-    )
-
-    # This blocks until the package is created
-    if FEAT_ALWAYS_UPLOAD_CODE_PACKAGE:
-        package_url = obj.package.package_url()
-        package_sha = obj.package.package_sha()
+    if dump_manifests:
+        # Skip code package upload; use placeholders for manifest inspection.
+        package_url = "__PLACEHOLDER_CODE_PACKAGE_URL__"
+        package_sha = "__PLACEHOLDER_CODE_PACKAGE_SHA__"
+        package_metadata = json.dumps({"version": 0})
     else:
-        package_url, package_sha = obj.flow_datastore.save_data(
-            [obj.package.blob], len_hint=1
-        )[0]
+        # Save the code package in the flow datastore so that both user code and
+        # metaflow package can be retrieved during workflow execution.
+        obj.package = MetaflowPackage(
+            obj.flow,
+            obj.environment,
+            obj.echo,
+            suffixes=obj.package_suffixes,
+            flow_datastore=(
+                obj.flow_datastore if FEAT_ALWAYS_UPLOAD_CODE_PACKAGE else None
+            ),
+        )
+
+        # This blocks until the package is created
+        if FEAT_ALWAYS_UPLOAD_CODE_PACKAGE:
+            package_url = obj.package.package_url()
+            package_sha = obj.package.package_sha()
+        else:
+            package_url, package_sha = obj.flow_datastore.save_data(
+                [obj.package.blob], len_hint=1
+            )[0]
+        package_metadata = obj.package.package_metadata
 
     return ArgoWorkflows(
         name,
         obj.graph,
         obj.flow,
-        obj.package.package_metadata,
+        package_metadata,
         package_sha,
         package_url,
         token,

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -717,13 +717,15 @@ def make_flow(
     enable_error_msg_capture,
     workflow_title,
     workflow_description,
+    dump_manifests=False,
 ):
-    # TODO: Make this check less specific to Amazon S3 as we introduce
-    #       support for more cloud object stores.
-    if obj.flow_datastore.TYPE not in ("azure", "gs", "s3"):
-        raise MetaflowException(
-            "Argo Workflows requires --datastore=s3 or --datastore=azure or --datastore=gs"
-        )
+    if not dump_manifests:
+        # TODO: Make this check less specific to Amazon S3 as we introduce
+        #       support for more cloud object stores.
+        if obj.flow_datastore.TYPE not in ("azure", "gs", "s3"):
+            raise MetaflowException(
+                "Argo Workflows requires --datastore=s3 or --datastore=azure or --datastore=gs"
+            )
 
     if (notify_on_error or notify_on_success) and not (
         notify_slack_webhook_url
@@ -764,30 +766,39 @@ def make_flow(
     )
     obj.graph = obj.flow._graph
 
-    # Save the code package in the flow datastore so that both user code and
-    # metaflow package can be retrieved during workflow execution.
-    obj.package = MetaflowPackage(
-        obj.flow,
-        obj.environment,
-        obj.echo,
-        suffixes=obj.package_suffixes,
-        flow_datastore=obj.flow_datastore if FEAT_ALWAYS_UPLOAD_CODE_PACKAGE else None,
-    )
-
-    # This blocks until the package is created
-    if FEAT_ALWAYS_UPLOAD_CODE_PACKAGE:
-        package_url = obj.package.package_url()
-        package_sha = obj.package.package_sha()
+    if dump_manifests:
+        # Skip code package upload; use placeholders for manifest inspection.
+        package_url = "__PLACEHOLDER_CODE_PACKAGE_URL__"
+        package_sha = "__PLACEHOLDER_CODE_PACKAGE_SHA__"
+        package_metadata = json.dumps({"version": 0})
     else:
-        package_url, package_sha = obj.flow_datastore.save_data(
-            [obj.package.blob], len_hint=1
-        )[0]
+        # Save the code package in the flow datastore so that both user code and
+        # metaflow package can be retrieved during workflow execution.
+        obj.package = MetaflowPackage(
+            obj.flow,
+            obj.environment,
+            obj.echo,
+            suffixes=obj.package_suffixes,
+            flow_datastore=(
+                obj.flow_datastore if FEAT_ALWAYS_UPLOAD_CODE_PACKAGE else None
+            ),
+        )
+
+        # This blocks until the package is created
+        if FEAT_ALWAYS_UPLOAD_CODE_PACKAGE:
+            package_url = obj.package.package_url()
+            package_sha = obj.package.package_sha()
+        else:
+            package_url, package_sha = obj.flow_datastore.save_data(
+                [obj.package.blob], len_hint=1
+            )[0]
+        package_metadata = obj.package.package_metadata
 
     return ArgoWorkflows(
         name,
         obj.graph,
         obj.flow,
-        obj.package.package_metadata,
+        package_metadata,
         package_sha,
         package_url,
         token,

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -160,6 +160,14 @@ def argo_workflows(obj, name=None):
     hidden=True,
 )
 @click.option(
+    "--dump-manifests",
+    is_flag=True,
+    default=False,
+    help="Print all Kubernetes manifests as JSON without connecting to the cluster "
+    "or uploading a code package. Suitable for GitOps workflows with kubectl apply, "
+    "kustomize, or ArgoCD. Code package fields use placeholder values.",
+)
+@click.option(
     "--max-workers",
     default=100,
     show_default=True,
@@ -259,6 +267,7 @@ def create(
     tags=None,
     user_namespace=None,
     only_json=False,
+    dump_manifests=False,
     authorize=None,
     generate_new_token=False,
     given_token=None,
@@ -291,12 +300,12 @@ def create(
 
     validate_tags(tags)
 
-    if not only_json:
+    if not only_json and not dump_manifests:
         _write_deployer_attributes(obj, deployer_attribute_file)
 
     obj.echo("Deploying *%s* to Argo Workflows..." % obj.flow.name, bold=True)
 
-    if only_json:
+    if only_json or dump_manifests:
         # When only generating JSON, we skip cluster access operations:
         # - Metadata service version check (requires service access)
         # - Token resolution (requires Kubernetes cluster access to check existing deployments)
@@ -366,9 +375,12 @@ def create(
         enable_error_msg_capture,
         workflow_title,
         workflow_description,
+        dump_manifests=dump_manifests,
     )
 
-    if only_json:
+    if dump_manifests:
+        obj.echo_always(flow.export_all_json(), err=False, no_bold=True)
+    elif only_json:
         _write_deployer_attributes(
             obj,
             deployer_attribute_file,

--- a/test/ux/core/test_argo_manifests.py
+++ b/test/ux/core/test_argo_manifests.py
@@ -316,3 +316,93 @@ class TestArgoCliOnlyJsonScheduledFlow:
         cron = data["cron_workflow"]
         wt_name = data["workflow_template"]["metadata"]["name"]
         assert cron["spec"]["workflowSpec"]["workflowTemplateRef"]["name"] == wt_name
+
+
+# ---------------------------------------------------------------------------
+# Helper for --dump-manifests integration tests
+# ---------------------------------------------------------------------------
+
+
+def _compile_flow_to_dump_manifests(flow_path, **extra_tl_args):
+    """Compile a flow to Argo JSON using the CLI with --dump-manifests.
+
+    Unlike --only-json, this skips datastore validation and code package upload,
+    so it works without any cloud datastore configured.
+    """
+    from .test_utils import _resolve_flow_path
+
+    full_path = _resolve_flow_path(flow_path)
+
+    cmd = [sys.executable, full_path, "--no-pylint"]
+    for k, v in extra_tl_args.items():
+        if v is not None:
+            cmd.extend([f"--{k.replace('_', '-')}", str(v)])
+    cmd.extend(["argo-workflows", "create", "--dump-manifests"])
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=_get_compile_env(),
+    )
+    if result.returncode != 0:
+        stderr = result.stderr or ""
+        stdout = result.stdout or ""
+        if "No such command" in stderr or "No such command" in stdout:
+            pytest.skip(
+                "argo-workflows CLI not available (extension may override plugins)"
+            )
+        if "ConnectionRefusedError" in stderr or "ConnectionError" in stderr:
+            pytest.skip(
+                "Argo backend not configured (connection refused to metadata service)"
+            )
+        # Note: do NOT skip for 'requires --datastore=' — that error would mean
+        # the datastore-bypass logic in make_flow() is broken.
+        pytest.fail(f"--dump-manifests failed:\nstderr: {stderr}\nstdout: {stdout}")
+
+    stdout = result.stdout.strip()
+    json_start = stdout.find("{")
+    if json_start == -1:
+        pytest.fail(f"No JSON found in --dump-manifests output:\n{stdout}")
+
+    return json.loads(stdout[json_start:])
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — --dump-manifests (no datastore required)
+# ---------------------------------------------------------------------------
+
+
+class TestArgoCliDumpManifests:
+    """Run `argo-workflows create --dump-manifests` via subprocess.
+
+    Unlike --only-json, --dump-manifests skips datastore validation and code
+    package upload, so it works without any cloud datastore configured.
+    """
+
+    def test_plain_flow_has_workflow_template(self):
+        data = _compile_flow_to_dump_manifests("basic/helloworld.py")
+        assert "workflow_template" in data
+        assert data["workflow_template"]["kind"] == "WorkflowTemplate"
+
+    def test_plain_flow_no_cron_or_sensor(self):
+        data = _compile_flow_to_dump_manifests("basic/helloworld.py")
+        assert "cron_workflow" not in data
+        assert "sensor" not in data
+
+    def test_output_is_valid_json_object(self):
+        data = _compile_flow_to_dump_manifests("basic/helloworld.py")
+        assert isinstance(data, dict)
+
+    def test_placeholder_package_values_present(self):
+        """Placeholder strings should appear in the manifest for code package fields."""
+        data = _compile_flow_to_dump_manifests("basic/helloworld.py")
+        manifest_str = json.dumps(data)
+        assert "__PLACEHOLDER_CODE_PACKAGE_URL__" in manifest_str
+        assert "__PLACEHOLDER_CODE_PACKAGE_SHA__" in manifest_str
+
+    def test_scheduled_flow_has_cron_workflow(self):
+        data = _compile_flow_to_dump_manifests("lifecycle/schedule_flow.py")
+        assert "cron_workflow" in data
+        assert data["cron_workflow"]["kind"] == "CronWorkflow"


### PR DESCRIPTION
## Summary
- Add \`--dump-manifests\` flag to \`argo-workflows create\` that outputs all Kubernetes manifests as JSON without connecting to the cluster or uploading a code package
- Skips datastore validation and code package upload, using placeholders instead
- Suitable for GitOps workflows with \`kubectl apply\`, kustomize, or ArgoCD

Depends on #3095.

## Changes (post-review)
- Register \`--dump-manifests\` as a Click option on the \`create\` command (was missing)
- Add \`elif dump_manifests:\` token branch to skip cluster access (alongside \`only_json\` path)
- Pass \`dump_manifests=dump_manifests\` through to \`make_flow()\`
- Add output branch: \`if dump_manifests: obj.echo_always(flow.export_all_json(), ...)\`
- Rebased on master

## Test plan
- [ ] Run \`python myflow.py argo-workflows create --dump-manifests\` and verify JSON output with placeholder code package values
- [ ] Verify \`--only-json\` still works as before (requires datastore)
- [ ] Verify normal \`create\` (deploy) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)