### PR TITLE
Improve `--compress-state-machine` help text

### DIFF
--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -145,7 +145,7 @@ def step_functions(obj, name=None):
     "--compress-state-machine/--no-compress-state-machine",
     is_flag=True,
     default=SFN_COMPRESS_STATE_MACHINE,
-    help="Compress AWS Step Functions state machine to fit within the 8K limit.",
+    help="Compress AWS Step Functions state machine to fit within AWS limits.",
 )
 @click.option(
     "--deployer-attribute-file",

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -145,7 +145,8 @@ def step_functions(obj, name=None):
     "--compress-state-machine/--no-compress-state-machine",
     is_flag=True,
     default=SFN_COMPRESS_STATE_MACHINE,
-    help="Compress AWS Step Functions state machine to fit within AWS limits.",
+    help="Offload Batch commands to S3 to keep within AWS service limits "
+    "(e.g. ContainerOverrides length limit or maximum size of state machine definition).",
 )
 @click.option(
     "--deployer-attribute-file",

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -146,7 +146,8 @@ def step_functions(obj, name=None):
     is_flag=True,
     default=SFN_COMPRESS_STATE_MACHINE,
     help="Offload Batch commands to S3 to keep within AWS service limits "
-    "(e.g. ContainerOverrides length limit or maximum size of state machine definition).",
+    "(e.g. ContainerOverrides length limit or maximum size of state machine definition), "
+    "thereby reducing the size of the state machine.",
 )
 @click.option(
     "--deployer-attribute-file",

--- a/metaflow/plugins/aws/step_functions/step_functions_deployer.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_deployer.py
@@ -78,7 +78,8 @@ class StepFunctionsDeployer(DeployerImpl):
             tasks in Amazon State Language.
         compress_state_machine : bool, optional, default False
             Offload Batch commands to S3 to keep within AWS service limits
-            (e.g. ContainerOverrides length limit or maximum size of state machine definition).
+            (e.g. ContainerOverrides length limit or maximum size of state machine definition),
+            thereby reducing the size of the state machine.
 
         deployer_attribute_file : str, optional, default None
             Write the workflow name to the specified file. Used internally for Metaflow's Deployer API.

--- a/metaflow/plugins/aws/step_functions/step_functions_deployer.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_deployer.py
@@ -77,7 +77,8 @@ class StepFunctionsDeployer(DeployerImpl):
             Use AWS Step Functions Distributed Map instead of Inline Map for defining foreach
             tasks in Amazon State Language.
         compress_state_machine : bool, optional, default False
-            Compress AWS Step Functions state machine to fit within AWS limits.
+            Offload Batch commands to S3 to keep within AWS service limits
+            (e.g. ContainerOverrides length limit or maximum size of state machine definition).
 
         deployer_attribute_file : str, optional, default None
             Write the workflow name to the specified file. Used internally for Metaflow's Deployer API.

--- a/metaflow/plugins/aws/step_functions/step_functions_deployer.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_deployer.py
@@ -77,7 +77,7 @@ class StepFunctionsDeployer(DeployerImpl):
             Use AWS Step Functions Distributed Map instead of Inline Map for defining foreach
             tasks in Amazon State Language.
         compress_state_machine : bool, optional, default False
-            Compress AWS Step Functions state machine to fit within the 8K limit.
+            Compress AWS Step Functions state machine to fit within AWS limits.
 
         deployer_attribute_file : str, optional, default None
             Write the workflow name to the specified file. Used internally for Metaflow's Deployer API.


### PR DESCRIPTION
## PR Type

- [x] Docs / tooling


## Summary

Based on #1482, I believe the "8K limit" referred to in the `--compress-state-machine` help text was the `ContainerOverrides` length limit, rather than the state machine definition, whose [size limit](https://docs.aws.amazon.com/step-functions/latest/dg/service-quotas.html) is 1 MB.


## AI Tool Usage

- [x] AI tools were used (describe below)

I used Copilot running Sonnet 4.6 to confirm the role of the parameter.
