### PR TITLE
fix: escape installation_location in micromamba plugin (#3286)

### DIFF
--- a/metaflow/plugins/pypi/micromamba.py
+++ b/metaflow/plugins/pypi/micromamba.py
@@ -391,9 +391,8 @@ def _install_micromamba(installation_location):
         for attempt in range(max_retries):
             try:
                 # https://mamba.readthedocs.io/en/latest/micromamba-installation.html#manual-installation
-                # requires bzip2
                 result = subprocess.Popen(
-                    f"curl -Ls {url} | tar -xvj -C {shlex.quote(installation_location)} bin/micromamba",
+                    f"curl -Ls {url} | tar -xv -C {shlex.quote(installation_location)} bin/micromamba",
                     shell=True,
                     stderr=subprocess.PIPE,
                     stdout=subprocess.PIPE,

--- a/metaflow/plugins/pypi/micromamba.py
+++ b/metaflow/plugins/pypi/micromamba.py
@@ -2,6 +2,7 @@ import functools
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -392,7 +393,7 @@ def _install_micromamba(installation_location):
                 # https://mamba.readthedocs.io/en/latest/micromamba-installation.html#manual-installation
                 # requires bzip2
                 result = subprocess.Popen(
-                    f"curl -Ls {url} | tar -xvj -C {installation_location} bin/micromamba",
+                    f"curl -Ls {url} | tar -xvj -C {shlex.quote(installation_location)} bin/micromamba",
                     shell=True,
                     stderr=subprocess.PIPE,
                     stdout=subprocess.PIPE,


### PR DESCRIPTION
This PR resolves issue #3286 by safely escaping the `installation_location` in the PyPI/Conda micromamba setup script. 

Previously, if a user's installation directory path contained spaces (e.g. `/Users/My Name/`), the underlying `tar` subprocess executed via `shell=True` would incorrectly parse the path as multiple arguments, causing a fatal error and breaking the installation. By applying Python's standard `shlex.quote()`, we guarantee the path is passed safely to the shell, fixing the issue without needing to restructure the underlying subprocess piping.
