### PR TITLE
Fix/logs help default command

### DIFF
--- a/metaflow/plugins/logs_cli.py
+++ b/metaflow/plugins/logs_cli.py
@@ -28,19 +28,29 @@ class CustomGroup(click.Group):
         return super(CustomGroup, self).get_command(ctx, cmd_name)
 
     def parse_args(self, ctx, args):
-        # We first try to parse args as is, to determine whether we need to fall back to the default commmand
+        # We first try to parse args as is, to determine whether we need to fall back to the default command
         # if any options are supplied, the parse will fail, as the group does not support the options.
         # In this case we fallback to the default command, inserting that as the first arg and parsing again.
         # copy args as trying to parse will destroy them.
         original_args = list(args)
+
+        help_option = self.get_help_option(ctx)
+        help_option_names = set(ctx.help_option_names)
+        if help_option is not None:
+            help_option_names.update(help_option.opts)
+        if original_args and original_args[0] in help_option_names:
+            click.echo(ctx.get_help(), color=ctx.color)
+            ctx.exit()
+
+        if not original_args:
+            return super().parse_args(ctx, [self.default_cmd])
+
         try:
-            super().parse_args(ctx, args)
-            args_parseable = True
+            return super().parse_args(ctx, args)
+        except click.exceptions.Exit:
+            raise
         except Exception:
-            args_parseable = False
-        if not args or not args_parseable:
-            original_args.insert(0, self.default_cmd)
-        return super().parse_args(ctx, original_args)
+            return super().parse_args(ctx, [self.default_cmd] + original_args)
 
     def resolve_command(self, ctx, args):
         cmd_name, cmd_obj, args = super(CustomGroup, self).resolve_command(ctx, args)

--- a/metaflow/plugins/logs_cli.py
+++ b/metaflow/plugins/logs_cli.py
@@ -34,14 +34,6 @@ class CustomGroup(click.Group):
         # copy args as trying to parse will destroy them.
         original_args = list(args)
 
-        help_option = self.get_help_option(ctx)
-        help_option_names = set(ctx.help_option_names)
-        if help_option is not None:
-            help_option_names.update(help_option.opts)
-        if original_args and original_args[0] in help_option_names:
-            click.echo(ctx.get_help(), color=ctx.color)
-            ctx.exit()
-
         if not original_args:
             return super().parse_args(ctx, [self.default_cmd])
 

--- a/test/unit/test_logs_cli.py
+++ b/test/unit/test_logs_cli.py
@@ -71,3 +71,28 @@ def test_logs_legacy_pathspec_routes_to_default_show():
             },
         )
     ]
+
+
+def test_logs_legacy_show_option_routes_to_default_show():
+    calls = []
+    logs_group = _make_logs_group(calls)
+
+    obj = SimpleNamespace(
+        echo=lambda *args, **kwargs: None,
+        flow_datastore=object(),
+    )
+    result = CliRunner().invoke(logs_group, ["--stdout", "123/start/1"], obj=obj)
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            "123/start/1",
+            {
+                "stdout": True,
+                "stderr": False,
+                "both": True,
+                "timestamps": False,
+                "attempt": None,
+            },
+        )
+    ]

--- a/test/unit/test_logs_cli.py
+++ b/test/unit/test_logs_cli.py
@@ -1,36 +1,53 @@
 from types import SimpleNamespace
 
+import pytest
+
 from metaflow._vendor import click
 from metaflow._vendor.click.testing import CliRunner
 from metaflow.plugins.logs_cli import CustomGroup
 
 
