### PR TITLE
Anchor metadata pattern matching so foreach paths do not prefix-match

### DIFF
--- a/metaflow/plugins/metadata_providers/local.py
+++ b/metaflow/plugins/metadata_providers/local.py
@@ -261,7 +261,7 @@ class LocalMetadataProvider(MetadataProvider):
 
             if any(
                 meta.get("field_name") == field_name
-                and regex.match(meta.get("value", ""))
+                and regex.fullmatch(meta.get("value", ""))
                 for meta in metadata
             ):
                 matching_task_pathspecs.append(

--- a/test/unit/test_local_metadata_provider.py
+++ b/test/unit/test_local_metadata_provider.py
@@ -29,3 +29,41 @@ def test_deduce_run_id_from_meta_dir():
             case["meta_path"], case["sub_type"]
         )
         assert case["expected_run_id"] == actual_run_id
+
+
+def test_filter_tasks_by_metadata_does_not_match_prefixes(monkeypatch):
+    # A foreach with 11+ items produces execution paths like "middle:1" and
+    # "middle:10". Matching with re.match only anchors the start, so the
+    # pattern "middle:1" also selected "middle:10" and "middle:11", giving
+    # Task.parent_tasks/child_tasks the wrong tasks.
+    paths = {
+        "1": "middle:1",
+        "2": "middle:10",
+        "3": "middle:11",
+        "4": "middle:1,inner:0",
+    }
+
+    def fake_get_object(cls, obj_type, sub_type, filters, attempt, *args):
+        if sub_type == "task":
+            return [{"task_id": task_id} for task_id in sorted(paths)]
+        task_id = args[-1]
+        return [
+            {"field_name": "foreach-execution-path", "value": paths[task_id]},
+        ]
+
+    monkeypatch.setattr(
+        LocalMetadataProvider, "get_object", classmethod(fake_get_object)
+    )
+
+    def filter_for(pattern):
+        return LocalMetadataProvider.filter_tasks_by_metadata(
+            "Flow", "run", "middle", "foreach-execution-path", pattern
+        )
+
+    # the exact path must not pull in the longer indices that start with it
+    assert filter_for("middle:1") == ["Flow/run/middle/1"]
+    assert filter_for("middle:10") == ["Flow/run/middle/2"]
+    # a nested foreach still resolves its children through the ",.*" pattern
+    assert filter_for("middle:1,.*") == ["Flow/run/middle/4"]
+    # and the match-all pattern keeps returning everything
+    assert len(filter_for(".*")) == len(paths)


### PR DESCRIPTION
Addresses the local-provider side of #3341. The service-provider side is handled by #3357.

`LocalMetadataProvider.filter_tasks_by_metadata` matched metadata values with `regex.match`, which anchors only at the start. `Task.parent_tasks` / `child_tasks` build their pattern from `foreach-execution-path`, so once a foreach has 11 or more items the pattern `middle:1` also matched the values `middle:10` and `middle:11`, and the client resolved the wrong tasks. With `spin` this turns into a hard failure ("not a join step but gets multiple inputs").

The fix switches that one call to `regex.fullmatch`, so a pattern has to match the whole value.

The reason `fullmatch` is safe here is that the patterns this function receives are already written to cover the part of the path they care about. From `metaflow/client/core.py`:

- an exact ancestor path, e.g. `middle:1` — should match only that task, which is what this fixes
- a descendant pattern built as `f"{current_path},.*"` — the trailing `.*` still consumes the rest of the value, so nested foreach lookups are unaffected
- `".*"` for the match-all case — unaffected, and it is short-circuited before the regex anyway

I checked the values that a 12 item foreach produces:

| pattern | `re.match` (before) | `re.fullmatch` (after) |
|---|---|---|
| `middle:1` | `middle:1`, `middle:10`, `middle:11`, `middle:1,inner:0` | `middle:1` |
| `middle:1,.*` | `middle:1,inner:0` | `middle:1,inner:0` |
| `.*` | all | all |

Only the over-matching case changes.

The service metadata provider passes the pattern to the backend instead of matching locally, so this is the only client-side matcher affected.

Added `test_filter_tasks_by_metadata_does_not_match_prefixes` in `test/unit/test_local_metadata_provider.py`, covering the exact path, the prefixed sibling, a nested descendant pattern and match-all. Verified it fails before the change (the `middle:1` lookup returns three extra tasks) and passes after; the existing test in that file still passes.

