### PR TITLE
[DO NOT REVIEW] Config-based log transfer tracing

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -534,6 +534,7 @@ PROFILE_FROM_START = from_conf("PROFILE_FROM_START", False)
 DEBUG_OPTIONS = [
     "subcommand",
     "sidecar",
+    "log_transfer",
     "s3client",
     "tracing",
     "stubgen",
@@ -544,6 +545,11 @@ DEBUG_OPTIONS = [
 
 for typ in DEBUG_OPTIONS:
     vars()["DEBUG_%s" % typ.upper()] = from_conf("DEBUG_%s" % typ.upper(), False)
+
+LOG_TRANSFER_TRACE_PATH = from_conf(
+    "LOG_TRANSFER_TRACE_PATH",
+    os.path.join(".logs", "periodical_uploader_stdout"),
+)
 
 ###
 # Plugin configuration

--- a/metaflow/mflog/save_logs.py
+++ b/metaflow/mflog/save_logs.py
@@ -1,9 +1,12 @@
 import os
+import sys
+import time
 
 # This script is used to upload logs during task bootstrapping, so
 # it shouldn't have external dependencies besides Metaflow itself
 # (e.g. no click for parsing CLI args).
 from metaflow.datastore import FlowDataStore
+from metaflow.metaflow_config import DEBUG_LOG_TRANSFER
 from metaflow.plugins import DATASTORES
 from metaflow.util import Path
 from . import TASK_LOG_SOURCE
@@ -41,6 +44,8 @@ def save_logs():
         run_id, step_name, task_id, int(attempt), mode="w"
     )
 
+    start_time = time.time()
+    sizes = []
     try:
         streams = ("stdout", "stderr")
         sizes = [
@@ -55,8 +60,27 @@ def save_logs():
             op = Path
 
         data = {stream: op(path) for stream, path, _ in sizes}
+        if DEBUG_LOG_TRANSFER:
+            print(
+                "[save_logs] upload_start datastore=%s files=%s" % (ds_type, sizes),
+                flush=True,
+            )
         task_datastore.save_logs(TASK_LOG_SOURCE, data)
-    except:
+        if DEBUG_LOG_TRANSFER:
+            print(
+                "[save_logs] upload_success datastore=%s files=%s "
+                "elapsed_seconds=%.3f" % (ds_type, sizes, time.time() - start_time),
+                flush=True,
+            )
+    except BaseException as error:
+        if DEBUG_LOG_TRANSFER:
+            print(
+                "[save_logs] upload_failure datastore=%s files=%s error=%r "
+                "elapsed_seconds=%.3f"
+                % (ds_type, sizes, error, time.time() - start_time),
+                file=sys.stderr,
+                flush=True,
+            )
         # Upload failing is not considered a fatal error.
         # This script shouldn't return non-zero exit codes
         # for transient errors.

--- a/metaflow/mflog/save_logs_periodically.py
+++ b/metaflow/mflog/save_logs_periodically.py
@@ -4,12 +4,27 @@ import time
 import subprocess
 from threading import Thread
 
+from metaflow.metaflow_config import DEBUG_LOG_TRANSFER, LOG_TRANSFER_TRACE_PATH
 from metaflow.sidecar import MessageTypes
-from . import update_delay, BASH_SAVE_LOGS_ARGS
+from metaflow.util import to_unicode
+from . import update_delay, BASH_SAVE_LOGS_ARGS, TASK_LOG_SOURCE
+from .mflog import decorate
+
+
+def _write_uploader_log(message):
+    payload = decorate(TASK_LOG_SOURCE, "%s\n" % message)
+    with open(LOG_TRANSFER_TRACE_PATH, "ab", buffering=0) as log:
+        log.write(payload)
+
+
+def _write_save_logs_output(stream, output):
+    for line in output.splitlines():
+        _write_uploader_log("[save_logs %s] %s" % (stream, to_unicode(line)))
 
 
 class SaveLogsPeriodicallySidecar(object):
     def __init__(self):
+        self._enable_tracing = DEBUG_LOG_TRANSFER
         self._thread = Thread(target=self._update_loop)
         self.is_alive = True
         self._thread.start()
@@ -21,6 +36,20 @@ class SaveLogsPeriodicallySidecar(object):
     @classmethod
     def get_worker(cls):
         return cls
+
+    def _call_save_logs(self):
+        if not self._enable_tracing:
+            return subprocess.call(BASH_SAVE_LOGS_ARGS)
+
+        process = subprocess.Popen(
+            BASH_SAVE_LOGS_ARGS,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = process.communicate()
+        _write_save_logs_output("stdout", stdout)
+        _write_save_logs_output("stderr", stderr)
+        return process.returncode
 
     def _update_loop(self):
         def _file_size(path):
@@ -36,9 +65,20 @@ class SaveLogsPeriodicallySidecar(object):
         while self.is_alive:
             new_sizes = list(map(_file_size, FILES))
             if new_sizes != sizes:
+                previous_sizes = sizes
                 sizes = new_sizes
+                if self._enable_tracing:
+                    elapsed = time.time() - start_time
+                    for path, previous, current in zip(
+                        FILES, previous_sizes, new_sizes
+                    ):
+                        _write_uploader_log(
+                            "[save_logs_periodically] file=%s previous_size=%d "
+                            "current_size=%d delta=%d elapsed_seconds=%.3f"
+                            % (path, previous, current, current - previous, elapsed),
+                        )
                 try:
-                    subprocess.call(BASH_SAVE_LOGS_ARGS)
+                    self._call_save_logs()
                 except:
                     pass
             time.sleep(update_delay(time.time() - start_time))

--- a/test/unit/test_log_transfer_tracing.py
+++ b/test/unit/test_log_transfer_tracing.py
@@ -1,0 +1,171 @@
+import json
+import os
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+import metaflow.mflog.save_logs as save_logs_module
+import metaflow.mflog.save_logs_periodically as publisher_module
+from metaflow.mflog.mflog import parse
+
+
+def test_log_transfer_config_values_are_exportable(tmp_path):
+    trace_path = tmp_path / "trace"
+    env = os.environ.copy()
+    env["METAFLOW_DEBUG_LOG_TRANSFER"] = "1"
+    env["METAFLOW_LOG_TRANSFER_TRACE_PATH"] = str(trace_path)
+    script = """
+import json
+from metaflow.metaflow_config import DEBUG_LOG_TRANSFER, LOG_TRANSFER_TRACE_PATH
+from metaflow.metaflow_config_funcs import config_values
+
+print(json.dumps({
+    "enabled": DEBUG_LOG_TRANSFER,
+    "path": LOG_TRANSFER_TRACE_PATH,
+    "exported": dict(config_values()),
+}))
+"""
+
+    result = json.loads(
+        subprocess.check_output([sys.executable, "-c", script], env=env, text=True)
+    )
+
+    assert result["enabled"] is True
+    assert result["path"] == str(trace_path)
+    assert result["exported"]["METAFLOW_DEBUG_LOG_TRANSFER"] == "True"
+    assert result["exported"]["METAFLOW_LOG_TRANSFER_TRACE_PATH"] == str(trace_path)
+
+
+@pytest.fixture
+def save_logs_context(monkeypatch, mocker, tmp_path):
+    stdout = tmp_path / "stdout"
+    stderr = tmp_path / "stderr"
+    stdout.write_bytes(b"out\n")
+    stderr.write_bytes(b"err\n")
+    monkeypatch.setenv("MF_PATHSPEC", "Flow/1/step/task")
+    monkeypatch.setenv("MF_ATTEMPT", "0")
+    monkeypatch.setenv("MF_DATASTORE", "test")
+    monkeypatch.setenv("MF_DATASTORE_ROOT", str(tmp_path))
+    monkeypatch.setenv("MFLOG_STDOUT", str(stdout))
+    monkeypatch.setenv("MFLOG_STDERR", str(stderr))
+
+    task_datastore = mocker.Mock()
+    flow_datastore = mocker.Mock()
+    flow_datastore.get_task_datastore.return_value = task_datastore
+    mocker.patch.object(
+        save_logs_module,
+        "DATASTORES",
+        [SimpleNamespace(TYPE="test")],
+    )
+    mocker.patch.object(
+        save_logs_module,
+        "FlowDataStore",
+        return_value=flow_datastore,
+    )
+    return task_datastore
+
+
+@pytest.mark.parametrize("enabled", [False, True], ids=["disabled", "enabled"])
+def test_publisher_reads_tracing_config(monkeypatch, mocker, enabled):
+    monkeypatch.setattr(publisher_module, "DEBUG_LOG_TRANSFER", enabled)
+    thread = mocker.patch.object(publisher_module, "Thread")
+
+    publisher = publisher_module.SaveLogsPeriodicallySidecar()
+
+    assert publisher._enable_tracing is enabled
+    assert thread.call_args.kwargs["target"].__self__ is publisher
+    thread.return_value.start.assert_called_once_with()
+
+
+def test_publisher_traces_file_sizes_and_child_output(monkeypatch, mocker, tmp_path):
+    stdout = tmp_path / "stdout"
+    stderr = tmp_path / "stderr"
+    trace = tmp_path / "periodical_uploader_stdout"
+    stdout.write_bytes(b"out\n")
+    stderr.write_bytes(b"err\n")
+    monkeypatch.setenv("MFLOG_STDOUT", str(stdout))
+    monkeypatch.setenv("MFLOG_STDERR", str(stderr))
+    monkeypatch.setattr(publisher_module, "LOG_TRANSFER_TRACE_PATH", str(trace))
+
+    publisher = publisher_module.SaveLogsPeriodicallySidecar.__new__(
+        publisher_module.SaveLogsPeriodicallySidecar
+    )
+    publisher._enable_tracing = True
+    publisher.is_alive = True
+    mocker.patch.object(
+        publisher_module.time,
+        "sleep",
+        side_effect=lambda _: setattr(publisher, "is_alive", False),
+    )
+    mocker.patch.object(publisher_module.time, "time", return_value=100)
+    process = SimpleNamespace(
+        communicate=mocker.Mock(return_value=(b"child stdout\n", b"child stderr\n")),
+        returncode=0,
+    )
+    popen = mocker.patch.object(
+        publisher_module.subprocess,
+        "Popen",
+        return_value=process,
+    )
+
+    publisher._update_loop()
+
+    records = [
+        parse(line)
+        for line in trace.read_bytes().splitlines(keepends=True)
+        if line.startswith(b"[MFLOG|")
+    ]
+    messages = [record.msg.decode() for record in records]
+    assert len(messages) == 4
+    assert "file=%s previous_size=0 current_size=4 delta=4" % stdout in messages[0]
+    assert "file=%s previous_size=0 current_size=4 delta=4" % stderr in messages[1]
+    assert "[save_logs stdout] child stdout" in messages[2]
+    assert "[save_logs stderr] child stderr" in messages[3]
+    popen.assert_called_once_with(
+        publisher_module.BASH_SAVE_LOGS_ARGS,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_publisher_uses_original_upload_path_when_tracing_is_disabled(mocker):
+    publisher = publisher_module.SaveLogsPeriodicallySidecar.__new__(
+        publisher_module.SaveLogsPeriodicallySidecar
+    )
+    publisher._enable_tracing = False
+    call = mocker.patch.object(publisher_module.subprocess, "call")
+
+    publisher._call_save_logs()
+
+    call.assert_called_once_with(publisher_module.BASH_SAVE_LOGS_ARGS)
+
+
+@pytest.mark.parametrize("enabled", [False, True], ids=["disabled", "enabled"])
+def test_save_logs_diagnostics_follow_config(
+    monkeypatch, save_logs_context, capsys, enabled
+):
+    monkeypatch.setattr(save_logs_module, "DEBUG_LOG_TRANSFER", enabled)
+
+    save_logs_module.save_logs()
+
+    save_logs_context.save_logs.assert_called_once()
+    captured = capsys.readouterr()
+    if enabled:
+        assert "[save_logs] upload_start" in captured.out
+        assert "[save_logs] upload_success" in captured.out
+    else:
+        assert captured == ("", "")
+
+
+def test_save_logs_traces_upload_failure(monkeypatch, save_logs_context, capsys):
+    monkeypatch.setattr(save_logs_module, "DEBUG_LOG_TRANSFER", True)
+    save_logs_context.save_logs.side_effect = RuntimeError("upload failed")
+
+    save_logs_module.save_logs()
+
+    captured = capsys.readouterr()
+    assert "[save_logs] upload_start" in captured.out
+    assert "[save_logs] upload_failure" in captured.err
+    assert "upload failed" in captured.err


### PR DESCRIPTION
> [!IMPORTANT]
> **DO NOT REVIEW OR MERGE.** This is an experimental comparison PR for design discussion.

## Summary

This branch implements the log-transfer tracing proposed in #3306 using standard Metaflow configuration instead of a generic JSON sidecar-options protocol.

- Adds `DEBUG_LOG_TRANSFER` and `LOG_TRANSFER_TRACE_PATH` configuration.
- Lets the task, sidecar, and uploader child inherit configuration normally.
- Preserves the original sidecar API and worker command line.
- Emits no new `save_logs.py` diagnostics when tracing is disabled.

## Status

Draft only. This is not intended for review or merge yet.

## Testing

- `14 passed`: focused log-transfer and config-value tests.
- All pre-commit hooks pass on the changed files.

## AI Tool Usage

AI tools were used to help prepare this experimental diff and its tests.
