### PR TITLE
Refactor ux/core compilation tests to function-style pytest

### DIFF
--- a/test/ux/core/test_airflow_compilation.py
+++ b/test/ux/core/test_airflow_compilation.py
@@ -136,10 +136,11 @@ def _validate_dag_source(dag_source, dag_file_path=None):
 # ---------------------------------------------------------------------------
 
 
-class TestAirflowCompilation:
-    """Compile each flow type to Airflow DAG and validate."""
+@pytest.fixture
+def compile_and_validate():
+    """Compile a flow to an Airflow DAG, validate it, and clean up the tempfile."""
 
-    def _compile_and_validate(self, flow_path, **extra_tl_args):
+    def _impl(flow_path, **extra_tl_args):
         dag_source, dag_file_path = _compile_flow_to_dag(flow_path, **extra_tl_args)
         try:
             result = _validate_dag_source(dag_source, dag_file_path)
@@ -153,41 +154,51 @@ class TestAirflowCompilation:
             except OSError:
                 pass
 
-    def test_linear_flow(self):
-        """Simple start->step->end flow compiles to valid Airflow DAG."""
-        self._compile_and_validate("basic/helloworld.py")
+    return _impl
 
-    def test_branch_flow(self):
-        """Parallel branch flow compiles to valid Airflow DAG."""
-        self._compile_and_validate("dag/branch_flow.py")
 
-    def test_foreach_flow(self):
-        """Foreach flow compiles to valid Airflow DAG."""
-        self._compile_and_validate("dag/foreach_flow.py")
+def test_linear_flow(compile_and_validate):
+    """Simple start->step->end flow compiles to valid Airflow DAG."""
+    compile_and_validate("basic/helloworld.py")
 
-    def test_retry_flow(self):
-        """Flow with @retry compiles to valid Airflow DAG."""
-        self._compile_and_validate("basic/retry_flow.py")
 
-    def test_resources_flow(self):
-        """Flow with @resources compiles to valid Airflow DAG."""
-        self._compile_and_validate("basic/resources_flow.py")
+def test_branch_flow(compile_and_validate):
+    """Parallel branch flow compiles to valid Airflow DAG."""
+    compile_and_validate("dag/branch_flow.py")
 
-    def test_schedule_flow(self):
-        """Flow with @schedule compiles to valid Airflow DAG."""
-        self._compile_and_validate("lifecycle/schedule_flow.py")
 
-    # ------------------------------------------------------------------
-    # Invariant checks (specific bugs we've fixed)
-    # ------------------------------------------------------------------
+def test_foreach_flow(compile_and_validate):
+    """Foreach flow compiles to valid Airflow DAG."""
+    compile_and_validate("dag/foreach_flow.py")
 
-    def test_tags_are_list_not_tuple(self):
-        """DAG tags must be a list, not a tuple (Airflow rejects tuples)."""
-        dag_source = self._compile_and_validate("basic/helloworld.py")
-        # Check that tags assignment uses list syntax
-        tree = ast.parse(dag_source)
-        for node in ast.walk(tree):
-            if isinstance(node, ast.keyword) and node.arg == "tags":
-                assert not isinstance(
-                    node.value, ast.Tuple
-                ), "DAG tags should be a list, not a tuple"
+
+def test_retry_flow(compile_and_validate):
+    """Flow with @retry compiles to valid Airflow DAG."""
+    compile_and_validate("basic/retry_flow.py")
+
+
+def test_resources_flow(compile_and_validate):
+    """Flow with @resources compiles to valid Airflow DAG."""
+    compile_and_validate("basic/resources_flow.py")
+
+
+def test_schedule_flow(compile_and_validate):
+    """Flow with @schedule compiles to valid Airflow DAG."""
+    compile_and_validate("lifecycle/schedule_flow.py")
+
+
+# ---------------------------------------------------------------------------
+# Invariant checks (specific bugs we've fixed)
+# ---------------------------------------------------------------------------
+
+
+def test_tags_are_list_not_tuple(compile_and_validate):
+    """DAG tags must be a list, not a tuple (Airflow rejects tuples)."""
+    dag_source = compile_and_validate("basic/helloworld.py")
+    # Check that tags assignment uses list syntax
+    tree = ast.parse(dag_source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.keyword) and node.arg == "tags":
+            assert not isinstance(
+                node.value, ast.Tuple
+            ), "DAG tags should be a list, not a tuple"

