### PR TITLE
fix(pypi): decode url-encoded wheel filenames

### DIFF
--- a/metaflow/plugins/pypi/bootstrap.py
+++ b/metaflow/plugins/pypi/bootstrap.py
@@ -208,6 +208,7 @@ if __name__ == "__main__":
     def download_pypi_packages(storage, packages, dest_dir):
         def process_pypi_package(args):
             key, tmpfile, dest_dir = args
+            # key (and path) might be url-encoded so we unquote this to get a usable filename for the package.
             dest = os.path.join(dest_dir, unquote(os.path.basename(key)))
             shutil.move(tmpfile, dest)
 

--- a/metaflow/plugins/pypi/bootstrap.py
+++ b/metaflow/plugins/pypi/bootstrap.py
@@ -10,6 +10,7 @@ import tarfile
 import time
 import platform
 from urllib.error import URLError
+from urllib.parse import unquote
 from urllib.request import urlopen
 from metaflow.metaflow_config import DATASTORE_LOCAL_DIR, CONDA_USE_FAST_INIT
 from metaflow.packaging_sys import MetaflowCodeContent, ContentType
@@ -207,7 +208,7 @@ if __name__ == "__main__":
     def download_pypi_packages(storage, packages, dest_dir):
         def process_pypi_package(args):
             key, tmpfile, dest_dir = args
-            dest = os.path.join(dest_dir, os.path.basename(key))
+            dest = os.path.join(dest_dir, unquote(os.path.basename(key)))
             shutil.move(tmpfile, dest)
 
         os.makedirs(dest_dir, exist_ok=True)


### PR DESCRIPTION
## PR Type

<!-- Check one -->

- [x] Bug fix

## Summary

<!-- What user-visible behavior changes? 1-2 sentences. -->
Some wheel names might end up url-encoded when persisted to the datastore. Handle unquoting in order to get a usable filename for packages during remote bootstrapping.

## Reproduction

<!-- Required for bug fixes. Required for Core Runtime changes. -->
<!-- Provide a minimal reproduction that fails before and succeeds after. -->

Example of the issue
```python
# from the index https://download.pytorch.org/whl/cu130
@pypi(python="3.12", packages={"torch": "2.10.0+cu130"})
```