-def _make_logs_group(calls=None):
-    @click.group(name="logs", cls=CustomGroup, default_cmd="show")
-    def logs_group():
-        pass
-
-    @logs_group.command()
-    @click.argument("input-path")
-    @click.option("--stdout/--no-stdout", default=False, show_default=True)
-    @click.option("--stderr/--no-stderr", default=False, show_default=True)
-    @click.option("--both/--no-both", default=True, show_default=True)
-    @click.option("--timestamps/--no-timestamps", default=False, show_default=True)
-    @click.option("--attempt", default=None, type=int)
-    @click.pass_obj
-    def show(obj, input_path, **kwargs):
-        if calls is not None:
-            calls.append((input_path, kwargs))
-
-    @logs_group.command()
-    def scrub():
-        pass
-
-    return logs_group
+INPUT_PATH = "123/start/1"
 
 
-def test_logs_help_does_not_include_show_help():
-    logs_group = _make_logs_group()
+@pytest.fixture
+def make_logs_group():
+    def _make_logs_group(show_callback=None):
+        @click.group(name="logs", cls=CustomGroup, default_cmd="show")
+        def logs_group():
+            pass
+
+        @logs_group.command()
+        @click.argument("input-path")
+        @click.option("--stdout/--no-stdout", default=False, show_default=True)
+        @click.option("--stderr/--no-stderr", default=False, show_default=True)
+        @click.option("--both/--no-both", default=True, show_default=True)
+        @click.option("--timestamps/--no-timestamps", default=False, show_default=True)
+        @click.option("--attempt", default=None, type=int)
+        @click.pass_obj
+        def show(obj, input_path, **kwargs):
+            if show_callback is not None:
+                show_callback(input_path, **kwargs)
+
+        @logs_group.command()
+        def scrub():
+            pass
+
+        return logs_group
+
+    return _make_logs_group
+
+
+@pytest.fixture
+def logs_obj():
+    return SimpleNamespace(
+        echo=lambda *args, **kwargs: None,
+        flow_datastore=object(),
+    )
+
+
+def test_logs_help_does_not_include_show_help(make_logs_group):
+    logs_group = make_logs_group()
     result = CliRunner().invoke(logs_group, ["--help"])
 
     assert result.exit_code == 0
@@ -39,29 +56,19 @@ def test_logs_help_does_not_include_show_help():
     assert "logs show [OPTIONS] INPUT_PATH" not in result.output
 
 
-def test_logs_show_help_still_works():
-    logs_group = _make_logs_group()
-    obj = SimpleNamespace(echo=lambda *args, **kwargs: None)
-    result = CliRunner().invoke(logs_group, ["show", "--help"], obj=obj)
+def test_logs_show_help_still_works(make_logs_group, logs_obj):
+    logs_group = make_logs_group()
+    result = CliRunner().invoke(logs_group, ["show", "--help"], obj=logs_obj)
 
     assert result.exit_code == 0
     assert "logs show [OPTIONS] INPUT_PATH" in result.output
 
 
-def test_logs_legacy_pathspec_routes_to_default_show():
-    calls = []
-    logs_group = _make_logs_group(calls)
-
-    obj = SimpleNamespace(
-        echo=lambda *args, **kwargs: None,
-        flow_datastore=object(),
-    )
-    result = CliRunner().invoke(logs_group, ["123/start/1"], obj=obj)
-
-    assert result.exit_code == 0
-    assert calls == [
+@pytest.mark.parametrize(
+    "args, expected_options",
+    [
         (
-            "123/start/1",
+            [INPUT_PATH],
             {
                 "stdout": False,
                 "stderr": False,
@@ -69,24 +76,9 @@ def test_logs_legacy_pathspec_routes_to_default_show():
                 "timestamps": False,
                 "attempt": None,
             },
-        )
-    ]
-
-
-def test_logs_legacy_show_option_routes_to_default_show():
-    calls = []
-    logs_group = _make_logs_group(calls)
-
-    obj = SimpleNamespace(
-        echo=lambda *args, **kwargs: None,
-        flow_datastore=object(),
-    )
-    result = CliRunner().invoke(logs_group, ["--stdout", "123/start/1"], obj=obj)
-
-    assert result.exit_code == 0
-    assert calls == [
+        ),
         (
-            "123/start/1",
+            ["--stdout", INPUT_PATH],
             {
                 "stdout": True,
                 "stderr": False,
@@ -94,5 +86,17 @@ def test_logs_legacy_show_option_routes_to_default_show():
                 "timestamps": False,
                 "attempt": None,
             },
-        )
-    ]
+        ),
+    ],
+    ids=["pathspec", "show-option"],
+)
+def test_logs_legacy_args_route_to_default_show(
+    make_logs_group, logs_obj, mocker, args, expected_options
+):
+    show_callback = mocker.Mock()
+    logs_group = make_logs_group(show_callback)
+
+    result = CliRunner().invoke(logs_group, args, obj=logs_obj)
+
+    assert result.exit_code == 0
+    show_callback.assert_called_once_with(INPUT_PATH, **expected_options)

