### PR TITLE
Fix bare except: use except Exception in get_task helper

### DIFF
--- a/metaflow/util.py
+++ b/metaflow/util.py
@@ -288,7 +288,7 @@ def get_latest_task_pathspec(
     try:
         task = Step(f"{flow_name}/{run_id}/{step_name}").task
         return task
-    except:
+    except Exception:
         raise MetaflowNotFound(f"No task found for step {step_name} in run {run_id}")
 
 


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `metaflow/util.py`.

In the `get_task` helper, the bare `except:` catches any exception from `Step(...).task` and re-raises it as `MetaflowNotFound`. Using `except Exception:` is more precise and avoids accidentally catching `SystemExit` or `KeyboardInterrupt`.