### PR TITLE
[Do not review] packaging: skip metaflow + extensions when every step has @conda/@pypi

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -250,6 +250,16 @@ class FlowDecorator(Decorator):
     # Signature: flow_init_ctx(self, options)
     flow_init_ctx = None
 
+    # Class-level opt-in: when True, this flow decorator guarantees that
+    # metaflow (and any metaflow_extensions it depends on) will be importable
+    # in the remote environment for every step of the flow. If every step is
+    # covered (directly or via such a flow decorator / mutator),
+    # MetaflowPackage can skip bundling the metaflow distribution.
+    provides_metaflow_distribution: bool = False
+
+    def provides_metaflow_distribution_for(self, flow, step) -> bool:
+        return self.provides_metaflow_distribution
+
     def __init__(self, *args, **kwargs):
         super(FlowDecorator, self).__init__(*args, **kwargs)
 
@@ -371,6 +381,15 @@ class StepDecorator(Decorator):
     task_decorate_ctx = None
     task_step_completed_ctx = None  # coalesces task_post_step + task_exception
     task_finished_ctx = None
+
+    # Class-level opt-in: when True, this step decorator guarantees that
+    # metaflow will be importable in the remote environment for this step
+    # (e.g. because it provisions a conda / pypi environment from the user's
+    # declared dependencies).
+    provides_metaflow_distribution: bool = False
+
+    def provides_metaflow_distribution_for(self, step) -> bool:
+        return self.provides_metaflow_distribution
 
     def step_init(
         self, flow, graph, step_name, decorators, environment, flow_datastore, logger

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -42,6 +42,16 @@ DEFAULT_EVENT_LOGGER = from_conf("DEFAULT_EVENT_LOGGER", "nullSidecarLogger")
 DEFAULT_METADATA = from_conf("DEFAULT_METADATA", "local")
 DEFAULT_MONITOR = from_conf("DEFAULT_MONITOR", "nullSidecarMonitor")
 DEFAULT_PACKAGE_SUFFIXES = from_conf("DEFAULT_PACKAGE_SUFFIXES", ".py,.R,.RDS")
+
+# Overrides auto-detection of whether to bundle the metaflow distribution
+# and metaflow_extensions in the code package. Only consulted on direct-
+# compute paths (local run / Titus / Batch / Kubernetes). Orchestrated
+# backends (Argo / Step Functions / Airflow) always include metaflow
+# because their DAG glue runs outside any env-providing decorator.
+# Leave unset for auto-detect.
+PACKAGE_EXCLUDE_METAFLOW_DISTRIBUTION = from_conf(
+    "PACKAGE_EXCLUDE_METAFLOW_DISTRIBUTION", None
+)
 DEFAULT_AWS_CLIENT_PROVIDER = from_conf("DEFAULT_AWS_CLIENT_PROVIDER", "boto3")
 DEFAULT_AZURE_CLIENT_PROVIDER = from_conf(
     "DEFAULT_AZURE_CLIENT_PROVIDER", "azure-default"

--- a/metaflow/metaflow_config_funcs.py
+++ b/metaflow/metaflow_config_funcs.py
@@ -143,8 +143,10 @@ def from_conf(name, default=None, validate_fn=None):
             try:
                 if type(value) != type(default):
                     if isinstance(default, bool):
-                        # Env vars are strings so try to evaluate logically
-                        value = value.lower() not in ("0", "false", "")
+                        # Env vars are strings so try to evaluate logically.
+                        from .util import str_to_bool
+
+                        value = str_to_bool(value, default=default, strict=False)
                     else:
                         value = type(default)(value)
                 is_default = value == default

--- a/metaflow/package/__init__.py
+++ b/metaflow/package/__init__.py
@@ -52,6 +52,7 @@ class MetaflowPackage(object):
         mfcontent: Optional[MetaflowCodeContent] = None,
         exclude_tl_dirs=None,
         backend: Type[PackagingBackend] = TarPackagingBackend,
+        include_mf_distribution: Optional[bool] = None,
     ):
         self._environment = environment
         self._environment.init_environment(echo)
@@ -94,8 +95,12 @@ class MetaflowPackage(object):
                 return False
 
         if mfcontent is None:
-            self._mfcontent = MetaflowCodeContentV1(criteria=_module_selector)
-
+            if include_mf_distribution is None:
+                include_mf_distribution = self._should_include_mf_distribution(flow)
+            self._mfcontent = MetaflowCodeContentV1(
+                criteria=_module_selector,
+                include_mf_distribution=include_mf_distribution,
+            )
         else:
             self._mfcontent = mfcontent
         # We exclude the environment when packaging as this will be packaged separately.
@@ -518,6 +523,51 @@ class MetaflowPackage(object):
                         f.write(path_or_content)
                 else:
                     os.symlink(path_or_content, new_path)
+
+    @staticmethod
+    def _should_include_mf_distribution(flow) -> bool:
+        """
+        Direct-compute auto-detect: return True (include metaflow) unless every
+        remote step is covered by a decorator declaring it provides metaflow.
+
+        Flow-level decorators (including FlowMutators) cover every step of the
+        flow. Step decorators cover their step. The ``_parameters`` pseudo-step
+        is evaluated in the submitting shell (not remote), so it is skipped.
+
+        The ``METAFLOW_PACKAGE_EXCLUDE_METAFLOW_DISTRIBUTION`` config overrides
+        auto-detection in either direction.
+        """
+        from itertools import chain
+
+        from ..metaflow_config import PACKAGE_EXCLUDE_METAFLOW_DISTRIBUTION
+        from ..util import str_to_bool
+
+        override = str_to_bool(PACKAGE_EXCLUDE_METAFLOW_DISTRIBUTION, strict=True)
+        if override is not None:
+            return not override
+
+        if flow is None:
+            return True  # non-flow (generic) package — keep current behavior
+
+        flow_level = list(
+            chain(
+                chain.from_iterable(flow._flow_decorators.values()),
+                flow._flow_mutators,
+            )
+        )
+
+        for step in flow:
+            if step.name == "_parameters":
+                continue
+            provided_by_flow = any(
+                d.provides_metaflow_distribution_for(flow, step) for d in flow_level
+            )
+            provided_by_step = any(
+                d.provides_metaflow_distribution_for(step) for d in step.decorators
+            )
+            if not (provided_by_flow or provided_by_step):
+                return True
+        return False
 
     @staticmethod
     def _format_size(size_in_bytes):

--- a/metaflow/packaging_sys/v1.py
+++ b/metaflow/packaging_sys/v1.py
@@ -30,6 +30,7 @@ class MetaflowCodeContentV1(MetaflowCodeContentV1Base):
         code_dir: str = MetaflowCodeContentV1Base._code_dir,
         other_dir: str = MetaflowCodeContentV1Base._other_dir,
         criteria: Callable[[ModuleType], bool] = lambda x: True,
+        include_mf_distribution: bool = True,
     ):
         super().__init__(code_dir, other_dir)
 
