### PR TITLE
Set METAFLOW_RUN_ID in step worker subprocess environment

### DIFF
--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -2333,6 +2333,7 @@ class Worker(object):
         # Pass configuration options
         env.update(args.get_env())
         env["PYTHONUNBUFFERED"] = "x"
+        env["METAFLOW_RUN_ID"] = str(self.task.run_id)
         tracing.inject_tracing_vars(env)
         # NOTE bufsize=1 below enables line buffering which is required
         # by read_logline() below that relies on readline() not blocking


### PR DESCRIPTION
### PR Type
- [x] New feature
- [x] Core Runtime change

### Summary
Local `run` execution spawns each step in a subprocess via `Worker` (`metaflow/runtime.py`). Today the subprocess only receives the run id as a CLI argument (`--run-id`), not as an environment variable. Code that needs the run id *before* the CLI is parsed — e.g. during `import metaflow` — has no way to read it. This PR sets `METAFLOW_RUN_ID` in the worker's `env` alongside the existing CLI arg.

### Issue
N/A

### Root Cause / Why This Fix Is Correct
N/A

### Failure Modes Considered
N/A

### Tests
- Internal CI passes
- Unit tests pass

### Non-Goals

### AI Tool Usage
- [x] AI-assisted (Claude Code)
