### PR TITLE
fix(client): guard against MetaflowObject subclasses with unrecognised _NAME

### DIFF
--- a/metaflow/client/core.py
+++ b/metaflow/client/core.py
@@ -269,6 +269,12 @@ class MetaflowObject(object):
     _CHILD_CLASS = None
     _PARENT_CLASS = None
 
+    # Subclasses must override _NAME.  Instantiating MetaflowObject directly
+    # with a pathspec would skip all component-count validation (because "base"
+    # is not in the expected-lengths table), producing hard-to-diagnose bugs.
+    # The guard below makes that misuse explicit.
+    _KNOWN_NAMES = frozenset({"flow", "run", "step", "task", "artifact"})
+
     def __init__(
         self,
         pathspec: Optional[str] = None,
@@ -319,6 +325,17 @@ class MetaflowObject(object):
             # attempt exists".
 
         if pathspec and _object is None:
+            if self._NAME not in self._KNOWN_NAMES:
+                raise MetaflowInternalError(
+                    "MetaflowObject subclass '%s' has _NAME='%s' which is not a "
+                    "recognised object type. Subclasses must set _NAME to one of: %s."
+                    % (
+                        type(self).__name__,
+                        self._NAME,
+                        ", ".join(sorted(self._KNOWN_NAMES)),
+                    )
+                )
+
             ids = pathspec.split("/")
 
             if self._NAME == "flow" and len(ids) != 1:


### PR DESCRIPTION
## Problem

`MetaflowObject._NAME` defaults to `"base"`. The pathspec component-count validation is a chain of `if self._NAME == "flow" ... elif self._NAME == "run" ...` branches. Any subclass that forgets to override `_NAME` (or sets it to an unrecognised value) silently skips **all** count validation and accepts any-length pathspec.

This is a silent failure: no exception is raised, the wrong object is looked up, and the error surfaces far later with a confusing traceback.

## Fix

1. Add a `_KNOWN_NAMES` class attribute (`frozenset` of the five valid names).
2. Add an explicit guard at the start of the pathspec block:

```python
if self._NAME not in self._KNOWN_NAMES:
    raise MetaflowInternalError(
        "MetaflowObject subclass '%s' has _NAME='%s' which is not a recognised ..."
    )
```

This converts a silent, hard-to-debug failure into an immediate, actionable error.

Fixes #948 (partial — defensive correctness)