### PR TITLE
added workflow concurrency to optimize runner usage

### DIFF
--- a/.github/workflows/full-stack-test.yml
+++ b/.github/workflows/full-stack-test.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - master
 
+# On PRs, cancel old runs when new commits are pushed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ux-tests.yml
+++ b/.github/workflows/ux-tests.yml
@@ -23,6 +23,11 @@ on:
       - master
   workflow_dispatch:
 
+# On PRs, cancel old runs when new commits are pushed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   unit-tests:
     name: "Unit Tests"


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [ ] Bug fix
- [x] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

<!-- What user-visible behavior changes? 1-2 sentences. -->
This PR adds `concurrency` controls to the `ux-tests.yml` and  `full-stack-test.yml` GitHub Actions workflows. 
Currently, if anyone pushes multiple commits to a PR very quick, GitHub Actions triggers workflows for every single commit. Since these workflows spin up heavy infrastructure like minikube, Tilt it comsumes a large amout of time.

So, This PR adds a `concurrency` block to the longer workflows:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}