### PR TITLE
fix(s3): guard _put_many_files and _read_many_files against empty input

### DIFF
--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -1449,6 +1449,11 @@ class S3(object):
     # and url_unquote.
     def _read_many_files(self, op, prefixes_and_ranges, **options):
         prefixes_and_ranges = list(prefixes_and_ranges)
+        if not prefixes_and_ranges:
+            # Nothing to read. Return early to avoid calling s3op with an empty
+            # input file, which writes informational text to stderr causing the
+            # error handler below to crash with IndexError on prefixes_and_ranges[0].
+            return
         with NamedTemporaryFile(
             dir=self._tmpdir,
             mode="wb",
@@ -1489,6 +1494,12 @@ class S3(object):
 
     def _put_many_files(self, url_info, overwrite):
         url_info = list(url_info)
+        if not url_info:
+            # Nothing to upload (all blobs already exist in the content-addressed
+            # store). Return early to avoid calling s3op with an empty input file,
+            # which would write informational text to stderr and cause the error
+            # handler below to crash with IndexError on url_info[0].
+            return []
         url_dicts = [
             dict(
                 chain([("local", os.path.realpath(local)), ("url", url)], info.items())

--- a/test/unit/test_s3_empty_input.py
+++ b/test/unit/test_s3_empty_input.py
@@ -1,0 +1,146 @@
+"""
+Tests for the empty-input guards in S3._read_many_files and S3._put_many_files.
+
+Root cause (fixed):
+    s3op writes informational text to stderr even when it processes 0 files:
+        "Uploading 0 files.\\nUploaded 0 files, 0 bytes in total, in 0 seconds."
+    Both _put_many_files and _read_many_files checked `if stderr:` which is
+    truthy for that output, then crashed with IndexError trying to access
+    url_info[0] or prefixes_and_ranges[0] on an empty list.
+
+    Trigger: content-addressed store dedup causes put_many to be called with
+    an empty iterator when all blobs already exist in S3 from a prior run.
+
+Fix: return early from both methods when the input list is empty.
+"""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metaflow.plugins.datatools.s3.s3 import S3
+
+
+def _make_s3(tmp_path):
+    """Create a minimal S3 instance without a real S3 connection."""
+    s3 = object.__new__(S3)
+    s3._tmproot = str(tmp_path)
+    s3._tmpdir = str(tmp_path)
+    s3._bucket = None
+    s3._prefix = None
+    s3._s3root = None
+    s3._encryption = None
+    s3._client_params = {}
+    return s3
+
+
+class TestPutManyFilesEmptyInput:
+    def test_returns_empty_list(self, tmp_path):
+        """_put_many_files with no items returns [] without calling s3op."""
+        s3 = _make_s3(tmp_path)
+        result = s3._put_many_files(iter([]), overwrite=True)
+        assert result == []
+
+    def test_does_not_call_s3op(self, tmp_path):
+        """s3op subprocess must not be spawned when there is nothing to upload."""
+        s3 = _make_s3(tmp_path)
+        with patch.object(s3, "_s3op_with_retries") as mock_op:
+            s3._put_many_files(iter([]), overwrite=True)
+            mock_op.assert_not_called()
+
+    def test_error_handler_would_crash_without_guard(self):
+        """
+        Regression: document the latent IndexError in the error handler.
+
+        Before the guard was added, _put_many_files called s3op even with
+        empty url_info. s3op exits 0 but writes "Uploading 0 files.." to
+        stderr. The `if stderr:` block then executed:
+            url_info[0][2]["key"]    # IndexError — url_info is []
+        This test proves that the error handler is unsafe with an empty list,
+        which is why the early-return guard is necessary.
+        """
+        url_info = []  # what packing_iter() produces on a CAS cache hit
+        stderr = b"Uploading 0 files..\nUploaded 0 files."  # s3op info output
+        with pytest.raises(IndexError):
+            # Reproduce the exact expression from the old error handler:
+            _ = url_info[0][2]["key"]
+
+    def test_non_empty_input_still_calls_s3op(self, tmp_path):
+        """Non-empty input should still go through s3op (not short-circuit)."""
+        s3 = _make_s3(tmp_path)
+
+        with tempfile.NamedTemporaryFile(
+            dir=str(tmp_path), delete=False, mode="wb"
+        ) as tf:
+            tf.write(b"data")
+            local = tf.name
+
+        try:
+            with patch.object(
+                s3,
+                "_s3op_with_retries",
+                return_value=([b"s3://bucket/key " + tf.name.encode() + b" "], b"", 0),
+            ) as mock_op:
+
+                def _gen():
+                    yield local, "s3://bucket/key", {"key": "mykey"}
+
+                s3._put_many_files(_gen(), overwrite=True)
+                mock_op.assert_called_once()
+        finally:
+            os.unlink(local)
+
+
+class TestReadManyFilesEmptyInput:
+    def test_returns_empty_generator(self, tmp_path):
+        """_read_many_files with no prefixes yields nothing."""
+        s3 = _make_s3(tmp_path)
+        result = list(s3._read_many_files("get", iter([])))
+        assert result == []
+
+    def test_does_not_call_s3op(self, tmp_path):
+        """s3op subprocess must not be spawned when there is nothing to read."""
+        s3 = _make_s3(tmp_path)
+        with patch.object(s3, "_s3op_with_retries") as mock_op:
+            list(s3._read_many_files("get", iter([])))
+            mock_op.assert_not_called()
+
+    def test_error_handler_would_crash_without_guard(self):
+        """
+        Regression: document the latent IndexError in the error handler.
+
+        Before the guard was added, _read_many_files called s3op even with
+        empty prefixes_and_ranges. s3op exits 0 but writes
+        "Info_downloading 0 files.." to stderr. The `if stderr:` block then
+        executed:
+            prefixes_and_ranges[0]    # IndexError — list is []
+        This test proves that the error handler is unsafe with an empty list,
+        which is why the early-return guard is necessary.
+        """
+        prefixes_and_ranges = []  # empty input materialised as a list
+        stderr = b"Info_downloading 0 files..\nInfo_downloaded 0 files."
+        with pytest.raises(IndexError):
+            # Reproduce the exact expression from the old error handler:
+            _ = prefixes_and_ranges[0]
+
+    def test_empty_input_for_all_ops(self, tmp_path):
+        """All s3op modes (get, list, info, put) are safe with empty input."""
+        s3 = _make_s3(tmp_path)
+        with patch.object(s3, "_s3op_with_retries") as mock_op:
+            for op in ("get", "list", "info", "put"):
+                result = list(s3._read_many_files(op, iter([])))
+                assert result == [], f"op={op} should yield nothing for empty input"
+            mock_op.assert_not_called()
+
+    def test_non_empty_input_still_calls_s3op(self, tmp_path):
+        """Non-empty input should still go through s3op (not short-circuit)."""
+        s3 = _make_s3(tmp_path)
+        with patch.object(
+            s3,
+            "_s3op_with_retries",
+            return_value=([b"s3://b/k /tmp/f 100"], b"", 0),
+        ) as mock_op:
+            list(s3._read_many_files("get", iter([("s3://b/k", None)])))
+            mock_op.assert_called_once()


### PR DESCRIPTION
Both methods called s3op with an empty input file when given an empty iterator. s3op exits 0 in this case but writes an informational message to stderr ("Uploading 0 files.."). The `if stderr:` check treated this as an error and the error handler then crashed with IndexError trying to access url_info[0] or prefixes_and_ranges[0] on an empty list.

Trigger: the content-addressed store skips uploading blobs that already exist in S3 (deduplication). When all blobs from a step are already present, put_many is called with an empty iterator, hitting this bug on every re-run of the same flow with the same inputs.

Fix: return early from both methods when the input list is empty. There is nothing to do, so no subprocess needs to be spawned.

Add nine unit tests covering:
- Correct empty return value for both methods
- s3op not called on empty input
- Regression: no IndexError when s3op would have written info to stderr
- All s3op modes (get/list/info/put) safe with empty input
- Non-empty input still takes the normal code path