--- a/test/ux/core/test_sfn_compilation.py
+++ b/test/ux/core/test_sfn_compilation.py
@@ -190,95 +190,79 @@ def _structural_validate(definition):
 # ---------------------------------------------------------------------------
 
 
-class TestSfnCompilation:
-    """Compile each flow type to SFN ASL JSON and validate."""
+@pytest.fixture
+def compile_and_validate():
+    """Compile a flow to SFN ASL JSON and assert it validates."""
 
-    def test_linear_flow(self):
-        """Simple start->step->end flow compiles to valid ASL."""
-        definition = _compile_flow_to_json("basic/helloworld.py")
+    def _impl(flow_path, **extra_tl_args):
+        definition = _compile_flow_to_json(flow_path, **extra_tl_args)
         result = _validate_state_machine(definition)
         assert (
             result.get("result", "OK") == "OK"
         ), f"Validation failed: {result.get('diagnostics', result)}"
+        return definition
 
-    @pytest.mark.xfail(
-        reason="requires npow/core-deployer-changes: step_functions.py must add "
-        "ResultSelector to Parallel states for sfn-local compatibility",
-        strict=False,
-    )
-    def test_branch_flow(self):
-        """Parallel branch flow produces valid Parallel states with ResultSelector."""
-        definition = _compile_flow_to_json("dag/branch_flow.py")
-        result = _validate_state_machine(definition)
-        assert (
-            result.get("result", "OK") == "OK"
-        ), f"Validation failed: {result.get('diagnostics', result)}"
+    return _impl
 
-        # Verify our specific invariant: Parallel states must have ResultSelector
-        raw = json.dumps(definition)
-        if '"Type": "Parallel"' in raw or '"Type":"Parallel"' in raw:
-            self._check_parallel_has_result_selector(definition["States"])
 
-    def test_foreach_flow(self):
-        """Foreach (Map state) flow compiles to valid ASL."""
-        definition = _compile_flow_to_json("dag/foreach_flow.py")
-        result = _validate_state_machine(definition)
-        assert (
-            result.get("result", "OK") == "OK"
-        ), f"Validation failed: {result.get('diagnostics', result)}"
+def _check_parallel_has_result_selector(states):
+    """Every Parallel state must have ResultSelector (sfn-local fix)."""
+    for name, state in states.items():
+        if state.get("Type") == "Parallel":
+            assert "ResultSelector" in state, (
+                f"Parallel state '{name}' missing ResultSelector -- "
+                "this breaks sfn-local which can't evaluate $[n].x array indexing"
+            )
+            # Recurse into branches
+            for branch in state.get("Branches", []):
+                _check_parallel_has_result_selector(branch.get("States", {}))
 
-    def test_retry_flow(self):
-        """Flow with @retry compiles to valid ASL with Retry config."""
-        definition = _compile_flow_to_json("basic/retry_flow.py")
-        result = _validate_state_machine(definition)
-        assert (
-            result.get("result", "OK") == "OK"
-        ), f"Validation failed: {result.get('diagnostics', result)}"
 
-    def test_catch_flow(self):
-        """Flow with @catch compiles to valid ASL."""
-        definition = _compile_flow_to_json("basic/catch_flow.py")
-        result = _validate_state_machine(definition)
-        assert (
-            result.get("result", "OK") == "OK"
-        ), f"Validation failed: {result.get('diagnostics', result)}"
+def test_linear_flow(compile_and_validate):
+    """Simple start->step->end flow compiles to valid ASL."""
+    compile_and_validate("basic/helloworld.py")
 
-    def test_resources_flow(self):
-        """Flow with @resources compiles to valid ASL."""
-        definition = _compile_flow_to_json("basic/resources_flow.py")
-        result = _validate_state_machine(definition)
-        assert (
-            result.get("result", "OK") == "OK"
-        ), f"Validation failed: {result.get('diagnostics', result)}"
 
