### PR TITLE
Fix get_pinned_conda_libs extension merge to skip empty-string versions

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -711,7 +711,18 @@ try:
                     d1 = f1(python_version, datastore_type)
                     d2 = f2(python_version, datastore_type)
                     for k, v in d2.items():
-                        d1[k] = v if k not in d1 else ",".join([d1[k], v])
+                        # An empty string means "any version" — treat it as a
+                        # no-op on either side of the merge instead of joining
+                        # with a comma. Joining "" with ">=X" produced ",>=X"
+                        # (or ">=X,") which downstream formatters turn into
+                        # malformed specs like `pkg==,>=X` that the conda
+                        # solver rejects with "Empty version".
+                        existing = d1.get(k, "")
+                        if not existing:
+                            d1[k] = v
+                        elif v:
+                            d1[k] = ",".join([existing, v])
+                        # else: v is empty — keep existing specifier
                     return d1
 
                 globals()[n] = _new_get_pinned_conda_libs


### PR DESCRIPTION
## Summary

When two extensions declare the same package in their \`get_pinned_conda_libs\`, the extension-loader merges them with a naive comma-join:

\`\`\`python
d1[k] = v if k not in d1 else \",\".join([d1[k], v])
\`\`\`

Extensions commonly use an empty string to mean \"any version\". When one extension declares a package with an empty string and another declares the same package with a real specifier, the join produces a malformed value with a leading or trailing comma:

\`\`\`python
\",\".join([\"\", \">=1.13.0,!=1.15.0\"])  ->  \",>=1.13.0,!=1.15.0\"
\`\`\`

Downstream formatters (e.g. \`\"%s==%s\" % (lib, vers)\`) then emit \`cffi==,>=1.13.0,!=1.15.0\`, which libmamba rejects with:

\`\`\`
critical libmamba Error parsing version \"\". Empty version.
\`\`\`

This was surfaced in the wild when both \`metaflow-functions\` (declaring \`{\"cffi\": \"\", \"fastavro\": \"\"}\` for \"any version\") and \`nflx-fastdata\` (declaring real pins for the same packages) were loaded together, breaking every hosting deployment at Netflix.

## Fix

Treat empty strings as no-ops on either side of the merge:
- If only one side has a real specifier, use it.
- If both do, join them (conda accepts redundant constraints; the solver dedupes).
- If both are empty, keep empty.

## Test plan

Verified against six merge cases:

| d1 | d2 | old merge | new merge |
|---|---|---|---|
| \`\"\"\` | \`\">=X\"\` | \`\",>=X\"\` (broken) | \`\">=X\"\` |
| \`\">=X\"\` | \`\"\"\` | \`\">=X,\"\` (broken) | \`\">=X\"\` |
| \`\">=X\"\` | \`\">=Y\"\` | \`\">=X,>=Y\"\` | \`\">=X,>=Y\"\` |
| \`\"\"\` | \`\"\"\` | \`\",\"\` (broken) | \`\"\"\` |
| \`\">=X\"\` | absent | \`\">=X\"\` | \`\">=X\"\` |
| absent | \`\">=X\"\` | \`\">=X\"\` | \`\">=X\"\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)