### PR TITLE
fix: remove duplicate --use-latest pytest option in spin conftest

### DIFF
--- a/test/unit/spin/conftest.py
+++ b/test/unit/spin/conftest.py
@@ -6,14 +6,6 @@ import os
 FLOWS_DIR = os.path.join(os.path.dirname(__file__), "flows")
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--use-latest",
-        action="store_true",
-        default=False,
-        help="Use latest run of each flow instead of running new ones",
-    )
-
 
 def create_flow_fixture(flow_name, flow_file, run_params=None, runner_params=None):
     """

--- a/test/unit/spin/conftest.py
+++ b/test/unit/spin/conftest.py
@@ -6,7 +6,6 @@ import os
 FLOWS_DIR = os.path.join(os.path.dirname(__file__), "flows")
 
 
-
 def create_flow_fixture(flow_name, flow_file, run_params=None, runner_params=None):
     """
     Factory function to create flow fixtures with common logic.


### PR DESCRIPTION
## Summary

Remove duplicate `--use-latest` pytest option registration that prevents the unit test suite from collecting.

## Problem

Running `pytest test/unit/` fails during collection with:

```
ValueError: option names {'--use-latest'} already added
```

`--use-latest` is registered in both `test/unit/conftest.py` (added in #3040) and `test/unit/spin/conftest.py` (from #2506). pytest raises on the duplicate.

## Fix

Remove `pytest_addoption` from `test/unit/spin/conftest.py`. The root `test/unit/conftest.py` already registers the option and it applies to all subdirectories.

## Testing

| State | Result |
|-------|--------|
| Before | `pytest test/unit/` fails with collection error |
| After | 468 passed, 1 failed, 19 skipped, 21 errors |

> **Note:** The 1 failure (`complex_dag`) and 21 errors (`secrets`/`system_context` tests) are pre-existing infrastructure issues unrelated to this change.