### PR TITLE
Narrow exception handling in CLI plugin commands

### DIFF
--- a/metaflow/cli_components/run_cmds.py
+++ b/metaflow/cli_components/run_cmds.py
@@ -278,7 +278,7 @@ def resume(
         # be non-integers to avoid any clashes. This condition ensures this.
         try:
             int(run_id)
-        except:
+        except (TypeError, ValueError):
             pass
         else:
             raise CommandException("run-id %s cannot be an integer" % run_id)

--- a/metaflow/cli_components/step_cmd.py
+++ b/metaflow/cli_components/step_cmd.py
@@ -127,7 +127,7 @@ def step(
     func = None
     try:
         func = getattr(ctx.obj.flow, step_name)
-    except:
+    except AttributeError:
         raise CommandException("Step *%s* doesn't exist." % step_name)
     if not func.is_step:
         raise CommandException("Function *%s* is not a step." % step_name)

--- a/metaflow/plugins/cards/card_cli.py
+++ b/metaflow/plugins/cards/card_cli.py
@@ -723,7 +723,7 @@ def create(
                     mf_card, mode, task, data, timeout_value=timeout
                 )
                 rendered_content = rendered_info.data
-            except:
+            except Exception:
                 rendered_info = CardRenderInfo(
                     mode=mode,
                     is_implemented=True,

--- a/metaflow/plugins/logs_cli.py
+++ b/metaflow/plugins/logs_cli.py
@@ -36,7 +36,7 @@ class CustomGroup(click.Group):
         try:
             super().parse_args(ctx, args)
             args_parseable = True
-        except Exception:
+        except click.ClickException:
             args_parseable = False
         if not args or not args_parseable:
             original_args.insert(0, self.default_cmd)

--- a/metaflow/plugins/logs_cli.py
+++ b/metaflow/plugins/logs_cli.py
@@ -36,7 +36,7 @@ class CustomGroup(click.Group):
         try:
             super().parse_args(ctx, args)
             args_parseable = True
-        except click.ClickException:
+        except Exception:
             args_parseable = False
         if not args or not args_parseable:
             original_args.insert(0, self.default_cmd)


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [ ] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [X] Refactoring

## Summary

This PR narrows broad exception handling in two CLI plugin paths. Replaced catch-all exception handling with more specific exception types in card rendering and logs command parsing.