### PR TITLE
Preserve KeyError for missing artifacts

### DIFF
--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -563,19 +563,7 @@ class TaskDataStore(object):
                     % (name, metadata.encoding, metadata.serializer_info, source_hint)
                 )
             deserializers[name] = (deserializer, metadata)
-            try:
-                to_load[self._objects[name]].append(name)
-            except KeyError:
-                # ``_info`` had a record for this artifact but ``_objects``
-                # did not — should not happen in normal write/read cycles,
-                # but if metadata was hand-edited or written by a partial
-                # save, surface the corruption clearly instead of bubbling a
-                # bare KeyError.
-                raise DataException(
-                    "Artifact '%s' has metadata but no stored blob "
-                    "(missing from _objects). The datastore is in an "
-                    "inconsistent state." % name
-                )
+            to_load[self._objects[name]].append(name)
 
         # Load blobs from CAS and deserialize
         for key, blob in self._ca_store.load_blobs(to_load.keys()):

--- a/test/unit/test_serializer_integration.py
+++ b/test/unit/test_serializer_integration.py
@@ -273,6 +273,39 @@ def test_backward_compat_no_encoding(task_datastore):
     assert loaded["ancient"] == 99
 
 
+def test_missing_artifact_raises_key_error(task_datastore):
+    """Missing artifacts preserve the historical KeyError contract."""
+    task_datastore.save_artifacts(iter([("present", 1)]))
+
+    with pytest.raises(KeyError):
+        list(task_datastore.load_artifacts(["missing"]))
+
+
+def test_missing_info_with_object_uses_pickle_defaults(task_datastore):
+    """Artifacts without metadata still use very old pickle defaults."""
+    task_datastore.save_artifacts(
+        iter([("present", {"value": 1}), ("keeps_metadata_non_empty", 2)])
+    )
+    del task_datastore._info["present"]
+
+    loaded = dict(task_datastore.load_artifacts(["present"]))
+
+    assert loaded["present"] == {"value": 1}
+
+
+def test_info_without_object_raises_key_error(task_datastore):
+    """Metadata-only artifacts preserve the historical KeyError behavior."""
+    task_datastore.save_artifacts(iter([("present", 1)]))
+    task_datastore._info["metadata_only"] = {
+        "size": 1,
+        "type": "<class 'int'>",
+        "encoding": "pickle-v4",
+    }
+
+    with pytest.raises(KeyError):
+        list(task_datastore.load_artifacts(["metadata_only"]))
+
+
 # ---------------------------------------------------------------------------
 # Dynamic registry: lazy registrations reach long-lived datastores
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove the `DataException` wrapper for artifacts missing from `_objects`
- let the natural `_objects[name]` lookup preserve the historical `KeyError` behavior
- keep the old metadata fallback path: if an artifact has an object entry but no `_info` entry, load it with very old pickle defaults
- add focused serializer integration coverage for missing artifact, missing metadata, and metadata-without-object cases

## Context
The pluggable serializer load path already uses `self._info.get(name, {})`, which is the right compatibility behavior for artifacts without metadata: assume the very old pickle serializer defaults. The regression came from wrapping the later `_objects[name]` miss in a `DataException`, which made truly absent artifacts look like metadata/blob corruption.

## Validation
- `python -m pytest test/unit/test_serializer_integration.py::test_missing_artifact_raises_key_error test/unit/test_serializer_integration.py::test_missing_info_with_object_uses_pickle_defaults test/unit/test_serializer_integration.py::test_info_without_object_raises_key_error -q`
- `python -m pytest test/unit/test_serializer_integration.py -q`
- `pre-commit run --files metaflow/datastore/task_datastore.py test/unit/test_serializer_integration.py`