### PR TITLE
fix: card DataFrame rendering on `pandas>=3.0`

### DIFF
--- a/metaflow/plugins/cards/card_modules/convert_to_native_type.py
+++ b/metaflow/plugins/cards/card_modules/convert_to_native_type.py
@@ -45,6 +45,17 @@ def _full_classname(obj):
     return name
 
 
+# Map class names that moved across library versions back to the canonical name
+# type detection keys on (e.g. pandas>=3.0 reports "pandas.DataFrame").
+_TYPE_NAME_ALIASES = {
+    "pandas.DataFrame": "pandas.core.frame.DataFrame",
+}
+
+
+def _normalize_type_name(name):
+    return _TYPE_NAME_ALIASES.get(name, name)
+
+
 class TaskToDict:
     def __init__(self, only_repr=False, runtime=False, max_artifact_size=None):
         # this dictionary holds all the supported functions
@@ -210,7 +221,7 @@ class TaskToDict:
     def _get_object_type(obj_val):
         """returns string or None"""
         try:
-            return _full_classname(obj_val)
+            return _normalize_type_name(_full_classname(obj_val))
         except AttributeError as e:
             pass
 

--- a/test/unit/test_convert_to_native_type_pandas.py
+++ b/test/unit/test_convert_to_native_type_pandas.py
@@ -4,8 +4,8 @@ Unit tests for pandas DataFrame handling in card native-type conversion.
 pandas >= 3.0 changed ``DataFrame.__module__`` from ``pandas.core.frame`` to
 ``pandas``, which shifted the type string that card serialization keys on and
 broke ``Table.from_dataframe`` (it rendered "Object type pandas.DataFrame not
-supported"). These tests pin the normalization so DataFrame detection stays
-version-agnostic.
+supported"). These tests pin the observable behavior so DataFrame detection
+stays version-agnostic.
 """
 
 import unittest
@@ -15,35 +15,46 @@ import pytest
 pd = pytest.importorskip("pandas")
 
 from metaflow.plugins.cards.card_modules.components import Table
-from metaflow.plugins.cards.card_modules.convert_to_native_type import (
-    TaskToDict,
-    _normalize_type_name,
-)
+from metaflow.plugins.cards.card_modules.convert_to_native_type import TaskToDict
 
 _CANONICAL_DATAFRAME_TYPE = "pandas.core.frame.DataFrame"
+
+
+def _obj_with_type(module, qualname):
+    """Return an instance whose type reports ``module``/``qualname``.
+
+    Lets us exercise a given pandas version's DataFrame class path (which
+    ``object_type`` keys on) without installing that pandas version.
+    """
+    cls = type(qualname, (), {})
+    cls.__module__ = module
+    cls.__qualname__ = qualname
+    return cls()
 
 
 class TestPandasDataframeConversion(unittest.TestCase):
     """Card serialization must recognize pandas DataFrames on any pandas version."""
 
-    def test_object_type_is_canonical_across_pandas_versions(self):
-        """object_type resolves a DataFrame to the canonical name regardless of
-        the (version-dependent) module path of the class."""
-        df = pd.DataFrame([{"a": 1}])
-        self.assertEqual(TaskToDict().object_type(df), _CANONICAL_DATAFRAME_TYPE)
-
-    def test_normalize_type_name_maps_moved_name(self):
-        """The pandas>=3.0 name is normalized; unrelated names pass through."""
+    def test_object_type_resolves_installed_dataframe(self):
+        """A real DataFrame resolves to the canonical type name."""
         self.assertEqual(
-            _normalize_type_name("pandas.DataFrame"), _CANONICAL_DATAFRAME_TYPE
+            TaskToDict().object_type(pd.DataFrame([{"a": 1}])),
+            _CANONICAL_DATAFRAME_TYPE,
         )
-        self.assertEqual(_normalize_type_name("builtins.int"), "builtins.int")
 
-    def test_normalize_type_name_is_noop_for_pandas2(self):
-        """Backwards compatible: the canonical name pandas<3.0 already produces
-        is passed through unchanged, so older pandas keeps its exact behavior."""
+    def test_object_type_is_version_agnostic(self):
+        """Both the pandas>=3.0 (``pandas.DataFrame``) and pandas<3.0
+        (``pandas.core.frame.DataFrame``) class paths resolve to the canonical
+        name, so detection is stable across pandas versions and older pandas
+        keeps its exact behavior."""
+        task_to_dict = TaskToDict()
         self.assertEqual(
-            _normalize_type_name(_CANONICAL_DATAFRAME_TYPE), _CANONICAL_DATAFRAME_TYPE
+            task_to_dict.object_type(_obj_with_type("pandas", "DataFrame")),
+            _CANONICAL_DATAFRAME_TYPE,
+        )
+        self.assertEqual(
+            task_to_dict.object_type(_obj_with_type("pandas.core.frame", "DataFrame")),
+            _CANONICAL_DATAFRAME_TYPE,
         )
 
     def test_table_from_dataframe_renders_rows(self):

--- a/test/unit/test_convert_to_native_type_pandas.py
+++ b/test/unit/test_convert_to_native_type_pandas.py
@@ -1,0 +1,64 @@
+"""
+Unit tests for pandas DataFrame handling in card native-type conversion.
+
+pandas >= 3.0 changed ``DataFrame.__module__`` from ``pandas.core.frame`` to
+``pandas``, which shifted the type string that card serialization keys on and
+broke ``Table.from_dataframe`` (it rendered "Object type pandas.DataFrame not
+supported"). These tests pin the normalization so DataFrame detection stays
+version-agnostic.
+"""
+import unittest
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from metaflow.plugins.cards.card_modules.components import Table
+from metaflow.plugins.cards.card_modules.convert_to_native_type import (
+    TaskToDict,
+    _normalize_type_name,
+)
+
+_CANONICAL_DATAFRAME_TYPE = "pandas.core.frame.DataFrame"
+
+
+class TestPandasDataframeConversion(unittest.TestCase):
+    """Card serialization must recognize pandas DataFrames on any pandas version."""
+
+    def test_object_type_is_canonical_across_pandas_versions(self):
+        """object_type resolves a DataFrame to the canonical name regardless of
+        the (version-dependent) module path of the class."""
+        df = pd.DataFrame([{"a": 1}])
+        self.assertEqual(TaskToDict().object_type(df), _CANONICAL_DATAFRAME_TYPE)
+
+    def test_normalize_type_name_maps_moved_name(self):
+        """The pandas>=3.0 name is normalized; unrelated names pass through."""
+        self.assertEqual(
+            _normalize_type_name("pandas.DataFrame"), _CANONICAL_DATAFRAME_TYPE
+        )
+        self.assertEqual(_normalize_type_name("builtins.int"), "builtins.int")
+
+    def test_normalize_type_name_is_noop_for_pandas2(self):
+        """Backwards compatible: the canonical name pandas<3.0 already produces
+        is passed through unchanged, so older pandas keeps its exact behavior."""
+        self.assertEqual(
+            _normalize_type_name(_CANONICAL_DATAFRAME_TYPE), _CANONICAL_DATAFRAME_TYPE
+        )
+
+    def test_table_from_dataframe_renders_rows(self):
+        """Table.from_dataframe renders the data instead of an
+        "Object type ... not supported" placeholder."""
+        df = pd.DataFrame(
+            [{"metric": "MAE", "value": 1.5}, {"metric": "RMSE", "value": 2.0}]
+        )
+        rendered = Table.from_dataframe(df).render()
+
+        self.assertEqual(rendered["type"], "table")
+        self.assertIn("metric", rendered["columns"])
+        self.assertIn("value", rendered["columns"])
+        # An unrecognized type would render a single "Object type ... not
+        # supported" column instead of the data.
+        self.assertFalse(
+            any("not supported" in str(col) for col in rendered["columns"])
+        )
+        self.assertEqual(len(rendered["data"]), len(df))

--- a/test/unit/test_convert_to_native_type_pandas.py
+++ b/test/unit/test_convert_to_native_type_pandas.py
@@ -7,6 +7,7 @@ broke ``Table.from_dataframe`` (it rendered "Object type pandas.DataFrame not
 supported"). These tests pin the normalization so DataFrame detection stays
 version-agnostic.
 """
+
 import unittest
 
 import pytest


### PR DESCRIPTION
This PR fixes Metaflow cards that use `Table.from_dataframe`, which broke on pandas 3.0 and rendered "Object type pandas.DataFrame not supported" instead of the table. The cause is that pandas 3.0 moved DataFrame's module path from `pandas.core.frame` to `pandas`, so Metaflow's hardcoded type-name check no longer matched. The fix normalizes the new name back to the canonical one in a single place (`_get_object_type`), which restores all three spots that key on it. It's backward compatible with older pandas and covered by unit tests that pass on both pandas 2.x and 3.x.
Fixes https://github.com/Netflix/metaflow/issues/3291

