### PR TITLE
   Fix #2981: Add Windows platform guard for SIGALRM in timeout_decorator and card_cli

### DIFF
--- a/metaflow/plugins/cards/card_cli.py
+++ b/metaflow/plugins/cards/card_cli.py
@@ -15,6 +15,7 @@ import time
 import json
 import uuid
 import signal
+import sys
 import random
 from contextlib import contextmanager
 from functools import wraps
@@ -161,13 +162,12 @@ def resolve_card(
 @contextmanager
 def timeout(time):
     # Register a function to raise a TimeoutError on the signal.
-import sys
-   if sys.platform == "win32":
-       raise RuntimeError(
-           "Card timeout is not supported on Windows (SIGALRM is POSIX-only)."
-       )
-   signal.signal(signal.SIGALRM, raise_timeout)
-   signal.alarm(time)
+    if sys.platform == "win32":
+        raise RuntimeError(
+            "Card timeout is not supported on Windows (SIGALRM is POSIX-only)."
+        )
+    signal.signal(signal.SIGALRM, raise_timeout)
+    signal.alarm(time)
 
     try:
         yield

--- a/metaflow/plugins/cards/card_cli.py
+++ b/metaflow/plugins/cards/card_cli.py
@@ -161,9 +161,13 @@ def resolve_card(
 @contextmanager
 def timeout(time):
     # Register a function to raise a TimeoutError on the signal.
-    signal.signal(signal.SIGALRM, raise_timeout)
-    # Schedule the signal to be sent after ``time``.
-    signal.alarm(time)
+import sys
+   if sys.platform == "win32":
+       raise RuntimeError(
+           "Card timeout is not supported on Windows (SIGALRM is POSIX-only)."
+       )
+   signal.signal(signal.SIGALRM, raise_timeout)
+   signal.alarm(time)
 
     try:
         yield

--- a/metaflow/plugins/timeout_decorator.py
+++ b/metaflow/plugins/timeout_decorator.py
@@ -70,8 +70,15 @@ class TimeoutDecorator(StepDecorator):
         if ubf_context != UBF_CONTROL and retry_count <= max_user_code_retries:
             # enable timeout only when executing user code
             self.step_name = step_name
-            signal.signal(signal.SIGALRM, self._sigalrm_handler)
-            signal.alarm(self.secs)
+   import sys
+   if sys.platform == "win32":
+       raise MetaflowException(
+           "@timeout is not supported on Windows because it relies on "
+           "POSIX signals (SIGALRM). Use a Linux-based compute backend "
+           "(e.g. @kubernetes or @batch) to use @timeout."
+       )
+   signal.signal(signal.SIGALRM, self._sigalrm_handler)
+   signal.alarm(self.secs)
 
     def task_post_step(
         self, step_name, flow, graph, retry_count, max_user_code_retries

--- a/metaflow/plugins/timeout_decorator.py
+++ b/metaflow/plugins/timeout_decorator.py
@@ -1,4 +1,5 @@
 import signal
+import sys
 import traceback
 
 from metaflow.exception import MetaflowException
@@ -70,15 +71,14 @@ class TimeoutDecorator(StepDecorator):
         if ubf_context != UBF_CONTROL and retry_count <= max_user_code_retries:
             # enable timeout only when executing user code
             self.step_name = step_name
-   import sys
-   if sys.platform == "win32":
-       raise MetaflowException(
-           "@timeout is not supported on Windows because it relies on "
-           "POSIX signals (SIGALRM). Use a Linux-based compute backend "
-           "(e.g. @kubernetes or @batch) to use @timeout."
-       )
-   signal.signal(signal.SIGALRM, self._sigalrm_handler)
-   signal.alarm(self.secs)
+            if sys.platform == "win32":
+                raise MetaflowException(
+                    "@timeout is not supported on Windows because it relies on "
+                    "POSIX signals (SIGALRM). Use a Linux-based compute backend "
+                    "(e.g. @kubernetes or @batch) to use @timeout."
+                )
+            signal.signal(signal.SIGALRM, self._sigalrm_handler)
+            signal.alarm(self.secs)
 
     def task_post_step(
         self, step_name, flow, graph, retry_count, max_user_code_retries

--- a/metaflow/plugins/timeout_decorator.py
+++ b/metaflow/plugins/timeout_decorator.py
@@ -1,16 +1,13 @@
 import signal
 import sys
 import traceback
-
 from metaflow.exception import MetaflowException
 from metaflow.decorators import StepDecorator
 from metaflow.unbounded_foreach import UBF_CONTROL
 from metaflow.metaflow_config import DEFAULT_RUNTIME_LIMIT
 
-
 class TimeoutException(MetaflowException):
     headline = "@timeout"
-
 
 class TimeoutDecorator(StepDecorator):
     """
@@ -39,10 +36,6 @@ class TimeoutDecorator(StepDecorator):
     defaults = {"seconds": 0, "minutes": 0, "hours": 0}
 
     def init(self):
-        # Initialize secs in __init__ so other decorators could safely use this
-        # value without worrying about decorator order.
-        # Convert values in attributes to type:int since they can be type:str
-        # when passed using the CLI option --with.
         self.secs = (
             int(self.attributes["hours"]) * 3600
             + int(self.attributes["minutes"]) * 60
@@ -69,7 +62,6 @@ class TimeoutDecorator(StepDecorator):
         inputs,
     ):
         if ubf_context != UBF_CONTROL and retry_count <= max_user_code_retries:
-            # enable timeout only when executing user code
             self.step_name = step_name
             if sys.platform == "win32":
                 raise MetaflowException(
@@ -80,7 +72,7 @@ class TimeoutDecorator(StepDecorator):
             signal.signal(signal.SIGALRM, self._sigalrm_handler)
             signal.alarm(self.secs)
 
-def task_post_step(
+    def task_post_step(
         self, step_name, flow, graph, retry_count, max_user_code_retries
     ):
         if sys.platform != "win32":
@@ -108,7 +100,7 @@ def task_post_step(
 
 def get_run_time_limit_for_task(step_decos):
     run_time_limit = DEFAULT_RUNTIME_LIMIT
-    for deco in step_decos:
+    replace for deco in step_decos:
         if isinstance(deco, TimeoutDecorator):
             run_time_limit = deco.secs
     return run_time_limit

--- a/metaflow/plugins/timeout_decorator.py
+++ b/metaflow/plugins/timeout_decorator.py
@@ -80,10 +80,11 @@ class TimeoutDecorator(StepDecorator):
             signal.signal(signal.SIGALRM, self._sigalrm_handler)
             signal.alarm(self.secs)
 
-    def task_post_step(
+def task_post_step(
         self, step_name, flow, graph, retry_count, max_user_code_retries
     ):
-        signal.alarm(0)
+        if sys.platform != "win32":
+            signal.alarm(0)
 
     def _sigalrm_handler(self, signum, frame):
         def pretty_print_stack():

--- a/metaflow/plugins/timeout_decorator.py
+++ b/metaflow/plugins/timeout_decorator.py
@@ -1,13 +1,16 @@
 import signal
 import sys
 import traceback
+
 from metaflow.exception import MetaflowException
 from metaflow.decorators import StepDecorator
 from metaflow.unbounded_foreach import UBF_CONTROL
 from metaflow.metaflow_config import DEFAULT_RUNTIME_LIMIT
 
+
 class TimeoutException(MetaflowException):
     headline = "@timeout"
+
 
 class TimeoutDecorator(StepDecorator):
     """
@@ -100,7 +103,7 @@ class TimeoutDecorator(StepDecorator):
 
 def get_run_time_limit_for_task(step_decos):
     run_time_limit = DEFAULT_RUNTIME_LIMIT
-    replace for deco in step_decos:
+    for deco in step_decos:
         if isinstance(deco, TimeoutDecorator):
             run_time_limit = deco.secs
     return run_time_limit


### PR DESCRIPTION
Fixes #2981

   Added sys.platform == "win32" guards to:
   - metaflow/plugins/timeout_decorator.py
   - metaflow/plugins/cards/card_cli.py

   Both files used signal.SIGALRM which is POSIX-only and crashes on Windows.
   This implements Option B from the issue: a clear early error instead of a 
   cryptic AttributeError mid-run.