### PR TITLE
fix: Added missing targets to .PHONY and removed duplicates

### DIFF
--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -346,6 +346,6 @@ ui: setup-tilt
 	@echo "🔗 Opening Metaflow UI at http://localhost:3000"
 	@open http://localhost:3000
 
-.PHONY: install-helm setup-minikube setup-tilt teardown-minikube tunnel up down check-docker install-curl install-gum install-brew up down dashboard shell ui all-up help
+.PHONY: install-helm check-docker install-brew install-curl install-gum setup-minikube setup-tilt tunnel teardown-minikube dashboard up all-up down shell wait-until-ready create-dev-shell ui help
 
 .DEFAULT_GOAL := help


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

<!-- What user-visible behavior changes? 1-2 sentences. -->
This PR updates the `.PHONY` in the `Makefile`.
Added missing targets `wait-until-ready` and `create-dev-shell` to the `.PHONY` .
And removed duplicates `up` and `down` from the `.PHONY`.