### PR TITLE
Fix stubs tests failing on Python 3.10+

### DIFF
--- a/.github/workflows/test-stubs.yml
+++ b/.github/workflows/test-stubs.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip setuptools
         if python3 -c "import sys; exit(0 if sys.version_info >= (3,10) else 1)"; then
-          python3 -m pip install pytest build "mypy<1.9" "pytest-mypy-plugins>=4"
+          python3 -m pip install pytest build "mypy<1.9" "pytest-mypy-plugins==4.0.0"
         else
           python3 -m pip install pytest build "mypy<1.9" "pytest-mypy-plugins<4"
         fi

--- a/stubs/test/test_stubs.yml
+++ b/stubs/test/test_stubs.yml
@@ -31,6 +31,7 @@
     class CorrectFlow2(FlowSpec):
       ...
   out: |
+    .*note: "project" defined here
     main:3: error: .*incompatible type.*expected "str"\s+\[arg-type\]
     main:4: error: .*Too many positional arguments for "project"\s+\[misc\]
     main:7: error: .*Too many positional arguments for "project"\s+\[misc\]


### PR DESCRIPTION
## Summary
- Pin `pytest-mypy-plugins==4.0.0` for Python 3.10+ (was `>=4`). Version 4.0.1 calls `FilesystemMetadataStore.close()` which doesn't exist in `mypy<1.9`, causing all 22 stubs tests to fail with `AttributeError`.
- Add expected mypy `note:` line for `project_decorator_validity` test that was previously masked by the `store.close()` crash.

## Test plan
- [x] Verified 22/22 stubs tests pass locally on Python 3.10 with `mypy==1.8.0` + `pytest-mypy-plugins==4.0.0`
- [x] Verified `--mypy-only-local-stub` on older plugin filters the added note line from expected output, so Python 3.7-3.9 are unaffected
- [ ] CI passes on all Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)