### PR TITLE
Preserve dashed tags in metaflow version parsing and public-version stripping

### DIFF
--- a/metaflow/metaflow_version.py
+++ b/metaflow/metaflow_version.py
@@ -13,7 +13,6 @@ from os import path, name, environ, listdir
 from metaflow.extension_support import update_package_info
 from metaflow.meta_files import read_info_file
 
-
 # True/False correspond to the value `public`` in get_version
 _version_cache = {True: None, False: None}
 
@@ -114,6 +113,9 @@ def format_git_describe(git_str, public=False):
     # (e.g. v1.0-rc.1). Parsing from the right lets dashed tags round-trip
     # instead of overflowing the unpack.
     if splits[-1] == "dirty":
+        if len(splits) < 4:
+            # Dirty suffix adds one token, so we need at least 4 total.
+            return None
         tag = "-".join(splits[:-3])
         post, h = splits[-3:-1]
         dirty = "-dirty"

--- a/metaflow/metaflow_version.py
+++ b/metaflow/metaflow_version.py
@@ -106,13 +106,20 @@ def format_git_describe(git_str, public=False):
     if git_str is None:
         return None
     splits = git_str.split("-")
-    if len(splits) == 4:
-        # Formatted as <tag>-<post>-<hash>-dirty
-        tag, post, h = splits[:3]
-        dirty = "-" + splits[3]
+    if len(splits) < 3:
+        # Unparseable; caller falls back to __version__ on None.
+        return None
+    # The rightmost tokens are always <post>-<hash>, optionally followed by
+    # "dirty". Everything before is the tag, which may itself contain dashes
+    # (e.g. v1.0-rc.1). Parsing from the right lets dashed tags round-trip
+    # instead of overflowing the unpack.
+    if splits[-1] == "dirty":
+        tag = "-".join(splits[:-3])
+        post, h = splits[-3:-1]
+        dirty = "-dirty"
     else:
-        # Formatted as <tag>-<post>-<hash>
-        tag, post, h = splits
+        tag = "-".join(splits[:-2])
+        post, h = splits[-2:]
         dirty = ""
     if post == "0":
         if public:

--- a/metaflow/metaflow_version.py
+++ b/metaflow/metaflow_version.py
@@ -7,6 +7,7 @@ See the documentation of get_version for more information
 
 # This file is adapted from https://github.com/aebrahim/python-git-version
 
+import re
 import subprocess
 from os import path, name, environ, listdir
 
@@ -144,12 +145,12 @@ def read_info_version():
 
 def make_public_version(version_string):
     """
-    Takes a complex version string and returns a public, PEP 440-compliant version.
-    It removes local version identifiers (+...) and development markers (-...).
+    Takes a complex Metaflow version string and returns its public portion.
+    Preserves dashes that belong to the tag itself and only strips Metaflow's
+    private git/dirty suffixes and local extension metadata.
     """
     base_version = version_string.split("+", 1)[0]
-    public_version = base_version.split("-", 1)[0]
-    return public_version
+    return re.sub(r"(?:-git[0-9a-f]+)?(?:-dirty)?$", "", base_version)
 
 
 def get_version(public=False):

--- a/metaflow/metaflow_version.py
+++ b/metaflow/metaflow_version.py
@@ -146,8 +146,14 @@ def read_info_version():
 def make_public_version(version_string):
     """
     Takes a complex Metaflow version string and returns its public portion.
-    Preserves dashes that belong to the tag itself and only strips Metaflow's
-    private git/dirty suffixes and local extension metadata.
+    Strips Metaflow's private suffixes -- ``-git<hash>`` produced by
+    ``format_git_describe`` and the optional ``-dirty`` marker -- plus any
+    PEP 440 local-version segment (``+...``).
+
+    The result is a canonical PEP 440 public version iff the source tag
+    itself was canonical. A non-canonical tag such as ``v1.0-rc.1`` will
+    survive intact rather than being silently truncated; downstream
+    consumers that require strict PEP 440 will reject it at their layer.
     """
     base_version = version_string.split("+", 1)[0]
     return re.sub(r"(?:-git[0-9a-f]+)?(?:-dirty)?$", "", base_version)

