### PR TITLE
release: 2.19.38

### DIFF
--- a/metaflow/version.py
+++ b/metaflow/version.py
@@ -1,1 +1,1 @@
-metaflow_version = "2.19.37"
+metaflow_version = "2.19.38"


### PR DESCRIPTION
## PR Type

- [ ] Bug fix
- [ ] New feature
- [ ] Core Runtime change
- [x] Docs / tooling
- [ ] Refactoring

## Summary

Bump the canonical Metaflow package version from `2.19.37` to `2.19.38` for the next patch release.

## Issue

N/A — routine patch release.

## Reproduction

Not applicable; this PR changes release metadata only.

## Root Cause

Not applicable.

## Why This Fix Is Correct

`2.19.37` is the latest published release, and this updates only `metaflow/version.py` to the next patch version.

## Failure Modes Considered

1. Incorrect version sequence: confirmed the latest published release and repository tag are both `2.19.37`.
2. Unrelated changes: confirmed the PR contains a one-line version change only.

## Tests

- [ ] Unit tests added/updated
- [ ] Reproduction script provided
- [ ] CI passes
- [x] If tests are impractical: release metadata was validated directly and all configured pre-commit hooks passed.

## Non-Goals

No runtime behavior, dependencies, or release automation are changed.

## AI Tool Usage

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (described below)

OpenAI Codex was used to inspect release conventions, make the one-line version bump, run validation, and create this PR.