### PR TITLE
Fix: Prevents incorrectly attaching of default decorators in spin-step

### DIFF
--- a/.github/workflows/ux-tests.yml
+++ b/.github/workflows/ux-tests.yml
@@ -114,7 +114,11 @@ jobs:
 
       - name: Run spin tests
         shell: bash -el {0}
-        run: tox -e spin -- --junit-xml=junit-spin.xml
+        run: |
+          export CONDA_PKGS_DIRS="$RUNNER_TEMP/metaflow-micromamba-pkgs"
+          export MAMBA_ROOT_PREFIX="$RUNNER_TEMP/metaflow-micromamba-root"
+          export METAFLOW_TOKEN_HOME="$RUNNER_TEMP/metaflowconfig"
+          tox -e spin -- --junit-xml=junit-spin.xml
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ux-tests.yml
+++ b/.github/workflows/ux-tests.yml
@@ -103,10 +103,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.9"
 
       - name: Install tox
         run: python -m pip install tox

--- a/.github/workflows/ux-tests.yml
+++ b/.github/workflows/ux-tests.yml
@@ -103,10 +103,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install tox
         run: python -m pip install tox

--- a/.github/workflows/ux-tests.yml
+++ b/.github/workflows/ux-tests.yml
@@ -117,8 +117,17 @@ jobs:
           export MAMBA_ROOT_PREFIX="$RUNNER_TEMP/metaflow-micromamba-root"
           export XDG_CACHE_HOME="$RUNNER_TEMP/metaflow-cache"
           export METAFLOW_TOKEN_HOME="$RUNNER_TEMP/metaflowconfig"
-          tox -e spin -- --junit-xml=junit-spin.xml
-
+          tox -e spin -- --junit-xml=junit-spin.xml --cov=metaflow --cov-report=xml:coverage.xml --cov-branch
+      - name: Upload coverage data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-spin
+          path: |
+            .coverage
+            coverage.xml
+          if-no-files-found: ignore
+          include-hidden-files: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ux-tests.yml
+++ b/.github/workflows/ux-tests.yml
@@ -103,20 +103,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
         with:
-          miniforge-version: latest
           python-version: "3.10"
 
       - name: Install tox
-        shell: bash -el {0}
         run: python -m pip install tox
 
       - name: Run spin tests
-        shell: bash -el {0}
         run: |
           export CONDA_PKGS_DIRS="$RUNNER_TEMP/metaflow-micromamba-pkgs"
           export MAMBA_ROOT_PREFIX="$RUNNER_TEMP/metaflow-micromamba-root"
+          export XDG_CACHE_HOME="$RUNNER_TEMP/metaflow-cache"
           export METAFLOW_TOKEN_HOME="$RUNNER_TEMP/metaflowconfig"
           tox -e spin -- --junit-xml=junit-spin.xml
 

--- a/.github/workflows/ux-tests.yml
+++ b/.github/workflows/ux-tests.yml
@@ -96,6 +96,44 @@ jobs:
           reporter: java-junit
           fail-on-error: false
 
+  spin-tests:
+    name: "Spin Tests"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          python-version: "3.10"
+
+      - name: Install tox
+        shell: bash -el {0}
+        run: python -m pip install tox
+
+      - name: Run spin tests
+        shell: bash -el {0}
+        run: tox -e spin -- --junit-xml=junit-spin.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-spin
+          path: junit-spin.xml
+          if-no-files-found: ignore
+
+      - name: Publish test results
+        if: always()
+        continue-on-error: true
+        uses: dorny/test-reporter@d61b558e8df85cb60d09ca3e5b09653b4477cea7  # v1
+        with:
+          name: "Test Results — Spin"
+          path: junit-spin.xml
+          reporter: java-junit
+          fail-on-error: false
+
   ux-tests:
     name: "${{ matrix.backend }}"
     strategy:
@@ -342,7 +380,7 @@ jobs:
 
   coverage-report:
     name: "Coverage Report"
-    needs: [unit-tests, ux-tests]
+    needs: [unit-tests, spin-tests, ux-tests]
     if: always()
     runs-on: ubuntu-latest
 

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -629,13 +629,10 @@ def start(
             ctx.obj.environment.decospecs() or []
         )
 
-        # If we are in spin-args, we will not attach any decorators
-        if ctx.saved_args[0] == "spin-step":
-            all_decospecs = []
-        # We add the default decospecs for everything except init and step since in those
-        # cases, the decospecs will already have been handled by either a run/resume
-        # or a scheduler setting them up in their own way.
-        elif ctx.saved_args[0] not in ("step", "init"):
+        # We add the default decospecs for everything except init, step, and
+        # spin-step since those decospecs are handled by run/resume/scheduler
+        # setup or are explicitly forwarded by SpinRuntime.
+        if ctx.saved_args[0] not in ("step", "init", "spin-step"):
             all_decospecs += DEFAULT_DECOSPECS.split()
 
         if all_decospecs:

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -1,4 +1,3 @@
-import os
 import functools
 import inspect
 import os
@@ -630,14 +629,15 @@ def start(
             ctx.obj.environment.decospecs() or []
         )
 
+        # If we are in spin-args, we will not attach any decorators
+        if ctx.saved_args[0] == "spin-step":
+            all_decospecs = []
         # We add the default decospecs for everything except init and step since in those
         # cases, the decospecs will already have been handled by either a run/resume
         # or a scheduler setting them up in their own way.
-        if ctx.saved_args[0] not in ("step", "init"):
+        elif ctx.saved_args[0] not in ("step", "init"):
             all_decospecs += DEFAULT_DECOSPECS.split()
