### PR TITLE
Fix incorrect parameter names in docstrings

### DIFF
--- a/metaflow/datastore/datastore_storage.py
+++ b/metaflow/datastore/datastore_storage.py
@@ -133,7 +133,7 @@ class DataStoreStorage(object):
 
         Parameters
         ----------
-        path : List[string]
+        paths : List[string]
             Path to the object
 
         Returns

--- a/metaflow/datastore/task_datastore.py
+++ b/metaflow/datastore/task_datastore.py
@@ -723,7 +723,7 @@ class TaskDataStore(object):
 
         Parameters
         ----------
-        names : string
+        name : string
             Metadata name to fetch
         add_attempt : bool, optional
             Adds the attempt identifier to the metadata name if True,

--- a/metaflow/packaging_sys/v1.py
+++ b/metaflow/packaging_sys/v1.py
@@ -261,7 +261,7 @@ class MetaflowCodeContentV1(MetaflowCodeContentV1Base):
 
         Parameters
         ----------
-        module_path: ModuleType
+        module: ModuleType
             The module to add
         """
         name = module.__name__

--- a/metaflow/plugins/cards/component_serializer.py
+++ b/metaflow/plugins/cards/component_serializer.py
@@ -737,7 +737,7 @@ class CardComponentCollector:
 
         Parameters
         ----------
-        component : Iterator[MetaflowCardComponent]
+        components : Iterator[MetaflowCardComponent]
             Card components to add to this card.
         """
         if self._default_editable_card is None:


### PR DESCRIPTION
Several docstrings document parameter names that don't match their function signatures. This corrects them so the docs match the code:

| Function | File | Docstring | Signature |
|---|---|---|---|
| `DatastoreStorage.is_file` | `datastore/datastore_storage.py` | `path` | `paths` |
| `TaskDataStore.has_metadata` | `datastore/task_datastore.py` | `names` | `name` |
| `add_module` | `packaging_sys/v1.py` | `module_path` | `module` |
| `CardComponentCollector.extend` | `plugins/cards/component_serializer.py` | `component` | `components` |

Documentation-only change; no runtime behavior is affected.