--- a/test/unit/test_logs_cli.py
+++ b/test/unit/test_logs_cli.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+
+from metaflow._vendor import click
+from metaflow._vendor.click.testing import CliRunner
+from metaflow.plugins.logs_cli import CustomGroup
+
+
+def _make_logs_group(calls=None):
+    @click.group(name="logs", cls=CustomGroup, default_cmd="show")
+    def logs_group():
+        pass
+
+    @logs_group.command()
+    @click.argument("input-path")
+    @click.option("--stdout/--no-stdout", default=False, show_default=True)
+    @click.option("--stderr/--no-stderr", default=False, show_default=True)
+    @click.option("--both/--no-both", default=True, show_default=True)
+    @click.option("--timestamps/--no-timestamps", default=False, show_default=True)
+    @click.option("--attempt", default=None, type=int)
+    @click.pass_obj
+    def show(obj, input_path, **kwargs):
+        if calls is not None:
+            calls.append((input_path, kwargs))
+
+    @logs_group.command()
+    def scrub():
+        pass
+
+    return logs_group
+
+
+def test_logs_help_does_not_include_show_help():
+    logs_group = _make_logs_group()
+    result = CliRunner().invoke(logs_group, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Usage: " in result.output
+    assert "logs [OPTIONS] COMMAND [ARGS]" in result.output
+    assert "logs show [OPTIONS] INPUT_PATH" not in result.output
+
+
+def test_logs_show_help_still_works():
+    logs_group = _make_logs_group()
+    obj = SimpleNamespace(echo=lambda *args, **kwargs: None)
+    result = CliRunner().invoke(logs_group, ["show", "--help"], obj=obj)
+
+    assert result.exit_code == 0
+    assert "logs show [OPTIONS] INPUT_PATH" in result.output
+
+
+def test_logs_legacy_pathspec_routes_to_default_show():
+    calls = []
+    logs_group = _make_logs_group(calls)
+
+    obj = SimpleNamespace(
+        echo=lambda *args, **kwargs: None,
+        flow_datastore=object(),
+    )
+    result = CliRunner().invoke(logs_group, ["123/start/1"], obj=obj)
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            "123/start/1",
+            {
+                "stdout": False,
+                "stderr": False,
+                "both": True,
+                "timestamps": False,
+                "attempt": None,
+            },
+        )
+    ]


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix

## Summary

Fix `logs --help` so it shows only the `logs` group help instead of also falling through to the default `logs show` command help.

## Issue 

Fixes [#3251](https://github.com/Netflix/metaflow/issues/3251)

## Reproduction

<!-- Required for bug fixes. Required for Core Runtime changes. -->
<!-- Provide a minimal reproduction that fails before and succeeds after. -->

**Runtime:** local

**Commands to run:**
```bash
PYTHONPATH=. python metaflow/tutorials/00-helloworld/helloworld.py logs --help
PYTHONPATH=. python metaflow/tutorials/00-helloworld/helloworld.py logs show --help
```

**Where evidence shows up:**  parent console

<details>
<summary>Before (error / log snippet)</summary>

```
Usage: helloworld.py logs [OPTIONS] COMMAND [ARGS]...

  Commands related to logs

Options:
  --help  Show this message and exit.

Commands:
  scrub           Scrub stdout/stderr produced by a task or all tasks in a
                  step.

  show [Default]  Show stdout/stderr produced by a task or all tasks in a
                  step.
Usage: helloworld.py logs show [OPTIONS] INPUT_PATH

  Show stdout/stderr produced by a task or all tasks in a step.
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
Usage: helloworld.py logs [OPTIONS] COMMAND [ARGS]...

  Commands related to logs

Options:
  --help  Show this message and exit.

Commands:
  scrub           Scrub stdout/stderr produced by a task or all tasks in a
                  step.

  show [Default]  Show stdout/stderr produced by a task or all tasks in a
                  step.
```

</details>

## Root Cause

logs uses a custom CustomGroup to preserve backward compatibility for legacy invocations such as logs <pathspec>, treating them as logs show <pathspec>.

The fallback logic in CustomGroup.parse_args() was too broad. It first attempted to parse the provided args, and if parsing consumed the argument list or failed, it retried with the default command inserted. Group-level help is handled by Click during parsing, so logs --help could be treated like a fallback case and append logs show --help output after the group help.

## Why This Fix Is Correct

The fix handles group-level help before default-command fallback. This restores the expected Click invariant:

logs --help shows group help.
logs show --help shows subcommand help.
logs <pathspec> still routes to the default show command.
The change is minimal because it stays inside the existing CustomGroup.parse_args() compatibility layer and does not change datastore, log loading, or command behavior outside argument parsing.

## Failure Modes Considered

The fix handles group-level help before default-command fallback. This restores the expected Click invariant:

logs --help shows group help.
logs show --help shows subcommand help.
logs <pathspec> still routes to the default show command.

## Tests

- [x] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [ ] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

This PR does not change log retrieval, log scrubbing, datastore behavior, or the existing default-command design for logs.

## AI Tool Usage
- [x] AI tools were used 

GPT-5.5

AI tools were used to inspect the relevant CLI code, propose the minimal parser fix, and draft tests. I reviewed the generated changes and verified them locally with focused unit tests and manual CLI checks.
