### PR TITLE
Fix invalid self.input access in spin complex DAG test

### DIFF
--- a/test/unit/spin/flows/complex_dag_flow.py
+++ b/test/unit/spin/flows/complex_dag_flow.py
@@ -42,7 +42,7 @@ class ComplexDAGFlow(FlowSpec):
 
     @step
     def step_e(self):
-        print(f"I am step E. Input is: {self.input}")
+        print("I am step E.")
         self.split_e = [9, 10]
         print("My output is: ", self.my_output)
         self.next(self.step_f, foreach="split_e")
@@ -83,7 +83,7 @@ class ComplexDAGFlow(FlowSpec):
 
     @step
     def step_l(self):
-        print(f"I am step L. Input is: {self.input}")
+        print("I am step L.")
         self.my_output = self.my_output + [12]
         print("My output is: ", self.my_output)
         self.next(self.step_m)


### PR DESCRIPTION
## Summary
- remove invalid `self.input` reads from non-foreach-body steps in the complex DAG spin test flow
- keep `self.input` usage only in steps where the step is directly executing a foreach item

## Validation
- `python -m pytest 'test/unit/spin/test_spin.py::test_simple_flows[complex_dag]' --confcutdir=test/unit/spin --use-latest -q`
- `pre-commit run --files test/unit/spin/flows/complex_dag_flow.py`