### PR TITLE
Consolidate duplicate KubernetesException into a single class

### DIFF
--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -51,6 +51,7 @@ from metaflow.mflog import (
     tail_logs,
 )
 
+from .kube_utils import KubernetesException
 from .kubernetes_client import KubernetesClient
 
 # Redirect structured logs to $PWD/.logs/
@@ -63,10 +64,6 @@ STDERR_PATH = os.path.join(LOGS_DIR, STDERR_FILE)
 METAFLOW_PARALLEL_STEP_CLI_OPTIONS_TEMPLATE = (
     "{METAFLOW_PARALLEL_STEP_CLI_OPTIONS_TEMPLATE}"
 )
-
-
-class KubernetesException(MetaflowException):
-    headline = "Kubernetes error"
 
 
 class KubernetesKilledException(MetaflowException):

--- a/test/unit/test_kubernetes_exception.py
+++ b/test/unit/test_kubernetes_exception.py
@@ -1,0 +1,26 @@
+def test_kubernetes_exception_is_single_class():
+    """KubernetesException must resolve to one class regardless of import path.
+
+    It was previously defined separately in both
+    ``metaflow/plugins/kubernetes/kubernetes.py`` and
+    ``metaflow/plugins/kubernetes/kube_utils.py``. Because different modules
+    imported it from different places (``kubernetes_decorator`` from
+    ``kubernetes``, ``kubernetes_cli`` from ``kube_utils``), an
+    ``except KubernetesException`` on one path would not catch a raise of the
+    class from the other. Both import paths must be the same object.
+    """
+    from metaflow.plugins.kubernetes.kubernetes import (
+        KubernetesException as FromKubernetes,
+    )
+    from metaflow.plugins.kubernetes.kube_utils import (
+        KubernetesException as FromKubeUtils,
+    )
+
+    assert FromKubernetes is FromKubeUtils
+
+    # And an except-clause using one path catches a raise from the other.
+    try:
+        raise FromKubeUtils("boom")
+    except FromKubernetes:
+        caught = True
+    assert caught


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [x] Core Runtime change (higher bar -- see [CONTRIBUTING.md](../CONTRIBUTING.md#core-runtime-contributions-higher-bar))

## Summary

`KubernetesException` was defined twice — in `kubernetes.py` and `kube_utils.py` —
so the two import paths returned distinct classes and `except KubernetesException`
on one path could miss a raise from the other. Consolidate to a single class.

## Issue

Fixes #3318

## Reproduction

**Runtime:** local (import-time / exception handling)

**Commands to run:**
```bash
python -m pytest test/unit/test_kubernetes_exception.py -v
```

**Where evidence shows up:** the identity assertion / except-clause in the test

<details>
<summary>Before (two distinct classes; except mismatch)</summary>

```python
from metaflow.plugins.kubernetes.kubernetes import KubernetesException as A
from metaflow.plugins.kubernetes.kube_utils import KubernetesException as B
assert A is B          # AssertionError — they are different classes
```
A handler `except A` does not catch a `raise B`.

</details>

<details>
<summary>After (single class; both paths identical)</summary>

```python
assert A is B          # passes
```

</details>

## Root Cause

`kube_utils.py` defines its own `KubernetesException` specifically to avoid a
circular import (it is a low-level module and cannot import from `kubernetes.py`).
`kubernetes.py` then defined a second, identical class. Different call sites
import different copies — `kubernetes_decorator` uses
`from .kubernetes import KubernetesException`, `kubernetes_cli` uses
`from ...kube_utils import KubernetesException` — so they reference different
class objects. Python exception matching is by class identity, so `except`/
`isinstance`/`is` across the two paths silently fails to match.

## Why This Fix Is Correct

Keep the single canonical definition in the low-level module (`kube_utils.py`)
and re-export it from `kubernetes.py` via `from .kube_utils import KubernetesException`.
This preserves **both** existing import paths (`from .kubernetes import ...` and
`from ...kube_utils import ...`) while making them resolve to the same object.
It is also cycle-safe: `kube_utils` imports only `metaflow.exception` and
`metaflow.util` (neither of which imports the kubernetes plugin), so
`kubernetes.py` importing `kube_utils` adds no import cycle — which is exactly
why the canonical copy must live in `kube_utils`, not the other way around.

## Failure Modes Considered

1. **Reintroducing the circular import the duplication was avoiding** — avoided
   by making `kubernetes.py` depend on `kube_utils` (the low-level module), never
   the reverse. Verified `kube_utils`'s only imports are `metaflow.exception` and
   `metaflow.util`.
2. **Breaking an existing import path** — both `from .kubernetes import
   KubernetesException` and `from ...kube_utils import KubernetesException`
   continue to resolve (now to the same class); the re-export keeps
   `kubernetes.KubernetesException` a valid name.

## Tests

- [x] Unit tests added/updated
- [x] CI passes
- [ ] Reproduction script provided (covered by the unit test above)

New `test/unit/test_kubernetes_exception.py` asserts the two import paths are the
same object and that `except` on one path catches a raise from the other — fails
before this change, passes after.

## Non-Goals

No change to the exception's behavior, message, or `headline`; no change to
`KubernetesKilledException` or any other class. Scope is limited to removing the
duplicate definition.

## AI Tool Usage

- [x] AI tools were used (describe below)

I found this duplication during independent analysis of the Kubernetes plugin a
few months ago and traced which modules import which copy. I used Claude to help
implement the consolidation, confirm the import direction is cycle-safe, write
the regression test, and draft this description. I reviewed and understand the
change and can explain the circular-import constraint that dictates the fix
direction.
