### PR TITLE
fix(cards): retry card.get() until reload token appears in HTML

### DIFF
--- a/test/core/tests/card_component_refresh_test.py
+++ b/test/core/tests/card_component_refresh_test.py
@@ -81,7 +81,14 @@ class CardComponentRefreshTest(MetaflowTest):
 
         sleep_between_refreshes = 2  # Set based on the RUNTIME_CARD_MIN_REFRESH_INTERVAL which acts as a rate-limit to what is refreshed.
 
-        card_html = card.get()
+        # Retry card.get() until the reload token appears; the card refresh is
+        # async so the HTML may lag behind the in-memory state.
+        _html_deadline = time.time() + 60
+        while True:
+            card_html = card.get()
+            if _reload_tok in card_html or time.time() >= _html_deadline:
+                break
+            time.sleep(1)
         possible_reload_tokens.append(_reload_tok)
         # The reload token for card type `test_component_refresh_card` contains a hash of the component values.
         # The first assertion will check if this reload token exists is set to what we expect in the HTML page.


### PR DESCRIPTION
## Summary

`CardComponentRefreshTest` has been intermittently failing (~40 s) across unrelated PRs in both the OSS repo and Netflix's internal mli-metaflow-custom CI.

**Root cause:** `try_to_get_card` returns as soon as the card file exists on disk, but the async background refresh process may not have finished writing the new reload token into the HTML yet. The subsequent `assert_equals(_reload_tok in card.get(), True)` therefore races against the writer and occasionally fails.

**Fix:** Poll `card.get()` in a tight loop (up to 60 s) until the expected reload token appears before asserting, eliminating the race condition.

## Test plan

- [ ] Existing card-refresh tests pass locally
- [ ] `CardComponentRefreshTest` no longer flakes in CI across multiple re-runs
- [ ] `CardWithRefreshTest` (similar pattern in `card_refresh_test.py`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)