### PR TITLE
Bump version to 2.19.31

### DIFF
--- a/metaflow/version.py
+++ b/metaflow/version.py
@@ -1,1 +1,1 @@
-metaflow_version = "2.19.30"
+metaflow_version = "2.19.31"


### PR DESCRIPTION
Bumps the Metaflow patch version from 2.19.30 to 2.19.31.