### PR TITLE
Fix/run cmds help typo

### DIFF
--- a/metaflow/cli_components/run_cmds.py
+++ b/metaflow/cli_components/run_cmds.py
@@ -361,7 +361,7 @@ def resume(
     "tags assigned to the objects produced by this run, just "
     "what existing objects are visible in the client API. You "
     "can enable the global namespace with an empty string."
-    "--namespace=",
+    " --namespace=",
 )
 @click.pass_obj
 def run(

--- a/metaflow/plugins/logs_cli.py
+++ b/metaflow/plugins/logs_cli.py
@@ -28,19 +28,29 @@ class CustomGroup(click.Group):
         return super(CustomGroup, self).get_command(ctx, cmd_name)
 
     def parse_args(self, ctx, args):
-        # We first try to parse args as is, to determine whether we need to fall back to the default commmand
+        # We first try to parse args as is, to determine whether we need to fall back to the default command
         # if any options are supplied, the parse will fail, as the group does not support the options.
         # In this case we fallback to the default command, inserting that as the first arg and parsing again.
         # copy args as trying to parse will destroy them.
         original_args = list(args)
+
+        help_option = self.get_help_option(ctx)
+        help_option_names = set(ctx.help_option_names)
+        if help_option is not None:
+            help_option_names.update(help_option.opts)
+        if original_args and original_args[0] in help_option_names:
+            click.echo(ctx.get_help(), color=ctx.color)
+            ctx.exit()
+
+        if not original_args:
+            return super().parse_args(ctx, [self.default_cmd])
+
         try:
-            super().parse_args(ctx, args)
-            args_parseable = True
+            return super().parse_args(ctx, args)
+        except click.exceptions.Exit:
+            raise
         except Exception:
-            args_parseable = False
-        if not args or not args_parseable:
-            original_args.insert(0, self.default_cmd)
-        return super().parse_args(ctx, original_args)
+            return super().parse_args(ctx, [self.default_cmd] + original_args)
 
     def resolve_command(self, ctx, args):
         cmd_name, cmd_obj, args = super(CustomGroup, self).resolve_command(ctx, args)

--- a/metaflow/plugins/logs_cli.py
+++ b/metaflow/plugins/logs_cli.py
@@ -34,14 +34,6 @@ class CustomGroup(click.Group):
         # copy args as trying to parse will destroy them.
         original_args = list(args)
 
-        help_option = self.get_help_option(ctx)
-        help_option_names = set(ctx.help_option_names)
-        if help_option is not None:
-            help_option_names.update(help_option.opts)
-        if original_args and original_args[0] in help_option_names:
-            click.echo(ctx.get_help(), color=ctx.color)
-            ctx.exit()
-
         if not original_args:
             return super().parse_args(ctx, [self.default_cmd])
 

--- a/test/unit/test_logs_cli.py
+++ b/test/unit/test_logs_cli.py
@@ -71,3 +71,28 @@ def test_logs_legacy_pathspec_routes_to_default_show():
             },
         )
     ]
+
+
+def test_logs_legacy_show_option_routes_to_default_show():
+    calls = []
+    logs_group = _make_logs_group(calls)
+
+    obj = SimpleNamespace(
+        echo=lambda *args, **kwargs: None,
+        flow_datastore=object(),
+    )
+    result = CliRunner().invoke(logs_group, ["--stdout", "123/start/1"], obj=obj)
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            "123/start/1",
+            {
+                "stdout": True,
+                "stderr": False,
+                "both": True,
+                "timestamps": False,
+                "attempt": None,
+            },
+        )
+    ]

--- a/test/unit/test_logs_cli.py
+++ b/test/unit/test_logs_cli.py
@@ -1,36 +1,53 @@
 from types import SimpleNamespace
 
+import pytest
+
 from metaflow._vendor import click
 from metaflow._vendor.click.testing import CliRunner
 from metaflow.plugins.logs_cli import CustomGroup
 
 
-def _make_logs_group(calls=None):
-    @click.group(name="logs", cls=CustomGroup, default_cmd="show")
-    def logs_group():
-        pass
-
-    @logs_group.command()
-    @click.argument("input-path")
-    @click.option("--stdout/--no-stdout", default=False, show_default=True)
-    @click.option("--stderr/--no-stderr", default=False, show_default=True)
-    @click.option("--both/--no-both", default=True, show_default=True)
-    @click.option("--timestamps/--no-timestamps", default=False, show_default=True)
-    @click.option("--attempt", default=None, type=int)
-    @click.pass_obj
-    def show(obj, input_path, **kwargs):
-        if calls is not None:
-            calls.append((input_path, kwargs))
-
-    @logs_group.command()
-    def scrub():
-        pass
-
-    return logs_group
+INPUT_PATH = "123/start/1"
 
 
-def test_logs_help_does_not_include_show_help():
-    logs_group = _make_logs_group()
+@pytest.fixture
+def make_logs_group():
+    def _make_logs_group(show_callback=None):
+        @click.group(name="logs", cls=CustomGroup, default_cmd="show")
+        def logs_group():
+            pass
+
+        @logs_group.command()
+        @click.argument("input-path")
+        @click.option("--stdout/--no-stdout", default=False, show_default=True)
+        @click.option("--stderr/--no-stderr", default=False, show_default=True)
+        @click.option("--both/--no-both", default=True, show_default=True)
+        @click.option("--timestamps/--no-timestamps", default=False, show_default=True)
+        @click.option("--attempt", default=None, type=int)
+        @click.pass_obj
+        def show(obj, input_path, **kwargs):
+            if show_callback is not None:
+                show_callback(input_path, **kwargs)
+
+        @logs_group.command()
+        def scrub():
+            pass
+
+        return logs_group
+
+    return _make_logs_group
+
+
+@pytest.fixture
+def logs_obj():
+    return SimpleNamespace(
+        echo=lambda *args, **kwargs: None,
+        flow_datastore=object(),
+    )
+
+
+def test_logs_help_does_not_include_show_help(make_logs_group):
+    logs_group = make_logs_group()
     result = CliRunner().invoke(logs_group, ["--help"])
 
     assert result.exit_code == 0
