### PR TITLE
Add NullMonitor.timer + SystemMonitor.count_once/timer

### DIFF
--- a/metaflow/monitor.py
+++ b/metaflow/monitor.py
@@ -54,6 +54,27 @@ class NullMonitor(object):
         else:
             yield
 
+    def timer(self, name, value):
+        """Emit a one-shot timer with a precomputed duration (seconds).
+
+        Use when the measured duration is computed externally (e.g.
+        wall-clock across separate processes/containers) and the
+        contextmanager ``measure()`` shape doesn't fit. Subclasses can
+        override; the base routes through the sidecar like ``measure()``.
+        """
+        if self._sidecar.is_active:
+            # Anchor the serialized start/end to real epoch timestamps so
+            # any consumer that inspects _start/_end (not just .value) sees
+            # meaningful data. _end - _start == value, so .value is the
+            # same as before.
+            now = time.time()
+            timer = Timer(name + "_timer")
+            timer.start(now - value)
+            timer.end(now)
+            payload = {"timer": timer.serialize()}
+            msg = Message(MessageTypes.BEST_EFFORT, payload)
+            self._sidecar.send(msg)
+
     def gauge(self, gauge):
         if self._sidecar.is_active:
             payload = {"gauge": gauge.serialize()}

--- a/metaflow/system/system_monitor.py
+++ b/metaflow/system/system_monitor.py
@@ -95,6 +95,42 @@ class SystemMonitor(object):
         with self.monitor.count(name):
             yield
 
+    def count_once(self, name: str) -> None:
+        """
+        Increment a counter exactly once.
+
+        Helper for discrete events where the contextmanager ``count()`` shape
+        doesn't fit (avoids the awkward ``with system_monitor.count(...): pass``).
+
+        Parameters
+        ----------
+        name : str
+            The name of the counter.
+        """
+        with self.monitor.count(name):
+            pass
+
+    def timer(self, name: str, value: float) -> None:
+        """
+        Emit a one-shot timer with a precomputed duration (seconds).
+
+        The monitor implementation appends ``"_timer"`` to ``name`` when
+        emitting (same convention as ``measure(name)``, which emits
+        ``<name>_timer`` plus ``<name>_counter``), so pass the base name
+        without the suffix.
+
+        Use when the duration is computed externally (e.g. wall-clock across
+        separate processes/containers) and ``measure()`` doesn't fit.
+
+        Parameters
+        ----------
+        name : str
+            The base name; ``"_timer"`` is appended automatically.
+        value : float
+            The duration to record, in seconds.
+        """
+        self.monitor.timer(name, value)
+
     def gauge(self, gauge: "metaflow.monitor.Gauge"):
         """
         Log a gauge.


### PR DESCRIPTION
## Summary

Adds two small additions to the monitor API so callers can:

1. Emit a one-shot timer with a **precomputed** duration (instead of `measure()`'s contextmanager that wraps wall-clock around a yielded block).
2. Increment a counter exactly once for discrete events, without the awkward `with system_monitor.count(name): pass` idiom.

## Motivation

The contextmanager-based `measure(name)` is great when the start and end of the measured interval happen in the same Python process and the same call site. It doesn't fit when the duration is computed externally — for example, wall-clock from a workflow's run-creation timestamp to the terminal step's success, where the two boundaries are in **different containers**.

The concrete use case: emitting a run-level `metaflow.run.duration_timer` metric from a terminal-step `task_finished` hook, computing duration as `now() - Run.created_at`. See companion internal PR for the consumer: corp/mli-metaflow-custom#1861 (the AtlasMonitor work where #3093's per-step tags are already being used in production).

## Changes

- **`metaflow/monitor.py`** — `NullMonitor.timer(name, value)`. Routes through the same sidecar protocol as `measure()`, so `DebugMonitor` and any other `NullMonitor` subclass inherits the behavior automatically.
- **`metaflow/system/system_monitor.py`** — `SystemMonitor.timer(name, value)` passthrough + `SystemMonitor.count_once(name)` helper.

No existing call sites change. Existing `count()` / `measure()` / `gauge()` APIs are untouched.

## Test plan

- [ ] `NullMonitor.timer()` is a no-op when the sidecar isn't active.
- [ ] `NullMonitor.timer()` sends a single `BEST_EFFORT` message with the precomputed duration when the sidecar is active.
- [ ] `DebugMonitor` (via inheritance) prints the timer through `DebugMonitorSidecar.process_message`.
- [ ] `SystemMonitor.count_once(name)` increments a counter exactly once (verified against an instrumented sub-monitor).