### PR TITLE
test: add pyproject.toml to card_via_* extension packages

### DIFF
--- a/test/extensions/packages/card_via_extinit/pyproject.toml
+++ b/test/extensions/packages/card_via_extinit/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/test/extensions/packages/card_via_init/pyproject.toml
+++ b/test/extensions/packages/card_via_init/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/test/extensions/packages/card_via_ns_subpackage/pyproject.toml
+++ b/test/extensions/packages/card_via_ns_subpackage/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary

Add a minimal `pyproject.toml` with the standard `[build-system]` table to three test-fixture packages:

- `test/extensions/packages/card_via_extinit/`
- `test/extensions/packages/card_via_init/`
- `test/extensions/packages/card_via_ns_subpackage/`

Each new file is 3 lines:

```toml
[build-system]
requires = ["setuptools>=61"]
build-backend = "setuptools.build_meta"
```

`setup.py` is preserved unchanged; `setuptools.build_meta` uses it as the metadata source.

## Motivation

These three packages currently ship `setup.py` only — no `pyproject.toml`. That forces pip onto the legacy non-PEP-517 build path, which writes `build/bdist.linux-x86_64/wheel/...` and `*.egg-info/` **inside the source directory**.

When CI installs them concurrently from the same source tree (e.g. multiple tox environments running in parallel installing them all as deps), the concurrent pip processes race on those in-source directories and produce errors like:

```
[Errno 2]  No such file or directory: 'build/bdist.linux-x86_64/wheel/./metaflow_card_via_extinit-1.0.0-py3.10.egg-info/dependency_links.txt'
[Errno 17] File exists:    'build/bdist.linux-x86_64/wheel/metaflow_card_via_extinit-1.0.0.dist-info'
[Errno 39] Directory not empty: 'build/bdist.linux-x86_64/wheel'
[Errno 2]  No such file or directory: 'metaflow_card_via_nspackage.egg-info/tmp8cck71cx'
```

Adding the `[build-system]` table switches pip to the PEP 517 isolated-build path: pip copies the source tree to a unique `/tmp/pip-build-env-*/` per install, and the wheel build runs there. Concurrent installs no longer share mutable state in the source directory, and the race goes away.

## Test plan

- [x] Local build still works: `pip wheel -w /tmp/wh ./test/extensions/packages/card_via_extinit/` produces `metaflow_card_via_extinit-1.0.0-py3-none-any.whl`
- [x] The legacy `python setup.py bdist_wheel` invocation still works (setuptools' build_meta backend is backed by setup.py)
- [x] No source-dir mutation after a PEP 517 install (verified `build/` and `*.egg-info/` do not appear in source after install)