### PR TITLE
fix typos in user-facing error messages and docstrings

### DIFF
--- a/metaflow/plugins/cards/card_cli.py
+++ b/metaflow/plugins/cards/card_cli.py
@@ -120,7 +120,7 @@ def resolve_card(
         hash (optional): This is to specifically resolve the card via the hash. This is useful when there may be many card with same id or type for a pathspec.
         type : type of card
         card_id : `id` given to card
-        no_echo : if set to `True` then supress logs about pathspec resolution.
+        no_echo : if set to `True` then suppress logs about pathspec resolution.
     Raises:
         CardNotPresentException: No card could be found for the pathspec
 

--- a/metaflow/plugins/pypi/utils.py
+++ b/metaflow/plugins/pypi/utils.py
@@ -5,12 +5,12 @@ if sys.version_info < (3, 6):
 
     class Tags:
         __getattr__ = lambda self, name: (_ for _ in ()).throw(
-            Exception("packaging.tags is not avaliable for Python < 3.6")
+            Exception("packaging.tags is not available for Python < 3.6")
         )
 
     tags = Tags()
     parse_wheel_filename = lambda: (_ for _ in ()).throw(
-        RuntimeError("packaging.utils is not avaliable for Python < 3.6")
+        RuntimeError("packaging.utils is not available for Python < 3.6")
     )
 else:
     from metaflow._vendor.packaging import tags

--- a/metaflow/runner/nbrun.py
+++ b/metaflow/runner/nbrun.py
@@ -21,7 +21,7 @@ class NBRunner(object):
     a `flow` is defined. In contrast to `Runner`, this class is not
     meant to be used in a context manager. Instead, use a blocking helper
     function like `nbrun` (which calls `cleanup()` internally) or call
-    `cleanup()` explictly when using non-blocking APIs.
+    `cleanup()` explicitly when using non-blocking APIs.
 
     ```python
     run = NBRunner(FlowName).nbrun()

--- a/metaflow/runner/subprocess_manager.py
+++ b/metaflow/runner/subprocess_manager.py
@@ -137,7 +137,7 @@ class SubprocessManager(object):
             The command to run in List form.
         env : Optional[Dict[str, str]], default None
             Environment variables to set for the subprocess; if not specified,
-            the current enviornment variables are used.
+            the current environment variables are used.
         cwd : Optional[str], default None
             The directory to run the subprocess in; if not specified, the current
             directory is used.
@@ -186,7 +186,7 @@ class SubprocessManager(object):
             The command to run in List form.
         env : Optional[Dict[str, str]], default None
             Environment variables to set for the subprocess; if not specified,
-            the current enviornment variables are used.
+            the current environment variables are used.
         cwd : Optional[str], default None
             The directory to run the subprocess in; if not specified, the current
             directory is used.
@@ -249,7 +249,7 @@ class CommandManager(object):
             The command to run in List form.
         env : Optional[Dict[str, str]], default None
             Environment variables to set for the subprocess; if not specified,
-            the current enviornment variables are used.
+            the current environment variables are used.
         cwd : Optional[str], default None
             The directory to run the subprocess in; if not specified, the current
             directory is used.


### PR DESCRIPTION
## PR Type

- [ ] Bug fix
- [ ] New feature
- [ ] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))
- [x] Docs / tooling
- [ ] Refactoring

## Summary

Fixes spelling in strings that users actually see: two runtime error messages in `plugins/pypi/utils.py` ("avaliable" -> "available") and rendered API docstrings in `runner/subprocess_manager.py` ("enviornment" -> "environment"), `runner/nbrun.py` ("explictly" -> "explicitly"), and `plugins/cards/card_cli.py` ("supress" -> "suppress"). No logic changes -- 7 string edits across 4 files.

## Issue

N/A -- not tied to an open issue.

## Tests

- [ ] Unit tests added/updated
- [ ] Reproduction script provided (required for Core Runtime)
- [x] CI passes
- [x] If tests are impractical: explain why below and provide manual evidence above

Pure string changes; all four files byte-compile cleanly, and a repo-wide search confirms no remaining occurrences of these misspellings outside `_vendor/`.

## Non-Goals

Typos in internal code comments and vendored code (`metaflow/_vendor/`) are intentionally left untouched to keep the diff minimal.

## AI Tool Usage

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

Used AI-assisted search to locate the misspellings; every change was reviewed and verified manually.