### PR TITLE
ci: publish metaflow before metaflow-stubs on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,9 +35,9 @@ jobs:
     - name: Build metaflow-stubs package
       run: |
         cd ./stubs && python3 setup.py sdist bdist_wheel --universal && cd -
+    - name: Publish metaflow package
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e #v1.13.0
     - name: Publish metaflow-stubs package
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e #v1.13.0
       with:
         packages-dir: ./stubs/dist
-    - name: Publish metaflow package
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e #v1.13.0


### PR DESCRIPTION

## PR Type

<!-- Check one -->

- [ ] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [x] Docs / tooling
- [ ] Refactoring


On release, `publish.yml` uploaded `metaflow-stubs` to PyPI before `metaflow`.
Because `metaflow-stubs` hard-pins `metaflow==<same version>`, publishing the
stubs first leaves them briefly (and, if the `metaflow` upload then fails,
permanently) uninstallable. This swaps the two publish steps so `metaflow`
publishes first.

## Issue

<!-- Link to issue. Required for bug fixes, required for Core Runtime. -->

Fixes #<!-- open/link an acknowledged issue first; see note below -->

## Reproduction

**Runtime:** release workflow (GitHub Actions `deploy` job in `.github/workflows/publish.yml`)

This is a release-pipeline ordering defect, so the "reproduction" is the ordering
plus the version pin rather than a runnable local command; a live failure only
surfaces during an actual PyPI release.

**Where evidence shows up:** the `deploy` job's publish steps / the resulting PyPI index state.

The dependent package pins the dependency exactly:

```python
# stubs/setup.py
version = <read from ../metaflow/version.py>          # same version as the metaflow package
install_requires=[f"metaflow=={version}"]             # stubs/setup.py:45
```

Before this change the `deploy` job published in this order:

```yaml
# .github/workflows/publish.yml (before)
- name: Publish metaflow-stubs package     # uploaded FIRST (packages-dir: ./stubs/dist)
- name: Publish metaflow package           # uploaded SECOND (root dist)
```

So immediately after the first step, `metaflow-stubs==X` is on PyPI while
`metaflow==X` is not, and `pip install metaflow-stubs==X` cannot resolve its
`metaflow==X` dependency. If the second step (publishing `metaflow`) fails for any
reason (a PyPI hiccup, a metadata rejection, a re-run where the file already
exists), the state is permanent: PyPI does not allow re-uploading the same file,
and `gh-action-pypi-publish` defaults `skip-existing: false`, so a retried release
also dies on the already-published stubs.

After this change:

```yaml
# .github/workflows/publish.yml (after)
- name: Publish metaflow package           # uploaded FIRST (root dist)
- name: Publish metaflow-stubs package     # uploaded SECOND (packages-dir: ./stubs/dist)
```

The depended-upon package is on the index before the package that pins it, so the
`metaflow-stubs` dependency is always resolvable.

## Root Cause

The two PyPI publish steps in the `deploy` job were ordered dependent-first: the
`metaflow-stubs` upload ran before the `metaflow` upload, even though
`metaflow-stubs`'s `install_requires` hard-pins the exact `metaflow` version
(`stubs/setup.py:45`), which is not on the index until the later step completes.

## Why This Fix Is Correct

Standard practice is to publish a depended-upon distribution before any
distribution that pins it, so the dependency is resolvable the moment the
dependent package appears. Swapping the two steps restores that invariant with the
smallest possible change: only the order of the two existing
`pypa/gh-action-pypi-publish` steps changes. The `packages-dir: ./stubs/dist`
setting stays attached to the `metaflow-stubs` step, and the action version pins
are untouched.

## Failure Modes Considered

1. Second upload fails after the first succeeds. Before: `metaflow-stubs==X` is
   orphaned with an unresolvable pin, and because PyPI blocks re-uploading the same
   file (`skip-existing` defaults to false), the release cannot be cleanly retried.
   After: if the second upload (`metaflow-stubs`) fails, `metaflow==X` is already
   published and installable on its own; only the stubs are missing, which is the
   less harmful ordering.
2. YAML step reordering misattaching `with: packages-dir`. Verified the
   `packages-dir: ./stubs/dist` block stays under the `metaflow-stubs` step and the
   `metaflow` step keeps no `packages-dir` (it uploads the root-built dist),
   confirmed by parsing the job with `yaml.safe_load`.

## Tests

- [ ] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [x] CI passes
- [x] If tests are impractical: explain why below and provide manual evidence above

No unit test applies to a release-workflow ordering change (the repo has no test
that executes `publish.yml`, and the effect only manifests during a real PyPI
release). Validation: `pre-commit run --files .github/workflows/publish.yml` passes
(check-yaml, end-of-file, trailing-whitespace, mixed-line-ending, detect-private-key
all Passed), and the post-swap step order was confirmed by parsing the `deploy` job.

## Non-Goals

- Not adding `skip-existing: true` to the publish steps. That would make re-runs
  idempotent and is arguably a good follow-up, but it changes publish semantics and
  is out of scope for this ordering fix. Kept the diff to the two-line reorder.
- Not touching the `metaflow-stubs` version pin in `stubs/setup.py`, the action SHA
  pins, or any other step.

## AI Tool Usage

<!-- We welcome responsible AI use. See CONTRIBUTING.md for our full policy. -->

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

An AI coding assistant helped locate the ordering defect and draft this PR text. I
reviewed and understand every line: the change is a two-line reorder of the two
existing `pypa/gh-action-pypi-publish` steps in `.github/workflows/publish.yml` so
the `metaflow` package publishes before the `metaflow-stubs` package that pins it.
I validated it with `pre-commit` and by re-parsing the resulting workflow.