@@ -39,29 +56,19 @@ def test_logs_help_does_not_include_show_help():
     assert "logs show [OPTIONS] INPUT_PATH" not in result.output
 
 
-def test_logs_show_help_still_works():
-    logs_group = _make_logs_group()
-    obj = SimpleNamespace(echo=lambda *args, **kwargs: None)
-    result = CliRunner().invoke(logs_group, ["show", "--help"], obj=obj)
+def test_logs_show_help_still_works(make_logs_group, logs_obj):
+    logs_group = make_logs_group()
+    result = CliRunner().invoke(logs_group, ["show", "--help"], obj=logs_obj)
 
     assert result.exit_code == 0
     assert "logs show [OPTIONS] INPUT_PATH" in result.output
 
 
-def test_logs_legacy_pathspec_routes_to_default_show():
-    calls = []
-    logs_group = _make_logs_group(calls)
-
-    obj = SimpleNamespace(
-        echo=lambda *args, **kwargs: None,
-        flow_datastore=object(),
-    )
-    result = CliRunner().invoke(logs_group, ["123/start/1"], obj=obj)
-
-    assert result.exit_code == 0
-    assert calls == [
+@pytest.mark.parametrize(
+    "args, expected_options",
+    [
         (
-            "123/start/1",
+            [INPUT_PATH],
             {
                 "stdout": False,
                 "stderr": False,
@@ -69,24 +76,9 @@ def test_logs_legacy_pathspec_routes_to_default_show():
                 "timestamps": False,
                 "attempt": None,
             },
-        )
-    ]
-
-
-def test_logs_legacy_show_option_routes_to_default_show():
-    calls = []
-    logs_group = _make_logs_group(calls)
-
-    obj = SimpleNamespace(
-        echo=lambda *args, **kwargs: None,
-        flow_datastore=object(),
-    )
-    result = CliRunner().invoke(logs_group, ["--stdout", "123/start/1"], obj=obj)
-
-    assert result.exit_code == 0
-    assert calls == [
+        ),
         (
-            "123/start/1",
+            ["--stdout", INPUT_PATH],
             {
                 "stdout": True,
                 "stderr": False,
@@ -94,5 +86,17 @@ def test_logs_legacy_show_option_routes_to_default_show():
                 "timestamps": False,
                 "attempt": None,
             },
-        )
-    ]
+        ),
+    ],
+    ids=["pathspec", "show-option"],
+)
+def test_logs_legacy_args_route_to_default_show(
+    make_logs_group, logs_obj, mocker, args, expected_options
+):
+    show_callback = mocker.Mock()
+    logs_group = make_logs_group(show_callback)
+
+    result = CliRunner().invoke(logs_group, args, obj=logs_obj)
+
+    assert result.exit_code == 0
+    show_callback.assert_called_once_with(INPUT_PATH, **expected_options)

--- a/test/unit/test_logs_cli.py
+++ b/test/unit/test_logs_cli.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+
+from metaflow._vendor import click
+from metaflow._vendor.click.testing import CliRunner
+from metaflow.plugins.logs_cli import CustomGroup
+
+
+def _make_logs_group(calls=None):
+    @click.group(name="logs", cls=CustomGroup, default_cmd="show")
+    def logs_group():
+        pass
+
+    @logs_group.command()
+    @click.argument("input-path")
+    @click.option("--stdout/--no-stdout", default=False, show_default=True)
+    @click.option("--stderr/--no-stderr", default=False, show_default=True)
+    @click.option("--both/--no-both", default=True, show_default=True)
+    @click.option("--timestamps/--no-timestamps", default=False, show_default=True)
+    @click.option("--attempt", default=None, type=int)
+    @click.pass_obj
+    def show(obj, input_path, **kwargs):
+        if calls is not None:
+            calls.append((input_path, kwargs))
+
+    @logs_group.command()
+    def scrub():
+        pass
+
+    return logs_group
+
+
+def test_logs_help_does_not_include_show_help():
+    logs_group = _make_logs_group()
+    result = CliRunner().invoke(logs_group, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Usage: " in result.output
+    assert "logs [OPTIONS] COMMAND [ARGS]" in result.output
+    assert "logs show [OPTIONS] INPUT_PATH" not in result.output
+
+
+def test_logs_show_help_still_works():
+    logs_group = _make_logs_group()
+    obj = SimpleNamespace(echo=lambda *args, **kwargs: None)
+    result = CliRunner().invoke(logs_group, ["show", "--help"], obj=obj)
+
+    assert result.exit_code == 0
+    assert "logs show [OPTIONS] INPUT_PATH" in result.output
+
+
+def test_logs_legacy_pathspec_routes_to_default_show():
+    calls = []
+    logs_group = _make_logs_group(calls)
+
+    obj = SimpleNamespace(
+        echo=lambda *args, **kwargs: None,
+        flow_datastore=object(),
+    )
+    result = CliRunner().invoke(logs_group, ["123/start/1"], obj=obj)
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            "123/start/1",
+            {
+                "stdout": False,
+                "stderr": False,
+                "both": True,
+                "timestamps": False,
+                "attempt": None,
+            },
+        )
+    ]


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix

## Summary
Fix a missing space in the `run --namespace` help text so the example renders as `empty string. --namespace=` instead of `empty string.--namespace=`.