--- a/test/unit/test_metaflow_version.py
+++ b/test/unit/test_metaflow_version.py
@@ -1,0 +1,45 @@
+import pytest
+
+from metaflow.metaflow_version import format_git_describe
+
+
+@pytest.mark.parametrize(
+    "git_str,public,expected",
+    [
+        # Plain tag at the tagged commit.
+        ("2.19.22-0-g4ff334e", False, "2.19.22"),
+        ("2.19.22-0-g4ff334e", True, "2.19.22"),
+        # Plain tag, N commits ahead.
+        ("2.19.22-5-g4ff334e", False, "2.19.22.post5-git4ff334e"),
+        ("2.19.22-5-g4ff334e", True, "2.19.22.post5"),
+        # Plain tag, dirty worktree.
+        ("2.19.22-5-g4ff334e-dirty", False, "2.19.22.post5-git4ff334e-dirty"),
+        ("2.19.22-0-g4ff334e-dirty", False, "2.19.22-dirty"),
+        # Dashed (PEP 440 pre-release) tag at the tagged commit.
+        ("v1.0-rc.1-0-gabcdef0", False, "v1.0-rc.1"),
+        # Dashed tag, N commits ahead.
+        ("v1.0-rc.1-12-gabcdef0", False, "v1.0-rc.1.post12-gitabcdef0"),
+        ("v1.0-rc.1-12-gabcdef0", True, "v1.0-rc.1.post12"),
+        # Dashed tag, dirty worktree — this is what used to crash with
+        # ValueError: too many values to unpack (expected 3).
+        ("v1.0-rc.1-12-gabcdef0-dirty", False, "v1.0-rc.1.post12-gitabcdef0-dirty"),
+        # Tag with multiple internal dashes.
+        ("v9.2.97-rc.15-100-g3a13f86-dirty", False, "v9.2.97-rc.15.post100-git3a13f86-dirty"),
+    ],
+)
+def test_format_git_describe_parses_known_shapes(git_str, public, expected):
+    assert format_git_describe(git_str, public=public) == expected
+
+
+@pytest.mark.parametrize(
+    "git_str",
+    [
+        None,
+        # Fewer than three dash-separated tokens — caller falls back to
+        # __version__ when format_git_describe returns None.
+        "short",
+        "a-b",
+    ],
+)
+def test_format_git_describe_returns_none_for_unparseable(git_str):
+    assert format_git_describe(git_str) is None

--- a/test/unit/test_metaflow_version.py
+++ b/test/unit/test_metaflow_version.py
@@ -24,7 +24,11 @@ from metaflow.metaflow_version import format_git_describe
         # ValueError: too many values to unpack (expected 3).
         ("v1.0-rc.1-12-gabcdef0-dirty", False, "v1.0-rc.1.post12-gitabcdef0-dirty"),
         # Tag with multiple internal dashes.
-        ("v9.2.97-rc.15-100-g3a13f86-dirty", False, "v9.2.97-rc.15.post100-git3a13f86-dirty"),
+        (
+            "v9.2.97-rc.15-100-g3a13f86-dirty",
+            False,
+            "v9.2.97-rc.15.post100-git3a13f86-dirty",
+        ),
     ],
 )
 def test_format_git_describe_parses_known_shapes(git_str, public, expected):
@@ -39,6 +43,9 @@ def test_format_git_describe_parses_known_shapes(git_str, public, expected):
         # __version__ when format_git_describe returns None.
         "short",
         "a-b",
+        # Three tokens with trailing "dirty" — not a real describe output
+        # but guarded symmetrically with the clean branch.
+        "a-b-dirty",
     ],
 )
 def test_format_git_describe_returns_none_for_unparseable(git_str):

--- a/test/unit/test_metaflow_version.py
+++ b/test/unit/test_metaflow_version.py
@@ -1,6 +1,7 @@
 import pytest
 
-from metaflow.metaflow_version import format_git_describe
+import metaflow.metaflow_version as metaflow_version
+from metaflow.metaflow_version import format_git_describe, make_public_version
 
 
 @pytest.mark.parametrize(
@@ -50,3 +51,39 @@ def test_format_git_describe_parses_known_shapes(git_str, public, expected):
 )
 def test_format_git_describe_returns_none_for_unparseable(git_str):
     assert format_git_describe(git_str) is None
