### PR TITLE
docs: correct CLIENT_CACHE_MAX_SIZE unit comment to MB

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -111,7 +111,7 @@ DATASTORE_SYSROOT_GS = from_conf("DATASTORE_SYSROOT_GS")
 
 # Path to the client cache
 CLIENT_CACHE_PATH = from_conf("CLIENT_CACHE_PATH", "/tmp/metaflow_client")
-# Maximum size (in bytes) of the cache
+# Maximum size (in MB) of the cache
 CLIENT_CACHE_MAX_SIZE = from_conf("CLIENT_CACHE_MAX_SIZE", 10000)
 # Maximum number of cached Flow and TaskDatastores in the cache
 CLIENT_CACHE_MAX_FLOWDATASTORE_COUNT = from_conf(


### PR DESCRIPTION

## PR Type

- [x] Docs / tooling


The inline comment above `CLIENT_CACHE_MAX_SIZE` says the value is "in bytes", but
the only consumer multiplies it by `1024**2`, so the value is actually interpreted
in megabytes. This corrects the comment to "in MB". No behavior changes.

## Issue

Fixes #<OPEN_ACKNOWLEDGED_ISSUE>   <!-- REQUIRED: do not open the PR until this
