### PR TITLE
Fix R run argument quoting

### DIFF
--- a/R/R/flags.R
+++ b/R/R/flags.R
@@ -136,6 +136,10 @@ split_flags <- function(arguments) {
 }
 
 split_parameters <- function(flags) {
+  paste(split_parameter_args(flags), collapse = " ")
+}
+
+split_parameter_args <- function(flags) {
   parameters <- !names(flags) %in% c(
     "metaflow_path", "run",
     "batch", "datastore", "metadata",
@@ -154,13 +158,15 @@ split_parameters <- function(flags) {
   )
   parameters <- flags[parameters]
   if (length(parameters) == 0) {
-    valid_params <- ""
+    valid_params <- character()
   } else {
     valid_params <- unlist(lapply(seq_along(parameters), function(x) {
-      paste(paste0("--", names(parameters[x]), " ", unlist(parameters[x])), collapse = " ")
-    })) %>%
-      paste(collapse = " ")
+      name <- paste0("--", gsub("_", "-", names(parameters[x])))
+      values <- as.character(unlist(parameters[x], use.names = FALSE))
+      unlist(lapply(values, function(value) {
+        c(name, value)
+      }), use.names = FALSE)
+    }), use.names = FALSE)
   }
-  valid_params <- gsub("_", "-", valid_params)
   valid_params
 }

--- a/R/R/run.R
+++ b/R/R/run.R
@@ -38,14 +38,18 @@ run <- function(flow = NULL, ...) {
     }
   )
 