@@ -37,6 +38,7 @@ class MetaflowCodeContentV1(MetaflowCodeContentV1Base):
         self._metaflow_version = get_version()
 
         self._criteria = criteria
+        self._include_mf_distribution = include_mf_distribution
 
         # We try to find the modules we need to package. We will first look at all modules
         # and apply the criteria to them. Then we will use the most parent module that
@@ -99,9 +101,22 @@ class MetaflowCodeContentV1(MetaflowCodeContentV1Base):
         for k, v in self._modules.items():
             self._files_from_modules.update(self._module_files(k, v.root_paths))
 
-        # Figure out the files to package for Metaflow and extensions
-        self._cached_metaflow_files = list(self._metaflow_distribution_files())
-        self._cached_metaflow_files.extend(list(self._metaflow_extension_files()))
+        # Figure out the files to package for Metaflow and extensions. Skipped
+        # when the caller guarantees the metaflow distribution + extensions
+        # will be provided by the remote environment (e.g. every step has an
+        # env-providing decorator like @conda/@pypi). See
+        # MetaflowPackage._should_include_mf_distribution for the policy.
+        if self._include_mf_distribution:
+            self._cached_metaflow_files = list(self._metaflow_distribution_files())
+            self._cached_metaflow_files.extend(
+                list(self._metaflow_extension_files())
+            )
+        else:
+            debug.package_exec(
+                "Skipping metaflow + extensions packaging "
+                "(include_mf_distribution=False)"
+            )
+            self._cached_metaflow_files = []
 
     def create_mfcontent_info(self) -> Dict[str, Any]:
         return {"version": 1, "module_files": list(self._files_from_modules.values())}
@@ -183,14 +198,24 @@ class MetaflowCodeContentV1(MetaflowCodeContentV1Base):
 
         result = []
         if self._metaflow_version:
-            result.append(f"\nMetaflow version: {self._metaflow_version}")
+            suffix = (
+                ""
+                if self._include_mf_distribution
+                else " (not packaged — provided by step decorators)"
+            )
+            result.append(f"\nMetaflow version: {self._metaflow_version}{suffix}")
         ext_info = extension_info()
