### PR TITLE
fix: replace bare except clauses with specific exception types (#3164)

### DIFF
--- a/metaflow/multicore_utils.py
+++ b/metaflow/multicore_utils.py
@@ -22,7 +22,7 @@ from typing import (
 try:
     # Python 2
     import cPickle as pickle
-except:
+except ImportError:
     # Python 3
     import pickle
 
@@ -66,7 +66,7 @@ def _spawn(
                 with open(output_file, "wb") as f:
                     pickle.dump(ret, f, protocol=pickle.HIGHEST_PROTOCOL)
                 exit_code = 0
-            except:
+            except Exception:
                 # we must not let any exceptions escape this function
                 # which might trigger unintended side-effects
                 traceback.print_exc()


### PR DESCRIPTION
Closes #3164 — replaces bare `except:` clauses in `multicore_utils.py` with specific exception types.

**Changes in `metaflow/multicore_utils.py`:**
- Line 25: `except:` → `except ImportError:` (py2/py3 cPickle compat pattern)
- Line 69: `except:` → `except Exception:` (child process error handler should allow SystemExit/KeyboardInterrupt to propagate to os._exit())