### PR TITLE
fix: PyPI environment resolve race condition

### DIFF
--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -227,6 +227,7 @@ class CondaEnvironment(MetaflowEnvironment):
             pypi_create_futures = []
 
             cache_futures = []
+            local_platform = self.solvers["conda"].platform()
             # Process conda results sequentially for downloads
             for future in as_completed(conda_solve_futures):
                 result = future.result()
@@ -245,11 +246,10 @@ class CondaEnvironment(MetaflowEnvironment):
                         executor.submit(cache, storage, [result], "conda")
                     )
 
-                # Queue PyPI solve to start after LOCAL platform conda create.
+                # Queue PyPI solve to start only after the local platform conda create.
                 # Pip.solve() needs the local conda env (path_to_environment defaults
                 # to the local platform), so we must wait for the local platform's
                 # conda create — not a cross-platform one, which is a no-op.
-                local_platform = self.solvers["conda"].platform()
                 if env_id in pypi_envs and result_platform == local_platform:
                     debug.conda_exec(
                         "Solving packages for PyPI environment %s" % env_id

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -252,11 +252,11 @@ class CondaEnvironment(MetaflowEnvironment):
                     # solve pypi envs uniquely
                     pypi_env = pypi_envs.pop(result[0])
 
-                    def pypi_solve(env):
-                        conda_create_future.result()  # Wait for conda create
+                    def pypi_solve(env, conda_env_future):
+                        conda_env_future.result()  # Wait for conda create
                         return solve(*env, "pypi")
 
-                    pypi_solve_futures.append(executor.submit(pypi_solve, pypi_env))
+                    pypi_solve_futures.append(executor.submit(pypi_solve, pypi_env, conda_create_future))
                 else:
                     # add conda create future to the generic list
                     conda_create_futures.append(conda_create_future)

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -244,8 +244,12 @@ class CondaEnvironment(MetaflowEnvironment):
                         executor.submit(cache, storage, [result], "conda")
                     )
 
-                # Queue PyPI solve to start after conda create
-                if result[0] in pypi_envs:
+                # Queue PyPI solve to start after LOCAL platform conda create.
+                # Pip.solve() needs the local conda env (path_to_environment defaults
+                # to the local platform), so we must wait for the local platform's
+                # conda create — not a cross-platform one, which is a no-op.
+                local_platform = self.solvers["conda"].platform()
+                if result[0] in pypi_envs and result[3] == local_platform:
                     debug.conda_exec(
                         "Solving packages for PyPI environment %s" % result[0]
                     )

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -261,7 +261,9 @@ class CondaEnvironment(MetaflowEnvironment):
                         conda_env_future.result()  # Wait for conda create
                         return solve(*env, "pypi")
 
-                    pypi_solve_futures.append(executor.submit(pypi_solve, pypi_env, conda_create_future))
+                    pypi_solve_futures.append(
+                        executor.submit(pypi_solve, pypi_env, conda_create_future)
+                    )
                 else:
                     # add conda create future to the generic list
                     conda_create_futures.append(conda_create_future)

--- a/metaflow/plugins/pypi/conda_environment.py
+++ b/metaflow/plugins/pypi/conda_environment.py
@@ -230,9 +230,10 @@ class CondaEnvironment(MetaflowEnvironment):
             # Process conda results sequentially for downloads
             for future in as_completed(conda_solve_futures):
                 result = future.result()
+                env_id, _, _, result_platform = result
                 # Sequential conda download
                 debug.conda_exec(
-                    "Downloading packages for Conda environment %s" % result[0]
+                    "Downloading packages for Conda environment %s" % env_id
                 )
                 self.solvers["conda"].download(*result)
                 # Parallel conda create and cache
@@ -249,12 +250,12 @@ class CondaEnvironment(MetaflowEnvironment):
                 # to the local platform), so we must wait for the local platform's
                 # conda create — not a cross-platform one, which is a no-op.
                 local_platform = self.solvers["conda"].platform()
-                if result[0] in pypi_envs and result[3] == local_platform:
+                if env_id in pypi_envs and result_platform == local_platform:
                     debug.conda_exec(
-                        "Solving packages for PyPI environment %s" % result[0]
+                        "Solving packages for PyPI environment %s" % env_id
                     )
                     # solve pypi envs uniquely
-                    pypi_env = pypi_envs.pop(result[0])
+                    pypi_env = pypi_envs.pop(env_id)
 
                     def pypi_solve(env, conda_env_future):
                         conda_env_future.result()  # Wait for conda create


### PR DESCRIPTION
There exists a race condition in the way `pypi` environments are resolved for remote execution. The `pypi` resolving builds upon a base conda environment, which for remote targets we solve two separate ones; a local one for fetching packages with, and a dummy remote one.

The race condition is caused by a code path that waits for the base conda environment to be created before starting the pypi environment solving, but this never made a distinction between the local and the dummy remote ones. In rare cases the pypi resolving could then start before the real base conda environment existed yet.