### PR TITLE
Sanitize StepMutator attributes with to_pod() in _graph_info

### DIFF
--- a/metaflow/graph.py
+++ b/metaflow/graph.py
@@ -625,7 +625,7 @@ class FlowGraph(object):
                 + [
                     {
                         "name": deco.decorator_name,
-                        "attributes": {"_args": deco._args, **deco._kwargs},
+                        "attributes": to_pod({"_args": deco._args, **deco._kwargs}),
                         "statically_defined": deco.statically_defined,
                         "inserted_by": deco.inserted_by,
                     }

--- a/test/unit/test_graph_structure.py
+++ b/test/unit/test_graph_structure.py
@@ -9,12 +9,14 @@ Verifies that:
 - _graph_info contains start_step/end_step fields
 - Lint validation works with structural inference
 - @step(start=True) / @step(end=True) annotations work correctly
+- StepMutator/config-decorator attributes go through to_pod() in output_steps()
 """
 
 import pytest
 from metaflow import Config, FlowMutator, FlowSpec, step, Parameter, retry, resources
 from metaflow.flowspec import FlowStateItems
 from metaflow.lint import linter, LintWarn
+from metaflow.user_decorators.user_step_decorator import StepMutator
 
 # ---------------------------------------------------------------------------
 # Flow definitions for testing
@@ -648,3 +650,46 @@ def test_malformed_flow_caught_by_lint(flow_factory, match_pattern):
         match_pattern,
         warnings,
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests: StepMutator attribute sanitization (regression test for #3338)
+# ---------------------------------------------------------------------------
+
+
+class _NonPrimitiveArg:
+    """Constructor argument for a StepMutator that has no importable
+    representation of its own, used to prove output_steps() sanitizes it
+    rather than embedding the raw object."""
+
+    def __init__(self, x):
+        self.x = x
+
+
+class _payload_mutator(StepMutator):
+    def init(self, payload=None):
+        self._payload = payload
+
+    def mutate(self, mutable_step):
+        pass
+
+
+class _StepMutatorPayloadFlow(FlowSpec):
+    @_payload_mutator(payload=_NonPrimitiveArg(1))
+    @step(start=True, end=True)
+    def only(self):
+        pass
+
+
+def test_step_mutator_non_primitive_attribute_sanitized_in_output_steps():
+    """StepMutator/config-decorator attributes must go through to_pod() the
+    same way classic decorator attributes already do (see the two branches
+    of node_to_dict() in graph.py). Before the fix, a non-primitive
+    constructor argument (like _NonPrimitiveArg here) was embedded raw in
+    _graph_info, which breaks pickling for any consumer that can't import
+    the argument's class -- e.g. the Metaflow UI backend reading a run's
+    _graph_info artifact for DAG rendering."""
+    steps_info, _ = _StepMutatorPayloadFlow._graph.output_steps()
+    decorators = steps_info["only"]["decorators"]
+    payload_deco = next(d for d in decorators if d["name"].endswith("_payload_mutator"))
+    assert isinstance(payload_deco["attributes"]["payload"], str)


### PR DESCRIPTION
## Summary
`node_to_dict()` in `graph.py` sanitizes classic step decorator attributes with `to_pod()`, but not StepMutator/config-decorator attributes. This fix applies the same `to_pod()` sanitization to both.

## Context / Motivation
A StepMutator whose constructor takes a non-primitive argument gets that raw object embedded in `_graph_info`, since the second branch of the `decorators` list in `node_to_dict()` skips `to_pod()`. Any consumer that later unpickles `_graph_info` without that argument's class importable fails with `ModuleNotFoundError`. This breaks the Metaflow UI's DAG tab for any flow using such a StepMutator, since the UI backend has no reason to have a given decorator's package installed. Fixes #3338.

Root cause: the two branches of `node_to_dict()`'s `decorators` list construction are inconsistent. `node.decorators` (classic StepDecorator) goes through `to_pod()`; `chain(node.wrappers, node.config_decorators)` (StepMutator/config decorators) does not.

Failure modes considered:
- A StepMutator with only primitive constructor arguments (str/int/float/dict/list): unaffected, `to_pod()` passes these through unchanged.
- A StepMutator with no constructor arguments at all (bare decorator): unaffected, `_args`/`_kwargs` are empty and `to_pod()` on an empty dict is a no-op.

## Changes Made
- Wrap the StepMutator/config-decorator attributes dict in `to_pod()` in `node_to_dict()` (`metaflow/graph.py`).
- Add `test_step_mutator_non_primitive_attribute_sanitized_in_output_steps` to `test/unit/test_graph_structure.py`, which fails without the fix and passes with it.

## Testing
- New unit test added and confirmed it fails without the fix (`assert isinstance(..., str)` fails on the raw object) and passes with it.
- Full unit suite: `cd test/unit && python -m pytest -q` (local runtime, no cloud/k8s involved since this is a pure DAG-serialization path): 563 passed.
- `black --check` on both changed files: clean.
- Manually reproduced the original bug end to end (see #3338 for the standalone repro script) before writing the fix, confirming the exact `ModuleNotFoundError` failure mode this fix addresses.

## AI disclosure
Parts of this PR (investigation, implementation, and test) were developed with AI assistance (Claude Code). I reviewed and understand every change and can answer questions about it.