-    def test_timeout_flow(self):
-        """Flow with @timeout compiles to valid ASL."""
-        definition = _compile_flow_to_json("basic/timeout_flow.py")
-        result = _validate_state_machine(definition)
-        assert (
-            result.get("result", "OK") == "OK"
-        ), f"Validation failed: {result.get('diagnostics', result)}"
+@pytest.mark.xfail(
+    reason="requires npow/core-deployer-changes: step_functions.py must add "
+    "ResultSelector to Parallel states for sfn-local compatibility",
+    strict=False,
+)
+def test_branch_flow(compile_and_validate):
+    """Parallel branch flow produces valid Parallel states with ResultSelector."""
+    definition = compile_and_validate("dag/branch_flow.py")
 
-    def test_schedule_flow(self):
-        """Flow with @schedule compiles to valid ASL."""
-        definition = _compile_flow_to_json("lifecycle/schedule_flow.py")
-        result = _validate_state_machine(definition)
-        assert (
-            result.get("result", "OK") == "OK"
-        ), f"Validation failed: {result.get('diagnostics', result)}"
+    # Verify our specific invariant: Parallel states must have ResultSelector
+    raw = json.dumps(definition)
+    if '"Type": "Parallel"' in raw or '"Type":"Parallel"' in raw:
+        _check_parallel_has_result_selector(definition["States"])
 
-    # ------------------------------------------------------------------
-    # Invariant checks (specific bugs we've fixed)
-    # ------------------------------------------------------------------
 
-    def _check_parallel_has_result_selector(self, states):
-        """Every Parallel state must have ResultSelector (sfn-local fix)."""
-        for name, state in states.items():
-            if state.get("Type") == "Parallel":
-                assert "ResultSelector" in state, (
-                    f"Parallel state '{name}' missing ResultSelector -- "
-                    "this breaks sfn-local which can't evaluate $[n].x array indexing"
-                )
-                # Recurse into branches
-                for branch in state.get("Branches", []):
-                    self._check_parallel_has_result_selector(branch.get("States", {}))
+def test_foreach_flow(compile_and_validate):
+    """Foreach (Map state) flow compiles to valid ASL."""
+    compile_and_validate("dag/foreach_flow.py")
+
+
+def test_retry_flow(compile_and_validate):
+    """Flow with @retry compiles to valid ASL with Retry config."""
+    compile_and_validate("basic/retry_flow.py")
+
+
+def test_catch_flow(compile_and_validate):
+    """Flow with @catch compiles to valid ASL."""
+    compile_and_validate("basic/catch_flow.py")
+
+
+def test_resources_flow(compile_and_validate):
+    """Flow with @resources compiles to valid ASL."""
+    compile_and_validate("basic/resources_flow.py")
+
+
+def test_timeout_flow(compile_and_validate):
+    """Flow with @timeout compiles to valid ASL."""
+    compile_and_validate("basic/timeout_flow.py")
+
+
+def test_schedule_flow(compile_and_validate):
+    """Flow with @schedule compiles to valid ASL."""
+    compile_and_validate("lifecycle/schedule_flow.py")


### PR DESCRIPTION
## Summary
- Flattens `TestAirflowCompilation` and `TestSfnCompilation` in `test/ux/core/` from class-based pytest to module-level functions, so they match the fixture+function style used by the other 8 files in that directory.
- Introduces a `compile_and_validate` fixture in each file (a pytest fixture returning a callable). Tests inject it and call it with a flow path.
- Moves `_check_parallel_has_result_selector` from an instance method to a module-level helper.
- Test IDs shorten from `TestX::test_foo` to `test_foo`. Parametrization, `xfail` markers, and `pytestmark` module-level markers are unchanged; the set of 15 tests (7 airflow + 8 sfn) is unchanged.

## Test plan
- [x] `pytest test/ux/core/test_airflow_compilation.py test/ux/core/test_sfn_compilation.py --collect-only` discovers all 15 tests at module level
- [x] `pre-commit run --files ...` passes (black accepted, no reformat)
- [ ] Run the full ux/core suite against a devstack to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)