### PR TITLE
Register --use-latest in test/plugins/conftest.py

### DIFF
--- a/test/plugins/conftest.py
+++ b/test/plugins/conftest.py
@@ -1,0 +1,19 @@
+"""Shared pytest configuration for plugins tests.
+
+Mirrors the ``--use-latest`` registration in ``test/unit/conftest.py`` so
+spin-style conftests that call ``request.config.getoption("--use-latest")``
+work when run under ``test/plugins/`` (e.g. when downstream consumers copy
+``test/unit/spin/`` into ``test/plugins/spin/spin/``).
+"""
+
+import pytest
+
+
+def pytest_addoption(parser):
+    """Add custom command line options shared across plugins test suites."""
+    parser.addoption(
+        "--use-latest",
+        action="store_true",
+        default=False,
+        help="Use latest run of each flow instead of running new ones",
+    )


### PR DESCRIPTION
## Summary

Mirrors the `--use-latest` pytest_addoption registration from `test/unit/conftest.py` into a new `test/plugins/conftest.py`, so spin-style conftests that call `request.config.getoption("--use-latest")` work when their tests are discovered under `test/plugins/`.

## Root cause

#3040 (8e29f77) consolidated the `--use-latest` option into a single top-of-unit conftest. Four subdirs under `test/unit/` call `getoption("--use-latest")` without a default and rely on pytest's conftest inheritance to pick up the registration from `test/unit/conftest.py`:

- `test/unit/spin/conftest.py`
- `test/unit/configs/conftest.py`
- `test/unit/inheritance/conftest.py`
- `test/unit/graph_inference/conftest.py` *(already passes a default, so unaffected)*

Downstream consumers that relocate these test trees lose the inheritance chain. In one concrete case (Netflix's `mli-metaflow-custom`), `bootstrap_testing_flow.py` copies `test/unit/spin/` to `test/plugins/spin/spin/` but does not copy `test/unit/conftest.py`. The copied spin conftest then raises at collection time:

```
ValueError: no option named '--use-latest'
```

Taking out all 11 `test_spin.py` tests plus `test/unit/deployer/test_wait_functionality.py::test_wait_for_start_and_completion_separately`.

## Fix

Add `test/plugins/conftest.py` with the same `pytest_addoption` as `test/unit/conftest.py`. When test modules land under `test/plugins/` (either natively or via copy), pytest's normal conftest inheritance picks up the registration.

## Alternatives considered

1. **Move the registration to `test/conftest.py`.** Broader, would cover every subdir under `test/` — but OSS has never needed it at that level, and the symptom is specifically in `test/plugins/`.
2. **Add `default=False` to each consuming `getoption` call.** Local-only fix at 3 sites. Fine in isolation, but the consolidation in #3040 was intentional — opt-in registration at the parent conftest is the paved path here.
3. **Handle the copy externally** (e.g. the downstream bootstrap script copies `test/unit/conftest.py` alongside the spin tree). Requires coordinated change in a separate repo and doesn't help any future plugins-layer test that wants `--use-latest`.

Option 1 (this PR) is smallest and self-contained.

## Test plan

- [x] `pytest test/plugins/ --help` shows `--use-latest`
- [x] Existing `test/plugins/` tests (29 collected) still pass
- [x] Simulated `cp -r test/unit/spin test/plugins/spin/spin` → `pytest test/plugins/spin/spin/ --collect-only` collects the 12 spin tests cleanly (no `ValueError: no option named '--use-latest'`)