### PR TITLE
fix one help-text typo

### DIFF
--- a/metaflow/cli_components/run_cmds.py
+++ b/metaflow/cli_components/run_cmds.py
@@ -361,7 +361,7 @@ def resume(
     "tags assigned to the objects produced by this run, just "
     "what existing objects are visible in the client API. You "
     "can enable the global namespace with an empty string."
-    "--namespace=",
+    " --namespace=",
 )
 @click.pass_obj
 def run(


### PR DESCRIPTION
## PR Type
- [x] Bug fix

## Summary
Fix a missing space in the run --namespace help text so the example renders as empty string. --namespace= instead of empty string.--namespace=.