### PR TITLE
env_escape: round-trip MF_ORIG_PYTHONPATH and MF_ORIG_PYTHONHOME

### DIFF
--- a/metaflow/plugins/env_escape/client.py
+++ b/metaflow/plugins/env_escape/client.py
@@ -86,8 +86,8 @@ class Client(object):
         # Append any saved MF_ORIG_PYTHONPATH so escape-out also retains the
         # host's original additions.
         orig_pythonpath = env.pop("MF_ORIG_PYTHONPATH", "")
-        env["PYTHONPATH"] = (
-            pythonpath + (os.pathsep + orig_pythonpath if orig_pythonpath else "")
+        env["PYTHONPATH"] = pythonpath + (
+            os.pathsep + orig_pythonpath if orig_pythonpath else ""
         )
         # Restore PYTHONHOME if Site 1 saved one; otherwise ensure it's unset.
         if "MF_ORIG_PYTHONHOME" in env:

--- a/metaflow/plugins/env_escape/client.py
+++ b/metaflow/plugins/env_escape/client.py
@@ -81,7 +81,19 @@ class Client(object):
         if os.path.exists(self._socket_path):
             raise RuntimeError("Existing socket: %s" % self._socket_path)
         env = os.environ.copy()
-        env["PYTHONPATH"] = pythonpath
+        # The pythonpath param carries the trampoline-curated host sys.path and
+        # MUST stay authoritative -- the env-escape server module is only on it.
+        # Append any saved MF_ORIG_PYTHONPATH so escape-out also retains the
+        # host's original additions.
+        orig_pythonpath = env.pop("MF_ORIG_PYTHONPATH", "")
+        env["PYTHONPATH"] = (
+            pythonpath + (os.pathsep + orig_pythonpath if orig_pythonpath else "")
+        )
+        # Restore PYTHONHOME if Site 1 saved one; otherwise ensure it's unset.
+        if "MF_ORIG_PYTHONHOME" in env:
+            env["PYTHONHOME"] = env.pop("MF_ORIG_PYTHONHOME")
+        elif "PYTHONHOME" in env:
+            del env["PYTHONHOME"]
         # When coming from a conda environment, LD_LIBRARY_PATH will be set to
         # first include the Conda environment's library. When breaking out to
         # the underlying python, we need to reset it to the original LD_LIBRARY_PATH

--- a/metaflow/plugins/env_escape/client.py
+++ b/metaflow/plugins/env_escape/client.py
@@ -82,18 +82,21 @@ class Client(object):
             raise RuntimeError("Existing socket: %s" % self._socket_path)
         env = os.environ.copy()
         # The pythonpath param carries the trampoline-curated host sys.path and
-        # MUST stay authoritative -- the env-escape server module is only on it.
+        # MUST stay authoritative: the env-escape server module is only on it.
         # Append any saved MF_ORIG_PYTHONPATH so escape-out also retains the
-        # host's original additions.
+        # host's original additions. Filter empties so an empty pythonpath or
+        # an empty original does not produce a leading/trailing separator
+        # (an empty PYTHONPATH entry would resolve to cwd).
         orig_pythonpath = env.pop("MF_ORIG_PYTHONPATH", "")
-        env["PYTHONPATH"] = pythonpath + (
-            os.pathsep + orig_pythonpath if orig_pythonpath else ""
+        env["PYTHONPATH"] = os.pathsep.join(
+            p for p in (pythonpath, orig_pythonpath) if p
         )
-        # Restore PYTHONHOME if Site 1 saved one; otherwise ensure it's unset.
+        # If a bootstrap saved a host PYTHONHOME via MF_ORIG_PYTHONHOME,
+        # restore it. Otherwise leave any existing PYTHONHOME pass-through
+        # unchanged (preserves prior behavior for callers that do not
+        # participate in the MF_ORIG_* save/restore protocol).
         if "MF_ORIG_PYTHONHOME" in env:
             env["PYTHONHOME"] = env.pop("MF_ORIG_PYTHONHOME")
-        elif "PYTHONHOME" in env:
-            del env["PYTHONHOME"]
         # When coming from a conda environment, LD_LIBRARY_PATH will be set to
         # first include the Conda environment's library. When breaking out to
         # the underlying python, we need to reset it to the original LD_LIBRARY_PATH


### PR DESCRIPTION
## Summary

The env-escape client at `metaflow/plugins/env_escape/client.py` already restores `MF_ORIG_LD_LIBRARY_PATH` on escape-out so that subprocesses launched against the host Python regain host LD context. This PR extends the same pattern to `PYTHONPATH` and `PYTHONHOME`.

## Motivation

Extensions that bootstrap a conda environment for a step often need to isolate it from any host `PYTHONPATH` / `PYTHONHOME`, otherwise a host entry pointing at e.g. `/usr/lib/python3.10` can shadow conda's stdlib on `sys.path`. A symmetric pattern is:

1. **On entry**, save host `PYTHONPATH` / `PYTHONHOME` to `MF_ORIG_*` and replace the live values with conda-only equivalents.
2. **On escape-out** (calling back to the host Python), restore the host values from `MF_ORIG_*`.

Step 1 is owned by whichever code authors the bootstrap. Step 2 is what this change adds, mirroring the existing `MF_ORIG_LD_LIBRARY_PATH` round-trip already in tree.

### Concrete bug class

When conda-forge's Python emits `sys.version` like:

```
'3.10.20 | packaged by conda-forge | (main, Mar  5 2026, 16:42:22) [GCC 14.3.0]'
```

only the patched `platform.py` shipped *with* the conda-forge stdlib parses it. A system `platform.py` (Python 3.10's stock regex, no alternation for `| packaged by conda-forge |`) raises:

```
ValueError: failed to parse CPython sys.version: '3.10.20 | packaged by conda-forge | ...'
```

So if a host `PYTHONPATH` puts `/usr/lib/python3.10` ahead of the conda stdlib on `sys.path`, pip bootstrap inside the conda env crashes via `import attr -> platform.python_implementation()`. Extensions defend against this by prepending the conda env's stdlib to `PYTHONPATH` and unsetting `PYTHONHOME` on entry, but they need this PR's symmetric restore on escape-out so the host process gets its original values back.

## Changes

`metaflow/plugins/env_escape/client.py`:

```python
env = os.environ.copy()
# PYTHONPATH: param wins; append MF_ORIG_PYTHONPATH if saved.
orig_pythonpath = env.pop("MF_ORIG_PYTHONPATH", "")
env["PYTHONPATH"] = (
    pythonpath + (os.pathsep + orig_pythonpath if orig_pythonpath else "")
)
# PYTHONHOME: restore from MF_ORIG_PYTHONHOME, else clear.
if "MF_ORIG_PYTHONHOME" in env:
    env["PYTHONHOME"] = env.pop("MF_ORIG_PYTHONHOME")
elif "PYTHONHOME" in env:
    del env["PYTHONHOME"]
# LD_LIBRARY_PATH unwind UNCHANGED below this point.
```

`MF_ORIG_LD_LIBRARY_PATH` round-trip is unchanged.

## Behavior change

Purely additive for callers that don't set `MF_ORIG_PYTHONPATH` / `MF_ORIG_PYTHONHOME`: env_escape behavior is identical to before (analogous to how `MF_ORIG_LD_LIBRARY_PATH` consumption is a no-op when not set). For callers that do set them, the spawned host subprocess now correctly inherits the originals.

## Test plan

Verified locally with three scenarios:
- `MF_ORIG_PYTHONPATH` set: consumed; `PYTHONPATH = pythonpath_param + os.pathsep + saved`. Param wins.
- `MF_ORIG_PYTHONPATH` unset: identical to current behavior; `PYTHONPATH = pythonpath_param`.
- `MF_ORIG_PYTHONHOME` set vs. unset vs. live-but-unsaved: restored / unset accordingly.

Existing env_escape behavior with no `MF_ORIG_*` vars set is unchanged. The `pythonpath` parameter remains authoritative when present.