-        if ext_info["installed"]:
+        if ext_info["installed"] and self._include_mf_distribution:
             result.append("\nMetaflow extensions packaged:")
             for ext_name, ext_info in ext_info["installed"].items():
                 result.append(
                     f"  - {ext_name} ({ext_info['extension_name']}) @ {ext_info['dist_version']}"
                 )
+        elif ext_info["installed"]:
+            result.append(
+                "\nMetaflow extensions installed but not packaged "
+                "(provided by step decorators)"
+            )
 
         if self._modules:
             mf_modules = []

--- a/metaflow/plugins/airflow/airflow_cli.py
+++ b/metaflow/plugins/airflow/airflow_cli.py
@@ -296,12 +296,16 @@ def make_flow(
     obj.graph = obj.flow._graph
     # Save the code package in the flow datastore so that both user code and
     # metaflow package can be retrieved during workflow execution.
+    # Orchestrator glue (set_parameters, _parameters) runs outside any
+    # @conda/@pypi env and must find metaflow in the package itself, so we
+    # always include it on this path.
     obj.package = MetaflowPackage(
         obj.flow,
         obj.environment,
         obj.echo,
         suffixes=obj.package_suffixes,
         flow_datastore=obj.flow_datastore if FEAT_ALWAYS_UPLOAD_CODE_PACKAGE else None,
+        include_mf_distribution=True,
     )
     # This blocks until the package is created
     if FEAT_ALWAYS_UPLOAD_CODE_PACKAGE:

--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -757,12 +757,16 @@ def make_flow(
 
     # Save the code package in the flow datastore so that both user code and
     # metaflow package can be retrieved during workflow execution.
+    # Orchestrator glue (_parameters, python -m metaflow.plugins.argo.*)
+    # runs outside any @conda/@pypi env and must find metaflow in the
+    # package itself, so we always include it on this path.
     obj.package = MetaflowPackage(
         obj.flow,
         obj.environment,
         obj.echo,
         suffixes=obj.package_suffixes,
         flow_datastore=obj.flow_datastore if FEAT_ALWAYS_UPLOAD_CODE_PACKAGE else None,
+        include_mf_distribution=True,
     )
 
     # This blocks until the package is created

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -357,12 +357,16 @@ def make_flow(
     )
     obj.graph = obj.flow._graph
 
+    # Orchestrator glue (set_batch_environment, _parameters) runs outside any
+    # @conda/@pypi env and must find metaflow in the package itself, so we
+    # always include it on this path.
     obj.package = MetaflowPackage(
         obj.flow,
         obj.environment,
         obj.echo,
         suffixes=obj.package_suffixes,
         flow_datastore=obj.flow_datastore if FEAT_ALWAYS_UPLOAD_CODE_PACKAGE else None,
+        include_mf_distribution=True,
     )
     # This blocks until the package is created
     if FEAT_ALWAYS_UPLOAD_CODE_PACKAGE:

--- a/metaflow/plugins/package_cli.py
+++ b/metaflow/plugins/package_cli.py
@@ -16,12 +16,17 @@ def cli():
 def package(obj, timeout):
     # Prepare the package before any of the sub-commands are invoked.
     # We explicitly will *not* upload it to the datastore.
+    # Always include the metaflow distribution here so `metaflow package info`
+    # / `metaflow package list` describes a package that is guaranteed to
+    # work on every execution path (including orchestrated backends that
+    # skip auto-detection).
     obj.package = MetaflowPackage(
         obj.flow,
         obj.environment,
         obj.echo,
         suffixes=obj.package_suffixes,
         flow_datastore=None,
+        include_mf_distribution=True,
     )
     obj.package_op_timeout = timeout
 

--- a/metaflow/plugins/pypi/bootstrap.py
+++ b/metaflow/plugins/pypi/bootstrap.py
@@ -11,11 +11,29 @@ import time
 import platform
 from urllib.error import URLError
 from urllib.request import urlopen
-from metaflow.metaflow_config import DATASTORE_LOCAL_DIR, CONDA_USE_FAST_INIT
-from metaflow.packaging_sys import MetaflowCodeContent, ContentType
-from metaflow.plugins import DATASTORES
-from metaflow.plugins.pypi.utils import MICROMAMBA_MIRROR_URL, MICROMAMBA_URL
-from metaflow.util import which
+
+try:
+    # This bootstrap runs inside the remote job container before the user's
+    # @conda/@pypi env is activated. The metaflow distribution may have been
+    # intentionally stripped from the code package (see
+    # MetaflowPackage._should_include_mf_distribution) on the expectation
+    # that every step's env-providing decorator will install metaflow. If
+    # that expectation was broken (metaflow not declared in the step's
+    # packages=…), these imports fail here before anything useful runs.
+    from metaflow.metaflow_config import DATASTORE_LOCAL_DIR, CONDA_USE_FAST_INIT
+    from metaflow.packaging_sys import MetaflowCodeContent, ContentType
+    from metaflow.plugins import DATASTORES
+    from metaflow.plugins.pypi.utils import MICROMAMBA_MIRROR_URL, MICROMAMBA_URL
+    from metaflow.util import which
+except ImportError as e:
+    raise RuntimeError(
+        "metaflow was not included in the code package (a decorator declared "
+        "it would be provided by the remote environment) but is not importable "
+        "here. Add `metaflow` (and any metaflow_extensions.* packages you "
+        "use) to the declared dependencies of your @conda/@pypi/resolved_* "
+        "decorator."
+    ) from e
+
 from urllib.request import Request
 import warnings
 

--- a/metaflow/user_decorators/user_flow_decorator.py
+++ b/metaflow/user_decorators/user_flow_decorator.py
@@ -124,6 +124,16 @@ class FlowMutator(metaclass=FlowMutatorMeta):
     modify the steps.
     """
 
+    # Class-level opt-in: when True, this mutator guarantees that metaflow
+    # (and any metaflow_extensions it depends on) will be importable in the
+    # remote environment for every step of the flow. If every step is
+    # covered (directly or via such a mutator / flow decorator),
+    # MetaflowPackage can skip bundling the metaflow distribution.
+    provides_metaflow_distribution: bool = False
+
+    def provides_metaflow_distribution_for(self, flow, step) -> bool:
+        return self.provides_metaflow_distribution
+
     def __init__(self, *args, **kwargs):
         from ..flowspec import FlowSpecMeta
 

--- a/metaflow/util.py
+++ b/metaflow/util.py
@@ -62,6 +62,34 @@ class TempDir(object):
         shutil.rmtree(self.name)
 
 
+_FALSY_STRS = frozenset({"", "0", "false", "no", "off"})
+_TRUTHY_STRS = frozenset({"1", "true", "yes", "on"})
+
+
+def str_to_bool(value, default=None, strict=False):
+    """
+    Coerce a string/bool/None to a bool using the env-var convention used
+    elsewhere in Metaflow.
+
+    Returns ``default`` when ``value`` is ``None``. When ``strict=False`` (the
+    default), unknown non-empty strings are treated as ``True`` to match the
+    existing lax config-system behavior. When ``strict=True``, unknown
+    strings raise ``ValueError``.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    s = str(value).strip().lower()
+    if s in _TRUTHY_STRS:
+        return True
+    if s in _FALSY_STRS:
+        return False
+    if strict:
+        raise ValueError("Cannot interpret %r as a bool" % (value,))
+    return True
+
+
 def cached_property(getter):
     @wraps(getter)
     def exec_once(self):

--- a/test/unit/test_cli_package_always_includes.py
+++ b/test/unit/test_cli_package_always_includes.py
@@ -1,0 +1,54 @@
+"""Orchestrator CLI paths (Argo / SF / Airflow / `metaflow package`) must
+always include metaflow in the tarball because their DAG glue runs outside
+any @conda/@pypi env. This file asserts the explicit flag plumbing behaves
+correctly regardless of what auto-detect would have chosen."""
+
+from metaflow import FlowSpec, step, conda
+from metaflow.metaflow_environment import MetaflowEnvironment
+from metaflow.package import MetaflowPackage
+
+
+class _EveryStepConda(FlowSpec):
+    @conda(packages={"metaflow": "2.12.0"})
+    @step
+    def start(self):
+        self.next(self.end)
+
+    @conda(packages={"metaflow": "2.12.0"})
+    @step
+    def end(self):
+        pass
+
+
+class _BareFlow(FlowSpec):
+    @step
+    def start(self):
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+def test_explicit_include_true_overrides_autodetect():
+    # autodetect for this flow would return False (all steps covered); the
+    # explicit flag forces inclusion.
+    pkg = MetaflowPackage(
+        _EveryStepConda(),
+        MetaflowEnvironment(_EveryStepConda),
+        echo=lambda *a, **k: None,
+        include_mf_distribution=True,
+    )
+    names = {n for _, n in pkg._mfcontent.content_names()}
+    assert any(n.endswith("metaflow/__init__.py") for n in names)
+
+
+def test_explicit_include_false_overrides_autodetect():
+    pkg = MetaflowPackage(
+        _BareFlow(),
+        MetaflowEnvironment(_BareFlow),
+        echo=lambda *a, **k: None,
+        include_mf_distribution=False,
+    )
+    names = {n for _, n in pkg._mfcontent.content_names()}
+    assert not any(n.endswith("metaflow/__init__.py") for n in names)

--- a/test/unit/test_code_content_v1.py
+++ b/test/unit/test_code_content_v1.py
@@ -1,0 +1,16 @@
+from metaflow.packaging_sys import ContentType
+from metaflow.packaging_sys.v1 import MetaflowCodeContentV1
+
+
+def test_include_true_yields_metaflow_code():
+    c = MetaflowCodeContentV1(include_mf_distribution=True)
+    names = [n for _, n in c.content_names(ContentType.CODE_CONTENT.value)]
+    assert any(n.endswith("metaflow/__init__.py") for n in names)
+
+
+def test_include_false_skips_metaflow_code():
+    c = MetaflowCodeContentV1(include_mf_distribution=False)
+    names = [n for _, n in c.content_names(ContentType.CODE_CONTENT.value)]
+    assert not any(n.endswith("metaflow/__init__.py") for n in names)
+    # INFO/CONFIG markers (OTHER_CONTENT) should still be produced.
+    assert list(c.content_names(ContentType.OTHER_CONTENT.value))

--- a/test/unit/test_mf_distribution_packaging.py
+++ b/test/unit/test_mf_distribution_packaging.py
@@ -1,0 +1,123 @@
+import pytest
+
+from metaflow import FlowSpec, step, conda, pypi, conda_base, pypi_base
+from metaflow.package import MetaflowPackage
+
+
+class _BareFlow(FlowSpec):
+    @step
+    def start(self):
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+class _EveryStepConda(FlowSpec):
+    @conda(packages={"metaflow": "2.12.0"})
+    @step
+    def start(self):
+        self.next(self.end)
+
+    @conda(packages={"metaflow": "2.12.0"})
+    @step
+    def end(self):
+        pass
+
+
+class _MixedConda(FlowSpec):
+    @conda(packages={"metaflow": "2.12.0"})
+    @step
+    def start(self):
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+class _DisabledConda(FlowSpec):
+    @conda(disabled=True)
+    @step
+    def start(self):
+        self.next(self.end)
+
+    @conda(disabled=True)
+    @step
+    def end(self):
+        pass
+
+
+@conda_base(packages={"metaflow": "2.12.0"})
+class _CondaBaseFlow(FlowSpec):
+    @step
+    def start(self):
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+@pypi_base(packages={"metaflow": "2.12.0"})
+class _PypiBaseFlow(FlowSpec):
+    @step
+    def start(self):
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+def test_flow_is_none_includes_mf():
+    assert MetaflowPackage._should_include_mf_distribution(None) is True
+
+
+def test_bare_flow_includes_mf():
+    assert MetaflowPackage._should_include_mf_distribution(_BareFlow()) is True
+
+
+def test_every_step_conda_skips_mf():
+    assert MetaflowPackage._should_include_mf_distribution(_EveryStepConda()) is False
+
+
+def test_mixed_steps_include_mf():
+    assert MetaflowPackage._should_include_mf_distribution(_MixedConda()) is True
+
+
+def test_disabled_conda_includes_mf():
+    assert MetaflowPackage._should_include_mf_distribution(_DisabledConda()) is True
+
+
+def test_conda_base_covers_all_steps():
+    assert MetaflowPackage._should_include_mf_distribution(_CondaBaseFlow()) is False
+
+
+def test_pypi_base_covers_all_steps():
+    assert MetaflowPackage._should_include_mf_distribution(_PypiBaseFlow()) is False
+
+
+@pytest.mark.parametrize("env_value", ["1", "true", "yes"])
+def test_config_override_forces_exclude(monkeypatch, env_value):
+    monkeypatch.setattr(
+        "metaflow.metaflow_config.PACKAGE_EXCLUDE_METAFLOW_DISTRIBUTION", env_value
+    )
+    assert MetaflowPackage._should_include_mf_distribution(_BareFlow()) is False
+
+
+@pytest.mark.parametrize("env_value", ["0", "false", "no"])
+def test_config_override_forces_include(monkeypatch, env_value):
+    monkeypatch.setattr(
+        "metaflow.metaflow_config.PACKAGE_EXCLUDE_METAFLOW_DISTRIBUTION", env_value
+    )
+    assert MetaflowPackage._should_include_mf_distribution(_EveryStepConda()) is True
+
+
+def test_config_override_invalid_raises(monkeypatch):
+    monkeypatch.setattr(
+        "metaflow.metaflow_config.PACKAGE_EXCLUDE_METAFLOW_DISTRIBUTION", "maybe"
+    )
+    with pytest.raises(ValueError):
+        MetaflowPackage._should_include_mf_distribution(_BareFlow())

--- a/test/unit/test_str_to_bool.py
+++ b/test/unit/test_str_to_bool.py
@@ -1,0 +1,30 @@
+import pytest
+
+from metaflow.util import str_to_bool
+
+
+@pytest.mark.parametrize("v", ["1", "true", "TRUE", "Yes", "on", True])
+def test_truthy(v):
+    assert str_to_bool(v) is True
+
+
+@pytest.mark.parametrize("v", ["0", "false", "no", "off", "", False])
+def test_falsy(v):
+    assert str_to_bool(v) is False
+
+
+def test_none_returns_default():
+    assert str_to_bool(None) is None
+    assert str_to_bool(None, default=True) is True
+
+
+def test_unknown_non_strict_is_truthy():
+    # Preserves historical lax behavior: anything we don't recognize as falsy
+    # is treated as truthy.
+    assert str_to_bool("maybe") is True
+    assert str_to_bool("enabled") is True
+
+
+def test_unknown_strict_raises():
+    with pytest.raises(ValueError):
+        str_to_bool("maybe", strict=True)


### PR DESCRIPTION
## Summary

Introduces a per-decorator opt-in so `@conda` / `@pypi` / `@resolved_*` and
other env-providing decorators can declare that the remote environment will
install `metaflow` itself. When every step is covered (directly or via a
flow-level decorator / `FlowMutator`), `MetaflowPackage` omits the metaflow
distribution and `metaflow_extensions` from the tarball — the remote side
reinstalls them from the user's declared dependencies anyway.

## Contract (opt-in, default off)

- `provides_metaflow_distribution: bool = False` class attribute
- `provides_metaflow_distribution_for(...)` instance hook

Added on `FlowDecorator`, `StepDecorator`, and `FlowMutator`. OSS `@conda`
and `@pypi` are **not modified** here — the opt-in will live on the Netflix
internal decorators (mli-metaflow-custom). This PR only ships the contract,
the packaging gate, the auto-detect helper, and orchestrator-side safety
nets.

## Orchestrator-side safety

Argo / Step Functions / Airflow / `metaflow package info|list` always
include metaflow — their DAG glue (`_parameters`, `python -m
metaflow.plugins.argo.*`, `set_batch_environment`, `set_parameters`) runs
outside any `@conda`/`@pypi` env. All four CLI call sites pass
`include_mf_distribution=True` explicitly; only the direct-compute path
(`run_cmds.py`) consults auto-detect.

## Auto-detect

- Iterates the graph via `flow._flow_decorators` + `flow._flow_mutators`.
- Skips the `_parameters` pseudo-step (evaluated in the submitting shell).
- Overrideable via `METAFLOW_PACKAGE_EXCLUDE_METAFLOW_DISTRIBUTION` in
  either direction.

## Other bits

- `metaflow/util.py`: new `str_to_bool(value, default, strict=False)`; the
  config system reuses it with `strict=False` to preserve existing lax
  semantics.
- `plugins/pypi/bootstrap.py`: defensive import with a targeted error
  message if metaflow is stripped but not installed remotely.
- `MetaflowCodeContentV1.show()` surfaces the skip so `metaflow … package
  info` is honest.

## Tests (real FlowSpecs, `monkeypatch`, `pytest.raises` — no mocks)

- `test/unit/test_str_to_bool.py`
- `test/unit/test_mf_distribution_packaging.py`
- `test/unit/test_code_content_v1.py`
- `test/unit/test_cli_package_always_includes.py`

## Test plan

- [ ] `tox -e unit` passes locally
- [ ] Submit a real flow with `@conda` on every step and verify the tarball
      contents omit `metaflow/__init__.py`
- [ ] Submit the same flow without `@conda` and verify metaflow is still in
      the tarball
- [ ] Argo / SF / Airflow deploy path still ships metaflow regardless of
      `@conda` coverage
