### PR TITLE
ci: declare read-all permissions on the kubernetes and card-build test workflows

### DIFF
--- a/.github/workflows/full-stack-test.yml
+++ b/.github/workflows/full-stack-test.yml
@@ -13,6 +13,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions: read-all
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-card-build.yml
+++ b/.github/workflows/test-card-build.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'metaflow/plugins/cards/ui/**'
 
+permissions: read-all
+
 jobs:
   testbuild:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two test workflows currently don't declare a `permissions:` block, so they inherit whatever scope the repo's default grants the workflow `GITHUB_TOKEN`:

- `.github/workflows/full-stack-test.yml` -- spins up a local minikube stack via `metaflow-dev all-up` and runs a tutorial flow. No GitHub API calls.
- `.github/workflows/test-card-build.yml` -- `npm ci && npm run build` inside `metaflow/plugins/cards/ui`. No GitHub API calls.

`permissions: read-all` at workflow scope is the same shorthand `test.yml` already uses, so this patch keeps the style consistent. With explicit read-only scope:

- a future change to the repo's default workflow-token grant can't widen these workflows
- the SLSA / OpenSSF Scorecard `Token-Permissions` check goes green for these files
- if any of the third-party actions reachable from these workflows is ever compromised (cf. tj-actions/changed-files CVE-2025-30066), the blast radius stays inside read.

I left `ux-tests.yml` out on purpose. It runs `dorny/test-reporter@d61b558...`, which writes check runs (`checks: write`), and it caches pip via `actions/cache`. Both touch the permissions story in ways I'd rather pin down in a separate PR if you're interested.