### PR TITLE
Fix duplicate test name masking parse_kube_keyvalue_list success cases

### DIFF
--- a/test/unit/test_kubernetes.py
+++ b/test/unit/test_kubernetes.py
@@ -80,7 +80,7 @@ def test_kubernetes_decorator_validate_kube_labels_fail(labels):
         (["key=value", "key2=value2"], True, {"key": "value", "key2": "value2"}),
     ],
 )
-def test_kubernetes_parse_keyvalue_list(items, requires_both, expected):
+def test_kubernetes_parse_keyvalue_list_success(items, requires_both, expected):
     ret = parse_kube_keyvalue_list(items, requires_both)
     assert ret == expected
 
@@ -92,6 +92,6 @@ def test_kubernetes_parse_keyvalue_list(items, requires_both, expected):
         (["key"], True),
     ],
 )
-def test_kubernetes_parse_keyvalue_list(items, requires_both):
+def test_kubernetes_parse_keyvalue_list_raises(items, requires_both):
     with pytest.raises(KubernetesException):
         parse_kube_keyvalue_list(items, requires_both)


### PR DESCRIPTION
## PR Type

- [x] Bug fix

## Summary

Two tests in `test/unit/test_kubernetes.py` share the name
`test_kubernetes_parse_keyvalue_list`; the second shadows the first, so the
`parse_kube_keyvalue_list` success cases never run. Rename them so both are
collected.

## Issue

Fixes #3314

## Reproduction

**Runtime:** local (unit test)

**Commands to run:**
```bash
python -m pytest test/unit/test_kubernetes.py --collect-only -q | grep parse_keyvalue_list
```

**Where evidence shows up:** pytest collection output

<details>
<summary>Before (only the failure-case test is collected)</summary>

```
test/unit/test_kubernetes.py::test_kubernetes_parse_keyvalue_list[key=value-key=value2-True]
test/unit/test_kubernetes.py::test_kubernetes_parse_keyvalue_list[key-True]
```
The four success-case parametrizations (lines 74–85) are missing — the second
`def test_kubernetes_parse_keyvalue_list` rebinds the name, discarding the
success-case function.

</details>

<details>
<summary>After (both success and failure cases are collected)</summary>

```
test/unit/test_kubernetes.py::test_kubernetes_parse_keyvalue_list_success[key=value-True-expected0]
test/unit/test_kubernetes.py::test_kubernetes_parse_keyvalue_list_success[key=value-False-expected1]
test/unit/test_kubernetes.py::test_kubernetes_parse_keyvalue_list_success[key-False-expected2]
test/unit/test_kubernetes.py::test_kubernetes_parse_keyvalue_list_success[key=value-key2=value2-True-expected3]
test/unit/test_kubernetes.py::test_kubernetes_parse_keyvalue_list_raises[key=value-key=value2-True]
test/unit/test_kubernetes.py::test_kubernetes_parse_keyvalue_list_raises[key-True]
```

</details>

## Root Cause

In Python, two module-level `def`s with the same name bind the same name in the
module namespace; the second wins. Both `test_kubernetes_parse_keyvalue_list`
definitions are module-level, so at collection time only the second (failure
cases) exists. pytest collects functions from the module namespace, so the
success-case function is never seen and its four parametrizations never run.

## Why This Fix Is Correct

The two tests cover distinct behaviors (valid parses vs. expected
`KubernetesException`) and were only ever meant to be separate. Giving them
distinct names restores the intended collection with no change to product code
and no change to the assertions themselves. The restored success cases pass
against the current `parse_kube_keyvalue_list` implementation, confirming the
happy path behaves as the parametrizations expect.

## Failure Modes Considered

1. **Renaming changes what is asserted** — it does not: only the two function
   names change; parametrize data and assertion bodies are untouched.
2. **Restored success cases might actually fail (a latent product bug)** — ran
   them against current `parse_kube_keyvalue_list`; all four pass, so this is a
   pure test-coverage restoration, not a masked product regression.

## Tests

- [x] Unit tests added/updated (restored the shadowed success-case test)
- [x] CI passes
- [ ] Reproduction script provided (not applicable — collection command above)

## Non-Goals

No change to `parse_kube_keyvalue_list` or any other production code; no new test
cases beyond restoring the ones that were being skipped.

## AI Tool Usage

- [x] AI tools were used (describe below)

I identified this bug (along with several others) during independent analysis of
the Client API and Kubernetes plugin internals a few months ago while exploring
the codebase. I used Claude to help draft the rename and this PR description. I
reviewed and understand the change, verified the shadowing behavior and the
restored collection myself, and can explain the fix and its rationale.
