### PR TITLE
Remove unused audit() callbacks from test_config flow files

### DIFF
--- a/test/test_config/config_corner_cases.py
+++ b/test/test_config/config_corner_cases.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 from metaflow import (
@@ -13,43 +12,6 @@ from metaflow import (
 )
 
 default_config = {"a": {"b": "41", "project_name": "config_project"}}
-
-
-def audit(run, parameters, configs, stdout_path):
-    # We should only have one run here
-    if len(run) != 1:
-        raise RuntimeError("Expected only one run; got %d" % len(run))
-    run = run[0]
-
-    # Check successful run
-    if not run.successful:
-        raise RuntimeError("Run was not successful")
-
-    if configs and configs.get("cfg_default_value"):
-        config = configs["cfg_default_value"]
-    else:
-        config = default_config
-
-    expected_token = parameters["trigger_param"]
-
-    # Check that we have the proper project name
-    if f"project:{config['a']['project_name']}" not in run.tags:
-        raise RuntimeError("Project name is incorrect.")
-
-    # Check the value of the artifacts in the end step
-    end_task = run["end"].task
-    assert end_task.data.trigger_param == expected_token
-    if (
-        end_task.data.config_val != 5
-        or end_task.data.config_val_2 != config["a"]["b"]
-        or end_task.data.config_from_env != "5"
-        or end_task.data.config_from_env_2 != config["a"]["b"]
-        or end_task.data.var1 != "1"
-        or end_task.data.var2 != "2"
-    ):
-        raise RuntimeError("Config values are incorrect.")
-
-    return None
 
 
 def trigger_name_func(ctx):

--- a/test/test_config/config_parser.py
+++ b/test/test_config/config_parser.py
@@ -1,6 +1,3 @@
-import json
-import os
-
 from metaflow import (
     Config,
     FlowSpec,
@@ -15,56 +12,6 @@ from metaflow import (
 )
 
 default_config = {"project_name": "config_parser"}
-
-
-def audit(run, parameters, configs, stdout_path):
-    # We should only have one run here
-    if len(run) != 1:
-        raise RuntimeError("Expected only one run; got %d" % len(run))
-    run = run[0]
-
-    # Check successful run
-    if not run.successful:
-        raise RuntimeError("Run was not successful")
-
-    if len(parameters) > 1:
-        expected_tokens = parameters[-1].split()
-        if len(expected_tokens) < 8:
-            raise RuntimeError("Unexpected parameter list: %s" % str(expected_tokens))
-        expected_token = expected_tokens[7]
-    else:
-        expected_token = ""
-
-    # Check that we have the proper project name
-    if f"project:{default_config['project_name']}" not in run.tags:
-        raise RuntimeError("Project name is incorrect.")
-
-    # Check the value of the artifacts in the end step
-    end_task = run["end"].task
-    assert end_task.data.trigger_param == expected_token
-
-    if end_task.data.lib_version != "2.5.148":
-        raise RuntimeError("Library version is incorrect.")
-
-    # Check we properly parsed the requirements file
-    if len(end_task.data.req_config) != 2:
-        raise RuntimeError(
-            "Requirements file is incorrect -- expected 2 keys, saw %s"
-            % str(end_task.data.req_config)
-        )
-    if end_task.data.req_config["python"] != "3.10.*":
-        raise RuntimeError(
-            "Requirements file is incorrect -- got python version %s"
-            % end_task.data.req_config["python"]
-        )
-
-    if end_task.data.req_config["packages"] != {"regex": "2024.11.6"}:
-        raise RuntimeError(
-            "Requirements file is incorrect -- got packages %s"
-            % end_task.data.req_config["packages"]
-        )
-
-    return None
 
 
 def trigger_name_func(ctx):

--- a/test/test_config/config_simple.py
+++ b/test/test_config/config_simple.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 from metaflow import (
@@ -13,47 +12,6 @@ from metaflow import (
 )
 
 default_config = {"a": {"b": "41", "project_name": "config_project"}}
-
-
-def audit(run, parameters, configs, stdout_path):
-    # We should only have one run here
-    if len(run) != 1:
-        raise RuntimeError("Expected only one run; got %d" % len(run))
-    run = run[0]
-
-    # Check successful run
-    if not run.successful:
-        raise RuntimeError("Run was not successful")
-
-    if configs and configs.get("cfg_default_value"):
-        config = json.loads(configs["cfg_default_value"])
-    else:
-        config = default_config
-
-    if len(parameters) > 1:
-        expected_tokens = parameters[-1].split()
-        if len(expected_tokens) < 8:
-            raise RuntimeError("Unexpected parameter list: %s" % str(expected_tokens))
-        expected_token = expected_tokens[7]
-    else:
-        expected_token = ""
-
-    # Check that we have the proper project name
-    if f"project:{config['a']['project_name']}" not in run.tags:
-        raise RuntimeError("Project name is incorrect.")
-
-    # Check the value of the artifacts in the end step
-    end_task = run["end"].task
-    assert end_task.data.trigger_param == expected_token
-    if (
-        end_task.data.config_val != 5
-        or end_task.data.config_val_2 != config["a"]["b"]
-        or end_task.data.config_from_env != "5"
-        or end_task.data.config_from_env_2 != config["a"]["b"]
-    ):
-        raise RuntimeError("Config values are incorrect.")
-
-    return None
 
 
 def trigger_name_func(ctx):

--- a/test/test_config/mutable_flow.py
+++ b/test/test_config/mutable_flow.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 from metaflow import (
@@ -26,77 +25,6 @@ default_config = {
     "flow_add_environment": {"vars": {"FLOW_LEVEL": "4"}},
     "project_name": "config_project",
 }
-
-
-def find_param_in_parameters(parameters, name):
-    for param in parameters:
-        splits = param.split(" ")
-        try:
-            idx = splits.index("--" + name)
-            return splits[idx + 1]
-        except ValueError:
-            continue
-    return None
-
-
-def audit(run, parameters, configs, stdout_path):
-    # We should only have one run here
-    if len(run) != 1:
-        raise RuntimeError("Expected only one run; got %d" % len(run))
-    run = run[0]
-
-    # Check successful run
-    if not run.successful:
-        raise RuntimeError("Run was not successful")
-
-    if configs:
-        # We should have one config called "config"
-        if len(configs) != 1 or not configs.get("config"):
-            raise RuntimeError("Expected one config called 'config'")
-        config = json.loads(configs["config"])
-    else:
-        config = default_config
-
-    if len(parameters) > 1:
-        expected_tokens = parameters[-1].split()
-        if len(expected_tokens) < 8:
-            raise RuntimeError("Unexpected parameter list: %s" % str(expected_tokens))
-        expected_token = expected_tokens[7]
-    else:
-        expected_token = ""
-
-    # Check that we have the proper project name
-    if f"project:{config['project_name']}" not in run.tags:
-        raise RuntimeError("Project name is incorrect.")
-
-    # Check the start step that all values are properly set. We don't need
-    # to check end step as it would be a duplicate
-    start_task_data = run["start"].task.data
-
-    assert start_task_data.trigger_param == expected_token
-    for param in config["parameters"]:
-        value = find_param_in_parameters(parameters, param["name"]) or param["default"]
-        if not hasattr(start_task_data, param["name"]):
-            raise RuntimeError(f"Missing parameter {param['name']}")
-        if getattr(start_task_data, param["name"]) != value:
-            raise RuntimeError(
-                f"Parameter {param['name']} has incorrect value %s versus %s expected"
-                % (getattr(start_task_data, param["name"]), value)
-            )
-    assert (
-        start_task_data.flow_level
-        == config["flow_add_environment"]["vars"]["FLOW_LEVEL"]
-    )
-    assert (
-        start_task_data.step_level
-        == config["step_add_environment"]["vars"]["STEP_LEVEL"]
-    )
-    assert (
-        start_task_data.step_level_2
-        == config["step_add_environment_2"]["vars"]["STEP_LEVEL_2"]
-    )
-
-    return None
 
 
 class ModifyFlow(FlowMutator):


### PR DESCRIPTION
## Summary

The four `test/test_config/*.py` flow files each defined an `audit(run, parameters, configs, stdout_path)` callback intended for an in-tree test runner that would execute the flow and post-validate artifacts on the resulting Run. That runner is no longer driving these flows — the validations have moved into the pytest suite — so the audit functions are dead code, along with the imports (`json`, `os`) and one helper (`find_param_in_parameters` in `mutable_flow.py`) that became unused.

## What changed

- `config_simple.py`: removed `audit()`, dropped now-unused `import json`.
- `config_parser.py`: removed `audit()`, dropped now-unused `import json` and `import os`.
- `config_corner_cases.py`: removed `audit()`, dropped now-unused `import json`.
- `mutable_flow.py`: removed `audit()` + `find_param_in_parameters()` helper, dropped now-unused `import json`.

Net: `4 files changed, 205 deletions(-)`. No behavior change — nothing in the repo imports or calls these functions (verified via grep across the tree).

## Test plan

- [x] `python -m py_compile` clean on all four files
- [x] `pre-commit run --files test/test_config/{config_simple,config_parser,config_corner_cases,mutable_flow}.py` passes (black, AST check, etc.)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)