### PR TITLE
Fix broad exception handling in CLI step lookup and resume run-id validation

### DIFF
--- a/metaflow/cli_components/run_cmds.py
+++ b/metaflow/cli_components/run_cmds.py
@@ -278,7 +278,7 @@ def resume(
         # be non-integers to avoid any clashes. This condition ensures this.
         try:
             int(run_id)
-        except:
+        except (TypeError, ValueError):
             pass
         else:
             raise CommandException("run-id %s cannot be an integer" % run_id)

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -127,7 +127,7 @@ def step(
     func = None
     try:
         func = getattr(ctx.obj.flow, step_name)
-    except:
+    except AttributeError:
         raise CommandException("Step *%s* doesn't exist." % step_name)
     if not func.is_step:
         raise CommandException("Function *%s* is not a step." % step_name)


### PR DESCRIPTION
## PR Type
- [x] Bug fix

## Summary
This PR fixes CLI error-handling behavior in two command paths.

In `metaflow/cli_components/step_cmd.py`, the step lookup now catches only `AttributeError` when a step is missing, instead of a bare `except`. In `metaflow/cli_components/run_cmds.py`, `run_id` validation now catches only `TypeError` and `ValueError` when checking whether the value is an integer.

I added these changes to prevent unrelated internal exceptions from being swallowed and reported as user-facing command errors, while preserving existing CLI behavior for valid and invalid inputs.
