### PR TITLE
Bump version to 2.19.28

### DIFF
--- a/metaflow/version.py
+++ b/metaflow/version.py
@@ -1,1 +1,1 @@
-metaflow_version = "2.19.27"
+metaflow_version = "2.19.28"


### PR DESCRIPTION
## Summary
- Bump `metaflow_version` from 2.19.27 to 2.19.28.

## Test plan
- [ ] CI passes