+
+
+@pytest.mark.parametrize(
+    "version_string,expected",
+    [
+        # Plain tag, no suffixes to strip.
+        ("2.19.22", "2.19.22"),
+        # Non-dashed tag with private git suffix, optionally dirty.
+        ("2.19.22.post5-git4ff334e", "2.19.22.post5"),
+        ("2.19.22.post5-git4ff334e-dirty", "2.19.22.post5"),
+        # Dashed tag alone — must survive the strip.
+        ("v1.0-rc.1", "v1.0-rc.1"),
+        # Dashed tag with private git suffix — post-release must be retained.
+        ("v1.0-rc.1.post12-gitabcdef0", "v1.0-rc.1.post12"),
+        ("v1.0-rc.1.post12-gitabcdef0-dirty", "v1.0-rc.1.post12"),
+        # PEP 440 local-version (+…) identifier is stripped alongside.
+        ("v1.0-rc.1.post12-gitabcdef0+ext(foo)", "v1.0-rc.1.post12"),
+    ],
+)
+def test_make_public_version_strips_only_private_suffixes(version_string, expected):
+    assert make_public_version(version_string) == expected
+
+
+def test_get_version_public_from_info_preserves_dashed_tags(monkeypatch):
+    # Exercise the INFO-file code path in get_version: when the recorded
+    # version comes from an installed/remote environment and the caller asks
+    # for the public form, dashed tags must survive the public-version
+    # derivation rather than being truncated at the first dash.
+    monkeypatch.setattr(metaflow_version, "_version_cache", {True: None, False: None})
+    monkeypatch.setattr(
+        metaflow_version,
+        "read_info_version",
+        lambda: "v1.0-rc.1.post12-gitabcdef0+ext(foo)",
+    )
+
+    assert metaflow_version.get_version(public=True) == "v1.0-rc.1.post12"


### PR DESCRIPTION
## Summary

`format_git_describe` crashed with `ValueError: too many values to unpack (expected 3)` when the latest reachable tag contained a dash (e.g. a PEP 440 pre-release like `v1.0-rc.1`). The crash happened during interpreter startup in `get_version()`, before the fallback to the recorded `__version__` could run, so any project whose extension lived inside a repo with such a tag failed to import cleanly.

Fixing `format_git_describe` alone was not enough. `get_version()` prefers the INFO-file path on packaged / remote installs, and when the caller asks for `public=True` it runs the stored version through `make_public_version`, which also truncated at the first `-`. A stored version like `v1.0-rc.1.post12-gitabcdef0` became `v1.0`, silently losing the prerelease and post-release components. This PR now handles both paths.

## Root cause

Both functions implicitly assumed that tags never contain dashes:

- `format_git_describe` split `git describe` output on `-` and unpacked left-to-right into 3 variables. A dashed tag produced 4 or 5 tokens and overflowed the unpack.
- `make_public_version` treated everything after the first `-` as a development / private suffix to strip. A dashed tag had its own internal dash consumed first, so the prerelease was lost.

## Fix

**`format_git_describe`**: Parse from the right. The rightmost two or three tokens are always `<post>-<hash>` (optionally `+ "dirty"`); everything before them is the tag. Tags with or without dashes now round-trip correctly, and strings with fewer than three tokens return `None` so the caller falls back to `__version__` exactly as before. The dirty branch has its own minimum-length guard to stay symmetric with the clean branch.

**`make_public_version`**: Strip only Metaflow's private suffixes — the optional `-git<hash>` produced by `format_git_describe` and the `-dirty` marker it appends for a modified worktree — plus the PEP 440 local-version tail (`+...`). Dashes that belong to the tag itself now survive. Behavior for non-dashed canonical tags is unchanged because those suffixes still match the same way they did when the old `split("-", 1)` happened to work.

## Scope / blast radius

- `make_public_version` has one in-tree caller: `get_version()` line 196, reached when `public=True` and the INFO file exists. The concrete behavior change is that stub wheel metadata (via `metaflow-stubs` / `stubs.py`) now records correct prerelease/postrelease versions for dashed tags.
- `get_version(public=False)` and the live-git path are not affected beyond the parser fix.

## Test plan

23 parametrized tests exercising all relevant shapes:

- `format_git_describe`:
  - plain tag, exact-match / N commits ahead / dirty
  - dashed tag, exact-match / N commits ahead / dirty
  - multi-dash tag
  - `public=True` variants
  - unparseable inputs (fewer than three tokens, or three tokens ending in `dirty`) return `None` so callers fall back to `__version__`

- `make_public_version`:
  - plain tag, tag + `-git<hash>`, tag + `-git<hash>-dirty`
  - dashed tag alone, dashed tag + `-git<hash>`, dashed tag + `-git<hash>-dirty`
  - dashed tag + `-git<hash>` + `+ext(foo)` local-version

- `get_version(public=True)` via a monkeypatched `read_info_version` that returns `v1.0-rc.1.post12-gitabcdef0+ext(foo)`, asserting it is reduced to `v1.0-rc.1.post12` rather than `v1.0`.

All 23 pass; broader `test/unit/` suite (159 passed, 19 skipped) shows no regressions.