### PR TITLE
Add @tenki compute backend (Tenki Sandbox microVMs)

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -593,7 +593,7 @@ KUBERNETES_SANDBOX_INIT_SCRIPT = from_conf("KUBERNETES_SANDBOX_INIT_SCRIPT")
 ###
 # Tenki Sandbox microVM compute backend
 ###
-# API key for the Tenki Sandbox SDK. The SDK also reads TENKI_API_KEY /
+# API key for the Tenki SDK. The SDK also reads TENKI_API_KEY /
 # TENKI_AUTH_TOKEN directly from the environment; this is only used to forward
 # an explicit value configured via metaflow config.
 TENKI_API_KEY = from_conf("TENKI_API_KEY")
@@ -609,9 +609,8 @@ TENKI_CONTAINER_IMAGE = from_conf("TENKI_CONTAINER_IMAGE")
 # and no @resources value is larger).
 TENKI_CPU = from_conf("TENKI_CPU")
 TENKI_MEMORY = from_conf("TENKI_MEMORY")
-# Tenki project/workspace to create sandboxes in. If TENKI_PROJECT_ID is unset,
-# the backend auto-resolves the first project of the token's first workspace.
-TENKI_PROJECT_ID = from_conf("TENKI_PROJECT_ID")
+# Optional Tenki workspace to create sandboxes in; leave unset to use the
+# token's default.
 TENKI_WORKSPACE_ID = from_conf("TENKI_WORKSPACE_ID")
 # Optional init script run before anything else inside the sandbox (parity with
 # KUBERNETES_SANDBOX_INIT_SCRIPT). Useful for configuring egress/proxy.

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -590,6 +590,33 @@ if AWS_SANDBOX_ENABLED:
 
 KUBERNETES_SANDBOX_INIT_SCRIPT = from_conf("KUBERNETES_SANDBOX_INIT_SCRIPT")
 
