### PR TITLE
fix: regression with StepMutator running multiple times in some cases

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -939,22 +939,12 @@ def _init_step_decorators(
             inserted_by_value = [deco.decorator_name] + (deco.inserted_by or [])
 
             if isinstance(deco, StepMutator):
-                # Before (re)running the mutator, remove any decorators it
-                # previously inserted in order to prevent adding duplicate decorators.
-                mutator_name = deco.decorator_name
-                step.decorators = [
-                    d
-                    for d in step.decorators
-                    if not (d.inserted_by and d.inserted_by[0] == mutator_name)
-                ]
-                step.wrappers = [
-                    d
-                    for d in (step.wrappers or [])
-                    if not (
-                        getattr(d, "inserted_by", None)
-                        and d.inserted_by[0] == mutator_name
-                    )
-                ]
+                # Guard against calling mutate more than once (e.g. if
+                # _init_step_decorators is invoked multiple times), which could
+                # have adverse effects for allow_multiple decorators like @card.
+                if deco._mutate_called:
+                    continue
+
                 debug.userconf_exec(
                     "Evaluating step level decorator %s for %s (mutate)"
                     % (deco.__class__.__name__, step.name)
@@ -968,6 +958,7 @@ def _init_step_decorators(
                         inserted_by=inserted_by_value,
                     )
                 )
+                deco._mutate_called = True
             else:
                 raise MetaflowInternalError(
                     "A non StepMutator found in step custom decorators"
@@ -1058,17 +1049,30 @@ def _process_late_attached_decorator(
             continue
         for deco in s.config_decorators:
             if isinstance(deco, StepMutator):
-                # Before (re)running the mutator, remove any decorators it
-                # previously inserted in order to prevent adding duplicate decorators.
+                # Guard against calling the same mutator more than once within
+                # this late-attached pass (e.g. if this function is called
+                # multiple times).  We use a separate flag (_late_mutate_called)
+                # so that a mutator already called by _init_step_decorators
+                # (_mutate_called=True) is still re-run here when @kubernetes
+                # (or similar) is genuinely late-attached.
+                if deco._late_mutate_called:
+                    continue
+                # Before re-running, remove any step decorators that this
+                # mutator inserted during the earlier _init_step_decorators
+                # pass so that the re-run is idempotent. Without this,
+                # allow_multiple decorators (e.g. @card) added by the mutator would duplicate.
                 mutator_name = deco.decorator_name
                 s.decorators = [
                     d
                     for d in s.decorators
-                    if not (d.inserted_by and d.inserted_by[0] == mutator_name)
+                    if not (
+                        getattr(d, "inserted_by", None)
+                        and d.inserted_by[0] == mutator_name
+                    )
                 ]
                 s.wrappers = [
                     d
-                    for d in (s.wrappers or [])
+                    for d in s.wrappers
                     if not (
                         getattr(d, "inserted_by", None)
                         and d.inserted_by[0] == mutator_name
@@ -1088,6 +1092,7 @@ def _process_late_attached_decorator(
                         inserted_by=inserted_by_value,
                     )
                 )
+                deco._late_mutate_called = True
                 mutators_ran = True
 
     # Rebuild the graph so node.decorators reflects mutator changes (OVERRIDE).

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -939,30 +939,17 @@ def _init_step_decorators(
             inserted_by_value = [deco.decorator_name] + (deco.inserted_by or [])
 
             if isinstance(deco, StepMutator):
-                # Guard against calling mutate more than once (e.g. if
-                # _init_step_decorators is invoked multiple times), which could
-                # have adverse effects for allow_multiple decorators like @card.
-                # Also skip if _process_late_attached_decorator already ran the
-                # mutator (_late_mutate_called=True): that happens when a
-                # platform's flow_init late-attaches decorators *before*
-                # _init_step_decorators is called (conda/pypi pattern).
-                if deco._mutate_called or deco._late_mutate_called:
+                # Skip if mutate() already ran (e.g. a @conda/@pypi late-attach pass
+                # ran it before this normal pass). The late-attach pass re-runs
+                # idempotently when genuinely new decorators appear.
+                if deco._mutate_called:
                     continue
-
-                debug.userconf_exec(
-                    "Evaluating step level decorator %s for %s (mutate)"
-                    % (deco.__class__.__name__, step.name)
+                _run_step_mutator(
+                    cls,
+                    step,
+                    deco,
+                    "Evaluating step level decorator %s for %s (mutate)",
                 )
-                deco.mutate(
-                    MutableStep(
-                        cls,
-                        step,
-                        pre_mutate=False,
-                        statically_defined=deco.statically_defined,
-                        inserted_by=inserted_by_value,
-                    )
-                )
-                deco._mutate_called = True
             else:
                 raise MetaflowInternalError(
                     "A non StepMutator found in step custom decorators"
@@ -1048,55 +1035,28 @@ def _process_late_attached_decorator(
     # This mirrors the StepMutator handling in _init_step_decorators.
     cls = flow.__class__
     mutators_ran = False
+    reinit_decorator_ids = set()
+    reinit_wrapper_ids = set()
     for s in cls._steps:
         if s.name not in late_attached_step_names:
             continue
         for deco in s.config_decorators:
             if isinstance(deco, StepMutator):
-                # Guard against calling the same mutator more than once within
-                # this late-attached pass (e.g. if this function is called
-                # multiple times).  We use a separate flag (_late_mutate_called)
-                # so that a mutator already called by _init_step_decorators
-                # (_mutate_called=True) is still re-run here when @kubernetes
-                # (or similar) is genuinely late-attached.
-                if deco._late_mutate_called:
-                    continue
-                # Before re-running, remove any step decorators that this
-                # mutator inserted during the earlier _init_step_decorators
-                # pass so that the re-run is idempotent. Without this,
-                # allow_multiple decorators (e.g. @card) added by the mutator would duplicate.
-                mutator_name = deco.decorator_name
-                s.decorators = [
-                    d
-                    for d in s.decorators
-                    if not (
-                        getattr(d, "inserted_by", None)
-                        and d.inserted_by[0] == mutator_name
-                    )
-                ]
-                s.wrappers = [
-                    d
-                    for d in s.wrappers
-                    if not (
-                        getattr(d, "inserted_by", None)
-                        and d.inserted_by[0] == mutator_name
-                    )
-                ]
-                inserted_by_value = [deco.decorator_name] + (deco.inserted_by or [])
-                debug.userconf_exec(
-                    "Re-evaluating step level decorator %s for %s (mutate) after "
-                    "late attachment" % (deco.__class__.__name__, s.name)
+                # We do NOT use a one-shot guard here: every genuinely new late
+                # attachment (gated by late_attached_step_names / _ran_init) must be
+                # able to re-run the mutator so it can react to it.
+                already_ran = deco._mutate_called
+                if already_ran:
+                    _remove_step_mutator_outputs(s, deco)
+                inserted = _run_step_mutator(
+                    cls,
+                    s,
+                    deco,
+                    "Re-evaluating step level decorator %s for %s (mutate) after late attachment",
                 )
-                deco.mutate(
-                    MutableStep(
-                        cls,
-                        s,
-                        pre_mutate=False,
-                        statically_defined=deco.statically_defined,
-                        inserted_by=inserted_by_value,
-                    )
-                )
-                deco._late_mutate_called = True
+                if already_ran:
+                    reinit_decorator_ids |= inserted["decorators"]
+                    reinit_wrapper_ids |= inserted["wrappers"]
                 mutators_ran = True
 
     # Rebuild the graph so node.decorators reflects mutator changes (OVERRIDE).
@@ -1104,18 +1064,20 @@ def _process_late_attached_decorator(
         cls._init_graph()
         graph = flow._graph
 
-    # Init late-attached decorators only now, after mutators ran, so a decorator
-    # replaced via OVERRIDE is never external_init'd. external_init is idempotent.
+    # Init late-attached decorators, plus any replacement outputs a re-run mutator
+    # just added (their initialized originals were removed above).
     for s in flow:
         for deco in s.decorators:
-            if deco.name in deco_names:
+            if deco.name in deco_names or id(deco) in reinit_decorator_ids:
+                deco.external_init()
+        for deco in s.wrappers or []:
+            if id(deco) in reinit_wrapper_ids:
                 deco.external_init()
 
     for s in flow:
         system_context.register_step_decorators(s.__name__, list(s.decorators))
-
         for deco in s.decorators:
-            if deco.name in deco_names:
+            if deco.name in deco_names or id(deco) in reinit_decorator_ids:
                 if _should_skip_decorator_for_spin(
                     deco, is_spin, skip_decorators, logger, "Step decorator"
                 ):
@@ -1241,3 +1203,36 @@ def _import_plugin_decorators(globals_dict):
     # add flow-level decorators
     for decotype in FLOW_DECORATORS:
         globals_dict[decotype.name] = partial(_base_flow_decorator, decotype)
+
+
+def _run_step_mutator(cls, step, deco, message):
+    inserted_by_value = [deco.decorator_name] + (deco.inserted_by or [])
+    before_decos = {id(d) for d in step.decorators}
+    before_wraps = {id(d) for d in (step.wrappers or [])}
+    debug.userconf_exec(message % (deco.__class__.__name__, step.name))
+    deco.mutate(
+        MutableStep(
+            cls,
+            step,
+            pre_mutate=False,
+            statically_defined=deco.statically_defined,
+            inserted_by=inserted_by_value,
+        )
+    )
+    deco._mutate_inserted = {
+        "decorators": {id(d) for d in step.decorators if id(d) not in before_decos},
+        "wrappers": {id(d) for d in (step.wrappers or []) if id(d) not in before_wraps},
+    }
+    deco._mutate_called = True
+    return deco._mutate_inserted
+
+
+def _remove_step_mutator_outputs(step, deco):
+    inserted = deco._mutate_inserted
+    if inserted["decorators"]:
+        step.decorators = [
+            d for d in step.decorators if id(d) not in inserted["decorators"]
+        ]
+    if inserted["wrappers"]:
+        step.wrappers = [d for d in step.wrappers if id(d) not in inserted["wrappers"]]
+    deco._mutate_inserted = {"decorators": set(), "wrappers": set()}

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -939,11 +939,6 @@ def _init_step_decorators(
             inserted_by_value = [deco.decorator_name] + (deco.inserted_by or [])
 
             if isinstance(deco, StepMutator):
-                # We do not want to perform step mutation more than once due to this possibly having adverse effects when
-                # f.ex. attaching decorators with allow_multiple=True
-                if getattr(deco, "_mutate_called", False):
-                    continue
-
                 debug.userconf_exec(
                     "Evaluating step level decorator %s for %s (mutate)"
                     % (deco.__class__.__name__, step.name)
@@ -957,7 +952,6 @@ def _init_step_decorators(
                         inserted_by=inserted_by_value,
                     )
                 )
-                setattr(deco, "_mutate_called", True)
             else:
                 raise MetaflowInternalError(
                     "A non StepMutator found in step custom decorators"
@@ -1048,10 +1042,22 @@ def _process_late_attached_decorator(
             continue
         for deco in s.config_decorators:
             if isinstance(deco, StepMutator):
-                # We do not want to perform step mutation more than once due to this possibly having adverse effects when
-                # f.ex. attaching decorators with allow_multiple=True
-                if getattr(deco, "_mutate_called", False):
-                    continue
+                # Before re-running the mutator, remove any decorators it
+                # previously inserted in order to prevent adding duplicate decorators.
+                mutator_name = deco.decorator_name
+                s.decorators = [
+                    d
+                    for d in s.decorators
+                    if not (d.inserted_by and d.inserted_by[0] == mutator_name)
+                ]
+                s.wrappers = [
+                    d
+                    for d in (s.wrappers or [])
+                    if not (
+                        getattr(d, "inserted_by", None)
+                        and d.inserted_by[0] == mutator_name
+                    )
+                ]
                 inserted_by_value = [deco.decorator_name] + (deco.inserted_by or [])
                 debug.userconf_exec(
                     "Re-evaluating step level decorator %s for %s (mutate) after "
@@ -1066,7 +1072,6 @@ def _process_late_attached_decorator(
                         inserted_by=inserted_by_value,
                     )
                 )
-                setattr(deco, "_mutate_called", True)
                 mutators_ran = True
 
     # Rebuild the graph so node.decorators reflects mutator changes (OVERRIDE).

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -939,6 +939,11 @@ def _init_step_decorators(
             inserted_by_value = [deco.decorator_name] + (deco.inserted_by or [])
 
             if isinstance(deco, StepMutator):
+                # We do not want to perform step mutation more than once due to this possibly having adverse effects when
+                # f.ex. attaching decorators with allow_multiple=True
+                if getattr(deco, "_mutate_called", False):
+                    continue
+
                 debug.userconf_exec(
                     "Evaluating step level decorator %s for %s (mutate)"
                     % (deco.__class__.__name__, step.name)
@@ -952,6 +957,7 @@ def _init_step_decorators(
                         inserted_by=inserted_by_value,
                     )
                 )
+                setattr(deco, "_mutate_called", True)
             else:
                 raise MetaflowInternalError(
                     "A non StepMutator found in step custom decorators"
@@ -1042,6 +1048,10 @@ def _process_late_attached_decorator(
             continue
         for deco in s.config_decorators:
             if isinstance(deco, StepMutator):
+                # We do not want to perform step mutation more than once due to this possibly having adverse effects when
+                # f.ex. attaching decorators with allow_multiple=True
+                if getattr(deco, "_mutate_called", False):
+                    continue
                 inserted_by_value = [deco.decorator_name] + (deco.inserted_by or [])
                 debug.userconf_exec(
                     "Re-evaluating step level decorator %s for %s (mutate) after "
@@ -1056,6 +1066,7 @@ def _process_late_attached_decorator(
                         inserted_by=inserted_by_value,
                     )
                 )
+                setattr(deco, "_mutate_called", True)
                 mutators_ran = True
 
     # Rebuild the graph so node.decorators reflects mutator changes (OVERRIDE).

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -942,7 +942,11 @@ def _init_step_decorators(
                 # Guard against calling mutate more than once (e.g. if
                 # _init_step_decorators is invoked multiple times), which could
                 # have adverse effects for allow_multiple decorators like @card.
-                if deco._mutate_called:
+                # Also skip if _process_late_attached_decorator already ran the
+                # mutator (_late_mutate_called=True): that happens when a
+                # platform's flow_init late-attaches decorators *before*
+                # _init_step_decorators is called (conda/pypi pattern).
+                if deco._mutate_called or deco._late_mutate_called:
                     continue
 
                 debug.userconf_exec(

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -939,6 +939,22 @@ def _init_step_decorators(
             inserted_by_value = [deco.decorator_name] + (deco.inserted_by or [])
 
             if isinstance(deco, StepMutator):
+                # Before (re)running the mutator, remove any decorators it
+                # previously inserted in order to prevent adding duplicate decorators.
+                mutator_name = deco.decorator_name
+                step.decorators = [
+                    d
+                    for d in step.decorators
+                    if not (d.inserted_by and d.inserted_by[0] == mutator_name)
+                ]
+                step.wrappers = [
+                    d
+                    for d in (step.wrappers or [])
+                    if not (
+                        getattr(d, "inserted_by", None)
+                        and d.inserted_by[0] == mutator_name
+                    )
+                ]
                 debug.userconf_exec(
                     "Evaluating step level decorator %s for %s (mutate)"
                     % (deco.__class__.__name__, step.name)
@@ -1042,7 +1058,7 @@ def _process_late_attached_decorator(
             continue
         for deco in s.config_decorators:
             if isinstance(deco, StepMutator):
-                # Before re-running the mutator, remove any decorators it
+                # Before (re)running the mutator, remove any decorators it
                 # previously inserted in order to prevent adding duplicate decorators.
                 mutator_name = deco.decorator_name
                 s.decorators = [

--- a/metaflow/user_decorators/user_step_decorator.py
+++ b/metaflow/user_decorators/user_step_decorator.py
@@ -746,6 +746,8 @@ class StepMutator(UserStepDecoratorBase):
     _step_field = "config_decorators"
     _allowed_args = True
     _allowed_kwargs = True
+    _mutate_called = False
+    _late_mutate_called = False
 
     def init(self, *args, **kwargs):
         """

--- a/metaflow/user_decorators/user_step_decorator.py
+++ b/metaflow/user_decorators/user_step_decorator.py
@@ -746,6 +746,7 @@ class StepMutator(UserStepDecoratorBase):
     _step_field = "config_decorators"
     _allowed_args = True
     _allowed_kwargs = True
+    _mutate_called = False
 
     def init(self, *args, **kwargs):
         """

--- a/metaflow/user_decorators/user_step_decorator.py
+++ b/metaflow/user_decorators/user_step_decorator.py
@@ -137,6 +137,13 @@ class UserStepDecoratorBase(metaclass=UserStepDecoratorMeta):
     _allowed_kwargs = False
 
     def __init__(self, *args, **kwargs):
+        # Whether mutate() has already been applied once (by either
+        # _init_step_decorators or an earlier late-attach pass).
+        self._mutate_called = False
+        # Object ids of the decorators/wrappers this mutator inserted on its last
+        # mutate() run, so a late re-run removes exactly its own previous outputs.
+        self._mutate_inserted = {"decorators": set(), "wrappers": set()}
+
         arg = None
         self._args = args
         self._kwargs = {}
@@ -746,8 +753,6 @@ class StepMutator(UserStepDecoratorBase):
     _step_field = "config_decorators"
     _allowed_args = True
     _allowed_kwargs = True
-    _mutate_called = False
-    _late_mutate_called = False
 
     def init(self, *args, **kwargs):
         """

--- a/metaflow/user_decorators/user_step_decorator.py
+++ b/metaflow/user_decorators/user_step_decorator.py
@@ -746,7 +746,6 @@ class StepMutator(UserStepDecoratorBase):
     _step_field = "config_decorators"
     _allowed_args = True
     _allowed_kwargs = True
-    _mutate_called = False
 
     def init(self, *args, **kwargs):
         """

--- a/test/unit/test_late_attached_mutator.py
+++ b/test/unit/test_late_attached_mutator.py
@@ -85,8 +85,8 @@ def _kube(step_obj):
 def test_allow_multiple_decorator_not_duplicated_on_mutator_rerun():
     """Regression test: a StepMutator that adds an allow_multiple decorator (e.g.
     @card) must not accumulate a duplicate when _process_late_attached_decorator
-    re-runs the mutator because a platform decorator (@kubernetes) was late-attached
-    to the same step."""
+    runs *before* _init_step_decorators (as happens with conda/pypi via flow_init).
+    """
 
     class AddCardMutator(StepMutator):
         def mutate(self, mutable_step):
@@ -104,28 +104,26 @@ def test_allow_multiple_decorator_not_duplicated_on_mutator_rerun():
 
     start_step = TestFlow.start
     _init_mutators(start_step)
-    _call_init_step_decorators(TestFlow)
-    _call_init_step_decorators(TestFlow)
 
-    card_count_before = sum(
-        1 for d in start_step.decorators if d.name == "card" and d.inserted_by
-    )
-    assert (
-        card_count_before == 1
-    ), "expected exactly one mutator-added @card before re-run"
-
-    # Late-attach @kubernetes (fresh — _ran_init=False) so the step enters
-    # late_attached_step_names and the mutator re-run is triggered.
+    # Late-attach @kubernetes *before* _init_step_decorators runs — this is the
+    # real production order for conda/pypi (their flow_init calls
+    # _attach_decorators + _process_late_attached_decorator before
+    # _init_step_decorators is called in cli.py).
     decorators._attach_decorators_to_step(start_step, [KubernetesDecorator.name])
 
+    # First late-attach pass: mutator runs here (adds @card), _late_mutate_called=True.
     _call_process_late_attached(TestFlow)
 
-    card_count_after = sum(
+    # _init_step_decorators runs afterwards (as it does in cli.py after flow_init).
+    # Without the fix it sees _mutate_called=False and runs the mutator again → duplicate.
+    _call_init_step_decorators(TestFlow)
+
+    card_count = sum(
         1 for d in start_step.decorators if d.name == "card" and d.inserted_by
     )
-    assert card_count_after == 1, (
+    assert card_count == 1, (
         "mutator re-run must not duplicate allow_multiple decorators; "
-        "got %d @card(id='test_card') instances" % card_count_after
+        "got %d @card(id='test_card') instances" % card_count
     )
 
 

--- a/test/unit/test_late_attached_mutator.py
+++ b/test/unit/test_late_attached_mutator.py
@@ -66,6 +66,7 @@ def _call_process_late_attached(flow_cls):
         logger=_logger,
     )
 
+
 def _call_init_step_decorators(flow_cls):
     flow = flow_cls(use_cli=False)
     decorators._init_step_decorators(
@@ -86,6 +87,7 @@ def test_allow_multiple_decorator_not_duplicated_on_mutator_rerun():
     @card) must not accumulate a duplicate when _process_late_attached_decorator
     re-runs the mutator because a platform decorator (@kubernetes) was late-attached
     to the same step."""
+
     class AddCardMutator(StepMutator):
         def mutate(self, mutable_step):
             mutable_step.add_decorator(card, deco_kwargs={"id": "test_card"})
@@ -107,7 +109,9 @@ def test_allow_multiple_decorator_not_duplicated_on_mutator_rerun():
     card_count_before = sum(
         1 for d in start_step.decorators if d.name == "card" and d.inserted_by
     )
-    assert card_count_before == 1, "expected exactly one mutator-added @card before re-run"
+    assert (
+        card_count_before == 1
+    ), "expected exactly one mutator-added @card before re-run"
 
     # Late-attach @kubernetes (fresh — _ran_init=False) so the step enters
     # late_attached_step_names and the mutator re-run is triggered.

--- a/test/unit/test_late_attached_mutator.py
+++ b/test/unit/test_late_attached_mutator.py
@@ -66,9 +66,69 @@ def _call_process_late_attached(flow_cls):
         logger=_logger,
     )
 
+def _call_init_step_decorators(flow_cls):
+    flow = flow_cls(use_cli=False)
+    decorators._init_step_decorators(
+        flow,
+        flow_cls._graph,
+        environment=None,
+        flow_datastore=_Datastore(),
+        logger=_logger,
+    )
+
 
 def _kube(step_obj):
     return [d for d in step_obj.decorators if d.name == "kubernetes"]
+
+
+def test_allow_multiple_decorator_not_duplicated_on_mutator_rerun(
+    counting_mutator_factory,
+):
+    """Regression test: a StepMutator that adds an allow_multiple decorator (e.g.
+    @card) must not accumulate a duplicate when _process_late_attached_decorator
+    re-runs the mutator because a platform decorator (@kubernetes) was late-attached
+    to the same step."""
+
+    card = pytest.importorskip("metaflow").card
+
+    _, calls = counting_mutator_factory()
+
+    class AddCardMutator(StepMutator):
+        def mutate(self, mutable_step):
+            mutable_step.add_decorator(card, deco_kwargs={"id": "test_card"})
+
+    class TestFlow(FlowSpec):
+        @AddCardMutator()
+        @step
+        def start(self):
+            self.next(self.end)
+
+        @step
+        def end(self):
+            pass
+
+    start_step = TestFlow.start
+    _init_mutators(start_step)
+    _call_init_step_decorators(TestFlow)
+
+    card_count_before = sum(
+        1 for d in start_step.decorators if d.name == "card" and d.inserted_by
+    )
+    assert card_count_before == 1, "expected exactly one mutator-added @card before re-run"
+
+    # Late-attach @kubernetes (fresh — _ran_init=False) so the step enters
+    # late_attached_step_names and the mutator re-run is triggered.
+    decorators._attach_decorators_to_step(start_step, [KubernetesDecorator.name])
+
+    _call_process_late_attached(TestFlow)
+
+    card_count_after = sum(
+        1 for d in start_step.decorators if d.name == "card" and d.inserted_by
+    )
+    assert card_count_after == 1, (
+        "mutator re-run must not duplicate allow_multiple decorators; "
+        "got %d @card(id='test_card') instances" % card_count_after
+    )
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_late_attached_mutator.py
+++ b/test/unit/test_late_attached_mutator.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from metaflow import FlowSpec, StepMutator, step
+from metaflow import FlowSpec, StepMutator, step, card
 from metaflow.user_decorators.user_step_decorator import UserStepDecoratorMeta
 from metaflow import decorators
 
@@ -81,18 +81,11 @@ def _kube(step_obj):
     return [d for d in step_obj.decorators if d.name == "kubernetes"]
 
 
-def test_allow_multiple_decorator_not_duplicated_on_mutator_rerun(
-    counting_mutator_factory,
-):
+def test_allow_multiple_decorator_not_duplicated_on_mutator_rerun():
     """Regression test: a StepMutator that adds an allow_multiple decorator (e.g.
     @card) must not accumulate a duplicate when _process_late_attached_decorator
     re-runs the mutator because a platform decorator (@kubernetes) was late-attached
     to the same step."""
-
-    card = pytest.importorskip("metaflow").card
-
-    _, calls = counting_mutator_factory()
-
     class AddCardMutator(StepMutator):
         def mutate(self, mutable_step):
             mutable_step.add_decorator(card, deco_kwargs={"id": "test_card"})

--- a/test/unit/test_late_attached_mutator.py
+++ b/test/unit/test_late_attached_mutator.py
@@ -3,6 +3,7 @@
 import pytest
 
 from metaflow import FlowSpec, StepMutator, step, card
+from metaflow.plugins.environment_decorator import EnvironmentDecorator
 from metaflow.user_decorators.user_step_decorator import UserStepDecoratorMeta
 from metaflow import decorators
 
@@ -162,3 +163,120 @@ def test_late_attachment_reruns_mutator_only_for_fresh_decorator(
 
     _call_process_late_attached(TestFlow)
     assert calls == expected_calls
+
+
+def test_late_attach_before_init_does_not_duplicate_allow_multiple():
+    """The @conda_base/@pypi_base ordering: those flow decorators call
+    _process_late_attached_decorator from flow_init, which cli.py runs *before*
+    _init_step_decorators. A StepMutator that adds an allow_multiple decorator
+    (e.g. @card) must not be applied by both passes and accumulate a duplicate."""
+
+    class AddCardMutator(StepMutator):
+        def mutate(self, mutable_step):
+            mutable_step.add_decorator(card, deco_kwargs={"id": "test_card"})
+
+    class TestFlow(FlowSpec):
+        @AddCardMutator()
+        @step
+        def start(self):
+            self.next(self.end)
+
+        @step
+        def end(self):
+            pass
+
+    start_step = TestFlow.start
+    _init_mutators(start_step)
+
+    # Late pass first (emulates conda/pypi flow_init), then the normal pass.
+    decorators._attach_decorators_to_step(start_step, [KubernetesDecorator.name])
+    _call_process_late_attached(TestFlow)
+    _call_init_step_decorators(TestFlow)
+
+    card_count = sum(
+        1 for d in start_step.decorators if d.name == "card" and d.inserted_by
+    )
+    assert card_count == 1, (
+        "late-before-init ordering must not duplicate allow_multiple decorators; "
+        "got %d @card(id='test_card') instances" % card_count
+    )
+
+
+def test_distinct_late_attaches_each_rerun_mutator():
+    """PR intent: a genuinely new late-attached decorator must still trigger a
+    mutator re-run so it can react to it. Two distinct late attachments
+    (@environment then @kubernetes) must each re-run the mutator."""
+
+    seen = []
+
+    class SpecRecordingMutator(StepMutator):
+        def mutate(self, mutable_step):
+            seen.append({name for name, _fq, _a, _k in mutable_step.decorator_specs})
+
+    class TestFlow(FlowSpec):
+        @SpecRecordingMutator()
+        @step
+        def start(self):
+            self.next(self.end)
+
+        @step
+        def end(self):
+            pass
+
+    start_step = TestFlow.start
+    _init_mutators(start_step)
+    _call_init_step_decorators(TestFlow)
+
+    decorators._attach_decorators_to_step(start_step, [EnvironmentDecorator.name])
+    decorators._process_late_attached_decorator(
+        [EnvironmentDecorator.name],
+        TestFlow(use_cli=False),
+        TestFlow._graph,
+        environment=None,
+        flow_datastore=_Datastore(),
+        logger=_logger,
+    )
+
+    decorators._attach_decorators_to_step(start_step, [KubernetesDecorator.name])
+    _call_process_late_attached(TestFlow)
+
+    assert any(
+        EnvironmentDecorator.name in s for s in seen
+    ), "mutator must re-run when @environment is late-attached"
+    assert any(
+        KubernetesDecorator.name in s for s in seen
+    ), "mutator must re-run again when @kubernetes is later late-attached"
+
+
+def test_late_rerun_initializes_replacement_output():
+    """When the late pass removes the mutator's previously-inserted (and already
+    initialized) output and re-adds a fresh one, the replacement must be
+    initialized too -- otherwise the surviving decorator silently never receives
+    external_init/step_init."""
+
+    class AddCardMutator(StepMutator):
+        def mutate(self, mutable_step):
+            mutable_step.add_decorator(card, deco_kwargs={"id": "test_card"})
+
+    class TestFlow(FlowSpec):
+        @AddCardMutator()
+        @step
+        def start(self):
+            self.next(self.end)
+
+        @step
+        def end(self):
+            pass
+
+    start_step = TestFlow.start
+    _init_mutators(start_step)
+    _call_init_step_decorators(TestFlow)
+
+    decorators._attach_decorators_to_step(start_step, [KubernetesDecorator.name])
+    _call_process_late_attached(TestFlow)
+
+    cards = [d for d in start_step.decorators if d.name == "card" and d.inserted_by]
+    assert len(cards) == 1
+    assert (
+        cards[0]._ran_init is True
+    ), "the @card surviving the late re-run must be initialized (external_init)"

--- a/test/unit/test_late_attached_mutator.py
+++ b/test/unit/test_late_attached_mutator.py
@@ -105,6 +105,7 @@ def test_allow_multiple_decorator_not_duplicated_on_mutator_rerun():
     start_step = TestFlow.start
     _init_mutators(start_step)
     _call_init_step_decorators(TestFlow)
+    _call_init_step_decorators(TestFlow)
 
     card_count_before = sum(
         1 for d in start_step.decorators if d.name == "card" and d.inserted_by


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

<!-- What user-visible behavior changes? 1-2 sentences. -->

## Issue

<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes #3258

## Reproduction

<!-- Required for bug fixes. Required for Core Runtime changes. -->
<!-- Provide a minimal reproduction that fails before and succeeds after. -->

**Runtime:** <!-- local / kubernetes / batch / argo / etc. -->

**Commands to run:**
```bash
# paste exact commands
```

**Where evidence shows up:** <!-- parent console / task logs / metadata / UI -->

<details>
<summary>Before (error / log snippet)</summary>

```
paste here
```

</details>

<details>
<summary>After (evidence that fix works)</summary>

```
paste here
```

</details>

## Root Cause

<!-- Required for Core Runtime. Recommended for all bug fixes. -->
<!-- Explain the causal chain: what invariant was violated, where in the code. -->
<!-- See PRs #2796, #2751, #2714 for examples of the level of detail we're looking for. -->

## Why This Fix Is Correct

<!-- What invariant is restored? Why is the fix minimal? -->

## Failure Modes Considered

<!-- Required for Core Runtime (at least 2). Recommended for all bug fixes. -->
<!-- Examples: concurrency/retries, subprocess output propagation, env-var leakage, backward compat -->

1.
2.

## Tests

- [x] Unit tests added/updated
- [x] Reproduction script provided (required for Core Runtime)
- [x] CI passes
- [ ] If tests are impractical: explain why below and provide manual evidence above

## Non-Goals

<!-- What you intentionally did not change. Helps reviewers scope their review. -->

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [ ] No AI tools were used in this contribution
- [ ] AI tools were used (describe below)

<!-- If you used AI tools:
- Which tool(s)?
- What did you use them for?
- Did you review, understand, and test all generated code?
-->
