### PR TITLE
Removed the redundant '_sfn_host_network' variable

### DIFF
--- a/devtools/tilt/sfn_local.tiltfile
+++ b/devtools/tilt/sfn_local.tiltfile
@@ -9,7 +9,6 @@ def setup_sfn_local(ctx):
             "docker network inspect minikube --format '{{range .IPAM.Config}}{{.Gateway}}{{end}}' 2>/dev/null || echo '192.168.49.1'",
             quiet=True,
         )).strip() or "192.168.49.1"
-        _sfn_host_network = False
         _batch_endpoint = 'http://localbatch-host:8000'
         k8s_yaml(encode_yaml({
             'apiVersion': 'v1', 'kind': 'Endpoints',
@@ -22,7 +21,6 @@ def setup_sfn_local(ctx):
             'spec': {'ports': [{'port': 8000, 'targetPort': 8000}]},
         }))
     else:
-        _sfn_host_network = False
         _batch_endpoint = 'http://host.docker.internal:8000'
 
     k8s_yaml(encode_yaml({
@@ -35,8 +33,8 @@ def setup_sfn_local(ctx):
             'template': {
                 'metadata': {'labels': {'app': 'sfn-local'}},
                 'spec': {
-                    'hostNetwork': _sfn_host_network,
-                    'dnsPolicy': 'ClusterFirstWithHostNet' if _sfn_host_network else 'ClusterFirst',
+                    'hostNetwork': False,
+                    'dnsPolicy': 'ClusterFirst',
                     'containers': [{
                         'name': 'sfn-local',
                         'image': 'amazon/aws-stepfunctions-local:latest',


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

<!-- What user-visible behavior changes? 1-2 sentences. -->

Previously, a `_sfn_host_network` variable was used to conditionally determine the `hostNetwork` and `dnsPolicy` settings. However, this variable was set to `False` for both Linux and non-Linux environments. 
So, this PR removes the  `_sfn_host_network` variable and  set `hostNetwork`  to False and `dnsPolicy` to `ClusterFirst` without any condition.

### Changes 
* Removed the redundant `_sfn_host_network` variable.
* Hardcoded `hostNetwork: False` in the `sfn-local` deployment spec.
* Hardcoded `dnsPolicy: 'ClusterFirst'` in the deployment spec.


## Issue

<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes #3170 