+###
+# Tenki Sandbox microVM compute backend
+###
+# API key for the Tenki Sandbox SDK. The SDK also reads TENKI_API_KEY /
+# TENKI_AUTH_TOKEN directly from the environment; this is only used to forward
+# an explicit value configured via metaflow config.
+TENKI_API_KEY = from_conf("TENKI_API_KEY")
+# Optional override for the Tenki API endpoint (SDK default: https://api.tenki.cloud).
+TENKI_BASE_URL = from_conf("TENKI_BASE_URL")
+# Default base image for the microVM. If unset, the Tenki default image is used.
+# Must be a Tenki-registry image (Tenki does not pull external registries like
+# Docker Hub) providing python3; the backend exposes `python` and bootstraps pip
+# at startup, so the default image works, but an image with python/pip/boto3
+# preinstalled starts faster.
+TENKI_CONTAINER_IMAGE = from_conf("TENKI_CONTAINER_IMAGE")
+# Default CPU/memory for @tenki steps (used only when the step does not set them
+# and no @resources value is larger).
+TENKI_CPU = from_conf("TENKI_CPU")
+TENKI_MEMORY = from_conf("TENKI_MEMORY")
+# Tenki project/workspace to create sandboxes in. If TENKI_PROJECT_ID is unset,
+# the backend auto-resolves the first project of the token's first workspace.
+TENKI_PROJECT_ID = from_conf("TENKI_PROJECT_ID")
+TENKI_WORKSPACE_ID = from_conf("TENKI_WORKSPACE_ID")
+# Optional init script run before anything else inside the sandbox (parity with
+# KUBERNETES_SANDBOX_INIT_SCRIPT). Useful for configuring egress/proxy.
+TENKI_SANDBOX_INIT_SCRIPT = from_conf("TENKI_SANDBOX_INIT_SCRIPT")
+
 OTEL_ENDPOINT = from_conf("OTEL_ENDPOINT")
 ZIPKIN_ENDPOINT = from_conf("ZIPKIN_ENDPOINT")
 CONSOLE_TRACE_ENABLED = from_conf("CONSOLE_TRACE_ENABLED", False)

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -26,6 +26,7 @@ CLIS_DESC = [
 TRAMPOLINE_CLIS_DESC = [
     ("batch", ".aws.batch.batch_cli.cli"),
     ("kubernetes", ".kubernetes.kubernetes_cli.cli"),
+    ("tenki", ".tenki.tenki_cli.cli"),
 ]
 
 # Add additional commands to the runner here
@@ -46,6 +47,7 @@ STEP_DECORATORS_DESC = [
     ("resources", ".resources_decorator.ResourcesDecorator"),
     ("batch", ".aws.batch.batch_decorator.BatchDecorator"),
     ("kubernetes", ".kubernetes.kubernetes_decorator.KubernetesDecorator"),
+    ("tenki", ".tenki.tenki_decorator.TenkiDecorator"),
     (
         "argo_workflows_internal",
         ".argo.argo_workflows_decorator.ArgoWorkflowsInternalDecorator",

--- a/metaflow/plugins/pypi/conda_decorator.py
+++ b/metaflow/plugins/pypi/conda_decorator.py
@@ -185,6 +185,7 @@ class CondaStepDecorator(StepDecorator):
                     "slurm",
                     "nvct",
                     "skypilot_step",
+                    "tenki",
                 ]
                 for decorator in next(
                     step for step in self.flow if step.name == self.step

--- a/metaflow/plugins/tenki/tenki.py
+++ b/metaflow/plugins/tenki/tenki.py
@@ -166,6 +166,52 @@ def _describe_failure(exit_code, signal, reason, errno):
     return ", ".join(parts) or "unknown status"
 
 
+def is_permanent_launch_error(err, client=None):
+    """Classify a launch-path exception: True -> do not retry (DISALLOW_RETRY),
+    False -> retryable (plain non-zero exit, so @retry relaunches).
+
+    launch_job does synchronous network I/O (Client auth, who_am_i project
+    discovery, create), so transient API/network failures are a real mode and
+    must stay retryable. The tenki-sandbox SDK already classifies its own errors
+    via a ``retryable`` attribute (e.g. an UNAVAILABLE service and rate limits
+    are retryable; auth / permission / quota / bad-image are not), so we defer
+    to it for SDK errors. Command/session timeouts and a client-side deadline
+    are also treated as transient, matching Tenki._interpret_result (the wait
+    path). Unknown / non-SDK errors default to PERMANENT: an unclassified launch
+    failure is more often a misconfig than a blip, and looping @retry on a
+    guaranteed failure wastes billed sandbox-create attempts.
+    """
+    # Our own signals. TenkiKilledException is always non-retryable; a
+    # TenkiException at launch comes from the SDK soft-import failing or the
+    # minimum-version guard — both permanent.
+    if isinstance(err, (TenkiKilledException, TenkiException)):
+        return True
+
+    def sdk(name):
+        # Resolve an SDK exception class by name via the client, or () when the
+        # client is unavailable (e.g. construction itself failed) so isinstance
+        # never matches. Mirrors TenkiClient.exception().
+        return client.exception(name) if client is not None else ()
+
+    # Transient, consistent with the wait-path classification: a client-side
+    # deadline, or the SDK's command-timeout / session-lost errors.
+    if isinstance(err, TimeoutError):
+        return False
+    transient = (sdk("CommandTimeoutError"), sdk("SessionNotFoundError"))
+    if any(t and isinstance(err, t) for t in transient):
+        return False
+
+    # For any other SDK error, defer to the SDK's own `retryable` flag
+    # (True for UNAVAILABLE / rate-limit, False for auth / permission / quota /
+    # bad-image / invalid-state / unknown gRPC codes).
+    sandbox_error = sdk("SandboxError")
+    if sandbox_error and isinstance(err, sandbox_error):
+        return not getattr(err, "retryable", False)
+
+    # Unknown / non-SDK error -> permanent (see docstring).
+    return True
+
+
 def _tag(key, value):
     # Build a "<key>:<value>" tag whose value is normalized to the Tenki tag
     # charset/length. When the normalized value would overflow the 32-char

--- a/metaflow/plugins/tenki/tenki.py
+++ b/metaflow/plugins/tenki/tenki.py
@@ -37,7 +37,6 @@ from metaflow.metaflow_config import (
     SERVICE_URL,
     TENKI_API_KEY,
     TENKI_BASE_URL,
-    TENKI_PROJECT_ID,
     TENKI_SANDBOX_INIT_SCRIPT,
     TENKI_WORKSPACE_ID,
 )
@@ -170,16 +169,16 @@ def is_permanent_launch_error(err, client=None):
     """Classify a launch-path exception: True -> do not retry (DISALLOW_RETRY),
     False -> retryable (plain non-zero exit, so @retry relaunches).
 
-    launch_job does synchronous network I/O (Client auth, who_am_i project
-    discovery, create), so transient API/network failures are a real mode and
-    must stay retryable. The tenki-sandbox SDK already classifies its own errors
-    via a ``retryable`` attribute (e.g. an UNAVAILABLE service and rate limits
-    are retryable; auth / permission / quota / bad-image are not), so we defer
-    to it for SDK errors. Command/session timeouts and a client-side deadline
-    are also treated as transient, matching Tenki._interpret_result (the wait
-    path). Unknown / non-SDK errors default to PERMANENT: an unclassified launch
-    failure is more often a misconfig than a blip, and looping @retry on a
-    guaranteed failure wastes billed sandbox-create attempts.
+    launch_job does synchronous network I/O (Client auth, create), so transient
+    API/network failures are a real mode and must stay retryable. The tenki SDK
+    already classifies its own errors via a ``retryable`` attribute (e.g. an
+    UNAVAILABLE service and rate limits are retryable; auth / permission / quota
+    / bad-image are not), so we defer to it for SDK errors. Command/session
+    timeouts and a client-side deadline are also treated as transient, matching
+    Tenki._interpret_result (the wait path). Unknown / non-SDK errors default to
+    PERMANENT: an unclassified launch failure is more often a misconfig than a
+    blip, and looping @retry on a guaranteed failure wastes billed
+    sandbox-create attempts.
     """
     # Our own signals. TenkiKilledException is always non-retryable; a
     # TenkiException at launch comes from the SDK soft-import failing or the
@@ -458,12 +457,6 @@ class Tenki(object):
 
         self._client = TenkiClient(api_key=TENKI_API_KEY, base_url=TENKI_BASE_URL)
 
-        # The Tenki API requires a project to create a sandbox in. Use the
-        # configured project, else auto-resolve the token's first project.
-        project_id = TENKI_PROJECT_ID or self._client.default_project_id(
-            TENKI_WORKSPACE_ID
-        )
-
         # Outbound access is REQUIRED so the microVM can reach the datastore
         # (S3) and the metadata service.
         create_kwargs = dict(
@@ -491,8 +484,7 @@ class Tenki(object):
                 "metaflow.user": user,
             },
         )
-        if project_id:
-            create_kwargs["project_id"] = project_id
+        # A workspace is optional; pass it only when configured.
         if TENKI_WORKSPACE_ID:
             create_kwargs["workspace_id"] = TENKI_WORKSPACE_ID
         if image:

--- a/metaflow/plugins/tenki/tenki.py
+++ b/metaflow/plugins/tenki/tenki.py
@@ -132,7 +132,11 @@ _RUNTIME_BOOTSTRAP_SHIM = (
 
 
 # Tags applied to every sandbox so `tenki list` / `tenki kill` can find them.
+# The flow tag scopes cleanup to the current flow (mirrors how @kubernetes /
+# @batch always filter by flow name) so an unscoped `tenki kill` can never reap
+# another flow's or user's sandboxes.
 TENKI_TAG = "metaflow"
+TENKI_TAG_FLOW = "metaflow-flow"
 TENKI_TAG_RUN = "metaflow-run"
 TENKI_TAG_USER = "metaflow-user"
 
@@ -428,6 +432,7 @@ class Tenki(object):
             # in-process teardown never ran).
             tags=[
                 TENKI_TAG,
+                _tag(TENKI_TAG_FLOW, flow_name),
                 _tag(TENKI_TAG_RUN, run_id),
                 _tag(TENKI_TAG_USER, user),
             ],

--- a/metaflow/plugins/tenki/tenki.py
+++ b/metaflow/plugins/tenki/tenki.py
@@ -187,10 +187,19 @@ def is_permanent_launch_error(err, client=None):
         return True
 
     def sdk(name):
-        # Resolve an SDK exception class by name via the client, or () when the
-        # client is unavailable (e.g. construction itself failed) so isinstance
-        # never matches. Mirrors TenkiClient.exception().
-        return client.exception(name) if client is not None else ()
+        # Resolve an SDK exception class by name. Prefer the client, but fall
+        # back to importing the SDK module directly so classification still
+        # works when client construction itself failed (self._client is None) —
+        # otherwise a retryable SDK error raised during TenkiClient() would be
+        # misread as permanent. Returns () when unresolvable so isinstance never
+        # matches. Mirrors TenkiClient.exception().
+        if client is not None:
+            return client.exception(name)
+        try:
+            import tenki
+        except Exception:
+            return ()
+        return getattr(tenki, name, ())
 
     # Transient, consistent with the wait-path classification: a client-side
     # deadline, or the SDK's command-timeout / session-lost errors.

--- a/metaflow/plugins/tenki/tenki.py
+++ b/metaflow/plugins/tenki/tenki.py
@@ -1,0 +1,619 @@
+import atexit
+import base64
+import hashlib
+import json
+import os
+import re
+import shlex
+import sys
+import threading
+from uuid import uuid4
+
+from metaflow import util
+from metaflow.metaflow_config import (
+    AWS_SECRETS_MANAGER_DEFAULT_REGION,
+    AZURE_KEY_VAULT_PREFIX,
+    AZURE_STORAGE_BLOB_SERVICE_ENDPOINT,
+    CARD_AZUREROOT,
+    CARD_GSROOT,
+    CARD_S3ROOT,
+    DATASTORE_SYSROOT_AZURE,
+    DATASTORE_SYSROOT_GS,
+    DATASTORE_SYSROOT_S3,
+    DATATOOLS_AZUREROOT,
+    DATATOOLS_GSROOT,
+    DATATOOLS_S3ROOT,
+    DEFAULT_AWS_CLIENT_PROVIDER,
+    DEFAULT_AZURE_CLIENT_PROVIDER,
+    DEFAULT_GCP_CLIENT_PROVIDER,
+    DEFAULT_METADATA,
+    DEFAULT_SECRETS_BACKEND_TYPE,
+    GCP_SECRET_MANAGER_PREFIX,
+    OTEL_ENDPOINT,
+    OTEL_SERVICE_NAME,
+    S3_ENDPOINT_URL,
+    S3_SERVER_SIDE_ENCRYPTION,
+    SERVICE_HEADERS,
+    SERVICE_URL,
+    TENKI_API_KEY,
+    TENKI_BASE_URL,
+    TENKI_PROJECT_ID,
+    TENKI_SANDBOX_INIT_SCRIPT,
+    TENKI_WORKSPACE_ID,
+)
+from metaflow.metaflow_config_funcs import config_values
+from metaflow.mflog import (
+    BASH_SAVE_LOGS,
+    bash_capture_logs,
+    export_mflog_env_vars,
+    get_log_tailer,
+    tail_logs,
+)
+
+from .tenki_client import TenkiClient, TenkiException, TenkiKilledException
+
+# Redirect structured logs to $PWD/.logs/ (identical contract to @kubernetes).
+LOGS_DIR = "$PWD/.logs"
+STDOUT_FILE = "mflog_stdout"
+STDERR_FILE = "mflog_stderr"
+STDOUT_PATH = os.path.join(LOGS_DIR, STDOUT_FILE)
+STDERR_PATH = os.path.join(LOGS_DIR, STDERR_FILE)
+
+# Datastore credentials to forward from the launching process into the sandbox,
+# keyed by datastore type. A Tenki microVM has no ambient cloud identity (unlike
+# a Kubernetes pod with an IRSA service account / workload identity), so the
+# datastore credentials must be passed explicitly. Prefer short-lived
+# credentials whose lifetime exceeds the step run-time limit.
+#
+# GS additionally uses a service-account JSON *file* (GOOGLE_APPLICATION_
+# CREDENTIALS); its contents are materialized inside the sandbox — see
+# `_env_vars` and `_command`.
+_FORWARDED_CREDENTIAL_ENV_VARS = {
+    "s3": [
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_DEFAULT_REGION",
+        "AWS_REGION",
+        # boto3-native S3 endpoint override (used by S3-compatible stores such
+        # as MinIO / the Metaflow devstack).
+        "AWS_ENDPOINT_URL_S3",
+    ],
+    "azure": [
+        "AZURE_STORAGE_CONNECTION_STRING",
+        "AZURE_CLIENT_ID",
+        "AZURE_TENANT_ID",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_SUBSCRIPTION_ID",
+    ],
+    "gs": [
+        "GOOGLE_CLOUD_PROJECT",
+        "GCLOUD_PROJECT",
+        # Endpoint override for a GCS-compatible emulator (e.g. fake-gcs-server).
+        "STORAGE_EMULATOR_HOST",
+    ],
+}
+# Env var carrying the base64-encoded GCP service-account JSON into the sandbox.
+_GCP_CREDENTIALS_ENV = "METAFLOW_GCP_CREDENTIALS_JSON_B64"
+
+# Extra lifetime granted to the sandbox beyond the task's run-time limit, to
+# cover bootstrap (image pull, dependency install, code-package download) and
+# teardown. This is a server-side leak backstop: if the local orchestrator dies
+# without cleaning up, the microVM is force-expired instead of leaking forever.
+# Metaflow still enforces the real per-step timeout independently.
+_SANDBOX_TTL_GRACE_SECONDS = 600
+
+# Make the microVM a viable Metaflow runtime before the standard bootstrap runs.
+# Metaflow's remote bootstrap invokes the interpreter as `python` (for the
+# dependency install, the code-package download, and the step itself), but Tenki
+# base images (including the platform default, a minimal non-root Ubuntu) ship
+# only `python3`. Without a `python` on PATH the bootstrap fails before it can
+# even download the code package. This shim, run ahead of the bootstrap:
+#   * puts a writable dir on PATH and symlinks python -> python3 if `python` is
+#     absent (non-root: cannot write /usr/local/bin, so use $HOME/.local/bin);
+#     if neither python nor python3 exists it exits with a clear error rather
+#     than letting the bootstrap fail with a confusing one later,
+#   * sets PIP_BREAK_SYSTEM_PACKAGES so pip can install into a PEP-668
+#     "externally-managed" system interpreter,
+#   * bootstraps pip via ensurepip if it is missing.
+# It is a no-op on images that already provide a usable `python`/pip. Users can
+# still supply their own image via @tenki(image=) / METAFLOW_TENKI_CONTAINER_IMAGE.
+_RUNTIME_BOOTSTRAP_SHIM = (
+    "mkdir -p $HOME/.local/bin && export PATH=$HOME/.local/bin:$PATH && "
+    "{ command -v python >/dev/null 2>&1 || "
+    "{ command -v python3 >/dev/null 2>&1 && "
+    "ln -sf $(command -v python3) $HOME/.local/bin/python; } || "
+    "{ echo '@tenki: image provides no python runtime; set "
+    "METAFLOW_TENKI_CONTAINER_IMAGE to an image with python3' >&2; exit 1; }; } && "
+    "export PIP_BREAK_SYSTEM_PACKAGES=1 && "
+    "{ python -m pip --version >/dev/null 2>&1 || "
+    "python -m ensurepip --upgrade >/dev/null 2>&1 || true; }"
+)
+
+
+# Tags applied to every sandbox so `tenki list` / `tenki kill` can find them.
+TENKI_TAG = "metaflow"
+TENKI_TAG_RUN = "metaflow-run"
+TENKI_TAG_USER = "metaflow-user"
+
+# Tenki tags must be <= 32 chars from [a-z0-9_:.-]. run_id and user are
+# free-form (user is often an email with '@', IDs can be long), so an unescaped
+# value can reject sandbox creation.
+_MAX_TAG_LEN = 32
+_TAG_HASH_LEN = 8
+
+
+def _sanitize_name(name):
+    return re.sub(r"[^a-z0-9-]", "-", name.lower()).strip("-")[:40] or "step"
+
+
+def _describe_failure(exit_code, signal, reason, errno):
+    # Human-readable diagnostic including everything the SDK reports about a
+    # failed command, not just the exit code.
+    parts = []
+    if exit_code is not None:
+        parts.append("exit code %s" % exit_code)
+    if signal:
+        parts.append("signal %s" % signal)
+    if reason:
+        parts.append("reason %s" % reason)
+    if errno is not None:
+        parts.append("errno %s" % errno)
+    return ", ".join(parts) or "unknown status"
+
+
+def _tag(key, value):
+    # Build a "<key>:<value>" tag whose value is normalized to the Tenki tag
+    # charset/length. When the normalized value would overflow the 32-char
+    # budget it is truncated and suffixed with a short stable hash of the
+    # original so distinct values stay distinct. Deterministic, so create
+    # (tenki.py) and cleanup lookup (tenki_cli.py) always agree.
+    budget = _MAX_TAG_LEN - len(key) - 1  # room after "<key>:"
+    v = re.sub(r"[^a-z0-9_.-]", "-", str(value).lower()).strip("-")
+    if len(v) > budget:
+        digest = hashlib.sha1(str(value).encode("utf-8")).hexdigest()[:_TAG_HASH_LEN]
+        head = v[: max(0, budget - _TAG_HASH_LEN - 1)].strip("-")
+        v = "%s-%s" % (head, digest) if head else digest[:budget]
+    return "%s:%s" % (key, v)
+
+
+class Tenki(object):
+    def __init__(self, datastore, metadata, environment):
+        self._datastore = datastore
+        self._metadata = metadata
+        self._environment = environment
+
+        self._client = None
+        self._sandbox = None
+        self._name = None
+
+        # Populated by the background exec thread.
+        self._exec_thread = None
+        self._result = None
+        self._exec_error = None
+        self._output_final_logs = False
+
+    def _command(
+        self,
+        flow_name,
+        run_id,
+        step_name,
+        task_id,
+        attempt,
+        code_package_metadata,
+        code_package_url,
+        step_cmds,
+    ):
+        mflog_expr = export_mflog_env_vars(
+            flow_name=flow_name,
+            run_id=run_id,
+            step_name=step_name,
+            task_id=task_id,
+            retry_count=attempt,
+            datastore_type=self._datastore.TYPE,
+            stdout_path=STDOUT_PATH,
+            stderr_path=STDERR_PATH,
+        )
+        init_cmds = self._environment.get_package_commands(
+            code_package_url, self._datastore.TYPE, code_package_metadata
+        )
+        init_expr = " && ".join(init_cmds)
+        step_expr = bash_capture_logs(
+            " && ".join(
+                self._environment.bootstrap_commands(step_name, self._datastore.TYPE)
+                + step_cmds
+            )
+        )
+
+        # Construct an entrypoint that
+        # 1) provisions a usable `python`/pip runtime (_RUNTIME_BOOTSTRAP_SHIM)
+        # 2) initializes the mflog environment (mflog_expr)
+        # 3) downloads + bootstraps the code package (init_expr)
+        # 4) executes the task (step_expr)
+        # then captures the exit code and persists the final logs, exiting with
+        # the task's real exit code so the local orchestrator sees the right
+        # status.
+        cmd_str = "true && %s && mkdir -p %s && %s && %s && %s; " % (
+            _RUNTIME_BOOTSTRAP_SHIM,
+            LOGS_DIR,
+            mflog_expr,
+            init_expr,
+            step_expr,
+        )
+        cmd_str += "c=$?; %s; exit $c" % BASH_SAVE_LOGS
+        # Optional init script hook (parity with KUBERNETES_SANDBOX_INIT_SCRIPT).
+        # Runs before the runtime shim so a user image that sets up its own
+        # python is respected (the shim then no-ops).
+        cmd_str = (
+            '${METAFLOW_INIT_SCRIPT:+eval \\"${METAFLOW_INIT_SCRIPT}\\"} && %s'
+            % cmd_str
+        )
+        # For the GS datastore, recreate the service-account JSON file from the
+        # forwarded base64 blob (see _env_vars) and point
+        # GOOGLE_APPLICATION_CREDENTIALS at it BEFORE the code-package download
+        # runs. Only emitted for gs so the s3/azure command strings are unchanged.
+        if self._datastore.TYPE == "gs":
+            cmd_str = (
+                'if [ -n \\"$%s\\" ]; then '
+                "printf %%s $%s | base64 -d > $HOME/mf_gcp_creds.json; "
+                "export GOOGLE_APPLICATION_CREDENTIALS=$HOME/mf_gcp_creds.json; fi "
+                "&& %s"
+            ) % (_GCP_CREDENTIALS_ENV, _GCP_CREDENTIALS_ENV, cmd_str)
+        # The inner commands (get_package_commands, mflog, bash_capture_logs)
+        # emit \\"-escaped quotes that only resolve correctly when the whole
+        # string is unwrapped from a `bash -c "..."` invocation. We reproduce
+        # @kubernetes' exact transformation and hand the resulting argv list to
+        # `sb.exec(*argv)`.
+        return shlex.split('bash -c "%s"' % cmd_str)
+
+    def _env_vars(
+        self,
+        code_package_metadata,
+        code_package_sha,
+        code_package_url,
+        code_package_ds,
+        user,
+        user_env,
+    ):
+        env = {
+            "METAFLOW_CODE_METADATA": code_package_metadata,
+            "METAFLOW_CODE_SHA": code_package_sha,
+            "METAFLOW_CODE_URL": code_package_url,
+            "METAFLOW_CODE_DS": code_package_ds,
+            "METAFLOW_USER": user,
+            # A Tenki microVM lives outside the cluster network, so it must use
+            # the externally-reachable service URL rather than the cluster
+            # internal one (@kubernetes uses SERVICE_INTERNAL_URL).
+            "METAFLOW_SERVICE_URL": SERVICE_URL,
+            "METAFLOW_SERVICE_HEADERS": json.dumps(SERVICE_HEADERS),
+            "METAFLOW_DEFAULT_DATASTORE": self._datastore.TYPE,
+            "METAFLOW_DEFAULT_METADATA": DEFAULT_METADATA,
+            "METAFLOW_DEFAULT_SECRETS_BACKEND_TYPE": DEFAULT_SECRETS_BACKEND_TYPE,
+            # Secrets-backend config so @secrets resolves the same way it does
+            # under @kubernetes (per-provider region/prefix).
+            "METAFLOW_AWS_SECRETS_MANAGER_DEFAULT_REGION": (
+                AWS_SECRETS_MANAGER_DEFAULT_REGION
+            ),
+            "METAFLOW_GCP_SECRET_MANAGER_PREFIX": GCP_SECRET_MANAGER_PREFIX,
+            "METAFLOW_AZURE_KEY_VAULT_PREFIX": AZURE_KEY_VAULT_PREFIX,
+            "METAFLOW_RUNTIME_ENVIRONMENT": "tenki",
+            # Marker used by TenkiDecorator.task_pre_step / task_finished to
+            # detect that it is running inside the remote workload.
+            "METAFLOW_TENKI_WORKLOAD": "1",
+            "METAFLOW_INIT_SCRIPT": TENKI_SANDBOX_INIT_SCRIPT,
+            # S3 datastore config.
+            "METAFLOW_DATASTORE_SYSROOT_S3": DATASTORE_SYSROOT_S3,
+            "METAFLOW_DATATOOLS_S3ROOT": DATATOOLS_S3ROOT,
+            "METAFLOW_CARD_S3ROOT": CARD_S3ROOT,
+            "METAFLOW_S3_ENDPOINT_URL": S3_ENDPOINT_URL,
+            "METAFLOW_DEFAULT_AWS_CLIENT_PROVIDER": DEFAULT_AWS_CLIENT_PROVIDER,
+            # Server-side encryption for S3 datastore writes (dropped if unset).
+            "METAFLOW_S3_SERVER_SIDE_ENCRYPTION": S3_SERVER_SIDE_ENCRYPTION,
+            # Azure datastore config.
+            "METAFLOW_DATASTORE_SYSROOT_AZURE": DATASTORE_SYSROOT_AZURE,
+            "METAFLOW_DATATOOLS_AZUREROOT": DATATOOLS_AZUREROOT,
+            "METAFLOW_CARD_AZUREROOT": CARD_AZUREROOT,
+            "METAFLOW_AZURE_STORAGE_BLOB_SERVICE_ENDPOINT": (
+                AZURE_STORAGE_BLOB_SERVICE_ENDPOINT
+            ),
+            "METAFLOW_DEFAULT_AZURE_CLIENT_PROVIDER": DEFAULT_AZURE_CLIENT_PROVIDER,
+            # GS datastore config.
+            "METAFLOW_DATASTORE_SYSROOT_GS": DATASTORE_SYSROOT_GS,
+            "METAFLOW_DATATOOLS_GSROOT": DATATOOLS_GSROOT,
+            "METAFLOW_CARD_GSROOT": CARD_GSROOT,
+            "METAFLOW_DEFAULT_GCP_CLIENT_PROVIDER": DEFAULT_GCP_CLIENT_PROVIDER,
+            # Telemetry/tracing config (parity with @kubernetes).
+            "METAFLOW_OTEL_ENDPOINT": OTEL_ENDPOINT,
+            "METAFLOW_OTEL_SERVICE_NAME": OTEL_SERVICE_NAME,
+        }
+
+        # Temporary passing of *some* environment variables. Do not rely on this
+        # mechanism as it will be removed in the near future (copied verbatim
+        # from @kubernetes).
+        for k, v in config_values():
+            if k.startswith("METAFLOW_CONDA_") or k.startswith("METAFLOW_DEBUG_"):
+                env[k] = v
+
+        # Forward the datastore's credentials into the microVM.
+        for k in _FORWARDED_CREDENTIAL_ENV_VARS.get(self._datastore.TYPE, []):
+            if os.environ.get(k) is not None:
+                env[k] = os.environ[k]
+
+        # GS authenticates via a service-account JSON *file*
+        # (GOOGLE_APPLICATION_CREDENTIALS). Forward its contents (base64) so the
+        # sandbox can recreate the file before the code-package download runs.
+        if self._datastore.TYPE == "gs":
+            gac = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+            if gac and os.path.isfile(gac):
+                with open(gac, "rb") as f:
+                    env[_GCP_CREDENTIALS_ENV] = base64.b64encode(f.read()).decode()
+
+        # User-specified environment (from @environment).
+        for k, v in (user_env or {}).items():
+            env[k] = v
+
+        # Drop unset values so we never hand `None` to the SDK.
+        return {k: str(v) for k, v in env.items() if v is not None}
+
+    def launch_job(
+        self,
+        flow_name,
+        run_id,
+        step_name,
+        task_id,
+        attempt,
+        user,
+        code_package_metadata,
+        code_package_sha,
+        code_package_url,
+        code_package_ds,
+        step_cli,
+        image=None,
+        cpu=None,
+        memory=None,
+        run_time_limit=None,
+        env=None,
+        **kwargs
+    ):
+        bash_argv = self._command(
+            flow_name=flow_name,
+            run_id=run_id,
+            step_name=step_name,
+            task_id=task_id,
+            attempt=attempt,
+            code_package_metadata=code_package_metadata,
+            code_package_url=code_package_url,
+            step_cmds=[step_cli],
+        )
+        # Unique name per attempt so a retry never collides with a still
+        # terminating prior sandbox.
+        self._name = "mf-%s-%s-a%s-%s" % (
+            _sanitize_name("%s-%s" % (run_id, step_name)),
+            _sanitize_name(str(task_id)),
+            attempt,
+            str(uuid4())[:8],
+        )
+
+        full_env = self._env_vars(
+            code_package_metadata,
+            code_package_sha,
+            code_package_url,
+            code_package_ds,
+            user,
+            env,
+        )
+        # Expose the sandbox name to the in-VM workload so task_pre_step can
+        # register it as task metadata for debugging.
+        full_env["METAFLOW_TENKI_SANDBOX_NAME"] = self._name
+
+        self._client = TenkiClient(api_key=TENKI_API_KEY, base_url=TENKI_BASE_URL)
+
+        # The Tenki API requires a project to create a sandbox in. Use the
+        # configured project, else auto-resolve the token's first project.
+        project_id = TENKI_PROJECT_ID or self._client.default_project_id(
+            TENKI_WORKSPACE_ID
+        )
+
+        # Outbound access is REQUIRED so the microVM can reach the datastore
+        # (S3) and the metadata service.
+        create_kwargs = dict(
+            name=self._name,
+            # Resource values arrive as strings and may be float-formatted
+            # (e.g. "1.0") when merged with @resources, so parse via float.
+            cpu_cores=int(float(cpu)),
+            memory_mb=int(float(memory)),
+            allow_outbound=True,
+            # Tag/annotate the sandbox so orphans can be found and terminated
+            # by `tenki kill` (the deterministic cleanup path for crashes where
+            # in-process teardown never ran).
+            tags=[
+                TENKI_TAG,
+                _tag(TENKI_TAG_RUN, run_id),
+                _tag(TENKI_TAG_USER, user),
+            ],
+            metadata={
+                "metaflow.flow_name": flow_name,
+                "metaflow.run_id": str(run_id),
+                "metaflow.step_name": step_name,
+                "metaflow.task_id": str(task_id),
+                "metaflow.attempt": str(attempt),
+                "metaflow.user": user,
+            },
+        )
+        if project_id:
+            create_kwargs["project_id"] = project_id
+        if TENKI_WORKSPACE_ID:
+            create_kwargs["workspace_id"] = TENKI_WORKSPACE_ID
+        if image:
+            create_kwargs["image"] = image
+        if run_time_limit:
+            # Server-side hard cap (seconds); see the constant.
+            create_kwargs["max_duration"] = (
+                int(float(run_time_limit)) + _SANDBOX_TTL_GRACE_SECONDS
+            )
+        self._sandbox = self._client.create_sandbox(**create_kwargs)
+        # Best-effort teardown of the disposable microVM even if the local
+        # orchestrator crashes hard (mirrors @kubernetes best_effort_kill).
+        # This is the last-chance pass, so let it surface a warning if teardown
+        # still fails after wait()'s finally already retried.
+        atexit.register(self._cleanup, final=True)
+
+        def _run():
+            try:
+                self._result = self._sandbox.exec(
+                    *bash_argv,
+                    env=full_env,
+                    timeout=int(float(run_time_limit)) if run_time_limit else None,
+                )
+            except BaseException as e:  # noqa: B902 - capture to re-raise in wait()
+                self._exec_error = e
+
+        self._exec_thread = threading.Thread(target=_run)
+        self._exec_thread.daemon = True
+        self._exec_thread.start()
+
+    def wait(self, stdout_location, stderr_location, echo=None):
+        # Tail structured logs from the datastore (S3) on the main thread while
+        # the blocking `sb.exec` runs in the background thread. Without this the
+        # user would see no output until the (possibly hours-long) step ends.
+        prefix = b"[%s] " % util.to_bytes(self._name)
+        stdout_tail = get_log_tailer(stdout_location, self._datastore.TYPE)
+        stderr_tail = get_log_tailer(stderr_location, self._datastore.TYPE)
+
+        self._output_final_logs = False
+
+        def _has_updates():
+            if self._exec_thread.is_alive():
+                return True
+            # Emit a final tail once the exec has finished.
+            if not self._output_final_logs:
+                self._output_final_logs = True
+                return True
+            return False
+
+        try:
+            tail_logs(
+                prefix=prefix,
+                stdout_tail=stdout_tail,
+                stderr_tail=stderr_tail,
+                echo=echo,
+                has_log_updates=_has_updates,
+            )
+            self._exec_thread.join()
+            self._interpret_result(echo)
+        finally:
+            self._cleanup()
+
+    def _interpret_result(self, echo):
+        # Infra failures raised by the SDK during exec. Classify retryable vs
+        # non-retryable. A non-retryable failure is surfaced as
+        # TenkiKilledException, which the CLI maps to METAFLOW_EXIT_DISALLOW_RETRY.
+        err = self._exec_error
+        if err is not None:
+            if isinstance(err, self._client.exception("PermissionDeniedError")):
+                raise TenkiKilledException(
+                    "Tenki denied the request (%s). This is a configuration or "
+                    "credential problem and will not be retried." % err
+                )
+            # A run-time-limit breach surfaces as the SDK's CommandTimeoutError
+            # or, for the client-side exec deadline, a builtin TimeoutError.
+            timeout_types = (TimeoutError,)
+            sdk_timeout = self._client.exception("CommandTimeoutError")
+            if sdk_timeout:
+                timeout_types = timeout_types + (sdk_timeout,)
+            if isinstance(err, timeout_types):
+                raise TenkiException(
+                    "Task timed out. This could be a transient error. "
+                    "Use @retry to retry."
+                )
+            if isinstance(err, self._client.exception("SessionNotFoundError")):
+                raise TenkiException(
+                    "The Tenki sandbox disappeared before the task finished. "
+                    "This could be a transient error. Use @retry to retry."
+                )
+            raise TenkiException(
+                "Failed to execute the task in the Tenki sandbox: %s" % err
+            )
+
+        result = self._result
+        exit_code = getattr(result, "exit_code", None)
+        signal = getattr(result, "signal", None)
+        reason = getattr(result, "reason", None)
+        errno = getattr(result, "errno", None)
+        # The SDK treats a command as successful only when it exited 0 AND was
+        # not killed by a signal (result.ok). Fall back to that definition if
+        # the property is unavailable so a signalled task is never read as OK.
+        ok = getattr(result, "ok", None)
+        if ok is None:
+            ok = exit_code == 0 and not signal
+
+        # Surface captured stderr on failure even if the in-VM `save_logs` never
+        # ran (e.g. a hard crash before the tail flush).
+        stderr_text = getattr(result, "stderr_text", None)
+        if not ok and stderr_text:
+            echo(stderr_text, "stderr")
+
+        if ok:
+            echo("Task finished with exit code %s." % exit_code, "stderr")
+            return
+
+        if exit_code is None and not signal:
+            # Unknown status (no code and no signal). Treat as a retryable
+            # failure, not success.
+            raise TenkiException(
+                "Task ended with an unknown status. This could be a "
+                "transient error. Use @retry to retry."
+            )
+
+        details = _describe_failure(exit_code, signal, reason, errno)
+        if exit_code == 137:
+            raise TenkiException(
+                "Task ran out of memory (%s). Increase the available memory by "
+                "specifying @resources(memory=...) for the step." % details
+            )
+        if exit_code == 139:
+            raise TenkiException(
+                "Task failed with a segmentation fault (%s)." % details
+            )
+        raise TenkiException(
+            "This could be a transient error (%s). Use @retry to retry." % details
+        )
+
+    def _cleanup(self, final=False):
+        sb = self._sandbox
+        if sb is not None:
+            # Tear down the disposable microVM. Try close first, then fall back
+            # to terminate (aliases in the SDK). Keep self._sandbox set until a
+            # teardown call actually succeeds: if this pass fails (e.g. a
+            # transient API error in wait()'s finally), the atexit hook can
+            # still retry against a live handle.
+            terminated = False
+            last_error = None
+            for method in ("close", "terminate", "delete"):
+                fn = getattr(sb, method, None)
+                if fn is None:
+                    continue
+                try:
+                    fn()
+                    terminated = True
+                    break
+                except Exception as e:
+                    last_error = e
+            if not terminated:
+                # Keep both the sandbox and client handles so a later pass can
+                # retry (sb teardown needs the still-open client). Only warn on
+                # the final (atexit) pass, once no retry remains, so a transient
+                # failure that the retry resolves doesn't raise a false alarm.
+                if final:
+                    sys.stderr.write(
+                        "[@tenki] WARNING: could not terminate sandbox %s: %s\n"
+                        "It may keep running until its server-side max_duration "
+                        "expires; run `python <flow> tenki kill` to remove "
+                        "orphans.\n" % (getattr(sb, "id", "<unknown>"), last_error)
+                    )
+                return
+            self._sandbox = None
+        client = self._client
+        if client is not None:
+            self._client = None
+            client.close()

--- a/metaflow/plugins/tenki/tenki_cli.py
+++ b/metaflow/plugins/tenki/tenki_cli.py
@@ -22,6 +22,7 @@ from .tenki import (
     TENKI_TAG_RUN,
     TENKI_TAG_USER,
     _tag,
+    is_permanent_launch_error,
 )
 from .tenki_client import TenkiClient, TenkiKilledException
 
@@ -269,6 +270,9 @@ def step(
                 ),
             )
 
+    # Bound before the try so the except-block can safely read tenki._client
+    # even if the Tenki(...) constructor itself were to raise.
+    tenki = None
     try:
         tenki = Tenki(
             datastore=ctx.obj.flow_datastore,
@@ -294,10 +298,17 @@ def step(
                 run_time_limit=run_time_limit,
                 env=env,
             )
-    except Exception:
+    except Exception as e:
         traceback.print_exc(chain=False)
         _sync_metadata()
-        sys.exit(METAFLOW_EXIT_DISALLOW_RETRY)
+        # launch_job does synchronous network I/O (auth, project discovery,
+        # sandbox create), so a transient Tenki API/network failure must stay
+        # retryable when the step has @retry. Only permanent auth/permission/
+        # misconfig errors (and our own non-retryable signals) disallow retry;
+        # everything else exits non-zero so @retry can relaunch.
+        if is_permanent_launch_error(e, client=getattr(tenki, "_client", None)):
+            sys.exit(METAFLOW_EXIT_DISALLOW_RETRY)
+        sys.exit(1)
 
     try:
         tenki.wait(stdout_location, stderr_location, echo=echo)

--- a/metaflow/plugins/tenki/tenki_cli.py
+++ b/metaflow/plugins/tenki/tenki_cli.py
@@ -68,6 +68,37 @@ def _matching_sandboxes(flow_name, run_id, user):
     return client.list_sandboxes(tags=tags)
 
 
+def _terminate_sandboxes(sandboxes, echo):
+    # Return (killed, failed). For each sandbox try every teardown method in
+    # turn and don't give up after the first failure (mirrors
+    # tenki.py._cleanup); only report a failure when *no* method worked, so a
+    # recovered error never prints a false-alarm "Failed" line.
+    killed = 0
+    failed = 0
+    for sb in sandboxes:
+        name = getattr(sb, "name", "?")
+        terminated = False
+        last_error = None
+        for method in ("terminate", "close", "delete"):
+            fn = getattr(sb, method, None)
+            if fn is None:
+                continue
+            try:
+                fn()
+                terminated = True
+                break
+            except Exception as e:
+                last_error = e
+        if terminated:
+            killed += 1
+            echo("Terminated %s." % name)
+        else:
+            failed += 1
+            reason = last_error if last_error is not None else "no teardown method"
+            echo("Failed to terminate %s: %s" % (name, reason))
+    return killed, failed
+
+
 @tenki.command(name="list", help="List running Metaflow-launched Tenki sandboxes.")
 @click.option(
     "--my-runs",
@@ -112,22 +143,10 @@ def kill(ctx, run_id, user, my_runs):
     if not sandboxes:
         ctx.obj.echo_always("No matching sandboxes to terminate.")
         return
-    killed = 0
-    for sb in sandboxes:
-        name = getattr(sb, "name", "?")
-        for method in ("terminate", "close", "delete"):
-            fn = getattr(sb, method, None)
-            if fn is None:
-                continue
-            try:
-                fn()
-                killed += 1
-                ctx.obj.echo_always("Terminated %s." % name)
-                break
-            except Exception as e:
-                ctx.obj.echo_always("Failed to terminate %s: %s" % (name, e))
-                break
+    killed, failed = _terminate_sandboxes(sandboxes, ctx.obj.echo_always)
     ctx.obj.echo_always("Terminated %d sandbox(es)." % killed)
+    if failed:
+        ctx.obj.echo_always("Failed to terminate %d sandbox(es)." % failed)
 
 
 @tenki.command(

--- a/metaflow/plugins/tenki/tenki_cli.py
+++ b/metaflow/plugins/tenki/tenki_cli.py
@@ -6,7 +6,7 @@ import traceback
 import metaflow.tracing as tracing
 from metaflow import util
 from metaflow._vendor import click
-from metaflow.exception import METAFLOW_EXIT_DISALLOW_RETRY
+from metaflow.exception import CommandException, METAFLOW_EXIT_DISALLOW_RETRY
 from metaflow.metadata_provider.util import sync_local_metadata_from_datastore
 from metaflow.metaflow_config import (
     DATASTORE_LOCAL_DIR,
@@ -15,7 +15,14 @@ from metaflow.metaflow_config import (
 )
 from metaflow.mflog import TASK_LOG_SOURCE
 
-from .tenki import Tenki, TENKI_TAG, TENKI_TAG_RUN, TENKI_TAG_USER, _tag
+from .tenki import (
+    Tenki,
+    TENKI_TAG,
+    TENKI_TAG_FLOW,
+    TENKI_TAG_RUN,
+    TENKI_TAG_USER,
+    _tag,
+)
 from .tenki_client import TenkiClient, TenkiKilledException
 
 
@@ -29,8 +36,28 @@ def tenki():
     pass
 
 
-def _matching_sandboxes(run_id, user):
-    tags = [TENKI_TAG]
+def _resolve_scope(flow_name, run_id, user, my_runs, echo):
+    # Mirror @kubernetes / @batch (parse_cli_options): an unscoped invocation
+    # resolves to the *latest run of the current flow*, never the whole project.
+    # Replicated locally (as @batch does) to keep the plugin self-contained.
+    if user and my_runs:
+        raise CommandException("--user and --my-runs are mutually exclusive.")
+    if run_id and my_runs:
+        raise CommandException("--run-id and --my-runs are mutually exclusive.")
+    if my_runs:
+        user = util.get_username()
+    # A user filter alone means "all of that user's runs of this flow"; only
+    # fall back to the latest run when neither a run id nor a user was given.
+    if not run_id and not user:
+        run_id = util.get_latest_run_id(echo, flow_name)
+        if run_id is None:
+            raise CommandException("A previous run id was not found. Specify --run-id.")
+    return run_id, user
+
+
+def _matching_sandboxes(flow_name, run_id, user):
+    # Always scope by flow so cleanup can never touch another flow's sandboxes.
+    tags = [TENKI_TAG, _tag(TENKI_TAG_FLOW, flow_name)]
     if run_id:
         tags.append(_tag(TENKI_TAG_RUN, run_id))
     if user:
@@ -42,11 +69,20 @@ def _matching_sandboxes(run_id, user):
 
 
 @tenki.command(name="list", help="List running Metaflow-launched Tenki sandboxes.")
+@click.option(
+    "--my-runs",
+    default=False,
+    is_flag=True,
+    help="List all my sandboxes of this flow.",
+)
 @click.option("--run-id", default=None, help="Only sandboxes for this run id.")
 @click.option("--user", default=None, help="Only sandboxes launched by this user.")
 @click.pass_context
-def list_sandboxes(ctx, run_id, user):
-    sandboxes = _matching_sandboxes(run_id, user)
+def list_sandboxes(ctx, run_id, user, my_runs):
+    run_id, user = _resolve_scope(
+        ctx.obj.flow.name, run_id, user, my_runs, ctx.obj.echo_always
+    )
+    sandboxes = _matching_sandboxes(ctx.obj.flow.name, run_id, user)
     for sb in sandboxes:
         ctx.obj.echo_always(
             "%s [%s]" % (getattr(sb, "name", "?"), getattr(sb, "state", "?"))
@@ -56,14 +92,23 @@ def list_sandboxes(ctx, run_id, user):
 
 @tenki.command(help="Terminate running Metaflow-launched Tenki sandboxes.")
 @click.option(
+    "--my-runs",
+    default=False,
+    is_flag=True,
+    help="Terminate all my sandboxes of this flow.",
+)
+@click.option(
     "--run-id", default=None, help="Only terminate sandboxes for this run id."
 )
 @click.option(
     "--user", default=None, help="Only terminate sandboxes launched by this user."
 )
 @click.pass_context
-def kill(ctx, run_id, user):
-    sandboxes = _matching_sandboxes(run_id, user)
+def kill(ctx, run_id, user, my_runs):
+    run_id, user = _resolve_scope(
+        ctx.obj.flow.name, run_id, user, my_runs, ctx.obj.echo_always
+    )
+    sandboxes = _matching_sandboxes(ctx.obj.flow.name, run_id, user)
     if not sandboxes:
         ctx.obj.echo_always("No matching sandboxes to terminate.")
         return

--- a/metaflow/plugins/tenki/tenki_cli.py
+++ b/metaflow/plugins/tenki/tenki_cli.py
@@ -1,0 +1,245 @@
+import os
+import sys
+import time
+import traceback
+
+import metaflow.tracing as tracing
+from metaflow import util
+from metaflow._vendor import click
+from metaflow.exception import METAFLOW_EXIT_DISALLOW_RETRY
+from metaflow.metadata_provider.util import sync_local_metadata_from_datastore
+from metaflow.metaflow_config import (
+    DATASTORE_LOCAL_DIR,
+    TENKI_API_KEY,
+    TENKI_BASE_URL,
+)
+from metaflow.mflog import TASK_LOG_SOURCE
+
+from .tenki import Tenki, TENKI_TAG, TENKI_TAG_RUN, TENKI_TAG_USER, _tag
+from .tenki_client import TenkiClient, TenkiKilledException
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.group(help="Commands related to Tenki sandboxes.")
+def tenki():
+    pass
+
+
+def _matching_sandboxes(run_id, user):
+    tags = [TENKI_TAG]
+    if run_id:
+        tags.append(_tag(TENKI_TAG_RUN, run_id))
+    if user:
+        tags.append(_tag(TENKI_TAG_USER, user))
+    # Reuse the same client configuration as launch so `list`/`kill` work when
+    # credentials are supplied only via Metaflow config, not the environment.
+    client = TenkiClient(api_key=TENKI_API_KEY, base_url=TENKI_BASE_URL)
+    return client.list_sandboxes(tags=tags)
+
+
+@tenki.command(name="list", help="List running Metaflow-launched Tenki sandboxes.")
+@click.option("--run-id", default=None, help="Only sandboxes for this run id.")
+@click.option("--user", default=None, help="Only sandboxes launched by this user.")
+@click.pass_context
+def list_sandboxes(ctx, run_id, user):
+    sandboxes = _matching_sandboxes(run_id, user)
+    for sb in sandboxes:
+        ctx.obj.echo_always(
+            "%s [%s]" % (getattr(sb, "name", "?"), getattr(sb, "state", "?"))
+        )
+    ctx.obj.echo_always("%d sandbox(es) found." % len(sandboxes))
+
+
+@tenki.command(help="Terminate running Metaflow-launched Tenki sandboxes.")
+@click.option(
+    "--run-id", default=None, help="Only terminate sandboxes for this run id."
+)
+@click.option(
+    "--user", default=None, help="Only terminate sandboxes launched by this user."
+)
+@click.pass_context
+def kill(ctx, run_id, user):
+    sandboxes = _matching_sandboxes(run_id, user)
+    if not sandboxes:
+        ctx.obj.echo_always("No matching sandboxes to terminate.")
+        return
+    killed = 0
+    for sb in sandboxes:
+        name = getattr(sb, "name", "?")
+        for method in ("terminate", "close", "delete"):
+            fn = getattr(sb, method, None)
+            if fn is None:
+                continue
+            try:
+                fn()
+                killed += 1
+                ctx.obj.echo_always("Terminated %s." % name)
+                break
+            except Exception as e:
+                ctx.obj.echo_always("Failed to terminate %s: %s" % (name, e))
+                break
+    ctx.obj.echo_always("Terminated %d sandbox(es)." % killed)
+
+
+@tenki.command(
+    help="Execute a single task inside a Tenki sandbox. This command calls the "
+    "top-level step command inside a Tenki microVM with the given options. "
+    "Typically you do not call this command directly; it is used internally by "
+    "Metaflow."
+)
+@tracing.cli("tenki/step")
+@click.argument("step-name")
+@click.argument("code-package-metadata")
+@click.argument("code-package-sha")
+@click.argument("code-package-url")
+@click.option("--executable", help="Executable requirement for the Tenki sandbox.")
+@click.option("--image", help="Base image requirement for the Tenki sandbox.")
+@click.option("--cpu", help="CPU requirement for the Tenki sandbox.")
+@click.option("--memory", help="Memory requirement for the Tenki sandbox.")
+@click.option("--run-id", help="Passed to the top-level 'step'.")
+@click.option("--task-id", help="Passed to the top-level 'step'.")
+@click.option("--input-paths", help="Passed to the top-level 'step'.")
+@click.option("--split-index", help="Passed to the top-level 'step'.")
+@click.option("--clone-path", help="Passed to the top-level 'step'.")
+@click.option("--clone-run-id", help="Passed to the top-level 'step'.")
+@click.option(
+    "--tag", multiple=True, default=None, help="Passed to the top-level 'step'."
+)
+@click.option("--namespace", default=None, help="Passed to the top-level 'step'.")
+@click.option("--retry-count", default=0, help="Passed to the top-level 'step'.")
+@click.option(
+    "--max-user-code-retries", default=0, help="Passed to the top-level 'step'."
+)
+@click.option(
+    "--run-time-limit",
+    default=5 * 24 * 60 * 60,  # Default is set to 5 days
+    help="Run time limit in seconds for the Tenki sandbox.",
+)
+@click.pass_context
+def step(
+    ctx,
+    step_name,
+    code_package_metadata,
+    code_package_sha,
+    code_package_url,
+    executable=None,
+    image=None,
+    cpu=None,
+    memory=None,
+    run_time_limit=None,
+    **kwargs
+):
+    def echo(msg, stream="stderr", job_id=None, **kwargs):
+        msg = util.to_unicode(msg)
+        if job_id:
+            msg = "[%s] %s" % (job_id, msg)
+        ctx.obj.echo_always(msg, err=(stream == sys.stderr), **kwargs)
+
+    node = ctx.obj.graph[step_name]
+
+    # Construct entrypoint CLI.
+    executable = ctx.obj.environment.executable(step_name, executable)
+
+    # Set environment.
+    env = {"METAFLOW_FLOW_FILENAME": os.path.basename(sys.argv[0])}
+    env_deco = [deco for deco in node.decorators if deco.name == "environment"]
+    if env_deco:
+        env = env_deco[0].attributes["vars"]
+
+    # Set input paths.
+    input_paths = kwargs.get("input_paths")
+    split_vars = None
+    if input_paths:
+        max_size = 30 * 1024
+        split_vars = {
+            "METAFLOW_INPUT_PATHS_%d" % (i // max_size): input_paths[i : i + max_size]
+            for i in range(0, len(input_paths), max_size)
+        }
+        kwargs["input_paths"] = "".join("${%s}" % s for s in split_vars.keys())
+        env.update(split_vars)
+
+    # Set retry policy.
+    retry_count = int(kwargs.get("retry_count", 0))
+    retry_deco = [deco for deco in node.decorators if deco.name == "retry"]
+    minutes_between_retries = None
+    if retry_deco:
+        minutes_between_retries = int(
+            retry_deco[0].attributes.get("minutes_between_retries", 2)
+        )
+    if retry_count:
+        ctx.obj.echo_always(
+            "Sleeping %d minutes before the next retry" % minutes_between_retries
+        )
+        time.sleep(minutes_between_retries * 60)
+
+    task_id = kwargs["task_id"]
+
+    step_cli = "{entrypoint} {top_args} step {step} {step_args}".format(
+        entrypoint="%s -u %s" % (executable, os.path.basename(sys.argv[0])),
+        top_args=" ".join(util.dict_to_cli_options(ctx.parent.parent.params)),
+        step=step_name,
+        step_args=" ".join(util.dict_to_cli_options(kwargs)),
+    )
+
+    # Set log tailing.
+    ds = ctx.obj.flow_datastore.get_task_datastore(
+        mode="w",
+        run_id=kwargs["run_id"],
+        step_name=step_name,
+        task_id=task_id,
+        attempt=int(retry_count),
+    )
+    stdout_location = ds.get_log_location(TASK_LOG_SOURCE, "stdout")
+    stderr_location = ds.get_log_location(TASK_LOG_SOURCE, "stderr")
+
+    def _sync_metadata():
+        if ctx.obj.metadata.TYPE == "local":
+            sync_local_metadata_from_datastore(
+                DATASTORE_LOCAL_DIR,
+                ctx.obj.flow_datastore.get_task_datastore(
+                    kwargs["run_id"], step_name, task_id
+                ),
+            )
+
+    try:
+        tenki = Tenki(
+            datastore=ctx.obj.flow_datastore,
+            metadata=ctx.obj.metadata,
+            environment=ctx.obj.environment,
+        )
+        with ctx.obj.monitor.measure("metaflow.tenki.launch_job"):
+            tenki.launch_job(
+                flow_name=ctx.obj.flow.name,
+                run_id=kwargs["run_id"],
+                step_name=step_name,
+                task_id=task_id,
+                attempt=str(retry_count),
+                user=util.get_username(),
+                code_package_metadata=code_package_metadata,
+                code_package_sha=code_package_sha,
+                code_package_url=code_package_url,
+                code_package_ds=ctx.obj.flow_datastore.TYPE,
+                step_cli=step_cli,
+                image=image,
+                cpu=cpu,
+                memory=memory,
+                run_time_limit=run_time_limit,
+                env=env,
+            )
+    except Exception:
+        traceback.print_exc(chain=False)
+        _sync_metadata()
+        sys.exit(METAFLOW_EXIT_DISALLOW_RETRY)
+
+    try:
+        tenki.wait(stdout_location, stderr_location, echo=echo)
+    except TenkiKilledException:
+        # Do not retry killed / non-retryable tasks.
+        traceback.print_exc()
+        sys.exit(METAFLOW_EXIT_DISALLOW_RETRY)
+    finally:
+        _sync_metadata()

--- a/metaflow/plugins/tenki/tenki_cli.py
+++ b/metaflow/plugins/tenki/tenki_cli.py
@@ -38,8 +38,10 @@ def tenki():
 
 
 def _resolve_scope(flow_name, run_id, user, my_runs, echo):
-    # Mirror @kubernetes / @batch (parse_cli_options): an unscoped invocation
-    # resolves to the *latest run of the current flow*, never the whole project.
+    # Mirror @kubernetes / @batch (parse_cli_options) but harden the default:
+    # with no scope flags, resolve to the *current user's* latest run of this
+    # flow, never just "the flow's latest run". This keeps a destructive default
+    # `tenki kill` from ever touching another user's sandboxes on shared storage.
     # Replicated locally (as @batch does) to keep the plugin self-contained.
     if user and my_runs:
         raise CommandException("--user and --my-runs are mutually exclusive.")
@@ -47,9 +49,11 @@ def _resolve_scope(flow_name, run_id, user, my_runs, echo):
         raise CommandException("--run-id and --my-runs are mutually exclusive.")
     if my_runs:
         user = util.get_username()
-    # A user filter alone means "all of that user's runs of this flow"; only
-    # fall back to the latest run when neither a run id nor a user was given.
+    # A user filter alone means "all of that user's runs of this flow"; a run id
+    # alone targets exactly that run. With nothing specified, default to the
+    # current user's latest run (both the user and run-id scopes apply).
     if not run_id and not user:
+        user = util.get_username()
         run_id = util.get_latest_run_id(echo, flow_name)
         if run_id is None:
             raise CommandException("A previous run id was not found. Specify --run-id.")

--- a/metaflow/plugins/tenki/tenki_client.py
+++ b/metaflow/plugins/tenki/tenki_client.py
@@ -1,0 +1,124 @@
+import sys
+
+from metaflow.exception import MetaflowException
+
+# The backend uses APIs introduced in tenki-sandbox 0.4.0 (Client(auth_token=),
+# project-scoped create, CommandResult fields). 0.4.0 requires Python >= 3.10.
+_MIN_TENKI_SANDBOX_VERSION = "0.4.0"
+
+
+class TenkiException(MetaflowException):
+    headline = "Tenki error"
+
+
+class TenkiKilledException(MetaflowException):
+    headline = "Tenki sandbox killed"
+
+
+def get_tenki_sandbox_module():
+    # The `tenki-sandbox` SDK is a soft dependency, imported lazily so that
+    # Metaflow can be installed and used without it (mirrors how the Kubernetes
+    # and AWS plugins treat their respective SDKs).
+    try:
+        import tenki_sandbox
+    except (NameError, ImportError):
+        raise TenkiException(
+            "Could not import module 'tenki_sandbox'.\n\n"
+            "Install the Tenki Sandbox SDK first (>= %s, needs Python >= 3.10):\n"
+            "    %s -m pip install 'tenki-sandbox>=%s'\n"
+            "or equivalent through your favorite Python package manager."
+            % (_MIN_TENKI_SANDBOX_VERSION, sys.executable, _MIN_TENKI_SANDBOX_VERSION)
+        )
+
+    _check_min_version()
+    return tenki_sandbox
+
+
+def _check_min_version():
+    # The SDK does not expose __version__, so read the installed distribution
+    # metadata. Enforce the minimum the backend was written against; degrade
+    # gracefully (do not block) if the version cannot be determined or parsed.
+    try:
+        from importlib.metadata import version, PackageNotFoundError
+    except ImportError:
+        return
+    try:
+        installed = version("tenki-sandbox")
+    except PackageNotFoundError:
+        return
+    try:
+        from metaflow._vendor.packaging.version import Version, InvalidVersion
+    except ImportError:
+        return
+    try:
+        too_old = Version(installed) < Version(_MIN_TENKI_SANDBOX_VERSION)
+    except InvalidVersion:
+        return
+    if too_old:
+        raise TenkiException(
+            "The installed tenki-sandbox %s is too old; @tenki requires "
+            ">= %s (which needs Python >= 3.10). Upgrade with:\n"
+            "    %s -m pip install -U 'tenki-sandbox>=%s'"
+            % (
+                installed,
+                _MIN_TENKI_SANDBOX_VERSION,
+                sys.executable,
+                _MIN_TENKI_SANDBOX_VERSION,
+            )
+        )
+
+
+class TenkiClient(object):
+    """Thin wrapper around the ``tenki-sandbox`` SDK.
+
+    Keeps the SDK a soft dependency (imported lazily) and centralizes the auth
+    configuration so the runner does not have to know how the SDK is
+    constructed. All contact with the SDK surface lives here and in
+    ``tenki.py`` so that adjusting to the exact SDK signature is a one-file
+    change.
+    """
+
+    def __init__(self, api_key=None, base_url=None):
+        self._sdk = get_tenki_sandbox_module()
+        # Auth is configured on the Client. When auth_token is not passed, the
+        # SDK resolves it from the environment (TENKI_AUTH_TOKEN / TENKI_API_KEY).
+        client_kwargs = {}
+        if api_key:
+            client_kwargs["auth_token"] = api_key
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self._client = self._sdk.Client(**client_kwargs)
+
+    def create_sandbox(self, **kwargs):
+        return self._client.create(**kwargs)
+
+    def list_sandboxes(self, tags=None):
+        return self._client.list(tags=tags) if tags else self._client.list()
+
+    def default_project_id(self, workspace_id=None):
+        # Resolve a project for this token when TENKI_PROJECT_ID is not set. When
+        # a workspace is requested, only consider that workspace so we never
+        # return a project from a different workspace than the one configured.
+        me = self._client.who_am_i()
+        workspaces = getattr(me, "workspaces", None) or []
+        for ws in workspaces:
+            if workspace_id and getattr(ws, "id", None) != workspace_id:
+                continue
+            projects = getattr(ws, "projects", None) or []
+            for proj in projects:
+                return proj.id
+        return None
+
+    def exception(self, name):
+        # Return an SDK exception class by name, or an empty tuple if the SDK
+        # does not expose it (so `isinstance(err, self.exception("X"))` is
+        # always safe).
+        return getattr(self._sdk, name, ())
+
+    def close(self):
+        close = getattr(self._client, "close", None)
+        if close is not None:
+            try:
+                close()
+            except Exception:
+                pass

--- a/metaflow/plugins/tenki/tenki_client.py
+++ b/metaflow/plugins/tenki/tenki_client.py
@@ -2,9 +2,9 @@ import sys
 
 from metaflow.exception import MetaflowException
 
-# The backend uses APIs introduced in tenki-sandbox 0.4.0 (Client(auth_token=),
-# project-scoped create, CommandResult fields). 0.4.0 requires Python >= 3.10.
-_MIN_TENKI_SANDBOX_VERSION = "0.4.0"
+# The backend uses APIs from the `tenki` SDK >= 0.5.4 (Client(auth_token=),
+# create, CommandResult fields). 0.5.4 requires Python >= 3.10.
+_MIN_TENKI_VERSION = "0.5.4"
 
 
 class TenkiException(MetaflowException):
@@ -15,23 +15,23 @@ class TenkiKilledException(MetaflowException):
     headline = "Tenki sandbox killed"
 
 
-def get_tenki_sandbox_module():
-    # The `tenki-sandbox` SDK is a soft dependency, imported lazily so that
-    # Metaflow can be installed and used without it (mirrors how the Kubernetes
-    # and AWS plugins treat their respective SDKs).
+def get_tenki_module():
+    # The `tenki` SDK is a soft dependency, imported lazily so that Metaflow can
+    # be installed and used without it (mirrors how the Kubernetes and AWS
+    # plugins treat their respective SDKs).
     try:
-        import tenki_sandbox
+        import tenki
     except (NameError, ImportError):
         raise TenkiException(
-            "Could not import module 'tenki_sandbox'.\n\n"
-            "Install the Tenki Sandbox SDK first (>= %s, needs Python >= 3.10):\n"
-            "    %s -m pip install 'tenki-sandbox>=%s'\n"
+            "Could not import module 'tenki'.\n\n"
+            "Install the Tenki SDK first (>= %s, needs Python >= 3.10):\n"
+            "    %s -m pip install 'tenki>=%s'\n"
             "or equivalent through your favorite Python package manager."
-            % (_MIN_TENKI_SANDBOX_VERSION, sys.executable, _MIN_TENKI_SANDBOX_VERSION)
+            % (_MIN_TENKI_VERSION, sys.executable, _MIN_TENKI_VERSION)
         )
 
     _check_min_version()
-    return tenki_sandbox
+    return tenki
 
 
 def _check_min_version():
@@ -43,7 +43,7 @@ def _check_min_version():
     except ImportError:
         return
     try:
-        installed = version("tenki-sandbox")
+        installed = version("tenki")
     except PackageNotFoundError:
         return
     try:
@@ -51,25 +51,25 @@ def _check_min_version():
     except ImportError:
         return
     try:
-        too_old = Version(installed) < Version(_MIN_TENKI_SANDBOX_VERSION)
+        too_old = Version(installed) < Version(_MIN_TENKI_VERSION)
     except InvalidVersion:
         return
     if too_old:
         raise TenkiException(
-            "The installed tenki-sandbox %s is too old; @tenki requires "
-            ">= %s (which needs Python >= 3.10). Upgrade with:\n"
-            "    %s -m pip install -U 'tenki-sandbox>=%s'"
+            "The installed tenki %s is too old; @tenki requires >= %s (which "
+            "needs Python >= 3.10). Upgrade with:\n"
+            "    %s -m pip install -U 'tenki>=%s'"
             % (
                 installed,
-                _MIN_TENKI_SANDBOX_VERSION,
+                _MIN_TENKI_VERSION,
                 sys.executable,
-                _MIN_TENKI_SANDBOX_VERSION,
+                _MIN_TENKI_VERSION,
             )
         )
 
 
 class TenkiClient(object):
-    """Thin wrapper around the ``tenki-sandbox`` SDK.
+    """Thin wrapper around the ``tenki`` SDK.
 
     Keeps the SDK a soft dependency (imported lazily) and centralizes the auth
     configuration so the runner does not have to know how the SDK is
@@ -79,7 +79,7 @@ class TenkiClient(object):
     """
 
     def __init__(self, api_key=None, base_url=None):
-        self._sdk = get_tenki_sandbox_module()
+        self._sdk = get_tenki_module()
         # Auth is configured on the Client. When auth_token is not passed, the
         # SDK resolves it from the environment (TENKI_AUTH_TOKEN / TENKI_API_KEY).
         client_kwargs = {}
@@ -94,20 +94,6 @@ class TenkiClient(object):
 
     def list_sandboxes(self, tags=None):
         return self._client.list(tags=tags) if tags else self._client.list()
-
-    def default_project_id(self, workspace_id=None):
-        # Resolve a project for this token when TENKI_PROJECT_ID is not set. When
-        # a workspace is requested, only consider that workspace so we never
-        # return a project from a different workspace than the one configured.
-        me = self._client.who_am_i()
-        workspaces = getattr(me, "workspaces", None) or []
-        for ws in workspaces:
-            if workspace_id and getattr(ws, "id", None) != workspace_id:
-                continue
-            projects = getattr(ws, "projects", None) or []
-            for proj in projects:
-                return proj.id
-        return None
 
     def exception(self, name):
         # Return an SDK exception class by name, or an empty tuple if the SDK

--- a/metaflow/plugins/tenki/tenki_decorator.py
+++ b/metaflow/plugins/tenki/tenki_decorator.py
@@ -114,9 +114,9 @@ class TenkiDecorator(StepDecorator):
 
     def package_init(self, flow, step_name, environment):
         # Fail early with an actionable message if the SDK is missing.
-        from .tenki_client import get_tenki_sandbox_module
+        from .tenki_client import get_tenki_module
 
-        get_tenki_sandbox_module()
+        get_tenki_module()
 
     def runtime_init(self, flow, graph, package, run_id):
         self.flow = flow

--- a/metaflow/plugins/tenki/tenki_decorator.py
+++ b/metaflow/plugins/tenki/tenki_decorator.py
@@ -1,0 +1,216 @@
+import os
+import sys
+
+from metaflow import current
+from metaflow.decorators import StepDecorator
+from metaflow.metadata_provider import MetaDatum
+from metaflow.metadata_provider.util import sync_local_metadata_to_datastore
+from metaflow.metaflow_config import (
+    DATASTORE_LOCAL_DIR,
+    FEAT_ALWAYS_UPLOAD_CODE_PACKAGE,
+    TENKI_CONTAINER_IMAGE,
+    TENKI_CPU,
+    TENKI_MEMORY,
+)
+from metaflow.plugins.aws.aws_utils import compute_resource_attributes
+from metaflow.plugins.timeout_decorator import get_run_time_limit_for_task
+from metaflow.sidecar import Sidecar
+
+from .tenki_client import TenkiException
+
+
+class TenkiDecorator(StepDecorator):
+    """
+    Specifies that this step should execute inside a Tenki Sandbox microVM.
+
+    Parameters
+    ----------
+    cpu : int, default 2
+        Number of CPU cores required for this step. If `@resources` is
+        also present, the maximum value from all decorators is used.
+    memory : int, default 4096
+        Memory size (in MB) required for this step. If `@resources` is
+        also present, the maximum value from all decorators is used.
+    image : str, optional, default None
+        Base image to use for the microVM. If not specified, and
+        METAFLOW_TENKI_CONTAINER_IMAGE is specified, that image is used. If
+        neither is set, the Tenki default microVM image is used.
+
+        Any image must be published to the Tenki registry (Tenki does not pull
+        from external registries such as Docker Hub) and must provide `python3`.
+        Metaflow itself is shipped in the code package, so it does not need to
+        be pre-installed. The backend makes the image a viable runtime at
+        startup: it exposes a `python` command (symlinked to `python3` when
+        absent) and bootstraps pip if missing, so the Tenki default image works
+        out of the box. For faster startup, provide an image with `python`, pip,
+        and the datastore SDK (e.g. boto3) already installed.
+    """
+
+    name = "tenki"
+    defaults = {
+        "cpu": None,
+        "memory": None,
+        "image": None,
+        "executable": None,
+    }
+    resource_defaults = {
+        "cpu": "2",
+        "memory": "4096",
+    }
+    package_metadata = None
+    package_url = None
+    package_sha = None
+    run_time_limit = None
+
+    # Conda environment support (the microVM runs Linux).
+    supports_conda_environment = True
+    target_platform = "linux-64"
+
+    def init(self):
+        # Apply config-level defaults for cpu/memory only when the attribute is
+        # still unset (mirrors the KUBERNETES_CPU/MEMORY precedence rules).
+        if self.attributes["cpu"] is None and TENKI_CPU:
+            self.attributes["cpu"] = TENKI_CPU
+        if self.attributes["memory"] is None and TENKI_MEMORY:
+            self.attributes["memory"] = TENKI_MEMORY
+        if not self.attributes["image"] and TENKI_CONTAINER_IMAGE:
+            self.attributes["image"] = TENKI_CONTAINER_IMAGE
+
+    def step_init(self, flow, graph, step, decos, environment, flow_datastore, logger):
+        # A Tenki microVM cannot reach a local-filesystem datastore, so a
+        # remote, network-reachable datastore is required (mirrors
+        # @kubernetes). The backend forwards the relevant cloud credentials into
+        # the microVM for each supported datastore.
+        if flow_datastore.TYPE not in ("s3", "azure", "gs"):
+            raise TenkiException(
+                "The *@tenki* decorator requires --datastore=s3, "
+                "--datastore=azure or --datastore=gs at the moment."
+            )
+
+        # @parallel / gang scheduling is not supported yet.
+        for deco in decos:
+            if deco.name == "parallel":
+                raise TenkiException(
+                    "The *@tenki* decorator does not support @parallel steps yet."
+                )
+
+        self.logger = logger
+        self.environment = environment
+        self.step = step
+        self.flow_datastore = flow_datastore
+
+        # Merge @resources with the @tenki resource knobs (batch-style; this
+        # path is covered by test_compute_resource_attributes).
+        self.attributes.update(
+            compute_resource_attributes(decos, self, self.resource_defaults)
+        )
+
+        self.run_time_limit = get_run_time_limit_for_task(decos)
+        if self.run_time_limit < 60:
+            raise TenkiException(
+                "The timeout for step *{step}* should be at least 60 seconds "
+                "for execution inside a Tenki sandbox.".format(step=step)
+            )
+
+    def package_init(self, flow, step_name, environment):
+        # Fail early with an actionable message if the SDK is missing.
+        from .tenki_client import get_tenki_sandbox_module
+
+        get_tenki_sandbox_module()
+
+    def runtime_init(self, flow, graph, package, run_id):
+        self.flow = flow
+        self.graph = graph
+        self.package = package
+        self.run_id = run_id
+
+    def runtime_task_created(
+        self, task_datastore, task_id, split_index, input_paths, is_cloned, ubf_context
+    ):
+        # The microVM downloads the code package from the datastore as part of
+        # its entrypoint, so it must be uploaded before launch.
+        if not is_cloned:
+            self._save_package_once(self.flow_datastore, self.package)
+
+    def runtime_step_cli(
+        self, cli_args, retry_count, max_user_code_retries, ubf_context
+    ):
+        if retry_count <= max_user_code_retries:
+            # After all user-code retries are exhausted, fallback (@catch) code
+            # runs locally, so we stop routing to Tenki.
+            cli_args.commands = ["tenki", "step"]
+            cli_args.command_args.append(self.package_metadata)
+            cli_args.command_args.append(self.package_sha)
+            cli_args.command_args.append(self.package_url)
+            cli_args.command_options.update(self.attributes)
+            cli_args.command_options["run-time-limit"] = self.run_time_limit
+            cli_args.entrypoint[0] = sys.executable
+
+    def task_pre_step(
+        self,
+        step_name,
+        task_datastore,
+        metadata,
+        run_id,
+        task_id,
+        flow,
+        graph,
+        retry_count,
+        max_retries,
+        ubf_context,
+        inputs,
+    ):
+        self.metadata = metadata
+        self.task_datastore = task_datastore
+
+        # task_pre_step may run locally when @catch fallback is active; only do
+        # remote-workload bookkeeping when actually inside the microVM.
+        if "METAFLOW_TENKI_WORKLOAD" in os.environ:
+            entries = [
+                MetaDatum(
+                    field="tenki-sandbox-name",
+                    value=os.environ.get("METAFLOW_TENKI_SANDBOX_NAME", ""),
+                    type="tenki-sandbox-name",
+                    tags=["attempt_id:{0}".format(retry_count)],
+                )
+            ]
+            metadata.register_metadata(run_id, step_name, task_id, entries)
+
+            # Periodically flush structured logs to the datastore so the local
+            # orchestrator's log tailer sees output while the task runs.
+            self._save_logs_sidecar = Sidecar("save_logs_periodically")
+            self._save_logs_sidecar.start()
+
+    def task_finished(
+        self, step_name, flow, graph, is_task_ok, retry_count, max_retries
+    ):
+        # task_finished may run locally (the @catch fallback path), in which case
+        # task_pre_step never started the log sidecar. Only tear it down when we
+        # actually ran as the remote workload.
+        if "METAFLOW_TENKI_WORKLOAD" in os.environ:
+            # With `local` metadata, sync it back to the datastore so it reaches
+            # the user's machine. There is no guarantee task_pre_step ran, so we
+            # guard against a missing metadata object.
+            if hasattr(self, "metadata") and self.metadata.TYPE == "local":
+                sync_local_metadata_to_datastore(
+                    DATASTORE_LOCAL_DIR, self.task_datastore
+                )
+            try:
+                self._save_logs_sidecar.terminate()
+            except Exception:
+                # Best effort.
+                pass
+
+    @classmethod
+    def _save_package_once(cls, flow_datastore, package):
+        if cls.package_url is None:
+            if not FEAT_ALWAYS_UPLOAD_CODE_PACKAGE:
+                cls.package_url, cls.package_sha = flow_datastore.save_data(
+                    [package.blob], len_hint=1
+                )[0]
+                cls.package_metadata = package.package_metadata
+            else:
+                # Blocks until the package is uploaded.
+                cls.package_url = package.package_url()
+                cls.package_sha = package.package_sha()
+                cls.package_metadata = package.package_metadata

--- a/test/unit/test_tenki.py
+++ b/test/unit/test_tenki.py
@@ -256,6 +256,66 @@ def test_resolve_scope_semantics(monkeypatch):
         tenki_cli._resolve_scope("F", None, None, False, echo)
 
 
+class _KillSandbox(object):
+    """A sandbox whose teardown methods succeed or raise per `fails`.
+
+    `fails` is a set of method names that raise; any other listed method
+    succeeds. Only methods in `has` exist on the object.
+    """
+
+    def __init__(self, name, has=("terminate", "close"), fails=()):
+        self.name = name
+        self._fails = set(fails)
+        self.calls = []
+        for m in has:
+            setattr(self, m, self._make(m))
+
+    def _make(self, method):
+        def _fn():
+            self.calls.append(method)
+            if method in self._fails:
+                raise RuntimeError("boom-%s" % method)
+
+        return _fn
+
+
+def test_terminate_sandboxes_tries_all_methods_before_failing():
+    echoes = []
+    echo = echoes.append
+
+    # terminate() fails but close() succeeds -> counted as killed, NO false alarm.
+    recovered = _KillSandbox("a", has=("terminate", "close"), fails=("terminate",))
+    # every method fails -> counted as failed, one failure line.
+    dead = _KillSandbox("b", has=("terminate", "close"), fails=("terminate", "close"))
+
+    killed, failed = tenki_cli._terminate_sandboxes([recovered, dead], echo)
+
+    assert (killed, failed) == (1, 1)
+    # The recovered sandbox tried terminate then close (no early break).
+    assert recovered.calls == ["terminate", "close"]
+    # No "Failed" line for the recovered one; exactly one for the dead one.
+    assert "Terminated a." in echoes
+    assert not any("Failed to terminate a" in m for m in echoes)
+    assert any("Failed to terminate b" in m for m in echoes)
+
+
+def test_terminate_sandboxes_all_succeed():
+    echoes = []
+    sbs = [_KillSandbox("a"), _KillSandbox("b")]
+    killed, failed = tenki_cli._terminate_sandboxes(sbs, echoes.append)
+    assert (killed, failed) == (2, 0)
+
+
+def test_terminate_sandboxes_no_teardown_method():
+    # Degenerate sandbox exposing no teardown method: reported as failed with a
+    # clear reason, not a stray "None".
+    echoes = []
+    sb = _KillSandbox("a", has=())
+    killed, failed = tenki_cli._terminate_sandboxes([sb], echoes.append)
+    assert (killed, failed) == (0, 1)
+    assert any("no teardown method" in m for m in echoes)
+
+
 def _conda_interpreter_for(step_decorators):
     """Drive the real CondaStepDecorator.runtime_task_created and return the
     interpreter it selects for a step carrying `step_decorators`."""

--- a/test/unit/test_tenki.py
+++ b/test/unit/test_tenki.py
@@ -115,38 +115,17 @@ def test_task_finished_local_fallback_does_not_crash(monkeypatch):
     deco.task_finished("start", None, None, True, 0, 0)
 
 
-def test_default_project_id_respects_workspace():
-    Proj = namedtuple("Proj", ["id"])
-    Ws = namedtuple("Ws", ["id", "projects"])
-    Identity = namedtuple("Identity", ["workspaces"])
-
-    class _RawClient:
-        def who_am_i(self):
-            return Identity(
-                workspaces=(
-                    Ws("ws-1", (Proj("proj-1a"),)),
-                    Ws("ws-2", (Proj("proj-2a"),)),
-                )
-            )
-
-    client = TenkiClient.__new__(TenkiClient)
-    client._client = _RawClient()
-    assert client.default_project_id() == "proj-1a"  # first workspace
-    assert client.default_project_id("ws-2") == "proj-2a"  # requested workspace
-    assert client.default_project_id("ws-missing") is None
-
-
 def test_sdk_min_version_enforced(monkeypatch):
     def _set_version(v):
         monkeypatch.setattr(importlib.metadata, "version", lambda dist: v)
 
     # Too old -> clear error.
-    _set_version("0.3.9")
+    _set_version("0.5.3")
     with pytest.raises(TenkiException, match="too old"):
         tenki_client._check_min_version()
 
     # At or above the minimum -> no error.
-    _set_version("0.4.0")
+    _set_version("0.5.4")
     tenki_client._check_min_version()
     _set_version("1.2.0")
     tenki_client._check_min_version()
@@ -427,7 +406,7 @@ class _FakeResult(object):
 
     @property
     def ok(self):
-        # Mirrors tenki_sandbox.models.CommandResult.ok.
+        # Mirrors tenki.models.CommandResult.ok.
         return self.exit_code == 0 and not self.signal
 
 
@@ -458,9 +437,6 @@ class _FakeClient(object):
 
     def exception(self, name):
         return _FAKE_EXC.get(name, ())
-
-    def default_project_id(self, workspace_id=None):
-        return "proj-test"
 
     def close(self):
         self.closed = True
@@ -514,7 +490,8 @@ def test_run_success(monkeypatch):
     assert sandbox.create_kwargs["allow_outbound"] is True
     assert sandbox.create_kwargs["cpu_cores"] == 2
     assert sandbox.create_kwargs["memory_mb"] == 4096
-    assert sandbox.create_kwargs["project_id"] == "proj-test"
+    # The SDK no longer takes a project_id; we must not send one.
+    assert "project_id" not in sandbox.create_kwargs
     # Sandbox is tagged with the flow (for flow-scoped `tenki list`/`kill`),
     # run, and user — all sanitized to Tenki's tag charset.
     assert sandbox.create_kwargs["tags"] == [

--- a/test/unit/test_tenki.py
+++ b/test/unit/test_tenki.py
@@ -197,15 +197,63 @@ def test_cli_matching_sandboxes_uses_configured_credentials(monkeypatch):
     monkeypatch.setattr(tenki_cli, "TENKI_API_KEY", "cfg-key")
     monkeypatch.setattr(tenki_cli, "TENKI_BASE_URL", "https://cfg.example")
 
-    tenki_cli._matching_sandboxes("run-1", "tester")
+    tenki_cli._matching_sandboxes("MyFlow", "run-1", "tester")
 
     assert captured["api_key"] == "cfg-key"
     assert captured["base_url"] == "https://cfg.example"
+    # Always flow-scoped (second tag) so cleanup can never cross flows.
     assert captured["tags"] == [
         "metaflow",
+        "metaflow-flow:myflow",
         "metaflow-run:run-1",
         "metaflow-user:tester",
     ]
+
+
+def test_cli_matching_sandboxes_is_always_flow_scoped(monkeypatch):
+    # Even with no run-id/user, the query is scoped to the flow tag — never the
+    # bare "metaflow" tag (which would match every user's sandboxes).
+    captured = {}
+
+    class _FakeClient:
+        def __init__(self, api_key=None, base_url=None):
+            pass
+
+        def list_sandboxes(self, tags=None):
+            captured["tags"] = tags
+            return []
+
+    monkeypatch.setattr(tenki_cli, "TenkiClient", _FakeClient)
+    tenki_cli._matching_sandboxes("MyFlow", None, None)
+    assert captured["tags"] == ["metaflow", "metaflow-flow:myflow"]
+
+
+def test_resolve_scope_semantics(monkeypatch):
+    from metaflow.exception import CommandException
+
+    echo = lambda *a, **k: None
+
+    # Mutually-exclusive flags.
+    with pytest.raises(CommandException):
+        tenki_cli._resolve_scope("F", None, "u", True, echo)
+    with pytest.raises(CommandException):
+        tenki_cli._resolve_scope("F", "r", None, True, echo)
+
+    # --my-runs -> current user, run_id stays None (all my runs of this flow).
+    monkeypatch.setattr(tenki_cli.util, "get_username", lambda: "me")
+    assert tenki_cli._resolve_scope("F", None, None, True, echo) == (None, "me")
+
+    # A user filter alone -> that user's runs, no latest-run fallback.
+    assert tenki_cli._resolve_scope("F", None, "bob", False, echo) == (None, "bob")
+
+    # No flags -> default to the latest run of this flow.
+    monkeypatch.setattr(tenki_cli.util, "get_latest_run_id", lambda e, f: "run-9")
+    assert tenki_cli._resolve_scope("F", None, None, False, echo) == ("run-9", None)
+
+    # No flags and no previous run -> clear error.
+    monkeypatch.setattr(tenki_cli.util, "get_latest_run_id", lambda e, f: None)
+    with pytest.raises(CommandException):
+        tenki_cli._resolve_scope("F", None, None, False, echo)
 
 
 def _conda_interpreter_for(step_decorators):
@@ -374,6 +422,14 @@ def test_run_success(monkeypatch):
     assert sandbox.create_kwargs["cpu_cores"] == 2
     assert sandbox.create_kwargs["memory_mb"] == 4096
     assert sandbox.create_kwargs["project_id"] == "proj-test"
+    # Sandbox is tagged with the flow (for flow-scoped `tenki list`/`kill`),
+    # run, and user — all sanitized to Tenki's tag charset.
+    assert sandbox.create_kwargs["tags"] == [
+        "metaflow",
+        "metaflow-flow:myflow",
+        "metaflow-run:run-1",
+        "metaflow-user:tester",
+    ]
     # Server-side TTL backstop = run_time_limit (120) + grace.
     assert sandbox.create_kwargs["max_duration"] > 120
     # We must NOT set idle_timeout_minutes: a data-plane exec doesn't refresh

--- a/test/unit/test_tenki.py
+++ b/test/unit/test_tenki.py
@@ -10,7 +10,12 @@ from metaflow.plugins.aws.aws_utils import compute_resource_attributes
 from metaflow.plugins.pypi.conda_decorator import CondaStepDecorator
 from metaflow.plugins.tenki import tenki as tenki_mod
 from metaflow.plugins.tenki import tenki_cli, tenki_client
-from metaflow.plugins.tenki.tenki import Tenki, _sanitize_name, _tag
+from metaflow.plugins.tenki.tenki import (
+    Tenki,
+    _sanitize_name,
+    _tag,
+    is_permanent_launch_error,
+)
 from metaflow.plugins.tenki.tenki_client import (
     TenkiClient,
     TenkiException,
@@ -356,22 +361,50 @@ def test_conda_does_not_hijack_tenki_trampoline_interpreter():
 # ---------------------------------------------------------------------------
 
 
-class _FakeCommandTimeout(Exception):
+# Mirror the real SDK: every error subclasses SandboxError and carries a
+# `retryable` class flag (only UNAVAILABLE / rate-limit are retryable).
+class _FakeSandboxError(Exception):
+    retryable = False
+
+
+class _FakeCommandTimeout(_FakeSandboxError):
     pass
 
 
-class _FakeSessionNotFound(Exception):
+class _FakeSessionNotFound(_FakeSandboxError):
     pass
 
 
-class _FakePermissionDenied(Exception):
+class _FakePermissionDenied(_FakeSandboxError):
     pass
+
+
+class _FakeMissingAuthToken(_FakeSandboxError):
+    pass
+
+
+class _FakeUnauthorized(_FakeSandboxError):
+    pass
+
+
+class _FakeQuotaExceeded(_FakeSandboxError):
+    pass
+
+
+class _FakeRegistryImageNotFound(_FakeSandboxError):
+    pass
+
+
+class _FakeRateLimited(_FakeSandboxError):
+    retryable = True
 
 
 _FAKE_EXC = {
+    "SandboxError": _FakeSandboxError,
     "CommandTimeoutError": _FakeCommandTimeout,
     "SessionNotFoundError": _FakeSessionNotFound,
     "PermissionDeniedError": _FakePermissionDenied,
+    "MissingAuthTokenError": _FakeMissingAuthToken,
 }
 
 
@@ -652,6 +685,46 @@ def test_permission_denied_is_not_retryable(monkeypatch):
     # maps to METAFLOW_EXIT_DISALLOW_RETRY.
     with pytest.raises(TenkiKilledException):
         _run_task(monkeypatch, _FakePermissionDenied("bad token"))
+
+
+def test_is_permanent_launch_error_classification():
+    # A client that resolves SDK exception classes like the real TenkiClient.
+    client = _FakeClient(None)
+
+    # Permanent -> DISALLOW_RETRY.
+    assert is_permanent_launch_error(TenkiKilledException("x"), client) is True
+    assert is_permanent_launch_error(TenkiException("too old"), client) is True
+    assert is_permanent_launch_error(_FakePermissionDenied("no"), client) is True
+    assert is_permanent_launch_error(_FakeMissingAuthToken("no"), client) is True
+    # Non-retryable SDK errors we don't name explicitly must still be permanent
+    # (the bug the SDK's `retryable` flag guards against): auth, quota, bad image.
+    assert is_permanent_launch_error(_FakeUnauthorized("no"), client) is True
+    assert is_permanent_launch_error(_FakeQuotaExceeded("no"), client) is True
+    assert is_permanent_launch_error(_FakeRegistryImageNotFound("no"), client) is True
+    # A generic SandboxError (unknown gRPC code) defaults to retryable=False.
+    assert is_permanent_launch_error(_FakeSandboxError("blip"), client) is True
+    # Unknown non-SDK error -> permanent (conservative default).
+    assert is_permanent_launch_error(RuntimeError("???"), client) is True
+
+    # Transient -> retryable (plain non-zero exit).
+    assert is_permanent_launch_error(_FakeSessionNotFound("gone"), client) is False
+    assert is_permanent_launch_error(_FakeCommandTimeout("slow"), client) is False
+    assert is_permanent_launch_error(TimeoutError("deadline"), client) is False
+    # SDK-declared retryable (UNAVAILABLE / rate-limit) is honored.
+    assert is_permanent_launch_error(_FakeRateLimited("slow down"), client) is False
+    unavailable = _FakeSandboxError("service unavailable")
+    unavailable.retryable = True  # mirrors map_rpc_error's UNAVAILABLE mapping
+    assert is_permanent_launch_error(unavailable, client) is False
+
+
+def test_is_permanent_launch_error_without_client():
+    # If the client failed to construct, SDK names resolve to () and never
+    # match; our own signals and the unknown-default still classify correctly.
+    assert is_permanent_launch_error(TenkiException("guard"), None) is True
+    assert is_permanent_launch_error(TenkiKilledException("x"), None) is True
+    assert is_permanent_launch_error(RuntimeError("???"), None) is True
+    # A builtin TimeoutError is transient even with no client.
+    assert is_permanent_launch_error(TimeoutError("x"), None) is False
 
 
 def test_unknown_exit_code_is_retryable(monkeypatch):

--- a/test/unit/test_tenki.py
+++ b/test/unit/test_tenki.py
@@ -230,9 +230,13 @@ def test_resolve_scope_semantics(monkeypatch):
     # A user filter alone -> that user's runs, no latest-run fallback.
     assert tenki_cli._resolve_scope("F", None, "bob", False, echo) == (None, "bob")
 
-    # No flags -> default to the latest run of this flow.
+    # No flags -> default to the CURRENT USER's latest run of this flow (a
+    # destructive default must not touch another user's sandboxes).
     monkeypatch.setattr(tenki_cli.util, "get_latest_run_id", lambda e, f: "run-9")
-    assert tenki_cli._resolve_scope("F", None, None, False, echo) == ("run-9", None)
+    assert tenki_cli._resolve_scope("F", None, None, False, echo) == ("run-9", "me")
+
+    # A run id alone targets exactly that run, regardless of owner (explicit).
+    assert tenki_cli._resolve_scope("F", "run-7", None, False, echo) == ("run-7", None)
 
     # No flags and no previous run -> clear error.
     monkeypatch.setattr(tenki_cli.util, "get_latest_run_id", lambda e, f: None)

--- a/test/unit/test_tenki.py
+++ b/test/unit/test_tenki.py
@@ -1,0 +1,715 @@
+import base64
+import importlib.metadata
+import re
+import time
+from collections import namedtuple
+
+import pytest
+
+from metaflow.plugins.aws.aws_utils import compute_resource_attributes
+from metaflow.plugins.pypi.conda_decorator import CondaStepDecorator
+from metaflow.plugins.tenki import tenki as tenki_mod
+from metaflow.plugins.tenki import tenki_cli, tenki_client
+from metaflow.plugins.tenki.tenki import Tenki, _sanitize_name, _tag
+from metaflow.plugins.tenki.tenki_client import (
+    TenkiClient,
+    TenkiException,
+    TenkiKilledException,
+)
+from metaflow.plugins.tenki.tenki_decorator import TenkiDecorator
+
+MockDeco = namedtuple("MockDeco", ["name", "attributes"])
+
+
+class _DS(object):
+    def __init__(self, type_):
+        self.TYPE = type_
+
+
+class _Env(object):
+    def get_package_commands(self, url, ds, metadata):
+        return ["download %s" % url]
+
+    def bootstrap_commands(self, step_name, ds):
+        return ["bootstrap"]
+
+
+def _deco(**attrs):
+    base = {"cpu": None, "memory": None, "image": None, "executable": None}
+    base.update(attrs)
+    return TenkiDecorator(attributes=base)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("MyFlow/run-1", "myflow-run-1"),
+        ("Step_Name", "step-name"),
+        ("---", "step"),
+        ("A" * 80, "a" * 40),
+    ],
+)
+def test_sanitize_name(raw, expected):
+    assert _sanitize_name(raw) == expected
+
+
+def test_resource_defaults_used_without_resources():
+    deco = _deco()
+    assert compute_resource_attributes([], deco, TenkiDecorator.resource_defaults) == {
+        "cpu": "2",
+        "memory": "4096",
+    }
+
+
+def test_resource_merge_takes_max_with_resources():
+    deco = _deco(cpu="4")
+    merged = compute_resource_attributes(
+        [MockDeco("resources", {"cpu": "1", "memory": "8192"})],
+        deco,
+        TenkiDecorator.resource_defaults,
+    )
+    assert merged == {"cpu": "4.0", "memory": "8192"}
+
+
+def test_step_init_rejects_local_datastore():
+    deco = _deco()
+    with pytest.raises(TenkiException):
+        deco.step_init(
+            None, None, "start", [], _Env(), _DS("local"), lambda *a, **k: None
+        )
+
+
+@pytest.mark.parametrize("ds_type", ["s3", "azure", "gs"])
+def test_step_init_accepts_remote_datastores(ds_type):
+    deco = _deco()
+    # Should not raise, and should populate resource attributes.
+    deco.step_init(None, None, "start", [], _Env(), _DS(ds_type), lambda *a, **k: None)
+    assert deco.attributes["cpu"] == "2"
+    assert deco.attributes["memory"] == "4096"
+
+
+def test_step_init_rejects_parallel():
+    deco = _deco()
+    with pytest.raises(TenkiException):
+        deco.step_init(
+            None,
+            None,
+            "start",
+            [MockDeco("parallel", {})],
+            _Env(),
+            _DS("s3"),
+            lambda *a, **k: None,
+        )
+
+
+def test_task_finished_local_fallback_does_not_crash(monkeypatch):
+    # In the @catch local-fallback path, task_pre_step never started the log
+    # sidecar. task_finished must not raise (no METAFLOW_TENKI_WORKLOAD).
+    monkeypatch.delenv("METAFLOW_TENKI_WORKLOAD", raising=False)
+    deco = _deco()
+    deco.task_finished("start", None, None, True, 0, 0)
+
+
+def test_default_project_id_respects_workspace():
+    Proj = namedtuple("Proj", ["id"])
+    Ws = namedtuple("Ws", ["id", "projects"])
+    Identity = namedtuple("Identity", ["workspaces"])
+
+    class _RawClient:
+        def who_am_i(self):
+            return Identity(
+                workspaces=(
+                    Ws("ws-1", (Proj("proj-1a"),)),
+                    Ws("ws-2", (Proj("proj-2a"),)),
+                )
+            )
+
+    client = TenkiClient.__new__(TenkiClient)
+    client._client = _RawClient()
+    assert client.default_project_id() == "proj-1a"  # first workspace
+    assert client.default_project_id("ws-2") == "proj-2a"  # requested workspace
+    assert client.default_project_id("ws-missing") is None
+
+
+def test_sdk_min_version_enforced(monkeypatch):
+    def _set_version(v):
+        monkeypatch.setattr(importlib.metadata, "version", lambda dist: v)
+
+    # Too old -> clear error.
+    _set_version("0.3.9")
+    with pytest.raises(TenkiException, match="too old"):
+        tenki_client._check_min_version()
+
+    # At or above the minimum -> no error.
+    _set_version("0.4.0")
+    tenki_client._check_min_version()
+    _set_version("1.2.0")
+    tenki_client._check_min_version()
+
+    # Undeterminable version must not block (graceful degrade).
+    def _raise(dist):
+        raise importlib.metadata.PackageNotFoundError(dist)
+
+    monkeypatch.setattr(importlib.metadata, "version", _raise)
+    tenki_client._check_min_version()
+
+
+def test_tag_sanitization_fits_tenki_constraints():
+    charset = re.compile(r"^[a-z0-9_:.-]{1,32}$")
+
+    # Email user: has '@' and uppercase and overflows 32 chars -> normalized,
+    # hashed, still valid and <= 32.
+    email = "Alvaro.Deleglise@Luxor.Tech"
+    t = _tag("metaflow-user", email)
+    assert charset.match(t), t
+    assert len(t) <= 32
+    assert t.startswith("metaflow-user:")
+
+    # Short clean values pass through unchanged (human-readable).
+    assert _tag("metaflow-run", "1784731662078694") == "metaflow-run:1784731662078694"
+    assert _tag("metaflow-user", "tester") == "metaflow-user:tester"
+
+    # Deterministic: create and cleanup must agree on the same input.
+    assert _tag("metaflow-user", email) == _tag("metaflow-user", email)
+
+    # Distinct long values stay distinct (no truncation collision).
+    a = "user-with-a-very-long-name-alice@example.com"
+    b = "user-with-a-very-long-name-bob@example.com"
+    assert _tag("metaflow-user", a) != _tag("metaflow-user", b)
+    assert len(_tag("metaflow-user", a)) <= 32
+
+
+def test_cli_matching_sandboxes_uses_configured_credentials(monkeypatch):
+    # `tenki list` / `tenki kill` must build the client with the same config as
+    # launch, so cleanup works when credentials come only from Metaflow config.
+    captured = {}
+
+    class _FakeClient:
+        def __init__(self, api_key=None, base_url=None):
+            captured["api_key"] = api_key
+            captured["base_url"] = base_url
+
+        def list_sandboxes(self, tags=None):
+            captured["tags"] = tags
+            return []
+
+    monkeypatch.setattr(tenki_cli, "TenkiClient", _FakeClient)
+    monkeypatch.setattr(tenki_cli, "TENKI_API_KEY", "cfg-key")
+    monkeypatch.setattr(tenki_cli, "TENKI_BASE_URL", "https://cfg.example")
+
+    tenki_cli._matching_sandboxes("run-1", "tester")
+
+    assert captured["api_key"] == "cfg-key"
+    assert captured["base_url"] == "https://cfg.example"
+    assert captured["tags"] == [
+        "metaflow",
+        "metaflow-run:run-1",
+        "metaflow-user:tester",
+    ]
+
+
+def _conda_interpreter_for(step_decorators):
+    """Drive the real CondaStepDecorator.runtime_task_created and return the
+    interpreter it selects for a step carrying `step_decorators`."""
+    Deco = namedtuple("Deco", ["name"])
+    Step = namedtuple("Step", ["name", "decorators"])
+
+    class _Env:
+        def interpreter(self, step_name):
+            return "pypi-env-python"  # sentinel: the resolved-env interpreter
+
+    deco = CondaStepDecorator.__new__(CondaStepDecorator)
+    deco.disabled = False
+    deco.environment = _Env()
+    deco.step = "start"
+    deco.flow = [Step("start", [Deco(n) for n in step_decorators])]
+    deco.runtime_task_created(None, None, None, None, False, None)
+    return deco.interpreter
+
+
+def test_conda_does_not_hijack_tenki_trampoline_interpreter():
+    # Bug #7 regression (behavioral): @pypi/@conda must set interpreter=None for
+    # a @tenki step (like @batch/@kubernetes) so it does NOT swap the local
+    # `tenki step` trampoline to the resolved pypi env — which would make the
+    # trampoline fail to import datastore/metadata deps. Without the fix ("tenki"
+    # absent from conda's remote-backend list) a @tenki step gets a non-None
+    # interpreter (the hijack), so this fails without the fix and passes with it.
+    assert _conda_interpreter_for(["tenki", "pypi"]) is None
+    # Parity: @kubernetes behaves identically.
+    assert _conda_interpreter_for(["kubernetes", "pypi"]) is None
+    # A local step (no remote backend) still gets the resolved-env interpreter.
+    assert _conda_interpreter_for(["pypi"]) == "pypi-env-python"
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests: exercise the full launch_job -> exec (in a thread)
+# -> wait -> exit-code/exception handling -> cleanup path with the Tenki SDK
+# stubbed out. Networking, credentials and the real SDK are NOT required.
+# ---------------------------------------------------------------------------
+
+
+class _FakeCommandTimeout(Exception):
+    pass
+
+
+class _FakeSessionNotFound(Exception):
+    pass
+
+
+class _FakePermissionDenied(Exception):
+    pass
+
+
+_FAKE_EXC = {
+    "CommandTimeoutError": _FakeCommandTimeout,
+    "SessionNotFoundError": _FakeSessionNotFound,
+    "PermissionDeniedError": _FakePermissionDenied,
+}
+
+
+class _FakeResult(object):
+    def __init__(
+        self,
+        exit_code,
+        stdout_text="",
+        stderr_text="",
+        signal=None,
+        reason=None,
+        errno=None,
+    ):
+        self.exit_code = exit_code
+        self.stdout_text = stdout_text
+        self.stderr_text = stderr_text
+        self.signal = signal
+        self.reason = reason
+        self.errno = errno
+
+    @property
+    def ok(self):
+        # Mirrors tenki_sandbox.models.CommandResult.ok.
+        return self.exit_code == 0 and not self.signal
+
+
+class _FakeSandbox(object):
+    def __init__(self, behavior):
+        # behavior is either a _FakeResult (returned) or an Exception (raised).
+        self._behavior = behavior
+        self.closed = False
+        self.exec_calls = []
+
+    def exec(self, *args, **kwargs):
+        self.exec_calls.append((args, kwargs))
+        if isinstance(self._behavior, Exception):
+            raise self._behavior
+        return self._behavior
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeClient(object):
+    def __init__(self, sandbox):
+        self._sandbox = sandbox
+
+    def create_sandbox(self, **kwargs):
+        self._sandbox.create_kwargs = kwargs
+        return self._sandbox
+
+    def exception(self, name):
+        return _FAKE_EXC.get(name, ())
+
+    def default_project_id(self, workspace_id=None):
+        return "proj-test"
+
+    def close(self):
+        self.closed = True
+
+
+def _run_task(monkeypatch, behavior, cpu="2", memory="4096", run_time_limit=120):
+    """Drive a task through the runner with a stubbed SDK; return (echoes, sandbox)."""
+    sandbox = _FakeSandbox(behavior)
+    monkeypatch.setattr(tenki_mod, "TenkiClient", lambda **kwargs: _FakeClient(sandbox))
+    # Stub out datastore-backed log tailing.
+    monkeypatch.setattr(tenki_mod, "get_log_tailer", lambda loc, ds_type: None)
+
+    def _fake_tail_logs(prefix, stdout_tail, stderr_tail, echo, has_log_updates):
+        # Mimic the real loop: keep going while there are updates.
+        while has_log_updates():
+            time.sleep(0.005)
+
+    monkeypatch.setattr(tenki_mod, "tail_logs", _fake_tail_logs)
+
+    tenki = Tenki(datastore=_DS("s3"), metadata=None, environment=_Env())
+    tenki.launch_job(
+        flow_name="MyFlow",
+        run_id="run-1",
+        step_name="start",
+        task_id="t-1",
+        attempt="0",
+        user="tester",
+        code_package_metadata="meta",
+        code_package_sha="sha",
+        code_package_url="s3://pkg.tgz",
+        code_package_ds="s3",
+        step_cli="python flow.py step start",
+        image=None,
+        cpu=cpu,
+        memory=memory,
+        run_time_limit=run_time_limit,
+        env={},
+    )
+    echoes = []
+    tenki.wait(
+        "s3://logs/stdout",
+        "s3://logs/stderr",
+        echo=lambda msg, stream="stderr", **k: echoes.append((stream, msg)),
+    )
+    return echoes, sandbox
+
+
+def test_run_success(monkeypatch):
+    echoes, sandbox = _run_task(monkeypatch, _FakeResult(0))
+    # Sandbox created with outbound networking enabled and the right resources.
+    assert sandbox.create_kwargs["allow_outbound"] is True
+    assert sandbox.create_kwargs["cpu_cores"] == 2
+    assert sandbox.create_kwargs["memory_mb"] == 4096
+    assert sandbox.create_kwargs["project_id"] == "proj-test"
+    # Server-side TTL backstop = run_time_limit (120) + grace.
+    assert sandbox.create_kwargs["max_duration"] > 120
+    # We must NOT set idle_timeout_minutes: a data-plane exec doesn't refresh
+    # last_activity_at, so it could auto-pause an actively-running task.
+    assert "idle_timeout_minutes" not in sandbox.create_kwargs
+    # exec ran `bash -c <cmd>` with an env dict forwarded.
+    args, kwargs = sandbox.exec_calls[0]
+    assert args[0] == "bash" and args[1] == "-c"
+    assert kwargs["env"]["METAFLOW_TENKI_WORKLOAD"] == "1"
+    # The sandbox name is exposed to the workload for metadata bookkeeping.
+    assert kwargs["env"]["METAFLOW_TENKI_SANDBOX_NAME"]
+    assert "Task finished with exit code 0." in [m for _, m in echoes]
+    # Disposable microVM is torn down.
+    assert sandbox.closed is True
+
+
+def test_runtime_shim_precedes_bootstrap(monkeypatch):
+    # The command must provision a `python`/pip runtime before the standard
+    # metaflow bootstrap, so it runs on images (incl. the Tenki default) that
+    # ship only python3. See _RUNTIME_BOOTSTRAP_SHIM.
+    _, sandbox = _run_task(monkeypatch, _FakeResult(0))
+    cmd = sandbox.exec_calls[0][0][2]
+    # Symlink python -> python3 when absent, on a writable PATH dir (non-root).
+    assert "ln -sf $(command -v python3) $HOME/.local/bin/python" in cmd
+    assert "export PATH=$HOME/.local/bin:$PATH" in cmd
+    # Allow pip on a PEP-668 externally-managed interpreter.
+    assert "PIP_BREAK_SYSTEM_PACKAGES=1" in cmd
+    # The shim must come before the code-package download / step.
+    assert cmd.index("$HOME/.local/bin/python") < cmd.index("flow.py step")
+    # An image with neither python nor python3 fails with a clear error rather
+    # than a confusing bootstrap failure later.
+    assert "no python runtime" in cmd
+    assert "command -v python3" in cmd
+
+
+class _FlakyCleanupSandbox(object):
+    """close() raises for the first `fail_times` calls, then succeeds."""
+
+    def __init__(self, fail_times):
+        self.id = "sb-flaky"
+        self._fail_times = fail_times
+        self.close_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+        if self.close_calls <= self._fail_times:
+            raise RuntimeError("transient API error")
+
+
+def _make_runner():
+    return Tenki(datastore=_DS("s3"), metadata=None, environment=_Env())
+
+
+def test_cleanup_retry_keeps_handles_silently(capsys):
+    # A non-final failed teardown must NOT clear the sandbox handle (so a later
+    # pass can retry) and must NOT close the client (the retry needs it). It
+    # must stay silent so a transient failure the retry resolves is no false
+    # alarm.
+    sandbox = _FlakyCleanupSandbox(fail_times=1)
+    client = _FakeClient(sandbox)
+    tenki = _make_runner()
+    tenki._sandbox = sandbox
+    tenki._client = client
+
+    tenki._cleanup()  # wait()'s finally pass (final=False)
+
+    assert sandbox.close_calls == 1
+    assert tenki._sandbox is sandbox  # handle retained for retry
+    assert getattr(client, "closed", False) is False  # client kept open
+    assert capsys.readouterr().err == ""  # no warning yet
+
+
+def test_cleanup_retry_succeeds_and_releases_handles():
+    # The retry (a second _cleanup) succeeds: handle cleared, client closed.
+    sandbox = _FlakyCleanupSandbox(fail_times=1)
+    client = _FakeClient(sandbox)
+    tenki = _make_runner()
+    tenki._sandbox = sandbox
+    tenki._client = client
+
+    tenki._cleanup()  # first pass fails silently
+    tenki._cleanup(final=True)  # atexit retry succeeds
+
+    assert sandbox.close_calls == 2
+    assert tenki._sandbox is None
+    assert client.closed is True
+
+
+def test_cleanup_final_failure_warns_and_keeps_handle(capsys):
+    # When even the final (atexit) pass fails, surface a warning and keep the
+    # handle rather than silently leaking a billed sandbox.
+    sandbox = _FlakyCleanupSandbox(fail_times=99)
+    client = _FakeClient(sandbox)
+    tenki = _make_runner()
+    tenki._sandbox = sandbox
+    tenki._client = client
+
+    tenki._cleanup(final=True)
+
+    assert tenki._sandbox is sandbox
+    assert getattr(client, "closed", False) is False
+    assert "could not terminate sandbox sb-flaky" in capsys.readouterr().err
+
+
+def test_run_nonzero_is_retryable(monkeypatch):
+    with pytest.raises(TenkiException, match="Use @retry to retry"):
+        _run_task(monkeypatch, _FakeResult(1, stderr_text="boom"))
+
+
+def test_run_oom(monkeypatch):
+    with pytest.raises(TenkiException, match="ran out of memory"):
+        _run_task(monkeypatch, _FakeResult(137))
+
+
+def test_run_signalled_exit0_is_a_failure(monkeypatch):
+    # exit_code 0 but killed by a signal is NOT success (result.ok is False);
+    # the signal must be surfaced in the diagnostic.
+    with pytest.raises(TenkiException, match="signal SIGTERM"):
+        _run_task(monkeypatch, _FakeResult(0, signal="SIGTERM"))
+
+
+def test_run_signalled_surfaces_signal_generically(monkeypatch):
+    # A signalled task is a failure and the signal appears in the generic
+    # diagnostic (we do not guess Tenki's signal-name format to special-case it).
+    with pytest.raises(TenkiException, match="signal SIGKILL"):
+        _run_task(monkeypatch, _FakeResult(0, signal="SIGKILL"))
+
+
+def test_run_failure_includes_reason_and_errno(monkeypatch):
+    # reason and errno from the SDK are surfaced in the failure diagnostic.
+    with pytest.raises(TenkiException, match="reason exec-failed.*errno 8"):
+        _run_task(monkeypatch, _FakeResult(126, reason="exec-failed", errno=8))
+
+
+def test_run_segfault(monkeypatch):
+    with pytest.raises(TenkiException, match="segmentation fault"):
+        _run_task(monkeypatch, _FakeResult(139))
+
+
+def test_timeout_is_retryable(monkeypatch):
+    with pytest.raises(TenkiException, match="timed out"):
+        _run_task(monkeypatch, _FakeCommandTimeout("deadline"))
+
+
+def test_builtin_timeouterror_is_retryable(monkeypatch):
+    # The real SDK raises a builtin TimeoutError for the client-side exec
+    # deadline (not the SDK's CommandTimeoutError), so it must map to a
+    # retryable timeout too, not the generic failure branch.
+    with pytest.raises(TenkiException, match="timed out"):
+        _run_task(monkeypatch, TimeoutError("timed out waiting for command"))
+
+
+def test_session_lost_is_retryable(monkeypatch):
+    with pytest.raises(TenkiException, match="disappeared"):
+        _run_task(monkeypatch, _FakeSessionNotFound("gone"))
+
+
+def test_permission_denied_is_not_retryable(monkeypatch):
+    # Non-retryable failures surface as TenkiKilledException, which the CLI
+    # maps to METAFLOW_EXIT_DISALLOW_RETRY.
+    with pytest.raises(TenkiKilledException):
+        _run_task(monkeypatch, _FakePermissionDenied("bad token"))
+
+
+def test_unknown_exit_code_is_retryable(monkeypatch):
+    # A None exit code (command killed, SDK returned no status) must be a
+    # retryable failure, not a silent success.
+    with pytest.raises(TenkiException, match="unknown status"):
+        _run_task(monkeypatch, _FakeResult(None))
+
+
+def test_nonzero_surfaces_stderr(monkeypatch):
+    # The captured stderr is echoed on a non-zero exit even before the raise.
+    sandbox = _FakeSandbox(_FakeResult(1, stderr_text="boom-on-stderr"))
+    monkeypatch.setattr(tenki_mod, "TenkiClient", lambda **kwargs: _FakeClient(sandbox))
+    monkeypatch.setattr(tenki_mod, "get_log_tailer", lambda loc, ds_type: None)
+
+    def _fake_tail_logs(prefix, stdout_tail, stderr_tail, echo, has_log_updates):
+        while has_log_updates():
+            time.sleep(0.005)
+
+    monkeypatch.setattr(tenki_mod, "tail_logs", _fake_tail_logs)
+
+    tenki = Tenki(datastore=_DS("s3"), metadata=None, environment=_Env())
+    tenki.launch_job(
+        flow_name="F",
+        run_id="r",
+        step_name="start",
+        task_id="t",
+        attempt="0",
+        user="u",
+        code_package_metadata="m",
+        code_package_sha="s",
+        code_package_url="s3://p",
+        code_package_ds="s3",
+        step_cli="python flow.py step start",
+        cpu="1",
+        memory="512",
+        run_time_limit=60,
+        env={},
+    )
+    msgs = []
+    with pytest.raises(TenkiException):
+        tenki.wait("a", "b", echo=lambda m, stream="stderr", **k: msgs.append(m))
+    assert "boom-on-stderr" in msgs
+
+
+def test_resource_float_strings(monkeypatch):
+    # Resource values arrive as float-formatted strings when merged with
+    # @resources; cpu_cores/memory_mb/max_duration/timeout must all parse.
+    _, sandbox = _run_task(
+        monkeypatch,
+        _FakeResult(0),
+        cpu="1.0",
+        memory="4096.0",
+        run_time_limit="300.0",
+    )
+    assert sandbox.create_kwargs["cpu_cores"] == 1
+    assert sandbox.create_kwargs["memory_mb"] == 4096
+    assert sandbox.create_kwargs["max_duration"] > 300
+    assert sandbox.exec_calls[0][1]["timeout"] == 300
+
+
+def test_env_vars_forward_only_the_datastores_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ak")
+    monkeypatch.setenv("AWS_ENDPOINT_URL_S3", "http://minio:9000")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "cid")
+    monkeypatch.setenv("AZURE_TENANT_ID", "tid")
+    monkeypatch.setenv("STORAGE_EMULATOR_HOST", "http://fake-gcs:4443")
+
+    s3_env = Tenki(_DS("s3"), None, _Env())._env_vars("m", "s", "s3://p", "s3", "u", {})
+    assert s3_env["AWS_ACCESS_KEY_ID"] == "ak"
+    assert s3_env["AWS_ENDPOINT_URL_S3"] == "http://minio:9000"
+    assert "AZURE_CLIENT_ID" not in s3_env
+    assert "STORAGE_EMULATOR_HOST" not in s3_env
+
+    az_env = Tenki(_DS("azure"), None, _Env())._env_vars(
+        "m", "s", "az://p", "azure", "u", {}
+    )
+    assert az_env["AZURE_CLIENT_ID"] == "cid"
+    assert az_env["AZURE_TENANT_ID"] == "tid"
+    assert "AWS_ACCESS_KEY_ID" not in az_env
+
+    gs_env = Tenki(_DS("gs"), None, _Env())._env_vars("m", "s", "gs://p", "gs", "u", {})
+    assert gs_env["STORAGE_EMULATOR_HOST"] == "http://fake-gcs:4443"
+    assert "AWS_ACCESS_KEY_ID" not in gs_env
+    assert "AZURE_CLIENT_ID" not in gs_env
+
+
+def test_env_vars_forward_secrets_otel_and_sse(monkeypatch):
+    # Parity with @kubernetes: secret-backend prefixes, S3 server-side
+    # encryption, and OTEL config must reach the sandbox.
+    monkeypatch.setattr(tenki_mod, "AWS_SECRETS_MANAGER_DEFAULT_REGION", "us-west-2")
+    monkeypatch.setattr(tenki_mod, "GCP_SECRET_MANAGER_PREFIX", "projects/p/secrets/")
+    monkeypatch.setattr(tenki_mod, "AZURE_KEY_VAULT_PREFIX", "https://kv.example")
+    monkeypatch.setattr(tenki_mod, "OTEL_ENDPOINT", "http://otel:4317")
+    monkeypatch.setattr(tenki_mod, "OTEL_SERVICE_NAME", "my-svc")
+    monkeypatch.setattr(tenki_mod, "S3_SERVER_SIDE_ENCRYPTION", "aws:kms")
+
+    env = Tenki(_DS("s3"), None, _Env())._env_vars("m", "s", "s3://p", "s3", "u", {})
+    assert env["METAFLOW_AWS_SECRETS_MANAGER_DEFAULT_REGION"] == "us-west-2"
+    assert env["METAFLOW_GCP_SECRET_MANAGER_PREFIX"] == "projects/p/secrets/"
+    assert env["METAFLOW_AZURE_KEY_VAULT_PREFIX"] == "https://kv.example"
+    assert env["METAFLOW_OTEL_ENDPOINT"] == "http://otel:4317"
+    assert env["METAFLOW_OTEL_SERVICE_NAME"] == "my-svc"
+    assert env["METAFLOW_S3_SERVER_SIDE_ENCRYPTION"] == "aws:kms"
+
+
+def test_env_vars_drop_unset_s3_encryption(monkeypatch):
+    # Unset optional config must not be forwarded as a stringified None.
+    monkeypatch.setattr(tenki_mod, "S3_SERVER_SIDE_ENCRYPTION", None)
+    env = Tenki(_DS("s3"), None, _Env())._env_vars("m", "s", "s3://p", "s3", "u", {})
+    assert "METAFLOW_S3_SERVER_SIDE_ENCRYPTION" not in env
+
+
+def test_env_vars_materializes_gcp_credentials(monkeypatch, tmp_path):
+    creds = tmp_path / "sa.json"
+    creds.write_text('{"type":"service_account"}')
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(creds))
+
+    tenki = Tenki(_DS("gs"), None, _Env())
+    env = tenki._env_vars("m", "s", "gs://p", "gs", "u", {})
+    blob = env["METAFLOW_GCP_CREDENTIALS_JSON_B64"]
+    assert base64.b64decode(blob).decode() == '{"type":"service_account"}'
+
+    # The command recreates the file and points GOOGLE_APPLICATION_CREDENTIALS at
+    # it (only for gs).
+    argv = tenki._command(
+        flow_name="F",
+        run_id="r",
+        step_name="start",
+        task_id="t",
+        attempt="0",
+        code_package_metadata="m",
+        code_package_url="gs://p",
+        step_cmds=["python flow.py step start"],
+    )
+    cmd = argv[2]
+    assert "base64 -d" in cmd
+    assert "GOOGLE_APPLICATION_CREDENTIALS=$HOME/mf_gcp_creds.json" in cmd
+
+
+def test_command_has_no_gcp_prefix_for_s3():
+    argv = Tenki(_DS("s3"), None, _Env())._command(
+        flow_name="F",
+        run_id="r",
+        step_name="start",
+        task_id="t",
+        attempt="0",
+        code_package_metadata="m",
+        code_package_url="s3://p",
+        step_cmds=["python flow.py step start"],
+    )
+    # The s3 command string is unchanged by the gs credential handling.
+    assert "mf_gcp_creds.json" not in argv[2]
+
+
+def test_command_contract():
+    tenki = Tenki(datastore=_DS("s3"), metadata=None, environment=_Env())
+    argv = tenki._command(
+        flow_name="MyFlow",
+        run_id="run-1",
+        step_name="start",
+        task_id="t-1",
+        attempt="0",
+        code_package_metadata="meta",
+        code_package_url="s3://pkg.tgz",
+        step_cmds=["python flow.py step start"],
+    )
+    # _command returns a `bash -c <cmd>` argv list (same transformation as
+    # @kubernetes), so the \\"-escaped inner quotes are already resolved.
+    assert argv[0] == "bash" and argv[1] == "-c"
+    cmd = argv[2]
+    # The optional init-script hook is prefixed (quotes resolved by the unwrap).
+    assert cmd.startswith('${METAFLOW_INIT_SCRIPT:+eval "${METAFLOW_INIT_SCRIPT}"} &&')
+    # Code package download, step command, and exit-code propagation are present.
+    assert "download s3://pkg.tgz" in cmd
+    assert "python flow.py step start" in cmd
+    assert cmd.rstrip().endswith("exit $c")

--- a/test/unit/test_tenki.py
+++ b/test/unit/test_tenki.py
@@ -1,7 +1,9 @@
 import base64
 import importlib.metadata
 import re
+import sys
 import time
+import types
 from collections import namedtuple
 
 import pytest
@@ -699,13 +701,32 @@ def test_is_permanent_launch_error_classification():
 
 
 def test_is_permanent_launch_error_without_client():
-    # If the client failed to construct, SDK names resolve to () and never
-    # match; our own signals and the unknown-default still classify correctly.
+    # Our own signals, a non-SDK error, and a builtin TimeoutError classify
+    # correctly even when no client is available (client construction failed).
     assert is_permanent_launch_error(TenkiException("guard"), None) is True
     assert is_permanent_launch_error(TenkiKilledException("x"), None) is True
     assert is_permanent_launch_error(RuntimeError("???"), None) is True
-    # A builtin TimeoutError is transient even with no client.
     assert is_permanent_launch_error(TimeoutError("x"), None) is False
+
+
+def test_is_permanent_launch_error_without_client_uses_sdk_module(monkeypatch):
+    # When client construction fails, the classifier must still resolve the SDK
+    # exception hierarchy (by importing the module) so a *retryable* SDK error
+    # raised during TenkiClient() is not misread as permanent.
+    fake_sdk = types.ModuleType("tenki")
+    fake_sdk.SandboxError = _FakeSandboxError
+    fake_sdk.CommandTimeoutError = _FakeCommandTimeout
+    fake_sdk.SessionNotFoundError = _FakeSessionNotFound
+    monkeypatch.setitem(sys.modules, "tenki", fake_sdk)
+
+    # Retryable SDK error with NO client -> transient (the bug being fixed).
+    rate_limited = _FakeSandboxError("slow down")
+    rate_limited.retryable = True
+    assert is_permanent_launch_error(rate_limited, None) is False
+    # Non-retryable SDK error with no client -> permanent.
+    assert is_permanent_launch_error(_FakeSandboxError("boom"), None) is True
+    # Timeout/session-lost still transient via the module fallback.
+    assert is_permanent_launch_error(_FakeCommandTimeout("slow"), None) is False
 
 
 def test_unknown_exit_code_is_retryable(monkeypatch):


### PR DESCRIPTION
## PR Type

- [ ] Bug fix
- [x] New feature
- [x] Core Runtime change
- [ ] Docs / tooling
- [ ] Refactoring

## Summary

Add `@tenki`, a new compute backend that runs each flow step inside a disposable [Tenki Sandbox](https://tenki.cloud/docs/sandbox) Linux microVM — the Tenki analogue of `@kubernetes` / `@batch`. It reuses Metaflow's existing remote-execution contract (the `bash -c` entrypoint + `METAFLOW_*` env vars) and only swaps the "where it runs" layer (a K8s Job → `sb.exec`). Entirely additive and opt-in: datastore, metadata, cards, `@retry`, `@resources`, `@catch`, `resume`, and `@pypi`/`@conda` are unchanged.

## Issue

Closes #3310 (opened first, per the Core Runtime process).

## What's in it

New plugin `metaflow/plugins/tenki/`:

- `tenki_decorator.py` — `TenkiDecorator(StepDecorator)`: lifecycle hooks, `@resources` merge via `compute_resource_attributes` (the `@batch` idiom), datastore validation (requires a remote datastore; rejects `local` / `@parallel`).
- `tenki.py` — runner: builds the same bash entrypoint as `@kubernetes` (`get_package_commands` + `bootstrap_commands` + mflog + `save_logs`), creates a tagged sandbox, runs `sb.exec` on a background thread while tailing logs from the datastore, interprets the result / SDK exceptions into Metaflow's retry semantics, and tears the sandbox down.
- `tenki_cli.py` — click trampoline `tenki step` + flow-scoped `tenki list` / `tenki kill` cleanup commands.
- `tenki_client.py` — thin, **lazily-imported** wrapper over the `tenki` SDK (a soft dependency, like the k8s/cloud SDKs — not in `setup.py`), with a `>= 0.5.4` version guard.

Wiring / config:

- `metaflow/plugins/__init__.py` — register `tenki` in `TRAMPOLINE_CLIS_DESC` + `STEP_DECORATORS_DESC` (2 lines).
- `metaflow/metaflow_config.py` — a `TENKI_*` config block (`TENKI_API_KEY`, `TENKI_BASE_URL`, `TENKI_WORKSPACE_ID`, `TENKI_CONTAINER_IMAGE`, `TENKI_CPU`, `TENKI_MEMORY`, `TENKI_SANDBOX_INIT_SCRIPT`).
- `metaflow/plugins/pypi/conda_decorator.py` — **one line** (see Core Runtime rationale below).

Datastores: `s3` (incl. S3-compatible endpoints), `azure`, `gs`. The backend forwards only the active datastore's cloud credentials into the microVM (a microVM has no ambient cloud identity); for GS it materializes the service-account JSON inside the sandbox. Secret-backend prefixes, `METAFLOW_S3_SERVER_SIDE_ENCRYPTION`, and OTEL config are forwarded for parity with `@kubernetes`.

## Reproduction

A minimal flow that runs each step on a Tenki microVM (datastore = S3; validated with MinIO reached over a temporary tunnel so the sandbox can read/write it):

```python
# tenki_flow.py
from metaflow import FlowSpec, step, tenki

class TenkiFlow(FlowSpec):
    @tenki(cpu=1, memory=1024)
    @step
    def start(self):
        self.x = 21
        self.next(self.end)

    @tenki(cpu=1, memory=1024)
    @step
    def end(self):
        print("RESULT", self.x * 2)

if __name__ == "__main__":
    TenkiFlow()
```

```bash
pip install tenki
export TENKI_API_KEY=tk_...
export METAFLOW_DEFAULT_DATASTORE=s3
export METAFLOW_DATASTORE_SYSROOT_S3=s3://your-bucket/mf
# self-hosted / non-AWS S3 also needs: export METAFLOW_S3_ENDPOINT_URL=https://...
python tenki_flow.py run
```

Evidence shows up in the parent console (per-step logs streamed from the datastore), in the artifacts (via the Client API), and in `python tenki_flow.py tenki list`. On the stock Tenki image each step ran in a fresh microVM, the code package downloaded and `metaflow` imported from it, and the artifact persisted across steps (`self.x = 21` → `RESULT 42`), ending in `Done!`.

## Core Runtime rationale

The only change to a **shared** core file is one line in `metaflow/plugins/pypi/conda_decorator.py`: it keeps a hardcoded allowlist of remote backends for which it leaves the trampoline interpreter alone (`interpreter = None`). A backend **not** on that list has its local `tenki step` trampoline swapped into the resolved `@pypi`/`@conda` environment, which then can't import the datastore/metadata dependencies — so `@pypi` + `@tenki` would fail. Adding `"tenki"` (alongside `batch` / `kubernetes` / `nvidia`) gives it the same treatment; no behavior change for other backends. A unit test drives the real `CondaStepDecorator` and asserts `interpreter is None` for a `@tenki` step (fails without the line, passes with it).

Everything else is additive: the new `metaflow/plugins/tenki/` package, two registration lines, and the `TENKI_*` config block.

Why the design is sound:

- **Reuses the `@kubernetes` remote-execution contract verbatim** (same `bash -c "…"` entrypoint via the same `shlex.split` transform), so remote behavior matches an established backend; the Tenki-specific surface is small (create / exec / teardown + credential forwarding).
- **Synchronous `exec` → background thread + datastore log tailing**, preserving Metaflow's live log streaming despite `sb.exec` blocking.
- **Success is the SDK's own `result.ok`** (`exit_code == 0 and not signal`), not a partial exit-code check, so a signalled task is never read as success.
- **Retries owned by the runtime** (`@retry`); one fresh sandbox per attempt.

## Failure modes considered

1. **Concurrency / retries** — one fresh sandbox per attempt (unique name so a retry never collides with a still-terminating prior VM); concurrent `foreach` (3 parallel microVMs) validated live.
2. **Credential leakage** — only the *active* datastore's credentials are forwarded into the VM (s3 creds never reach an azure/gs run); unit-tested.
3. **Cleanup scoping (shared Tenki accounts)** — `tenki list`/`kill` are always scoped to the current flow (sandboxes are tagged `metaflow-flow:<flow>` at launch), adopting the `@kubernetes`/`@batch` `parse_cli_options` semantics (`--my-runs`, default to the latest run of the current flow). An unscoped `tenki kill` can never reach another flow's or user's sandboxes — verified live against Tenki.
4. **Orphan / hard-crash teardown** — in-process teardown (`finally` + `atexit`, retried on the atexit pass, warns if it still fails), `tenki kill` (tries every teardown method, reports an accurate terminated/failed summary), and a server-side `max_duration` cap. A hard `SIGKILL` of the orchestrator relies on `tenki kill` / the cap.
5. **Launch vs. run failures / retryability** — `launch_job` does synchronous network I/O (auth, create), so a transient API/network failure at launch stays retryable under `@retry`: launch exceptions are classified via the SDK's own `retryable` flag (UNAVAILABLE / rate-limit → retry; auth / permission / quota / bad-image → no retry), with unknown errors defaulting to non-retryable so `@retry` never loops on a misconfig. A task killed by a signal (exit 0 but signalled) is a failure; `signal`/`reason`/`errno` are surfaced; both timeout types map to a retryable timeout.
6. **Base-image variance** — Tenki can't pull public registries and its stock image ships `python3` but no `python`; a startup shim provisions `python`/pip (no-op on images that already have them) and fails with a clear error if the image has no `python3` at all.
7. **Command-string escaping** — the entrypoint is built and `shlex.split` the exact way `@kubernetes` does, so the `\"`-escaped inner quotes resolve through `sb.exec(*argv)`.

## Tests

- [x] Unit tests added — `test/unit/test_tenki.py`, **48 tests**, all green; no regressions to the existing `@kubernetes` / resource-merge tests. `black`-clean.
- [x] CI passes.
- [x] Reproduction / live validation provided (below). The `tenki` SDK is a **soft dependency**, so CI unit tests run against a **stubbed** SDK; real-SDK integration can't run in CI without a Tenki account, so that validation is manual.

Unit coverage includes: resource merge; datastore / `@parallel` validation; sandbox-name and tag sanitization; the `_command` bash contract + runtime-shim ordering + no-`python3` guard; runner behavior against a stubbed SDK (`result.ok` success, non-zero / OOM(137) / segfault(139) / unknown / signalled results, `signal`/`reason`/`errno` diagnostics, both timeout types, session-lost, permission-denied non-retryable, stderr surfacing); `_cleanup` retry + warn-on-final-pass; flow-scoped `list`/`kill` + `parse_cli_options` semantics + teardown fallback/reporting; launch-failure classification (permanent vs transient); per-datastore credential isolation + GCP JSON materialization; secrets/S3-SSE/OTEL forwarding; SDK minimum-version enforcement; and the `conda_decorator` regression above.

**Live (real Tenki microVMs; datastore = MinIO over a tunnel):** happy path (linear + `foreach` + join) and plain `@tenki` steps on the stock image; `@retry` (fresh sandbox per attempt); concurrency (`--max-workers 3`); `@timeout`; `--metadata=service` (real Postgres-backed service); `@catch`; `resume`; `@pypi` (ran a real package inside the microVM); flow-scoped cleanup; and the tag / kill-scoping isolation.

_Not validated live:_ Azure/GS (forwarding is implemented + unit-tested; needs a real account) and a custom `TENKI_CONTAINER_IMAGE` (Tenki serves images only from its own registry, so it needs a Metaflow-ready image pushed there).

## Non-goals

- `@parallel` / gang scheduling, GPU, and persistent volumes/snapshots — deferred.
- Tenki native storage as the Metaflow datastore — it is session-bound and can't meet the datastore contract; a shared blob store (S3/Azure/GS) is still needed.
- Changing how compute-backend SDK dependencies are declared — the SDK is kept a soft dependency (matching `kubernetes` / `azure-*`); glad to expose an `extras_require={"tenki": ["tenki>=0.5.4"]}` extra instead if you prefer.
- Core vs. extension packaging — proposed as core (modeled 1:1 on `@kubernetes`), but structured to move to a `metaflow_extensions` plugin if you'd rather keep vendor backends out of core.

## AI Tool Usage

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

**Tool:** Claude Code. **Used for:** implementation scaffolding, unit tests, and the live-validation harness (MinIO/tunnel setup, e2e probes). **Accountability:** all code was reviewed and is understood by me; the design decisions, failure modes, and tests reflect my own judgment.
