### PR TITLE
Expose Argo only-json workflow template on DeployedFlow

### DIFF
--- a/metaflow/plugins/argo/argo_workflows_cli.py
+++ b/metaflow/plugins/argo/argo_workflows_cli.py
@@ -48,6 +48,19 @@ unsupported_decorators = {
 }
 
 
+def _write_deployer_attributes(obj, deployer_attribute_file, additional_info=None):
+    if deployer_attribute_file:
+        payload = {
+            "name": obj.workflow_name,
+            "flow_name": obj.flow.name,
+            "metadata": obj.metadata.metadata_str(),
+        }
+        if additional_info is not None:
+            payload["additional_info"] = additional_info
+        with open(deployer_attribute_file, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+
+
 class IncorrectProductionToken(MetaflowException):
     headline = "Incorrect production token"
 
@@ -278,16 +291,8 @@ def create(
 
     validate_tags(tags)
 
-    if deployer_attribute_file:
-        with open(deployer_attribute_file, "w", encoding="utf-8") as f:
-            json.dump(
-                {
-                    "name": obj.workflow_name,
-                    "flow_name": obj.flow.name,
-                    "metadata": obj.metadata.metadata_str(),
-                },
-                f,
-            )
+    if not only_json:
+        _write_deployer_attributes(obj, deployer_attribute_file)
 
     obj.echo("Deploying *%s* to Argo Workflows..." % obj.flow.name, bold=True)
 
@@ -364,6 +369,11 @@ def create(
     )
 
     if only_json:
+        _write_deployer_attributes(
+            obj,
+            deployer_attribute_file,
+            additional_info={"workflow_template": flow._workflow_template.to_json()},
+        )
         obj.echo_always(str(flow), err=False, no_bold=True)
         # TODO: Support echo-ing Argo Events Sensor template
     else:

--- a/metaflow/plugins/argo/argo_workflows_deployer_objects.py
+++ b/metaflow/plugins/argo/argo_workflows_deployer_objects.py
@@ -203,6 +203,16 @@ class ArgoWorkflowsDeployedFlow(DeployedFlow):
 
     TYPE: ClassVar[Optional[str]] = "argo-workflows"
 
+    @property
+    def workflow_template(self) -> Optional[dict]:
+        """
+        Return the compiled Argo WorkflowTemplate from an ``only_json=True`` create.
+
+        Normal deployments and objects reconstructed with ``from_deployment`` do not
+        retain the local compilation payload and return ``None``.
+        """
+        return getattr(self.deployer, "additional_info", {}).get("workflow_template")
+
     @classmethod
     def list_deployed_flows(cls, flow_name: Optional[str] = None):
         """

--- a/test/unit/test_argo_workflows_cli.py
+++ b/test/unit/test_argo_workflows_cli.py
@@ -4,6 +4,9 @@ import pytest
 
 from metaflow.plugins.argo.argo_workflows_cli import sanitize_for_argo
 from metaflow.plugins.argo.argo_workflows import ArgoWorkflows
+from metaflow.plugins.argo.argo_workflows_deployer_objects import (
+    ArgoWorkflowsDeployedFlow,
+)
 
 
 @pytest.mark.parametrize(
@@ -132,3 +135,29 @@ def test_trigger_explanation_active_schedule_claims_cronworkflow(
     assert result is not None
     assert "CronWorkflow" in result
     assert "myflow" in result
+
+
+def test_deployed_flow_workflow_template_returns_only_json_payload():
+    workflow_template = {"kind": "WorkflowTemplate", "metadata": {"name": "myflow"}}
+    deployer = types.SimpleNamespace(
+        name="myflow",
+        flow_name="MyFlow",
+        metadata="local@user:test",
+        additional_info={"workflow_template": workflow_template},
+    )
+
+    deployed_flow = ArgoWorkflowsDeployedFlow(deployer)
+
+    assert deployed_flow.workflow_template == workflow_template
+
+
+def test_deployed_flow_workflow_template_returns_none_without_payload():
+    deployer = types.SimpleNamespace(
+        name="myflow",
+        flow_name="MyFlow",
+        metadata="local@user:test",
+    )
+
+    deployed_flow = ArgoWorkflowsDeployedFlow(deployer)
+
+    assert deployed_flow.workflow_template is None

--- a/test/ux/core/test_argo_compilation.py
+++ b/test/ux/core/test_argo_compilation.py
@@ -1,0 +1,36 @@
+import pytest
+
+pytestmark = [pytest.mark.argo_compilation, pytest.mark.scheduler_only]
+
+
+def test_argo_only_json_exposes_workflow_template(
+    exec_mode, decospecs, tag, scheduler_config
+):
+    if exec_mode != "deployer":
+        pytest.skip("Argo compilation tests require deployer mode")
+    if scheduler_config.scheduler_type != "argo-workflows":
+        pytest.skip("Argo compilation tests require the argo-workflows scheduler")
+
+    from metaflow import Deployer
+
+    from .test_utils import _resolve_flow_path, prepare_runner_deployer_args
+
+    deployed_flow = (
+        Deployer(
+            flow_file=_resolve_flow_path("basic/helloworld.py"),
+            show_output=False,
+            **prepare_runner_deployer_args({"decospecs": decospecs}),
+        )
+        .argo_workflows()
+        .create(
+            only_json=True,
+            tags=tag + ["test_argo_only_json_exposes_workflow_template"],
+            **(scheduler_config.deploy_args or {}),
+        )
+    )
+
+    workflow_template = deployed_flow.workflow_template
+    assert workflow_template is not None
+    assert workflow_template["kind"] == "WorkflowTemplate"
+    assert workflow_template["metadata"]["name"] == deployed_flow.name
+    assert workflow_template["spec"]["templates"]

--- a/test/ux/pytest.ini
+++ b/test/ux/pytest.ini
@@ -13,3 +13,4 @@ markers =
     decorators: Decorator coverage tests (@environment, @card, etc.)
     sfn_compilation: Step Functions ASL compilation validation tests
     airflow_compilation: Airflow DAG compilation validation tests
+    argo_compilation: Argo Workflows compilation validation tests


### PR DESCRIPTION
## Summary
- Preserve existing `argo-workflows create --only-json` stdout behavior
- Attach the compiled Argo WorkflowTemplate to Deployer `additional_info` for `only_json=True`
- Expose it as `ArgoWorkflowsDeployedFlow.workflow_template`
- Add unit coverage and a UX/core Argo compilation integration test