### PR TITLE
Removed the duplicate and unused pretty_print function

### DIFF
--- a/devtools/pick_services.sh
+++ b/devtools/pick_services.sh
@@ -35,24 +35,6 @@ gum style "Select services to deploy (press enter to select all):" \
 
 pretty_print() {
   local items=("$@")
-  
-  if [ "${#items[@]}" -eq 1 ]; then
-    echo "${items[0]}"
-    return
-  fi
-
-  if [ "${#items[@]}" -eq 2 ]; then
-    echo "${items[0]} and ${items[1]}"
-    return
-  fi
-
-  local last_item="${items[-1]}"
-  unset 'items[-1]'
-  echo "$(IFS=,; echo "${items[*]}"), and $last_item"
-}
-
-pretty_print() {
-  local items=("$@")
   local length=${#items[@]}
 
   if [ "$length" -eq 0 ]; then


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary
There are two `pretty_print` functions in the `pick_services.sh` file. The second functions is updated version of the first one. And also the the second one overwrites the first one.