-  cmd <- run_cmd(flow_file = flow_file, ...)
-  #message(paste0("Flow cli:\n", cmd))
-  status_code <- system(cmd)
+  args <- run_argv(flow_file = flow_file, ...)
+  #message(paste0("Flow cli:\n", run_cmd(flow_file = flow_file, ...)))
+  status_code <- system2("Rscript", args = shell_quote_args(args))
   invisible(file.remove(flow_file))
   return(invisible(status_code))
 }
 
 run_cmd <- function(flow_file, ...) {
+  paste(shell_quote_args(c("Rscript", run_argv(flow_file = flow_file, ...))), collapse = " ")
+}
+
+run_argv <- function(flow_file, ...) {
   run_options <- list(...)
   flags <- flags(...)
 
@@ -55,12 +59,14 @@ run_cmd <- function(flow_file, ...) {
     if (is.logical(flags$resume)) {
       if (flags$resume) {
         run <- "resume"
+      } else {
+        run <- "run"
       }
     } else {
-      run <- paste0("resume", " ", flags$resume)
+      run <- c("resume", as_cli_args(flags$resume))
     }
     if ("origin_run_id" %in% names(flags)) {
-      run <- paste0(run, " --origin-run-id=", flags$origin_run_id)
+      run <- c(run, paste0("--origin-run-id=", flags$origin_run_id))
     }
   } else {
     run <- "run"
@@ -69,36 +75,36 @@ run_cmd <- function(flow_file, ...) {
   if ("batch" %in% names(flags)) {
     if (is.logical(flags$batch)) {
       if (flags$batch) {
-        batch <- "--with batch"
+        batch <- c("--with", "batch")
       } else {
-        batch <- ""
+        batch <- character()
       }
     } else {
-      batch <- paste0("batch ", flags$batch)
-      run <- ""
+      batch <- c("batch", as_cli_args(flags$batch))
+      run <- character()
       if ("my_runs" %in% names(flags) && flags$my_runs) {
-        batch <- paste0(batch, " --my-runs")
+        batch <- c(batch, "--my-runs")
       }
       if ("run_id" %in% names(flags)) {
-        batch <- paste0(batch, " --run-id=", flags$run_id)
+        batch <- c(batch, paste0("--run-id=", flags$run_id))
       }
       if ("user" %in% names(flags)) {
-        batch <- paste0(batch, " --user=", flags$user)
+        batch <- c(batch, paste0("--user=", flags$user))
       }
     }
   } else {
-    batch <- ""
+    batch <- character()
   }
 
   if ("step_functions" %in% names(flags)) {
-    sfn_cmd <- paste("step-functions", flags$step_functions)
+    sfn_cmd <- c("step-functions", as_cli_args(flags$step_functions))
     # subcommands without an argument
     for (subcommand in c("generate_new_token",
                          "only_json", "running", "succeeded",
                          "failed", "timed_out", "aborted")){
       if (subcommand %in% names(flags)){
         subcommand_valid <- gsub("_", "-", subcommand)
-        sfn_cmd <- paste(sfn_cmd, paste0("--", subcommand_valid))
+        sfn_cmd <- c(sfn_cmd, paste0("--", subcommand_valid))
       }
     }
 
@@ -107,59 +113,57 @@ run_cmd <- function(flow_file, ...) {
                          "max_workers", "workflow_timeout")){
       if (subcommand %in% names(flags)){
         subcommand_valid <- gsub("_", "-", subcommand)
-        sfn_cmd <- paste(sfn_cmd, paste0("--", subcommand_valid), flags[[subcommand]])
+        sfn_cmd <- c(sfn_cmd, paste0("--", subcommand_valid), as_cli_args(flags[[subcommand]]))
       }
     }
   } else {
-    sfn_cmd <- ""
+    sfn_cmd <- character()
   }
 
   if ("max_workers" %in% names(flags)) {
     max_workers <- paste0("--max-workers=", flags$max_workers)
   } else {
-    max_workers <- ""
+    max_workers <- character()
   }
   if ("max_num_splits" %in% names(flags)) {
     max_num_splits <- paste0("--max-num-splits=", flags$max_num_splits)
   } else {
-    max_num_splits <- ""
+    max_num_splits <- character()
   }
 
   if ("other_args" %in% names(flags)) {
-    other_args <- paste(flags$other_args)
+    other_args <- as_cli_args(flags$other_args)
   } else {
-    other_args <- ""
+    other_args <- character()
   }
 
-  parameters <- split_parameters(flags)
+  parameters <- split_parameter_args(flags)
 
   if ("with" %in% names(flags)) {
     with <- unlist(lapply(seq_along(flags$with), function(x) {
-      paste(paste0("--with ", unlist(flags$with[x])), collapse = " ")
-    })) %>%
-      paste(collapse = " ")
+      c("--with", as_cli_args(flags$with[x]))
+    }), use.names = FALSE)
   } else {
-    with <- ""
+    with <- character()
   }
 
   if ("tag" %in% names(flags)) {
     tag <- unlist(lapply(seq_along(flags$tag), function(x) {
-      paste(paste0("--tag ", unlist(flags$tag[x])), collapse = " ")
-    })) %>%
-      paste(collapse = " ")
+      c("--tag", as_cli_args(flags$tag[x]))
+    }), use.names = FALSE)
   } else {
-    tag <- ""
+    tag <- character()
   }
 
   if ("package_suffixes" %in% names(flags)) {
     package_suffixes <- paste0("--package-suffixes=", paste(flags$package_suffixes, collapse = ","))
   } else {
-    package_suffixes <- ""
+    package_suffixes <- character()
   }
 
   flow_RDS <- paste0("--flowRDS=", flow_file)