-        elif ctx.saved_args[0] == "spin-step":
-            # If we are in spin-args, we will not attach any decorators
-            all_decospecs = []
+
         if all_decospecs:
             decorators._attach_decorators(ctx.obj.flow, all_decospecs)
             # Regenerate graph if we attached more decorators

--- a/test/unit/spin/conftest.py
+++ b/test/unit/spin/conftest.py
@@ -71,6 +71,10 @@ simple_config_run = pytest.fixture(scope="session")(
     )
 )
 
+spin_decospec_run = pytest.fixture(scope="session")(
+    create_flow_fixture("SpinDecospecFlow", "spin_decospec_flow.py")
+)
+
 
 @pytest.fixture
 def complex_dag_step_d_artifacts(complex_dag_run):

--- a/test/unit/spin/flows/complex_dag_flow.py
+++ b/test/unit/spin/flows/complex_dag_flow.py
@@ -88,14 +88,14 @@ class ComplexDAGFlow(FlowSpec):
         print("My output is: ", self.my_output)
         self.next(self.step_m)
 
-    @conda(libraries={"scikit-learn": "1.5.0"})
+    @conda(libraries={"numpy": "2.2.0"})
     @step
     def step_m(self, inputs):
-        import sklearn
+        import numpy as np
 
-        self.sklearn_version = sklearn.__version__
+        self.np_version_m = np.__version__
         self.my_output = sorted([inp.my_output for inp in inputs])[0]
-        print("Sklearn version: ", self.sklearn_version)
+        print("numpy version: ", self.np_version_m)
         print("My output is: ", self.my_output)
         self.next(self.step_n)
 

--- a/test/unit/spin/flows/spin_decospec_flow.py
+++ b/test/unit/spin/flows/spin_decospec_flow.py
@@ -1,0 +1,19 @@
+import time
+
+from metaflow import FlowSpec, step
+
+
+class SpinDecospecFlow(FlowSpec):
+    @step
+    def start(self):
+        time.sleep(3)
+        self.done = True
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+if __name__ == "__main__":
+    SpinDecospecFlow()

--- a/test/unit/spin/test_spin.py
+++ b/test/unit/spin/test_spin.py
@@ -33,7 +33,7 @@ def test_artifacts_module(complex_dag_run):
     flow_path = os.path.join(FLOWS_DIR, "complex_dag_flow.py")
     artifacts_path = os.path.join(ARTIFACTS_DIR, "complex_dag_step_a.py")
 
-    with Runner(flow_path, environment="conda").spin(
+    with Runner(flow_path, cwd=FLOWS_DIR, environment="conda").spin(
         task.pathspec,
         artifacts_module=artifacts_path,
         persist=True,
@@ -57,7 +57,7 @@ def test_artifacts_module_join_step(
     temp_artifacts_file = tmp_path / "temp_complex_dag_step_d.py"
     temp_artifacts_file.write_text(f"ARTIFACTS = {repr(complex_dag_step_d_artifacts)}")
 
-    with Runner(flow_path, environment="conda").spin(
+    with Runner(flow_path, cwd=FLOWS_DIR, environment="conda").spin(
         task.pathspec,
         artifacts_module=str(temp_artifacts_file),
         persist=True,

--- a/test/unit/spin/test_spin.py
+++ b/test/unit/spin/test_spin.py
@@ -105,6 +105,42 @@ def test_skip_decorators_bypass(simple_config_run):
         assert spin_task.finished
 
 
+def test_spin_preserves_explicit_top_level_decospecs(spin_decospec_run):
+    task = spin_decospec_run["start"].task
+    flow_path = os.path.join(FLOWS_DIR, "spin_decospec_flow.py")
+
+    with pytest.raises(Exception, match="timed out"):
+        with Runner(
+            flow_path,
+            cwd=FLOWS_DIR,
+            decospecs=["timeout:seconds=1"],
+            file_read_timeout=30,
+            show_output=False,
+        ).spin(
+            task.pathspec,
+            persist=True,
+        ):
+            pass
+
+
+def test_spin_step_does_not_apply_default_decospecs(spin_decospec_run):
+    task = spin_decospec_run["start"].task
+    flow_path = os.path.join(FLOWS_DIR, "spin_decospec_flow.py")
+
+    with Runner(
+        flow_path,
+        cwd=FLOWS_DIR,
+        env={"METAFLOW_DEFAULT_DECOSPECS": "timeout:seconds=1"},
+        file_read_timeout=30,
+        show_output=False,
+    ).spin(
+        task.pathspec,
+        persist=True,
+    ) as spin:
+        assert spin.task.finished
+        assert spin.task["done"].data is True
+
+
 def test_hidden_artifacts(simple_parameter_run):
     """Test simple flows that just need artifact validation."""
     step_name = "start"

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,12 @@ deps =
 [testenv:unit]
 commands = pytest test/unit/ test/cmd/ test/plugins/ --ignore=test/unit/spin -m "not docker" -v --tb=short --timeout=120 {posargs}
 
+[testenv:spin]
+deps =
+    {[testenv]deps}
+    pandas
+commands = pytest test/unit/spin -v --tb=short --timeout=600 {posargs}
+
 [testenv:ux-local]
 commands = pytest test/ux/core/ --only-backend local -n 4 -v --tb=short --timeout=1800 {posargs}
 


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

<!-- What user-visible behavior changes? 1-2 sentences. -->
### Description
This PR fixes a bug in `metaflow/cli.py` where default decorators were incorrectly being attached when running a `spin-step`. 

I fixed the order of the `if`/`elif` blocks. By checking for `"spin-step"` first, we ensure it correctly assigns an empty list for `all_decospecs` and safely bypasses the block that attaches the default decorators.

And also removes the duplicate os module import.


## Issue

<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes #3221 

