### PR TITLE
Set METAFLOW_RUN_ID in AWS Batch and Kubernetes task environments

### DIFF
--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -297,7 +297,10 @@ def step(
         "metaflow_version"
     ]
 
-    env = {"METAFLOW_FLOW_FILENAME": os.path.basename(sys.argv[0])}
+    env = {
+        "METAFLOW_FLOW_FILENAME": os.path.basename(sys.argv[0]),
+        "METAFLOW_RUN_ID": kwargs["run_id"],
+    }
 
     if aws_batch_tags is not None:
         # We do not need to validate these again,

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -242,6 +242,7 @@ class Kubernetes(object):
             .environment_variable("METAFLOW_CODE_URL", code_package_url)
             .environment_variable("METAFLOW_CODE_DS", code_package_ds)
             .environment_variable("METAFLOW_USER", user)
+            .environment_variable("METAFLOW_RUN_ID", run_id)
             .environment_variable("METAFLOW_SERVICE_URL", SERVICE_INTERNAL_URL)
             .environment_variable(
                 "METAFLOW_SERVICE_HEADERS",
@@ -556,6 +557,7 @@ class Kubernetes(object):
             .environment_variable("METAFLOW_CODE_URL", code_package_url)
             .environment_variable("METAFLOW_CODE_DS", code_package_ds)
             .environment_variable("METAFLOW_USER", user)
+            .environment_variable("METAFLOW_RUN_ID", run_id)
             .environment_variable("METAFLOW_SERVICE_URL", SERVICE_INTERNAL_URL)
             .environment_variable(
                 "METAFLOW_SERVICE_HEADERS",


### PR DESCRIPTION
## Summary

Follow-up to #3327, per the review comment noting that `METAFLOW_RUN_ID` was set for the local-run worker subprocess but not for `--with kubernetes`.

This PR extends the same fix to the two other execution backends that build their own task environments from scratch:

- **AWS Batch** (`batch_cli.py`): add `METAFLOW_RUN_ID` to the `env` dict passed to `Batch.launch_job()`.
- **Kubernetes** (`kubernetes.py`): add `.environment_variable("METAFLOW_RUN_ID", run_id)` to both the regular job path (`create_job_object`) and the JobSet/multi-node path (`create_jobset`) — `JobSet.environment_variable()` fans out to both control and worker pod specs, so one call covers both.

Argo Workflows already sets `METAFLOW_RUN_ID` for both its regular-pod and jobset-scheduled Kubernetes paths (via a shared `env` dict), so no change was needed there. Netflix-internal Titus/Maestro backends already set it independently and are out of scope for this repo.

## Test plan
Passing unit tests

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>