### PR TITLE
fix: raise on 404 in ArgoClient.get_workflow_templates (#3239)

### DIFF
--- a/metaflow/plugins/argo/argo_client.py
+++ b/metaflow/plugins/argo/argo_client.py
@@ -109,7 +109,7 @@ class ArgoClient(object):
                 error_body = json.loads(e.body) if e.body else {}
                 error_message = error_body.get("message", e.reason)
                 if e.status == 404:
-                    return None
+                    raise ArgoClientException(error_message)
                 elif e.status == 410 and error_body.get("reason") == "Expired":
                     new_token = error_body.get("metadata", {}).get("continue")
                     if new_token:

--- a/test/unit/test_argo_client.py
+++ b/test/unit/test_argo_client.py
@@ -1,0 +1,44 @@
+import pytest
+from kubernetes.client.rest import ApiException
+
+from metaflow.plugins.argo.argo_client import ArgoClient, ArgoClientException
+
+
+@pytest.fixture
+def argo_client(mocker):
+    mock_custom_objects_api = mocker.Mock()
+    mock_k8s = mocker.Mock()
+    mock_k8s.CustomObjectsApi.return_value = mock_custom_objects_api
+    mock_k8s.rest.ApiException = ApiException
+
+    mock_kubernetes_client = mocker.Mock()
+    mock_kubernetes_client.get.return_value = mock_k8s
+
+    mocker.patch(
+        "metaflow.plugins.argo.argo_client.KubernetesClient",
+        return_value=mock_kubernetes_client,
+    )
+
+    client = ArgoClient(namespace="test-ns")
+    return client, mock_custom_objects_api
+
+
+def test_get_workflow_templates_404_raises(argo_client):
+    client, mock_api = argo_client
+    api_error = ApiException(status=404, reason="Not Found")
+    api_error.body = '{"message": "workflowtemplates.argoproj.io not found"}'
+    mock_api.list_namespaced_custom_object.side_effect = api_error
+
+    with pytest.raises(ArgoClientException):
+        list(client.get_workflow_templates())
+
+
+def test_get_workflow_templates_empty_200_does_not_raise(argo_client):
+    client, mock_api = argo_client
+    mock_api.list_namespaced_custom_object.return_value = {
+        "items": [],
+        "metadata": {},
+    }
+
+    result = list(client.get_workflow_templates())
+    assert result == []


### PR DESCRIPTION
## PR Type
- [x] Bug fix

## Summary
`get_workflow_templates` silently yields `[]` on a 404, making an enumeration failure indistinguishable from a healthy empty namespace.

## Issue
Fixes #3239

## Root Cause
`return None` inside a generator stops iteration without raising. A 404 on `list_namespaced_custom_object` means the namespace or CRD is missing — not "zero templates" (that's a 200 with `items: []`).

## Why This Fix Is Correct
`error_message` is already constructed before the 404 branch. Every other non-410 status in that block raises `ArgoClientException(error_message)` — this makes 404 consistent with that fallthrough. Singular getters keep `return None` on 404; there a missing named resource is the correct semantic.

## Tests
- [x] Unit tests added/updated
- [x] CI passes

Two tests added:
- `test_get_workflow_templates_404_raises` — 404 raises `ArgoClientException`
- `test_get_workflow_templates_empty_200_does_not_raise` — empty 200 yields `[]`

## Non-Goals
Singular getters (`get_workflow_template`, etc.) intentionally not changed.

## AI Tool Usage
- [x] AI tools were used (describe below)

Used Cursor for initial analysis assistance. Reviewed, understood, and tested all code personally.