### PR TITLE
fix: corrected package name typo in MutableStep flow type hint

### DIFF
--- a/metaflow/user_decorators/mutable_step.py
+++ b/metaflow/user_decorators/mutable_step.py
@@ -61,7 +61,7 @@ class MutableStep:
             )
 
     @property
-    def flow(self) -> "metaflow.user_decorator.mutable_flow.MutableFlow":
+    def flow(self) -> "metaflow.user_decorators.mutable_flow.MutableFlow":
         """
         The flow that contains this step
 


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

<!-- What user-visible behavior changes? 1-2 sentences. -->

This PR fixes a typo in the type hint for the `flow` property in the `mutable_step.py` file.