### PR TITLE
fix(client): give specific error for blank/whitespace pathspec components

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -321,6 +321,16 @@ class MetaflowObject(object):
         if pathspec and _object is None:
             ids = pathspec.split("/")
 
+            # Reject blank components (empty string or whitespace-only), e.g. "Flow//Step"
+            # or "Flow/ /Step".  Check before the length tests so the error is specific.
+            blank = [i for i, c in enumerate(ids) if not c.strip()]
+            if blank:
+                raise MetaflowInvalidPathspec(
+                    "Pathspec '%s' has an empty or blank component at position(s) %s. "
+                    "Each '/' must separate non-empty path parts."
+                    % (pathspec, ", ".join(str(p) for p in blank))
+                )
+
             if self._NAME == "flow" and len(ids) != 1:
                 raise MetaflowInvalidPathspec("Expects Flow('FlowName')")
             elif self._NAME == "run" and len(ids) != 2:


### PR DESCRIPTION
## Problem

When a pathspec contains a whitespace-only component (e.g. `"Flow/ /Step"`), the existing code produces a confusing error:

- If the whitespace-only component causes a wrong count → the error says _"Expects Run(...)"_ — no mention of the blank segment
- If there are the right number of components → no error at all (whitespace passes `str.split("/")` silently)

In both cases the user has no clear signal about what is wrong.

## Fix

Add an explicit check before the component-count validation that:
1. Finds all blank or whitespace-only component positions
2. Raises `MetaflowInvalidPathspec` with the offending position(s) called out

```python
blank = [i for i, c in enumerate(ids) if not c.strip()]
if blank:
    raise MetaflowInvalidPathspec(
        "Pathspec '%s' has an empty or blank component at position(s) %s. ..."
        % (pathspec, ...)
    )
```

No behaviour change for valid pathspecs.

Fixes #948 (partial — error message quality)