### PR TITLE
fix: use sys.version_info instead of platform.python_version() in conda decorator

### DIFF
--- a/metaflow/plugins/pypi/conda_decorator.py
+++ b/metaflow/plugins/pypi/conda_decorator.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import re
 import sys
 import tempfile
@@ -107,7 +106,7 @@ class CondaStepDecorator(StepDecorator):
             self.attributes["disabled"] = False
         # Set Python interpreter to user's Python if necessary.
         if not self.attributes["python"]:
-            self.attributes["python"] = platform.python_version()  # CPython!
+            self.attributes["python"] = "%d.%d.%d" % sys.version_info[:3]
 
         # @conda uses a conda environment to create a virtual environment.
         # The conda environment can be created through micromamba.


### PR DESCRIPTION
## Summary

- Replace `platform.python_version()` with `"%d.%d.%d" % sys.version_info[:3]` in `conda_decorator.py`
- Remove unused `import platform`

## Problem

On Python 3.10 installed from conda-forge, `sys.version` contains `| packaged by conda-forge |` (e.g., `3.10.20 | packaged by conda-forge | (main, Mar 5 2026, 16:53:43) [GCC 14.3.0]`).

Python 3.10's `platform.py` stdlib uses a regex that can't parse this format, causing:
```
ValueError: failed to parse CPython sys.version: '3.10.20 | packaged by conda-forge | ...'
```

This crashes any `@conda`/`@pypi`/`@pypi_base` decorated flow during decorator init on conda-forge Python 3.10. The regex was fixed in CPython 3.11+ but never backported to 3.10.

## Fix

`sys.version_info` is a `struct_sequence` populated at interpreter startup — it doesn't parse `sys.version` at all, so it works regardless of the version string format.

## Test plan

- [x] Verified `"%d.%d.%d" % sys.version_info[:3]` produces identical output to `platform.python_version()` on standard CPython
- [x] Verified the old regex fails on conda-forge version strings (Python 3.10)
- [x] Verified `sys.version_info` is unaffected by conda-forge's sys.version format

🤖 Generated with [Claude Code](https://claude.com/claude-code)