### PR TITLE
fix: validate run IDs during resume operations

### DIFF
--- a/metaflow/cli_components/run_cmds.py
+++ b/metaflow/cli_components/run_cmds.py
@@ -129,6 +129,7 @@ def _validate_resume_run_id(flow_name, run_id, reentrant=False):
     try:
         Run(pathspec=pathspec, _namespace_check=False)
     except MetaflowNotFound:
+        # Expected when run doesn't exist. This is the desired outcome.
         pass
     else:
         raise CommandException(
@@ -145,6 +146,7 @@ def _validate_resume_run_id(flow_name, run_id, reentrant=False):
     try:
         int(run_id)
     except ValueError:
+        # Non-integer run-id (external scheduler): OK
         pass
     else:
         raise CommandException("run-id %s cannot be an integer" % run_id)

--- a/metaflow/cli_components/run_cmds.py
+++ b/metaflow/cli_components/run_cmds.py
@@ -5,7 +5,7 @@ from functools import wraps
 from metaflow._vendor import click
 
 from .. import decorators, namespace, parameters, tracing
-from ..exception import CommandException
+from ..exception import CommandException, MetaflowNotFound
 from ..graph import FlowGraph
 from ..metaflow_current import current
 from ..metaflow_config import (
@@ -114,6 +114,40 @@ def write_file(file_path, content):
     if file_path is not None:
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(str(content))
+
+
+def _validate_resume_run_id(flow_name, run_id, reentrant=False):
+    """
+    Validate --run-id for resume: it must name a new run, not an existing one.
+    """
+    if not run_id or reentrant:
+        return
+
+    from ..client.core import Run
+
+    pathspec = "%s/%s" % (flow_name, run_id)
+    try:
+        Run(pathspec=pathspec, _namespace_check=False)
+    except MetaflowNotFound:
+        pass
+    else:
+        raise CommandException(
+            "Run ID %s already exists.\n\n"
+            "Did you mean:\n\n"
+            "    resume --origin-run-id %s\n\n"
+            "instead of:\n\n"
+            "    resume --run-id %s"
+            % (run_id, run_id, run_id)
+        )
+
+    # Run-ids from the metadata service are integers. External schedulers use
+    # non-integer run-ids to avoid clashes.
+    try:
+        int(run_id)
+    except ValueError:
+        pass
+    else:
+        raise CommandException("run-id %s cannot be an integer" % run_id)
 
 
 def config_callback(ctx, param, value):
@@ -271,16 +305,7 @@ def resume(
 
         steps_to_rerun = {step_to_rerun}
 
-    if run_id:
-        # Run-ids that are provided by the metadata service are always integers.
-        # External providers or run-ids (like external schedulers) always need to
-        # be non-integers to avoid any clashes. This condition ensures this.
-        try:
-            int(run_id)
-        except:
-            pass
-        else:
-            raise CommandException("run-id %s cannot be an integer" % run_id)
+    _validate_resume_run_id(obj.flow.name, run_id, reentrant=reentrant)
 
     runtime = NativeRuntime(
         obj.flow,

--- a/test/unit/test_resume_run_id_validation.py
+++ b/test/unit/test_resume_run_id_validation.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metaflow.cli_components.run_cmds import _validate_resume_run_id
+from metaflow.exception import CommandException, MetaflowNotFound
+
+
+def test_existing_run_id_raises_helpful_error():
+    with patch("metaflow.client.core.Run", return_value=MagicMock()):
+        with pytest.raises(CommandException) as exc_info:
+            _validate_resume_run_id("TestFlow", "123")
+
+    msg = str(exc_info.value)
+    assert "Run ID 123 already exists" in msg
+    assert "resume --origin-run-id 123" in msg
+    assert "resume --run-id 123" in msg
+
+
+def test_new_non_integer_run_id_allowed():
+    with patch(
+        "metaflow.client.core.Run",
+        side_effect=MetaflowNotFound("missing"),
+    ):
+        _validate_resume_run_id("TestFlow", "scheduler-run-abc")
+
+
+def test_new_integer_run_id_rejected():
+    with patch(
+        "metaflow.client.core.Run",
+        side_effect=MetaflowNotFound("missing"),
+    ):
+        with pytest.raises(CommandException, match="cannot be an integer"):
+            _validate_resume_run_id("TestFlow", "999")
+
+
+def test_reentrant_resume_skips_run_id_validation():
+    with patch("metaflow.client.core.Run") as run_mock:
+        _validate_resume_run_id("TestFlow", "123", reentrant=True)
+
+    run_mock.assert_not_called()
+
+
+def test_no_run_id_skips_validation():
+    with patch("metaflow.client.core.Run") as run_mock:
+        _validate_resume_run_id("TestFlow", None)
+
+    run_mock.assert_not_called()

--- a/test/unit/test_resume_run_id_validation.py
+++ b/test/unit/test_resume_run_id_validation.py
@@ -1,48 +1,56 @@
-from unittest.mock import MagicMock, patch
-
 import pytest
 
 from metaflow.cli_components.run_cmds import _validate_resume_run_id
 from metaflow.exception import CommandException, MetaflowNotFound
 
 
-def test_existing_run_id_raises_helpful_error():
-    with patch("metaflow.client.core.Run", return_value=MagicMock()):
-        with pytest.raises(CommandException) as exc_info:
-            _validate_resume_run_id("TestFlow", "123")
+def test_existing_run_id_raises_helpful_error(mocker):
+    """Test that attempting to resume with an existing run ID raises an error."""
+    mocker.patch("metaflow.client.core.Run", return_value=mocker.MagicMock())
+
+    with pytest.raises(CommandException) as exc_info:
+        _validate_resume_run_id("TestFlow", "ext-scheduler-run")
 
     msg = str(exc_info.value)
-    assert "Run ID 123 already exists" in msg
-    assert "resume --origin-run-id 123" in msg
-    assert "resume --run-id 123" in msg
+    assert "Run ID ext-scheduler-run already exists" in msg
+    assert "resume --origin-run-id ext-scheduler-run" in msg
+    assert "resume --run-id ext-scheduler-run" in msg
 
 
-def test_new_non_integer_run_id_allowed():
-    with patch(
+def test_new_non_integer_run_id_allowed(mocker):
+    """Test that a new non-integer run ID is allowed."""
+    mocker.patch(
         "metaflow.client.core.Run",
         side_effect=MetaflowNotFound("missing"),
-    ):
-        _validate_resume_run_id("TestFlow", "scheduler-run-abc")
+    )
+
+    _validate_resume_run_id("TestFlow", "scheduler-run-abc")
 
 
-def test_new_integer_run_id_rejected():
-    with patch(
+def test_new_integer_run_id_rejected(mocker):
+    """Test that a new integer run ID is rejected."""
+    mocker.patch(
         "metaflow.client.core.Run",
         side_effect=MetaflowNotFound("missing"),
-    ):
-        with pytest.raises(CommandException, match="cannot be an integer"):
-            _validate_resume_run_id("TestFlow", "999")
+    )
+
+    with pytest.raises(CommandException, match="cannot be an integer"):
+        _validate_resume_run_id("TestFlow", "999")
 
 
-def test_reentrant_resume_skips_run_id_validation():
-    with patch("metaflow.client.core.Run") as run_mock:
-        _validate_resume_run_id("TestFlow", "123", reentrant=True)
+def test_reentrant_resume_skips_run_id_validation(mocker):
+    """Test that reentrant resume skips run ID validation."""
+    run_mock = mocker.patch("metaflow.client.core.Run")
+
+    _validate_resume_run_id("TestFlow", "123", reentrant=True)
 
     run_mock.assert_not_called()
 
 
-def test_no_run_id_skips_validation():
-    with patch("metaflow.client.core.Run") as run_mock:
-        _validate_resume_run_id("TestFlow", None)
+def test_no_run_id_skips_validation(mocker):
+    """Test that validation is skipped when no run ID is provided."""
+    run_mock = mocker.patch("metaflow.client.core.Run")
+
+    _validate_resume_run_id("TestFlow", None)
 
     run_mock.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes issue #3229 by adding validation for resume workflows when a user specifies a `--run-id` that already exists.

Previously, Metaflow could continue execution when a user accidentally ran:

```bash
python flow.py resume --run-id <existing_run_id>
```

instead of:

```bash
python flow.py resume --origin-run-id <existing_run_id>
```

This could lead to unexpected behavior and mixing of execution metadata between the original run and the resumed run.

## Changes

* Added validation to detect when a resume operation attempts to use an existing run ID.
* Fail early with a clear error message instead of continuing execution.
* Preserved existing behavior for valid resume workflows using `--origin-run-id`.
* Added/updated tests to cover duplicate run ID validation during resume operations.

## Example

Before:

```bash
python flow.py resume --run-id 123
```

If run `123` already existed, Metaflow could continue execution unexpectedly.

After:

```bash
python flow.py resume --run-id 123
```

Metaflow now raises a validation error and guides the user toward using:

```bash
python flow.py resume --origin-run-id 123
```

## Testing

* Verified duplicate run IDs are rejected during resume operations.
* Verified valid resume workflows continue to work as expected.
* Verified normal run creation behavior remains unchanged.

Fixes #3229