-  cmd <- paste(
-    "Rscript", run_path,
+  args <- compact_args(c(
+    run_path,
     flow_RDS,
     "--no-pylint",
     package_suffixes,
@@ -171,26 +175,26 @@ run_cmd <- function(flow_file, ...) {
     max_workers,
     max_num_splits,
     other_args
-  )
+  ))
 
-  if (batch %in% c("batch list", "batch kill")) {
-    cmd <- paste("Rscript", run_path, flow_RDS, batch)
+  if (identical(batch, c("batch", "list")) || identical(batch, c("batch", "kill"))) {
+    args <- compact_args(c(run_path, flow_RDS, batch))
   }
 
   if ("logs" %in% names(flags)) {
-    logs <- paste("logs", flags$logs, sep = " ")
-    cmd <- paste("Rscript", run_path, flow_RDS, logs)
+    logs <- c("logs", as_cli_args(flags$logs))
+    args <- compact_args(c(run_path, flow_RDS, logs))
   }
 
   if ("show" %in% names(flags) && flags$show) {
     show <- "show"
-    cmd <- paste("Rscript", run_path, flow_RDS, show)
+    args <- compact_args(c(run_path, flow_RDS, show))
   }
 
   if ("step_functions" %in% names(flags)){
-    cmd <- paste("Rscript", run_path, flow_RDS,
-                 "--no-pylint", package_suffixes, sfn_cmd,
-                    parameters,  other_args)
+    args <- compact_args(c(run_path, flow_RDS,
+                           "--no-pylint", package_suffixes, sfn_cmd,
+                           parameters,  other_args))
   }
 
   if ("help" %in% names(flags) && flags$help) {
@@ -198,9 +202,22 @@ run_cmd <- function(flow_file, ...) {
     if ("help" %in% names(run_options) && run_options$help) {
       help_cmd <- "--help"
     } else { # if help is specified in command line
-      help_cmd <- paste(commandArgs(trailingOnly = TRUE), collapse = " ")
+      help_cmd <- commandArgs(trailingOnly = TRUE)
     }
-    cmd <- paste("Rscript", run_path, flow_RDS, "--no-pylint", help_cmd)
+    args <- compact_args(c(run_path, flow_RDS, "--no-pylint", help_cmd))
   }
-  cmd
+  args
+}
+
+as_cli_args <- function(x) {
+  as.character(unlist(x, use.names = FALSE))
+}
+
+compact_args <- function(args) {
+  args <- as_cli_args(args)
+  args[!is.na(args) & nzchar(args)]
+}
+
+shell_quote_args <- function(args) {
+  shQuote(compact_args(args))
 }

--- a/R/tests/testthat/test-flags.R
+++ b/R/tests/testthat/test-flags.R
@@ -32,8 +32,10 @@ test_that("parse arguments from R", {
 
 test_that("parse arguments from command line", {
   skip_if_no_metaflow()
-  cmd <- "Rscript test-command-args.R --alpha 100 --with catch --with retry"
-  system(cmd)
+  system2(
+    "Rscript",
+    args = c("test-command-args.R", "--alpha", "100", "--with", "catch", "--with", "retry")
+  )
   actual <- readRDS("flags.RDS")
   message(actual)
   expected <- list(
@@ -54,6 +56,30 @@ test_that("split parameters sets valid params", {
   flags <- flags()
   actual <- split_parameters(flags)
   expected <- ""
+  expect_equal(actual, expected)
+})
+
+test_that("split parameter args preserves shell-sensitive values", {
+  skip_if_no_metaflow()
+  arguments <- list(
+    alpha = "has spaces; and semicolon",
+    name = "quotes \" '",
+    label = "unicode \u2603"
+  )
+  actual <- split_parameter_args(arguments)
+  expected <- c(
+    "--alpha", "has spaces; and semicolon",
+    "--name", "quotes \" '",
+    "--label", "unicode \u2603"
+  )
+  expect_equal(actual, expected)
+})
+
+test_that("split parameter args repeats vector parameter flags", {
+  skip_if_no_metaflow()
+  arguments <- list(alpha = c("one", "two"))
+  actual <- split_parameter_args(arguments)
+  expected <- c("--alpha", "one", "--alpha", "two")
   expect_equal(actual, expected)
 })
 

--- a/R/tests/testthat/test-run-cmd.R
+++ b/R/tests/testthat/test-run-cmd.R
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
 library(metaflow)
 
-run_cmd <- metaflow:::run_cmd("flow.RDS")
-saveRDS(run_cmd, "run_cmd.RDS")
+run_argv <- metaflow:::run_argv("flow.RDS")
+saveRDS(run_argv, "run_cmd.RDS")

--- a/R/tests/testthat/test-run.R
+++ b/R/tests/testthat/test-run.R
@@ -1,26 +1,23 @@
 context("test-run.R")
 
 extract_args <- function(x) {
-  args <- strsplit(x, " ")[[1]][-c(1:2)]
-  args[args != ""]
+  x[-1]
 }
 
-test_that("test run_cmd is correctly passing default flags.", {
+test_that("test run_argv is correctly passing default flags.", {
   skip_if_no_metaflow()
   expected <- c(
     "--flowRDS=flow.RDS",
     "--no-pylint", "run"
   )
-  actual <- run_cmd("flow.RDS") %>%
-    as.character() %>%
+  actual <- run_argv("flow.RDS") %>%
     extract_args()
   expect_equal(actual, expected)
 })
 
-test_that("test run_cmd correctly parses --with batch", {
+test_that("test run_argv correctly parses --with batch", {
   skip_if_no_metaflow()
-  actual <- run_cmd("flow.RDS", batch = TRUE) %>%
-    as.character() %>%
+  actual <- run_argv("flow.RDS", batch = TRUE) %>%
     extract_args()
   expected <- c(
     "--flowRDS=flow.RDS",
@@ -30,11 +27,62 @@ test_that("test run_cmd correctly parses --with batch", {
   expect_equal(actual, expected)
 })
 
-test_that("test run_cmd correctly parses help", {
+test_that("test run_argv correctly parses help", {
   skip_if_no_metaflow()
-  actual <- run_cmd("flow.RDS", help = TRUE) %>%
-    as.character() %>%
+  actual <- run_argv("flow.RDS", help = TRUE) %>%
     extract_args()
   expected <- c("--flowRDS=flow.RDS", "--no-pylint", "--help")
   expect_equal(actual, expected)
+})
+
+test_that("test run_argv preserves shell-sensitive values", {
+  skip_if_no_metaflow()
+  dangerous_value <- "spaces quotes \" ' semicolon; dollar$HOME"
+  unicode_value <- "unicode \u2603"
+  expected <- c(
+    "--flowRDS=flow file.RDS",
+    "--no-pylint", "run",
+    "--tag", dangerous_value,
+    "--tag", unicode_value,
+    "--name", dangerous_value,
+    "--extra", dangerous_value,
+    "--unicode", unicode_value
+  )
+  actual <- run_argv(
+    "flow file.RDS",
+    tag = c(dangerous_value, unicode_value),
+    name = dangerous_value,
+    other_args = c("--extra", dangerous_value, "--unicode", unicode_value)
+  ) %>%
+    extract_args()
+  expect_equal(actual, expected)
+})
+
+test_that("test run_argv preserves batch identifiers as single arguments", {
+  skip_if_no_metaflow()
+  run_id <- "run id; still one arg"
+  user <- "user quotes \" ' \u2603"
+  expected <- c(
+    "--flowRDS=flow.RDS",
+    "--no-pylint",
+    "batch", "status",
+    paste0("--run-id=", run_id),
+    paste0("--user=", user)
+  )
+  actual <- run_argv(
+    "flow.RDS",
+    batch = "status",
+    run_id = run_id,
+    user = user
+  ) %>%
+    extract_args()
+  expect_equal(actual, expected)
+})
+
+test_that("test run_cmd quotes shell-sensitive values", {
+  skip_if_no_metaflow()
+  dangerous_value <- "spaces quotes \" ' semicolon; dollar$HOME"
+  actual <- run_cmd("flow file.RDS", tag = dangerous_value)
+  expect_match(actual, shQuote("--flowRDS=flow file.RDS"), fixed = TRUE)
+  expect_match(actual, shQuote(dangerous_value), fixed = TRUE)
 })

--- a/R/tests/testthat/test-sfn-cli-parsing.R
+++ b/R/tests/testthat/test-sfn-cli-parsing.R
@@ -1,106 +1,106 @@
+read_run_argv <- function(...) {
+  on.exit(if (file.exists("run_cmd.RDS")) file.remove("run_cmd.RDS"), add = TRUE)
+  system2("Rscript", args = c("test-run-cmd.R", ...))
+  run_argv <- readRDS("run_cmd.RDS")
+  run_argv[-1]
+}
+
 test_that("SFN create", {
   skip_if_no_metaflow()
 
-  cmd <- "Rscript test-run-cmd.R step-functions create"
-  system(cmd)
+  actual <- read_run_argv("step-functions", "create")
 
-  # Rscript /Library/../metaflow/run.R --flowRDS=flow.RDS step-functions create
-  run_cmd <- strsplit(trimws(readRDS("run_cmd.RDS")), split=" ")[[1]]
-  actual <- paste(run_cmd[3:length(run_cmd)], collapse=" ")
-
-  expected <- "--flowRDS=flow.RDS --no-pylint  step-functions create"
+  expected <- c("--flowRDS=flow.RDS", "--no-pylint", "step-functions", "create")
 
   expect_equal(actual, expected)
-  on.exit(file.remove("run_cmd.RDS"))
 })
 
 test_that("SFN create --help", {
   skip_if_no_metaflow()
 
-  cmd <- "Rscript test-run-cmd.R step-functions create --help"
-  system(cmd)
+  actual <- read_run_argv("step-functions", "create", "--help")
 
-  run_cmd <- strsplit(trimws(readRDS("run_cmd.RDS")), split=" ")[[1]]
-  actual <- paste(run_cmd[3:length(run_cmd)], collapse=" ")
-
-  expected <- "--flowRDS=flow.RDS --no-pylint step-functions create --help"
+  expected <- c("--flowRDS=flow.RDS", "--no-pylint", "step-functions", "create", "--help")
 
   expect_equal(actual, expected)
-  on.exit(file.remove("run_cmd.RDS"))
 })
 
 test_that("SFN create --package-suffixes", {
   skip_if_no_metaflow()
 
-  cmd <- "Rscript test-run-cmd.R --package-suffixes=.csv,.RDS,.R step-functions create"
-  system(cmd)
+  actual <- read_run_argv("--package-suffixes=.csv,.RDS,.R", "step-functions", "create")
 
-  run_cmd <- strsplit(trimws(readRDS("run_cmd.RDS")), split=" ")[[1]]
-  actual <- paste(run_cmd[3:length(run_cmd)], collapse=" ")
-
-  expected <- "--flowRDS=flow.RDS --no-pylint --package-suffixes=.csv,.RDS,.R step-functions create"
+  expected <- c(
+    "--flowRDS=flow.RDS",
+    "--no-pylint",
+    "--package-suffixes=.csv,.RDS,.R",
+    "step-functions",
+    "create"
+  )
 
   expect_equal(actual, expected)
-  on.exit(file.remove("run_cmd.RDS"))
 })
 
 test_that("SFN create --generate-new-token", {
   skip_if_no_metaflow()
 
-  cmd <- "Rscript test-run-cmd.R step-functions create --generate-new-token"
-  system(cmd)
+  actual <- read_run_argv("step-functions", "create", "--generate-new-token")
 
-  run_cmd <- strsplit(trimws(readRDS("run_cmd.RDS")), split=" ")[[1]]
-  actual <- paste(run_cmd[3:length(run_cmd)], collapse=" ")
-
-  expected <- "--flowRDS=flow.RDS --no-pylint  step-functions create --generate-new-token"
+  expected <- c(
+    "--flowRDS=flow.RDS",
+    "--no-pylint",
+    "step-functions",
+    "create",
+    "--generate-new-token"
+  )
 
   expect_equal(actual, expected)
-  on.exit(file.remove("run_cmd.RDS"))
 })
 
 test_that("SFN create --generate-new-token --max-workers 100 --lr 0.01", {
   skip_if_no_metaflow()
 
-  cmd <- "Rscript test-run-cmd.R step-functions create --generate-new-token --max-workers 100 --lr 0.01"
-  system(cmd)
+  actual <- read_run_argv(
+    "step-functions", "create", "--generate-new-token",
+    "--max-workers", "100", "--lr", "0.01"
+  )
 
-  run_cmd <- strsplit(trimws(readRDS("run_cmd.RDS")), split=" ")[[1]]
-  actual <- paste(run_cmd[3:length(run_cmd)], collapse=" ")
-
-  expected <- "--flowRDS=flow.RDS --no-pylint  step-functions create --generate-new-token --max-workers 100 --lr 0.01"
+  expected <- c(
+    "--flowRDS=flow.RDS",
+    "--no-pylint",
+    "step-functions",
+    "create",
+    "--generate-new-token",
+    "--max-workers", "100",
+    "--lr", "0.01"
+  )
   expect_equal(actual, expected)
-  on.exit(file.remove("run_cmd.RDS"))
 })
 
 
 test_that("SFN trigger", {
   skip_if_no_metaflow()
 
-  cmd <- "Rscript test-run-cmd.R step-functions trigger"
-  system(cmd)
+  actual <- read_run_argv("step-functions", "trigger")
 
-  run_cmd <- strsplit(trimws(readRDS("run_cmd.RDS")), split=" ")[[1]]
-  actual <- paste(run_cmd[3:length(run_cmd)], collapse=" ")
-
-  expected <- "--flowRDS=flow.RDS --no-pylint  step-functions trigger"
+  expected <- c("--flowRDS=flow.RDS", "--no-pylint", "step-functions", "trigger")
 
   expect_equal(actual, expected)
-  on.exit(file.remove("run_cmd.RDS"))
 })
 
 
 test_that("SFN list-runs --running", {
   skip_if_no_metaflow()
 
-  cmd <- "Rscript test-run-cmd.R step-functions list-runs --running"
-  system(cmd)
+  actual <- read_run_argv("step-functions", "list-runs", "--running")
 
-  run_cmd <- strsplit(trimws(readRDS("run_cmd.RDS")), split=" ")[[1]]
-  actual <- paste(run_cmd[3:length(run_cmd)], collapse=" ")
-
-  expected <- "--flowRDS=flow.RDS --no-pylint  step-functions list-runs --running"
+  expected <- c(
+    "--flowRDS=flow.RDS",
+    "--no-pylint",
+    "step-functions",
+    "list-runs",
+    "--running"
+  )
 
   expect_equal(actual, expected)
-  on.exit(file.remove("run_cmd.RDS"))
 })


### PR DESCRIPTION
## Summary

Updates the R `run()` path to build `Rscript` arguments as an argv vector and execute them through `system2()`, with shell quoting applied at the execution boundary.

## Issue

No existing issue.

## Reproduction

**Runtime:** local R binding

**Commands to run:**
```bash
cd R
Rscript -e 'testthat::test_file("tests/testthat/test-run.R")'
Rscript -e 'testthat::test_file("tests/testthat/test-flags.R")'
Rscript -e 'testthat::test_file("tests/testthat/test-sfn-cli-parsing.R")'
```

**Where evidence shows up:** testthat output from the focused R tests.

<details>
<summary>Before</summary>

`run_cmd()` assembled one command string with `paste()`, so values containing spaces, quotes, semicolons, or other shell-sensitive characters were interpreted as part of the shell command line instead of staying as single CLI arguments.

</details>

<details>
<summary>After</summary>

`run_argv()` keeps each CLI token as a separate argument. `run()` passes the quoted argv vector to `system2("Rscript", ...)`, and `run_cmd()` now returns a shell-quoted display command.

</details>

## Root Cause

The R wrapper built a single shell command string by concatenating the wrapper path, flow RDS path, run mode, tags, parameters, batch identifiers, and extra args. That mixed argument construction with shell parsing, so argument boundaries depended on shell syntax instead of the values passed to `run()`.

## Why This Fix Is Correct

The fix separates command construction from command rendering. `run_argv()` builds the intended CLI argument vector, `run()` quotes that vector only at the `system2()` boundary, and `run_cmd()` remains available as a quoted display string.

## Failure Modes Considered

1. Values containing spaces, quotes, semicolons, `$`, and unicode must remain single arguments.
2. Existing R binding command shapes still need to be preserved for default runs, `batch = TRUE`, Step Functions commands, help, and vector-valued parameters.

## Tests

- Added argv regression coverage for spaces, quotes, semicolons, `$`, and unicode in tags, parameters, batch user/run IDs, and `other_args`.
- Updated Step Functions command parsing tests to assert argv vectors instead of splitting shell strings.
- Updated the R test helper commands to use `system2()`.
- Ran `git diff --check` locally.
- Could not run the focused R tests locally because `Rscript` is not installed in this environment.

## Non-Goals

- This does not change the Python CLI behavior.
- This does not rewrite the R command-line parser beyond preserving argument boundaries for the command that `run()` executes.
